### PR TITLE
fix(euroscope-plugin): use live callsign lookups for strips

### DIFF
--- a/euroscope-plugin/src/plugin/flightplan/FlightPlanService.cpp
+++ b/euroscope-plugin/src/plugin/flightplan/FlightPlanService.cpp
@@ -18,8 +18,8 @@ namespace FlightStrips::flightplan {
         const auto position = radarTarget.GetPosition();
         if (!position.IsValid()) return;
 
-        const auto fp = radarTarget.GetCorrelatedFlightPlan();
-        // Treat auto-correlated FPs with no received data (VFR squawk correlation) as no-FP.
+        const auto callsign = std::string(radarTarget.GetCallsign());
+        const auto fp = m_flightStripsPlugin->FlightPlanSelect(callsign.c_str());
         const bool hasFp = fp.IsValid();
         const auto isArrival = hasFp
             ? strcmp(fp.GetFlightPlanData().GetDestination(),
@@ -39,7 +39,6 @@ namespace FlightStrips::flightplan {
             std::string(position.GetSquawk()),
             stand
         };
-        const auto callsign = std::string(radarTarget.GetCallsign());
 
         if (isRangeOnly) {
             m_rangeTrackedCallsigns.insert(callsign);
@@ -112,10 +111,11 @@ namespace FlightStrips::flightplan {
         }
 
         if (!m_websocketService->ShouldSend()) return;
+        const auto radarTarget = m_flightStripsPlugin->RadarTargetSelect(callsign.c_str());
+        const auto radarPosition = radarTarget.GetPosition();
+        if (!radarPosition.IsValid()) return;
+        const auto position = radarPosition.GetPosition();
         const auto flightPlanData = flightPlan.GetFlightPlanData();
-        const auto trackPosition = flightPlan.GetFPTrackPosition();
-        if (!trackPosition.IsValid()) return;
-        const auto position = trackPosition.GetPosition();
 
         const auto isArrival = strcmp(flightPlan.GetFlightPlanData().GetDestination(), relevantAirport.c_str()) == 0;
         const auto runway = std::string(isArrival
@@ -139,7 +139,7 @@ namespace FlightStrips::flightplan {
             std::string(flightPlanData.GetRoute()),
             std::string(flightPlanData.GetRemarks()),
             runway,
-            std::string(trackPosition.GetSquawk()),
+            std::string(radarPosition.GetSquawk()),
             std::string(controllerAssignedData.GetSquawk()),
             std::string(flightPlanData.GetSidName()),
             flightPlan.GetClearenceFlag(),
@@ -150,8 +150,7 @@ namespace FlightStrips::flightplan {
             std::string(flightPlanData.GetAircraftInfo()),
             {flightPlanData.GetAircraftWtc()},
             Position{
-                position.m_Latitude, position.m_Longitude,
-                trackPosition.GetPressureAltitude()
+                position.m_Latitude, position.m_Longitude, radarPosition.GetPressureAltitude()
             },
             standName,
             {flightPlanData.GetCommunicationType()},

--- a/euroscope-plugin/src/plugin/messages/MessageService.cpp
+++ b/euroscope-plugin/src/plugin/messages/MessageService.cpp
@@ -137,13 +137,22 @@ namespace FlightStrips::messages {
             if (!m_plugin->IsRelevant(it)) continue;;
             if (it.GetSimulated()) continue;;
             const auto flightPlanData = it.GetFlightPlanData();
-            if (!flightPlanData.IsReceived()) continue;;
-            const auto trackPosition = it.GetFPTrackPosition();
-            // TODO: is this a problem?
-            if (!trackPosition.IsValid()) continue;;
-            const auto position = trackPosition.GetPosition();
 
             const auto callsign = std::string(it.GetCallsign());
+            const auto radarTarget = m_plugin->RadarTargetSelect(callsign.c_str());
+            const auto radarPosition = radarTarget.GetPosition();
+            const auto hasRadarPosition = radarPosition.IsValid();
+            double latitude = 0.0;
+            double longitude = 0.0;
+            int altitude = 0;
+            std::string squawk;
+            if (hasRadarPosition) {
+                const auto position = radarPosition.GetPosition();
+                latitude = position.m_Latitude;
+                longitude = position.m_Longitude;
+                altitude = radarPosition.GetPressureAltitude();
+                squawk = std::string(radarPosition.GetSquawk());
+            }
             const auto info = m_flightPlanService->GetFlightPlan(callsign);
             const auto isArrival = strcmp(it.GetFlightPlanData().GetDestination(), relevantAirport) == 0;
             const auto runway = std::string(isArrival
@@ -155,8 +164,8 @@ namespace FlightStrips::messages {
                 stand = info->stand;
             }
 
-            if (stand.empty() && trackPosition.GetPressureAltitude() < 1000) {
-                if (const auto standPtr = m_standService->GetStandFromFlightPlan(it); standPtr != nullptr) {
+            if (stand.empty() && hasRadarPosition && altitude < 1000) {
+                if (const auto standPtr = m_standService->GetStandFromFlightPlan(it, radarTarget); standPtr != nullptr) {
                     stand = standPtr->GetName();
                     m_flightPlanService->SetStand(callsign, stand);
                 }
@@ -170,7 +179,7 @@ namespace FlightStrips::messages {
                 std::string(flightPlanData.GetRoute()),
                 std::string(flightPlanData.GetRemarks()),
                 runway,
-                std::string(trackPosition.GetSquawk()),
+                squawk,
                 std::string(controllerAssignedData.GetSquawk()),
                 std::string(flightPlanData.GetSidName()),
                 it.GetClearenceFlag(),
@@ -181,8 +190,7 @@ namespace FlightStrips::messages {
                 std::string(flightPlanData.GetAircraftInfo()),
                 {flightPlanData.GetAircraftWtc()},
                 Position{
-                    position.m_Latitude, position.m_Longitude,
-                    trackPosition.GetPressureAltitude()
+                    latitude, longitude, altitude
                 },
                 stand,
                 {flightPlanData.GetCommunicationType()},
@@ -199,16 +207,14 @@ namespace FlightStrips::messages {
         // the backend never receives a strip_update for them and every subsequent position event
         // is silently dropped with "strip does not exist".
         for (auto rt = m_plugin->RadarTargetSelectFirst(); rt.IsValid(); rt = m_plugin->RadarTargetSelectNext(rt)) {
-            // Skip only if a received FP exists — those are handled by the FlightPlanSelectFirst loop above.
-            // An auto-correlated FP with IsReceived()=false has no real origin/destination and must be
-            // treated as no-FP here so the strip record gets created.
-            const auto rtFp = rt.GetCorrelatedFlightPlan();
-            if (rtFp.IsValid() && rtFp.GetFlightPlanData().IsReceived()) continue;
+            const auto callsign = std::string(rt.GetCallsign());
+            // Skip any aircraft with a live FP — those are handled by the FlightPlanSelectFirst loop above.
+            const auto rtFp = m_plugin->FlightPlanSelect(callsign.c_str());
+            if (rtFp.IsValid()) continue;
 
             const auto position = rt.GetPosition();
             if (!position.IsValid()) continue;
 
-            const auto callsign = std::string(rt.GetCallsign());
             const auto pos = position.GetPosition();
             const auto info = m_flightPlanService->GetFlightPlan(callsign);
             std::string stand;
@@ -308,7 +314,8 @@ namespace FlightStrips::messages {
 
     void MessageService::HandleGenerateSquawkEvent(const GenerateSquawkEvent &event) const {
         const auto fp = m_plugin->FlightPlanSelect(event.callsign.c_str());
-        if (!fp.IsValid() || !fp.GetCorrelatedRadarTarget().IsValid()) return;
+        const auto radarTarget = m_plugin->RadarTargetSelect(event.callsign.c_str());
+        if (!fp.IsValid() || !radarTarget.IsValid()) return;
         m_plugin->AddNeedsSquawk(std::string(fp.GetCallsign()));
     }
 

--- a/euroscope-plugin/src/plugin/plugin/FlightStripsPlugin.cpp
+++ b/euroscope-plugin/src/plugin/plugin/FlightStripsPlugin.cpp
@@ -228,10 +228,11 @@ namespace FlightStrips {
     void FlightStripsPlugin::OnRadarTargetPositionUpdate(EuroScopePlugIn::CRadarTarget RadarTarget) {
         if (!RadarTarget.IsValid()) return;
 
-        const auto flightPlan = RadarTarget.GetCorrelatedFlightPlan();
+        const auto callsign = std::string(RadarTarget.GetCallsign());
+        const auto flightPlan = FlightPlanSelect(callsign.c_str());
 
         if (!flightPlan.IsValid()) {
-            // No correlated flight plan — VFR/no-FP aircraft. Use radar target position for range check.
+            // No live flight plan found by callsign — treat as VFR/no-FP and use radar target position.
             DispatchRangeCheck(RadarTarget);
             return;
         }
@@ -267,10 +268,11 @@ namespace FlightStrips {
     }
 
     bool FlightStripsPlugin::IsRelevant(const CFlightPlan flightPlan) const {
-        if (!flightPlan.IsValid() || flightPlan.GetSimulated() ||
-            !flightPlan.GetCorrelatedRadarTarget().IsValid()) {
+        if (!flightPlan.IsValid() || flightPlan.GetSimulated()) {
             return false;
         }
+        const auto radarTarget = RadarTargetSelect(flightPlan.GetCallsign());
+        if (!radarTarget.IsValid()) return false;
         if (IsValidAirports(flightPlan)) return true;
         // Reject IFR aircraft with a valid flight plan to/from a non-matching airport.
         // Only VFR or no-FP aircraft are eligible for the range-based fallback.
@@ -280,7 +282,7 @@ namespace FlightStrips {
         if (!origin.empty() && !destination.empty() && origin != "ZZZZ" && destination != "ZZZZ") {
             return false;
         }
-        return IsWithinRange(flightPlan.GetCorrelatedRadarTarget(), 30.0f);
+        return IsWithinRange(radarTarget, 30.0f);
     }
 
     void FlightStripsPlugin::SetAirportCoordinates(const double latitude, const double longitude) {

--- a/euroscope-plugin/src/plugin/stands/StandService.cpp
+++ b/euroscope-plugin/src/plugin/stands/StandService.cpp
@@ -57,14 +57,13 @@ namespace FlightStrips::stands {
         return &*iter;
     }
 
-    Stand *StandService::GetStandFromFlightPlan(EuroScopePlugIn::CFlightPlan flightPlan) {
-        const auto trackPosition = flightPlan.GetFPTrackPosition();
-        if (trackPosition.IsValid()) {
-            const auto stand = this->GetStand(trackPosition.GetPosition());
+    Stand *StandService::GetStandFromFlightPlan(EuroScopePlugIn::CFlightPlan flightPlan, EuroScopePlugIn::CRadarTarget radarTarget) {
+        const auto position = radarTarget.GetPosition();
+        if (position.IsValid()) {
+            const auto stand = this->GetStand(position.GetPosition());
             if (stand != nullptr) {
                 return stand;
             }
-
         }
 
         const auto stand = this->GetStand(flightPlan.GetControllerAssignedData().GetFlightStripAnnotation(6), "EKCH");

--- a/euroscope-plugin/src/plugin/stands/StandService.h
+++ b/euroscope-plugin/src/plugin/stands/StandService.h
@@ -13,7 +13,7 @@ namespace FlightStrips::stands {
         explicit StandService(std::vector<Stand> stands);
         Stand* GetStand(EuroScopePlugIn::CPosition position);
         Stand* GetStand(const std::string& stand, const std::string& airport);
-        Stand* GetStandFromFlightPlan(EuroScopePlugIn::CFlightPlan flightPlan);
+        Stand* GetStandFromFlightPlan(EuroScopePlugIn::CFlightPlan flightPlan, EuroScopePlugIn::CRadarTarget radarTarget);
 
     private:
         // this may end up being a map but should make no change to the caller

--- a/euroscope-plugin/src/plugin/tag_items/CdmStateHandler.cpp
+++ b/euroscope-plugin/src/plugin/tag_items/CdmStateHandler.cpp
@@ -125,7 +125,7 @@ namespace FlightStrips::TagItems {
         if (plan == nullptr) return;
 
         const auto fpData = FlightPlan.GetFlightPlanData();
-        const std::string fallbackEobt = fpData.IsReceived() ? std::string(fpData.GetEstimatedDepartureTime()) : std::string{};
+        const std::string fallbackEobt = std::string(fpData.GetEstimatedDepartureTime());
         const auto presentation = ResolvePresentation(plan->cdm, m_field, fallbackEobt);
         if (!presentation.hasValue) return;
 

--- a/euroscope-plugin/src/plugin/tag_items/DeIceHandler.cpp
+++ b/euroscope-plugin/src/plugin/tag_items/DeIceHandler.cpp
@@ -59,7 +59,7 @@ namespace FlightStrips::TagItems
                     return;
                 }
             } else if (action == "stand") {
-                const auto stand = m_standService->GetStandFromFlightPlan(FlightPlan);
+                const auto stand = m_standService->GetStandFromFlightPlan(FlightPlan, RadarTarget);
                 if (stand == nullptr) {
                     continue;
                 }

--- a/euroscope-plugin/test/plugin/CMakeLists.txt
+++ b/euroscope-plugin/test/plugin/CMakeLists.txt
@@ -44,6 +44,9 @@ set(ALL_FILES
         messages/CdmReadyTriggerTest.cpp
         messages/MessageServiceTest.cpp
 
+        # Plugin
+        plugin/LookupAuditTest.cpp
+
         # Handlers
         handlers/FlightPlanEventHandlersTest.cpp
         handlers/RadarTargetEventHandlersTest.cpp

--- a/euroscope-plugin/test/plugin/plugin/LookupAuditTest.cpp
+++ b/euroscope-plugin/test/plugin/plugin/LookupAuditTest.cpp
@@ -1,0 +1,43 @@
+#include <gtest/gtest.h>
+
+#include <array>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+
+namespace {
+    auto GetPluginSourceRoot() -> std::filesystem::path {
+        return std::filesystem::path(__FILE__).parent_path().parent_path().parent_path().parent_path() / "src" / "plugin";
+    }
+
+    auto ReadFile(const std::filesystem::path& path) -> std::string {
+        std::ifstream input(path, std::ios::binary);
+        return std::string(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+    }
+
+    auto IsSourceFile(const std::filesystem::path& path) -> bool {
+        const auto extension = path.extension().string();
+        return extension == ".cpp" || extension == ".h";
+    }
+}
+
+TEST(LookupAuditTest, PluginSourceDoesNotUseDeprecatedEuroScopeLookups) {
+    const auto sourceRoot = GetPluginSourceRoot();
+    const std::array forbiddenAccessors = {
+        "GetCorrelatedFlightPlan(",
+        "GetCorrelatedRadarTarget(",
+        "GetFPTrackPosition(",
+        "IsReceived("
+    };
+
+    for (const auto& entry : std::filesystem::recursive_directory_iterator(sourceRoot)) {
+        if (!entry.is_regular_file() || !IsSourceFile(entry.path())) continue;
+
+        const auto contents = ReadFile(entry.path());
+        for (const auto* accessor : forbiddenAccessors) {
+            EXPECT_EQ(contents.find(accessor), std::string::npos)
+                << accessor << " found in " << entry.path().string();
+        }
+    }
+}


### PR DESCRIPTION
Replace correlated and FP-track based strip lookups with live FlightPlanSelect and RadarTargetSelect calls where correlation can be invalid, keep trusted flight-plan callbacks in place, and add an audit test that forbids reintroducing the deprecated EuroScope accessors.