### PR TITLE
fix(backend): reduce controller offline grace period from 60s to 15s

### DIFF
--- a/backend/internal/euroscope/handlers.go
+++ b/backend/internal/euroscope/handlers.go
@@ -155,7 +155,7 @@ func handleControllerOffline(ctx context.Context, client *Client, message Messag
 			slog.String("callsign", event.Callsign),
 			slog.String("position", result.PositionName),
 			slog.Int("session", int(session)))
-		client.hub.scheduleOfflineActions(session, event.Callsign, result.PositionFrequency, result.PositionName, offlineGracePeriod)
+		client.hub.scheduleOfflineActions(session, event.Callsign, result.PositionFrequency, result.PositionName, controllerOfflineGracePeriod)
 	}
 
 	return nil

--- a/backend/internal/euroscope/hub_offline_timers.go
+++ b/backend/internal/euroscope/hub_offline_timers.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	offlineGracePeriod        = 60 * time.Second
-	masterTransferGracePeriod = 45 * time.Second
+	offlineGracePeriod             = 60 * time.Second
+	controllerOfflineGracePeriod   = 15 * time.Second
+	masterTransferGracePeriod      = 45 * time.Second
 )
 
 // offlineTimerEntry holds the cancel function and metadata for a pending position offline timer.
@@ -41,13 +42,16 @@ type sessionUpdatePending struct {
 	positions []string // offline position names gathered in this debounce window
 }
 
-// scheduleOfflineActions starts a goroutine that, after the given grace period,
+// scheduleOfflineActions starts a goroutine that, after the given delay,
 // deletes the controller from the database, notifies all frontend clients that the
 // controller is offline, recalculates sector ownership, and — 5 seconds later —
 // broadcasts a specific sector-change notification.
 //
-// If cancelOfflineTimer is called for the same position key before the grace period
+// If cancelOfflineTimer is called for the same position key before the delay
 // elapses, the goroutine exits cleanly and none of the above happens.
+// When the position has no remaining controller coverage, the delay is
+// controllerOfflineGracePeriod (15s) so the frontend receives the offline
+// notification promptly while still allowing time for a quick reconnect.
 func (hub *Hub) scheduleOfflineActions(session int32, callsign, positionFreq, positionName string, delay time.Duration) {
 	key := fmt.Sprintf("%d:%s", session, positionName)
 

--- a/backend/internal/euroscope/hub_offline_timers_test.go
+++ b/backend/internal/euroscope/hub_offline_timers_test.go
@@ -371,3 +371,100 @@ func TestScheduleOfflineActions_UsesStoredTimerEntryMetadata(t *testing.T) {
 	assert.Equal(t, replacementCallsign, frontendHub.ControllerOfflines[0].Callsign)
 	assert.Equal(t, replacementPosition, frontendHub.ControllerOfflines[0].Position)
 }
+
+func TestControllerOfflineGracePeriodValue(t *testing.T) {
+	assert.Equal(t, 15*time.Second, controllerOfflineGracePeriod, "controllerOfflineGracePeriod should be 15s")
+}
+
+func TestScheduleOfflineActions_ControllerOfflineGracePeriodFinalizes(t *testing.T) {
+	const session = int32(1)
+	const callsign = "EKCH_TWR"
+	const position = "118.700"
+	const positionName = "EKCH_TWR"
+	t.Cleanup(config.SetOwnerCallsignPrefixesForTest([]string{"EKCH", "EKDK"}))
+
+	var deleteCalls atomic.Int32
+	var recalculateCalls atomic.Int32
+
+	frontendHub := &testutil.MockFrontendHub{}
+	server := &testutil.MockServer{
+		FrontendHubVal: frontendHub,
+		ControllerRepoVal: &testutil.MockControllerRepository{
+			GetByCallsignFn: func(_ context.Context, sess int32, cs string) (*models.Controller, error) {
+				assert.Equal(t, session, sess)
+				assert.Equal(t, callsign, cs)
+				return &models.Controller{
+					Callsign: callsign,
+					Position: position,
+				}, nil
+			},
+			GetByPositionFn: func(_ context.Context, sess int32, pos string) ([]*models.Controller, error) {
+				assert.Equal(t, session, sess)
+				assert.Equal(t, position, pos)
+				return []*models.Controller{
+					{Callsign: callsign, Position: position},
+				}, nil
+			},
+			DeleteFn: func(_ context.Context, sess int32, cs string) error {
+				assert.Equal(t, session, sess)
+				assert.Equal(t, callsign, cs)
+				deleteCalls.Add(1)
+				return nil
+			},
+		},
+		RecalculateSessionFn: func(_ int32, _ bool) ([]shared.SectorChange, error) {
+			recalculateCalls.Add(1)
+			return nil, nil
+		},
+	}
+
+	hub := buildReconcileHub(server)
+	hub.scheduleOfflineActions(session, callsign, position, positionName, 10*time.Millisecond)
+
+	require.Eventually(t, func() bool { return deleteCalls.Load() == 1 }, 2*time.Second, 50*time.Millisecond,
+		"controller should be deleted after grace period")
+	require.Eventually(t, func() bool { return len(frontendHub.ControllerOfflines) >= 1 }, 2*time.Second, 50*time.Millisecond,
+		"offline notification should be sent after grace period")
+	assert.Equal(t, callsign, frontendHub.ControllerOfflines[0].Callsign)
+	assert.Equal(t, position, frontendHub.ControllerOfflines[0].Position)
+
+	require.Eventually(t, func() bool { return recalculateCalls.Load() == 1 }, 2*time.Second, 50*time.Millisecond,
+		"session should be recalculated after finalization (debounced)")
+
+	hub.offlineMu.Lock()
+	assert.Empty(t, hub.offlineTimers, "timer entry should be removed after execution")
+	hub.offlineMu.Unlock()
+}
+
+func TestScheduleOfflineActions_CancelPreventsFinalization(t *testing.T) {
+	const session = int32(1)
+	const callsign = "EKCH_TWR"
+	const position = "118.700"
+	const positionName = "EKCH_TWR"
+	t.Cleanup(config.SetOwnerCallsignPrefixesForTest([]string{"EKCH", "EKDK"}))
+
+	var deleteCalls atomic.Int32
+
+	frontendHub := &testutil.MockFrontendHub{}
+	server := &testutil.MockServer{
+		FrontendHubVal: frontendHub,
+		ControllerRepoVal: &testutil.MockControllerRepository{
+			DeleteFn: func(_ context.Context, _ int32, _ string) error {
+				deleteCalls.Add(1)
+				return nil
+			},
+		},
+	}
+
+	hub := buildReconcileHub(server)
+
+	hub.scheduleOfflineActions(session, callsign, position, positionName, 10*time.Millisecond)
+
+	cancelled := hub.cancelOfflineTimer(session, positionName)
+	assert.True(t, cancelled, "timer should be cancelled before it fires")
+
+	time.Sleep(120 * time.Millisecond)
+
+	assert.Equal(t, int32(0), deleteCalls.Load(), "cancelled timer should not delete controller")
+	assert.Empty(t, frontendHub.ControllerOfflines, "cancelled timer should not send offline notification")
+}


### PR DESCRIPTION
When no controller covers a position, the frontend clearance list was delayed by 60 seconds before becoming available to the next controller. Reduce the grace period to 15 seconds so positions are marked offline promptly, while still allowing time for quick reconnects.

- Add controllerOfflineGracePeriod constant (15s) separate from offlineGracePeriod (60s) which is still used for aircraft disconnects and sync reconciliation
- Use controllerOfflineGracePeriod in handleControllerOffline
- Add test asserting the constant value is 15s
- Add test verifying finalization flow with the new grace period
- Add test verifying cancellation still prevents finalization