### PR TITLE
feat(callsigns): source spoken callsigns from the Euroscope plugin

### DIFF
--- a/backend/internal/database/models.go
+++ b/backend/internal/database/models.go
@@ -113,6 +113,7 @@ type Strip struct {
 	PdcData                  []byte
 	ValidationStatus         []byte
 	StartReq                 bool
+	SpokenCallsign           *string
 }
 
 type TacticalStrip struct {

--- a/backend/internal/database/strips.sql.go
+++ b/backend/internal/database/strips.sql.go
@@ -295,7 +295,7 @@ func (q *Queries) GetSequence(ctx context.Context, arg GetSequenceParams) (int32
 }
 
 const getStrip = `-- name: GetStrip :one
-SELECT id, version, callsign, session, origin, destination, alternative, route, remarks, assigned_squawk, squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities, communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay, position_latitude, position_longitude, position_altitude, next_owners, previous_owners, release_point, marked, registration, tracking_controller, runway_cleared, unexpected_change_fields, controller_modified_fields, engine_type, is_manual, persons_on_board, fpl_type, language, has_fp, cdm_data, runway_confirmed, pdc_data, validation_status, start_req
+SELECT id, version, callsign, session, origin, destination, alternative, route, remarks, assigned_squawk, squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities, communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay, position_latitude, position_longitude, position_altitude, next_owners, previous_owners, release_point, marked, registration, tracking_controller, runway_cleared, unexpected_change_fields, controller_modified_fields, engine_type, is_manual, persons_on_board, fpl_type, language, has_fp, cdm_data, runway_confirmed, pdc_data, validation_status, start_req, spoken_callsign
 FROM strips
 WHERE callsign = $1 AND session = $2
 `
@@ -358,6 +358,7 @@ func (q *Queries) GetStrip(ctx context.Context, arg GetStripParams) (Strip, erro
 		&i.PdcData,
 		&i.ValidationStatus,
 		&i.StartReq,
+		&i.SpokenCallsign,
 	)
 	return i, err
 }
@@ -367,7 +368,7 @@ INSERT INTO strips (version, callsign, session, origin, destination, alternative
                      squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities,
                      communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay,
                      position_latitude, position_longitude, position_altitude, cdm_data, next_owners, previous_owners,
-                     registration, tracking_controller, engine_type, has_fp, start_req)
+                     registration, tracking_controller, engine_type, spoken_callsign, has_fp, start_req)
 VALUES (
     1,
     $1,
@@ -404,7 +405,8 @@ VALUES (
     $32,
     $33,
     $34,
-    $35
+    $35,
+    $36
 )
 `
 
@@ -442,6 +444,7 @@ type InsertStripParams struct {
 	Registration       *string
 	TrackingController string
 	EngineType         string
+	SpokenCallsign     *string
 	HasFp              bool
 	StartReq           bool
 }
@@ -481,6 +484,7 @@ func (q *Queries) InsertStrip(ctx context.Context, arg InsertStripParams) error 
 		arg.Registration,
 		arg.TrackingController,
 		arg.EngineType,
+		arg.SpokenCallsign,
 		arg.HasFp,
 		arg.StartReq,
 	)
@@ -525,7 +529,7 @@ func (q *Queries) ListStripSequences(ctx context.Context, arg ListStripSequences
 }
 
 const listStrips = `-- name: ListStrips :many
-SELECT id, version, callsign, session, origin, destination, alternative, route, remarks, assigned_squawk, squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities, communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay, position_latitude, position_longitude, position_altitude, next_owners, previous_owners, release_point, marked, registration, tracking_controller, runway_cleared, unexpected_change_fields, controller_modified_fields, engine_type, is_manual, persons_on_board, fpl_type, language, has_fp, cdm_data, runway_confirmed, pdc_data, validation_status, start_req
+SELECT id, version, callsign, session, origin, destination, alternative, route, remarks, assigned_squawk, squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities, communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay, position_latitude, position_longitude, position_altitude, next_owners, previous_owners, release_point, marked, registration, tracking_controller, runway_cleared, unexpected_change_fields, controller_modified_fields, engine_type, is_manual, persons_on_board, fpl_type, language, has_fp, cdm_data, runway_confirmed, pdc_data, validation_status, start_req, spoken_callsign
 FROM strips
 WHERE session = $1
 ORDER BY callsign
@@ -590,6 +594,7 @@ func (q *Queries) ListStrips(ctx context.Context, session int32) ([]Strip, error
 			&i.PdcData,
 			&i.ValidationStatus,
 			&i.StartReq,
+			&i.SpokenCallsign,
 		); err != nil {
 			return nil, err
 		}
@@ -602,7 +607,7 @@ func (q *Queries) ListStrips(ctx context.Context, session int32) ([]Strip, error
 }
 
 const listStripsByOrigin = `-- name: ListStripsByOrigin :many
-SELECT id, version, callsign, session, origin, destination, alternative, route, remarks, assigned_squawk, squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities, communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay, position_latitude, position_longitude, position_altitude, next_owners, previous_owners, release_point, marked, registration, tracking_controller, runway_cleared, unexpected_change_fields, controller_modified_fields, engine_type, is_manual, persons_on_board, fpl_type, language, has_fp, cdm_data, runway_confirmed, pdc_data, validation_status, start_req
+SELECT id, version, callsign, session, origin, destination, alternative, route, remarks, assigned_squawk, squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities, communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay, position_latitude, position_longitude, position_altitude, next_owners, previous_owners, release_point, marked, registration, tracking_controller, runway_cleared, unexpected_change_fields, controller_modified_fields, engine_type, is_manual, persons_on_board, fpl_type, language, has_fp, cdm_data, runway_confirmed, pdc_data, validation_status, start_req, spoken_callsign
 FROM strips
 WHERE origin = $1 AND session = $2
 ORDER BY callsign
@@ -672,6 +677,7 @@ func (q *Queries) ListStripsByOrigin(ctx context.Context, arg ListStripsByOrigin
 			&i.PdcData,
 			&i.ValidationStatus,
 			&i.StartReq,
+			&i.SpokenCallsign,
 		); err != nil {
 			return nil, err
 		}
@@ -979,20 +985,21 @@ SET version = version + 1,
     marked = $30,
     registration = $31,
     tracking_controller = $32,
-    runway_cleared = $33,
-    runway_confirmed = $34,
-    engine_type = $35,
-    unexpected_change_fields = COALESCE($36::text[], '{}'::text[]),
-    controller_modified_fields = COALESCE($37::text[], '{}'::text[]),
-    is_manual = $38,
-    persons_on_board = $39,
-    fpl_type = $40,
-    language = $41,
-    has_fp = $42,
-    pdc_data = $43,
-    validation_status = $44,
-    start_req = $45
-WHERE callsign = $46 AND session = $47
+    spoken_callsign = $33,
+    runway_cleared = $34,
+    runway_confirmed = $35,
+    engine_type = $36,
+    unexpected_change_fields = COALESCE($37::text[], '{}'::text[]),
+    controller_modified_fields = COALESCE($38::text[], '{}'::text[]),
+    is_manual = $39,
+    persons_on_board = $40,
+    fpl_type = $41,
+    language = $42,
+    has_fp = $43,
+    pdc_data = $44,
+    validation_status = $45,
+    start_req = $46
+WHERE callsign = $47 AND session = $48
 `
 
 type UpdateStripParams struct {
@@ -1028,6 +1035,7 @@ type UpdateStripParams struct {
 	Marked                   bool
 	Registration             *string
 	TrackingController       string
+	SpokenCallsign           *string
 	RunwayCleared            bool
 	RunwayConfirmed          bool
 	EngineType               string
@@ -1079,6 +1087,7 @@ func (q *Queries) UpdateStrip(ctx context.Context, arg UpdateStripParams) (int64
 		arg.Marked,
 		arg.Registration,
 		arg.TrackingController,
+		arg.SpokenCallsign,
 		arg.RunwayCleared,
 		arg.RunwayConfirmed,
 		arg.EngineType,

--- a/backend/internal/frontend/hub.go
+++ b/backend/internal/frontend/hub.go
@@ -499,6 +499,7 @@ func MapStripToFrontendModelWithClx(strip *internalModels.Strip, clxContext clx.
 		PositionAltitude:         helpers.ValueOrDefault(strip.PositionAltitude),
 		AircraftType:             helpers.ValueOrDefault(strip.AircraftType),
 		AircraftCategory:         helpers.ValueOrDefault(strip.AircraftCategory),
+		SpokenCallsign:           helpers.ValueOrDefault(strip.SpokenCallsign),
 		Stand:                    helpers.ValueOrDefault(strip.Stand),
 		Capabilities:             rnav.DeriveCapability(helpers.ValueOrDefault(strip.AircraftType), helpers.ValueOrDefault(strip.Remarks)),
 		CommunicationType:        helpers.ValueOrDefault(strip.CommunicationType),

--- a/backend/internal/frontend/rnav_mapping_test.go
+++ b/backend/internal/frontend/rnav_mapping_test.go
@@ -37,3 +37,22 @@ func TestMapStripToFrontendModelRNAVIsNilWhenEquipmentMarkerRAbsent(t *testing.T
 
 	assert.Equal(t, "NIL", strip.Capabilities)
 }
+
+func TestMapStripToFrontendModelMapsStoredSpokenCallsign(t *testing.T) {
+	spokenCallsign := "ALPACA"
+
+	strip := MapStripToFrontendModel(&models.Strip{
+		Callsign:       "WLF166",
+		SpokenCallsign: &spokenCallsign,
+	})
+
+	assert.Equal(t, "ALPACA", strip.SpokenCallsign)
+}
+
+func TestMapStripToFrontendModelLeavesSpokenCallsignEmptyWhenMissing(t *testing.T) {
+	strip := MapStripToFrontendModel(&models.Strip{
+		Callsign: "SAS123",
+	})
+
+	assert.Equal(t, "", strip.SpokenCallsign)
+}

--- a/backend/internal/models/strip.go
+++ b/backend/internal/models/strip.go
@@ -53,6 +53,7 @@ type Strip struct {
 	Registration             *string
 	TrackingController       string
 	EngineType               string
+	SpokenCallsign           *string
 	RunwayCleared            bool
 	RunwayConfirmed          bool
 	UnexpectedChangeFields   []string

--- a/backend/internal/repository/postgres/strip.go
+++ b/backend/internal/repository/postgres/strip.go
@@ -138,6 +138,7 @@ func stripToModel(db database.Strip) (*models.Strip, error) {
 		Registration:             db.Registration,
 		TrackingController:       db.TrackingController,
 		EngineType:               db.EngineType,
+		SpokenCallsign:           db.SpokenCallsign,
 		RunwayCleared:            db.RunwayCleared,
 		RunwayConfirmed:          db.RunwayConfirmed,
 		UnexpectedChangeFields:   db.UnexpectedChangeFields,
@@ -209,6 +210,7 @@ func (r *stripRepository) Create(ctx context.Context, strip *models.Strip) error
 		Registration:       strip.Registration,
 		TrackingController: strip.TrackingController,
 		EngineType:         strip.EngineType,
+		SpokenCallsign:     strip.SpokenCallsign,
 		HasFp:              strip.HasFP,
 		StartReq:           strip.StartReq,
 	})
@@ -348,6 +350,7 @@ func (r *stripRepository) Update(ctx context.Context, strip *models.Strip) (int6
 		Marked:                   strip.Marked,
 		Registration:             strip.Registration,
 		TrackingController:       strip.TrackingController,
+		SpokenCallsign:           strip.SpokenCallsign,
 		RunwayCleared:            strip.RunwayCleared,
 		RunwayConfirmed:          strip.RunwayConfirmed,
 		EngineType:               strip.EngineType,

--- a/backend/internal/services/strip_sync.go
+++ b/backend/internal/services/strip_sync.go
@@ -137,6 +137,7 @@ func (s *StripService) syncEuroscopeStrip(ctx context.Context, session int32, ci
 			Bay:                bay,
 			TrackingController: strip.TrackingController,
 			EngineType:         strip.EngineType,
+			SpokenCallsign:     &strip.SpokenCallsign,
 			HasFP:              strip.HasFP,
 			StartReq:           false,
 		}
@@ -400,6 +401,7 @@ func (s *StripService) syncEuroscopeStrip(ctx context.Context, session int32, ci
 			PdcMessageSent:           pdcData.MessageSent,
 			TrackingController:       strip.TrackingController,
 			EngineType:               strip.EngineType,
+			SpokenCallsign:           &strip.SpokenCallsign,
 			StartReq:                 startReq,
 			UnexpectedChangeFields:   unexpectedChangeFields,
 			ValidationStatus:         validationStatus,
@@ -657,6 +659,7 @@ func syncStripChanged(existingStrip, updateStrip *internalModels.Strip) bool {
 		existingStrip.Marked != updateStrip.Marked ||
 		!reflect.DeepEqual(existingStrip.Registration, updateStrip.Registration) ||
 		existingStrip.TrackingController != updateStrip.TrackingController ||
+		!reflect.DeepEqual(existingStrip.SpokenCallsign, updateStrip.SpokenCallsign) ||
 		existingStrip.RunwayCleared != updateStrip.RunwayCleared ||
 		existingStrip.RunwayConfirmed != updateStrip.RunwayConfirmed ||
 		existingStrip.EngineType != updateStrip.EngineType ||
@@ -729,6 +732,7 @@ func applySyncStripUpdate(existingStrip, updateStrip *internalModels.Strip) {
 	existingStrip.PdcMessageSequence = updateStrip.PdcMessageSequence
 	existingStrip.PdcMessageSent = updateStrip.PdcMessageSent
 	existingStrip.TrackingController = updateStrip.TrackingController
+	existingStrip.SpokenCallsign = updateStrip.SpokenCallsign
 	existingStrip.RunwayCleared = updateStrip.RunwayCleared
 	existingStrip.RunwayConfirmed = updateStrip.RunwayConfirmed
 	existingStrip.EngineType = updateStrip.EngineType

--- a/backend/internal/services/strip_sync_test.go
+++ b/backend/internal/services/strip_sync_test.go
@@ -158,6 +158,77 @@ func TestSyncEuroscopeStrip_ExistingStripWritesRouteAndHasFPInPrimaryUpdate(t *t
 	assert.Zero(t, routeUpdateCalls)
 }
 
+func TestSyncEuroscopeStrip_NewStripPersistsSpokenCallsign(t *testing.T) {
+	ctx := context.Background()
+	const session = int32(1)
+
+	var createdStrip *models.Strip
+	stripRepo := &testutil.MockStripRepository{
+		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
+			return nil, pgx.ErrNoRows
+		},
+		CreateFn: func(_ context.Context, strip *models.Strip) error {
+			createdStrip = strip
+			return nil
+		},
+	}
+
+	svc, _, _ := newSyncTestFixture(t, nil, stripRepo)
+
+	err := svc.syncEuroscopeStrip(ctx, session, "", euroscope.Strip{
+		Callsign:       "WLF166",
+		Origin:         "EKCH",
+		SpokenCallsign: "WOLFAIR",
+	}, "EKCH")
+	require.NoError(t, err)
+	require.NotNil(t, createdStrip)
+	require.NotNil(t, createdStrip.SpokenCallsign)
+	assert.Equal(t, "WOLFAIR", *createdStrip.SpokenCallsign)
+}
+
+func TestSyncEuroscopeStrip_ExistingStripUpdatesSpokenCallsign(t *testing.T) {
+	ctx := context.Background()
+	const session = int32(1)
+	const callsign = "WLF166"
+	sequence := int32(300)
+	existingSpokenCallsign := "OLDAIR"
+
+	existingStrip := &models.Strip{
+		Callsign:       callsign,
+		Origin:         "EKCH",
+		Destination:    "EGLL",
+		Bay:            shared.BAY_PUSH,
+		Sequence:       &sequence,
+		SpokenCallsign: &existingSpokenCallsign,
+	}
+
+	var updatedStrip *models.Strip
+	stripRepo := &testutil.MockStripRepository{
+		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
+			return existingStrip, nil
+		},
+		UpdateFn: func(_ context.Context, strip *models.Strip) (int64, error) {
+			updatedStrip = strip
+			return 1, nil
+		},
+	}
+
+	svc, _, _ := newSyncTestFixture(t, existingStrip, stripRepo)
+
+	err := svc.syncEuroscopeStrip(ctx, session, "", euroscope.Strip{
+		Callsign:       callsign,
+		Origin:         "EKCH",
+		Destination:    "EGLL",
+		Runway:         "22L",
+		SpokenCallsign: "WOLFAIR",
+		HasFP:          true,
+	}, "EKCH")
+	require.NoError(t, err)
+	require.NotNil(t, updatedStrip)
+	require.NotNil(t, updatedStrip.SpokenCallsign)
+	assert.Equal(t, "WOLFAIR", *updatedStrip.SpokenCallsign)
+}
+
 func TestSyncEuroscopeStrip_ParkedArrivalRefilesAsDepartureResetsLifecycleState(t *testing.T) {
 	ctx := context.Background()
 	const session = int32(1)

--- a/backend/migrations/0027-add-spoken-callsign.sql
+++ b/backend/migrations/0027-add-spoken-callsign.sql
@@ -1,0 +1,2 @@
+ALTER TABLE strips
+    ADD COLUMN IF NOT EXISTS spoken_callsign varchar;

--- a/backend/pkg/events/euroscope/events.go
+++ b/backend/pkg/events/euroscope/events.go
@@ -58,7 +58,7 @@ const (
 	PdcStateChange            EventType = "pdc_state_change"
 	IssuePdcClearance         EventType = "issue_pdc_clearance"
 	PdcRevertToVoice          EventType = "pdc_revert_to_voice"
-	SendPrivateMessage         EventType = "send_private_message"
+	SendPrivateMessage        EventType = "send_private_message"
 )
 
 const (
@@ -133,6 +133,7 @@ type Strip struct {
 	Heading           int32  `json:"heading"`
 	AircraftType      string `json:"aircraft_type"`
 	AircraftCategory  string `json:"aircraft_category"`
+	SpokenCallsign    string `json:"spoken_callsign"`
 	Position          struct {
 		Lat      float64 `json:"lat"`
 		Lon      float64 `json:"lon"`
@@ -325,24 +326,24 @@ type EcfmpRestrictionDTO struct {
 }
 
 type CdmUpdateEvent struct {
-	Callsign                  string `json:"callsign"`
-	Eobt                      string `json:"eobt,omitempty"`
-	Tobt                      string `json:"tobt,omitempty"`
-	TobtSetBy                 string `json:"tobt_set_by,omitempty"`
-	TobtConfirmedBy           string `json:"tobt_confirmed_by,omitempty"`
-	ReqTobt                  string `json:"req_tobt,omitempty"`
-	ReqTobtType              string `json:"req_tobt_type,omitempty"`
-	Tsat                      string `json:"tsat,omitempty"`
-	Ttot                      string `json:"ttot,omitempty"`
-	Ctot                      string `json:"ctot,omitempty"`
-	CtotSource                string `json:"ctot_source,omitempty"`
-	Asat                      string `json:"asat,omitempty"`
-	Asrt                      string `json:"asrt,omitempty"`
-	Tsac                      string `json:"tsac,omitempty"`
-	Status                    string `json:"status,omitempty"`
-	EcfmpID                   string `json:"ecfmp_id,omitempty"`
-	Phase                     string `json:"phase,omitempty"`
-	EcfmpRestrictionsJSON      string `json:"ecfmp_restrictions_json,omitempty"`
+	Callsign              string `json:"callsign"`
+	Eobt                  string `json:"eobt,omitempty"`
+	Tobt                  string `json:"tobt,omitempty"`
+	TobtSetBy             string `json:"tobt_set_by,omitempty"`
+	TobtConfirmedBy       string `json:"tobt_confirmed_by,omitempty"`
+	ReqTobt               string `json:"req_tobt,omitempty"`
+	ReqTobtType           string `json:"req_tobt_type,omitempty"`
+	Tsat                  string `json:"tsat,omitempty"`
+	Ttot                  string `json:"ttot,omitempty"`
+	Ctot                  string `json:"ctot,omitempty"`
+	CtotSource            string `json:"ctot_source,omitempty"`
+	Asat                  string `json:"asat,omitempty"`
+	Asrt                  string `json:"asrt,omitempty"`
+	Tsac                  string `json:"tsac,omitempty"`
+	Status                string `json:"status,omitempty"`
+	EcfmpID               string `json:"ecfmp_id,omitempty"`
+	Phase                 string `json:"phase,omitempty"`
+	EcfmpRestrictionsJSON string `json:"ecfmp_restrictions_json,omitempty"`
 }
 
 type CdmUpdateBatchEvent struct {
@@ -377,22 +378,22 @@ type CdmMasterToggleEvent struct {
 }
 
 type BackendSyncCdmData struct {
-	Eobt                 string `json:"eobt,omitempty"`
-	Tobt                 string `json:"tobt,omitempty"`
-	TobtSetBy            string `json:"tobt_set_by,omitempty"`
-	TobtConfirmedBy      string `json:"tobt_confirmed_by,omitempty"`
-	ReqTobt             string `json:"req_tobt,omitempty"`
-	ReqTobtType         string `json:"req_tobt_type,omitempty"`
-	Tsat                 string `json:"tsat,omitempty"`
-	Ttot                 string `json:"ttot,omitempty"`
-	Ctot                 string `json:"ctot,omitempty"`
-	CtotSource           string `json:"ctot_source,omitempty"`
-	Asat                 string `json:"asat,omitempty"`
-	Asrt                 string `json:"asrt,omitempty"`
-	Tsac                 string `json:"tsac,omitempty"`
-	Status               string `json:"status,omitempty"`
-	EcfmpID              string `json:"ecfmp_id,omitempty"`
-	Phase                string `json:"phase,omitempty"`
+	Eobt                  string `json:"eobt,omitempty"`
+	Tobt                  string `json:"tobt,omitempty"`
+	TobtSetBy             string `json:"tobt_set_by,omitempty"`
+	TobtConfirmedBy       string `json:"tobt_confirmed_by,omitempty"`
+	ReqTobt               string `json:"req_tobt,omitempty"`
+	ReqTobtType           string `json:"req_tobt_type,omitempty"`
+	Tsat                  string `json:"tsat,omitempty"`
+	Ttot                  string `json:"ttot,omitempty"`
+	Ctot                  string `json:"ctot,omitempty"`
+	CtotSource            string `json:"ctot_source,omitempty"`
+	Asat                  string `json:"asat,omitempty"`
+	Asrt                  string `json:"asrt,omitempty"`
+	Tsac                  string `json:"tsac,omitempty"`
+	Status                string `json:"status,omitempty"`
+	EcfmpID               string `json:"ecfmp_id,omitempty"`
+	Phase                 string `json:"phase,omitempty"`
 	EcfmpRestrictionsJSON string `json:"ecfmp_restrictions_json,omitempty"`
 }
 

--- a/backend/pkg/events/frontend/events.go
+++ b/backend/pkg/events/frontend/events.go
@@ -138,6 +138,7 @@ type Strip struct {
 	PositionAltitude         int32                 `json:"position_altitude"`
 	AircraftType             string                `json:"aircraft_type"`
 	AircraftCategory         string                `json:"aircraft_category"`
+	SpokenCallsign           string                `json:"spoken_callsign,omitempty"`
 	Stand                    string                `json:"stand"`
 	Capabilities             string                `json:"capabilities"`
 	CommunicationType        string                `json:"communication_type"`

--- a/backend/queries/strips.sql
+++ b/backend/queries/strips.sql
@@ -3,7 +3,7 @@ INSERT INTO strips (version, callsign, session, origin, destination, alternative
                      squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities,
                      communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay,
                      position_latitude, position_longitude, position_altitude, cdm_data, next_owners, previous_owners,
-                     registration, tracking_controller, engine_type, has_fp, start_req)
+                     registration, tracking_controller, engine_type, spoken_callsign, has_fp, start_req)
 VALUES (
     1,
     sqlc.arg(callsign),
@@ -39,6 +39,7 @@ VALUES (
     sqlc.arg(registration),
     sqlc.arg(tracking_controller),
     sqlc.arg(engine_type),
+    sqlc.arg(spoken_callsign),
     sqlc.arg(has_fp),
     sqlc.arg(start_req)
 );
@@ -78,6 +79,7 @@ SET version = version + 1,
     marked = sqlc.arg(marked),
     registration = sqlc.arg(registration),
     tracking_controller = sqlc.arg(tracking_controller),
+    spoken_callsign = sqlc.arg(spoken_callsign),
     runway_cleared = sqlc.arg(runway_cleared),
     runway_confirmed = sqlc.arg(runway_confirmed),
     engine_type = sqlc.arg(engine_type),

--- a/euroscope-plugin/src/config.ini
+++ b/euroscope-plugin/src/config.ini
@@ -31,3 +31,4 @@ stand_rule_2 = A F -> B
 
 [files]
 stands = ../GRplugin/GRpluginStands.txt
+airlines = ../ICAO/ICAO_Airlines.txt

--- a/euroscope-plugin/src/config_dev.ini
+++ b/euroscope-plugin/src/config_dev.ini
@@ -31,3 +31,4 @@ stand_rule_2 = A F -> B
 
 [files]
 stands = GRpluginStands.txt
+airlines = ../ICAO/ICAO_Airlines.txt

--- a/euroscope-plugin/src/plugin/CMakeLists.txt
+++ b/euroscope-plugin/src/plugin/CMakeLists.txt
@@ -67,6 +67,8 @@ set(src__handlers
 source_group("src\\collections" FILES ${src__handlers})
 
 set(src__flightplan
+        flightplan/AirlineCallsignService.h
+        flightplan/AirlineCallsignService.cpp
         flightplan/FlightPlanService.h
         flightplan/FlightPlanService.cpp
         flightplan/FlightPlan.h

--- a/euroscope-plugin/src/plugin/configuration/AppConfig.cpp
+++ b/euroscope-plugin/src/plugin/configuration/AppConfig.cpp
@@ -123,6 +123,10 @@ namespace FlightStrips::configuration {
         return std::string(ini["files"]["stands"] | "GRpluginStands.txt");
     }
 
+    std::string AppConfig::GetAirlinesFile() {
+        return std::string(ini["files"]["airlines"] | "../ICAO/ICAO_Airlines.txt");
+    }
+
     bool AppConfig::GetDisconnectOnOutOfRange() {
         return ini["api"]["disconnect_on_out_of_range"] | false;
     }

--- a/euroscope-plugin/src/plugin/configuration/AppConfig.h
+++ b/euroscope-plugin/src/plugin/configuration/AppConfig.h
@@ -44,6 +44,7 @@ public:
     [[nodiscard]] DeIceConfig& GetDeIceConfig();
     [[nodiscard]] int GetPositionUpdateIntervalSeconds();
     [[nodiscard]] std::string GetStandsFile();
+    [[nodiscard]] std::string GetAirlinesFile();
     [[nodiscard]] bool GetDisconnectOnOutOfRange();
 private:
     CallsignAirportMap callsignAirportMap = {};

--- a/euroscope-plugin/src/plugin/flightplan/AirlineCallsignService.cpp
+++ b/euroscope-plugin/src/plugin/flightplan/AirlineCallsignService.cpp
@@ -1,0 +1,177 @@
+#include "AirlineCallsignService.h"
+
+namespace FlightStrips::flightplan {
+    namespace {
+        const std::regex kCallsignEqualsPattern(R"(CALLSIGN\s+([^=|/]+?)=)", std::regex::icase);
+        const std::regex kCsPattern(R"(\bCS\s*=\s*([^|=/]+))", std::regex::icase);
+    }
+
+    AirlineCallsignService::AirlineCallsignService(std::string filePath) {
+        LoadFromFile(filePath);
+    }
+
+    std::string AirlineCallsignService::ResolveSpokenCallsign(const std::string& callsign, const std::string& remarks) const {
+        if (const auto fromRemarks = ResolveFromRemarks(remarks); !fromRemarks.empty()) {
+            return fromRemarks;
+        }
+
+        return ResolveFromCallsignMap(callsign, telephonyByIcao_);
+    }
+
+    size_t AirlineCallsignService::Size() const {
+        return telephonyByIcao_.size();
+    }
+
+    void AirlineCallsignService::LoadFromFile(const std::string& filePath) {
+        if (filePath.empty()) {
+            return;
+        }
+
+        std::ifstream input(filePath);
+        if (!input.is_open()) {
+            return;
+        }
+
+        std::string line;
+        while (std::getline(input, line)) {
+            if (!line.empty() && line.back() == '\r') {
+                line.pop_back();
+            }
+
+            const auto trimmed = Trim(line);
+            if (trimmed.empty() || trimmed[0] == ';') {
+                continue;
+            }
+
+            std::vector<std::string> columns;
+            size_t start = 0;
+            while (start <= trimmed.size()) {
+                const auto tab = trimmed.find('\t', start);
+                columns.push_back(trimmed.substr(start, tab == std::string::npos ? std::string::npos : tab - start));
+                if (tab == std::string::npos) {
+                    break;
+                }
+                start = tab + 1;
+            }
+
+            if (columns.size() < 3) {
+                continue;
+            }
+
+            auto icao = ToUpper(Trim(columns[0]));
+            auto telephony = NormalizeWhitespace(Trim(columns[2]));
+            if (icao.size() != 3 || telephony.empty()) {
+                continue;
+            }
+
+            telephonyByIcao_.insert_or_assign(std::move(icao), std::move(telephony));
+        }
+    }
+
+    std::string AirlineCallsignService::ResolveFromRemarks(const std::string& remarks) {
+        if (remarks.empty()) {
+            return "";
+        }
+
+        if (const auto fromBackslashPattern = ResolveCallsignBackslashPattern(remarks); !fromBackslashPattern.empty()) {
+            return fromBackslashPattern;
+        }
+
+        std::smatch match;
+        if (std::regex_search(remarks, match, kCallsignEqualsPattern) && match.size() > 1) {
+            return NormalizeWhitespace(Trim(match[1].str()));
+        }
+        if (std::regex_search(remarks, match, kCsPattern) && match.size() > 1) {
+            return NormalizeWhitespace(Trim(match[1].str()));
+        }
+
+        return "";
+    }
+
+    std::string AirlineCallsignService::ResolveCallsignBackslashPattern(const std::string& remarks) {
+        const auto uppercaseRemarks = ToUpper(remarks);
+        const auto callsignIndex = uppercaseRemarks.find("CALLSIGN");
+        if (callsignIndex == std::string::npos) {
+            return "";
+        }
+
+        const auto backslashIndex = remarks.find('\\', callsignIndex);
+        if (backslashIndex == std::string::npos) {
+            return "";
+        }
+
+        auto valueStart = backslashIndex + 1;
+        while (valueStart < remarks.size() &&
+               (std::isspace(static_cast<unsigned char>(remarks[valueStart])) || remarks[valueStart] == '\\')) {
+            ++valueStart;
+        }
+
+        if (valueStart >= remarks.size()) {
+            return "";
+        }
+
+        auto valueEnd = remarks.find("/V/", valueStart);
+        if (valueEnd == std::string::npos) {
+            valueEnd = remarks.find('/', valueStart);
+        }
+        if (valueEnd == std::string::npos) {
+            valueEnd = remarks.size();
+        }
+
+        return NormalizeWhitespace(Trim(remarks.substr(valueStart, valueEnd - valueStart)));
+    }
+
+    std::string AirlineCallsignService::ResolveFromCallsignMap(
+        const std::string& callsign,
+        const std::unordered_map<std::string, std::string>& telephonyByIcao) {
+        if (callsign.size() < 4 || !std::isdigit(static_cast<unsigned char>(callsign[3]))) {
+            return "";
+        }
+
+        const auto prefix = ToUpper(callsign.substr(0, 3));
+        const auto it = telephonyByIcao.find(prefix);
+        if (it == telephonyByIcao.end()) {
+            return "";
+        }
+
+        return it->second;
+    }
+
+    std::string AirlineCallsignService::NormalizeWhitespace(std::string value) {
+        std::string normalized;
+        normalized.reserve(value.size());
+
+        bool previousWasSpace = false;
+        for (const unsigned char ch : value) {
+            if (std::isspace(ch)) {
+                if (!previousWasSpace) {
+                    normalized.push_back(' ');
+                    previousWasSpace = true;
+                }
+                continue;
+            }
+
+            normalized.push_back(static_cast<char>(ch));
+            previousWasSpace = false;
+        }
+
+        return Trim(normalized);
+    }
+
+    std::string AirlineCallsignService::Trim(const std::string& value) {
+        const auto start = value.find_first_not_of(" \t\n\r");
+        if (start == std::string::npos) {
+            return "";
+        }
+
+        const auto end = value.find_last_not_of(" \t\n\r");
+        return value.substr(start, end - start + 1);
+    }
+
+    std::string AirlineCallsignService::ToUpper(std::string value) {
+        std::ranges::transform(value, value.begin(), [](const unsigned char c) {
+            return static_cast<char>(std::toupper(c));
+        });
+        return value;
+    }
+}

--- a/euroscope-plugin/src/plugin/flightplan/AirlineCallsignService.h
+++ b/euroscope-plugin/src/plugin/flightplan/AirlineCallsignService.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+namespace FlightStrips::flightplan {
+    class AirlineCallsignService {
+    public:
+        explicit AirlineCallsignService(std::string filePath);
+
+        [[nodiscard]] std::string ResolveSpokenCallsign(const std::string& callsign, const std::string& remarks) const;
+        [[nodiscard]] size_t Size() const;
+
+    private:
+        std::unordered_map<std::string, std::string> telephonyByIcao_;
+
+        void LoadFromFile(const std::string& filePath);
+
+        static std::string ResolveFromRemarks(const std::string& remarks);
+        static std::string ResolveCallsignBackslashPattern(const std::string& remarks);
+        static std::string ResolveFromCallsignMap(const std::string& callsign,
+                                                  const std::unordered_map<std::string, std::string>& telephonyByIcao);
+        static std::string NormalizeWhitespace(std::string value);
+        static std::string Trim(const std::string& value);
+        static std::string ToUpper(std::string value);
+    };
+}

--- a/euroscope-plugin/src/plugin/flightplan/FlightPlanBootstrapper.cpp
+++ b/euroscope-plugin/src/plugin/flightplan/FlightPlanBootstrapper.cpp
@@ -5,7 +5,12 @@
 
 namespace FlightStrips::flightplan {
     void FlightPlanBootstrapper::Bootstrap(Container &container) {
-        container.flightPlanService = std::make_shared<FlightPlanService>(container.webSocketService, container.plugin, container.standService, container.appConfig);
+        container.flightPlanService = std::make_shared<FlightPlanService>(
+            container.webSocketService,
+            container.plugin,
+            container.standService,
+            container.appConfig,
+            container.filesystem.get());
         container.radarTargetEventHandlers->RegisterHandler(container.flightPlanService);
         container.flightPlanEventHandlers->RegisterHandler(container.flightPlanService);
         container.timedEventHandlers->RegisterHandler(container.flightPlanService);

--- a/euroscope-plugin/src/plugin/flightplan/FlightPlanService.cpp
+++ b/euroscope-plugin/src/plugin/flightplan/FlightPlanService.cpp
@@ -40,11 +40,24 @@ namespace FlightStrips::flightplan {
         const std::shared_ptr<websocket::WebSocketService> &websocketService,
         const std::shared_ptr<FlightStripsPlugin> &flightStripsPlugin,
         const std::shared_ptr<stands::StandService> &standService,
-        const std::shared_ptr<configuration::AppConfig> &appConfig) : m_websocketService(websocketService),
+        const std::shared_ptr<configuration::AppConfig> &appConfig,
+        filesystem::FileSystem* fileSystem) : m_websocketService(websocketService),
                                                                       m_flightStripsPlugin(flightStripsPlugin),
                                                                       m_standService(standService),
                                                                       m_appConfig(appConfig),
+                                                                      m_airlineCallsignService(std::make_unique<AirlineCallsignService>(
+                                                                          fileSystem == nullptr
+                                                                              ? ""
+                                                                              : fileSystem->GetLocalFilePath(m_appConfig->GetAirlinesFile()).string())),
                                                                       m_flightPlans({}) {
+    }
+
+    std::string FlightPlanService::ResolveSpokenCallsign(const std::string& callsign, const std::string& remarks) const {
+        if (m_airlineCallsignService == nullptr) {
+            return "";
+        }
+
+        return m_airlineCallsignService->ResolveSpokenCallsign(callsign, remarks);
     }
 
     void FlightPlanService::RadarTargetPositionEvent(EuroScopePlugIn::CRadarTarget radarTarget, const bool isRangeOnly) {
@@ -107,7 +120,7 @@ namespace FlightStrips::flightplan {
                 std::string(position.GetSquawk()), "", "",  // squawk, assigned_squawk, sid
                 false, "",   // cleared, ground_state
                 0, 0, 0,    // cleared_altitude, requested_altitude, heading
-                "", "",     // aircraft_type, aircraft_category
+                "", "", "", // aircraft_type, aircraft_category, spoken_callsign
                 Position{aircraftPosition.m_Latitude, aircraftPosition.m_Longitude, position.GetPressureAltitude()},
                 stand,
                 "", "", "",  // communication_type, capabilities, eobt
@@ -149,6 +162,7 @@ namespace FlightStrips::flightplan {
         if (!radarPosition.IsValid()) return;
         const auto position = radarPosition.GetPosition();
         const auto flightPlanData = flightPlan.GetFlightPlanData();
+        const auto remarks = std::string(flightPlanData.GetRemarks());
 
         const auto isArrival = strcmp(flightPlan.GetFlightPlanData().GetDestination(), relevantAirport.c_str()) == 0;
         const auto runway = std::string(isArrival
@@ -170,7 +184,7 @@ namespace FlightStrips::flightplan {
             std::string(flightPlanData.GetDestination()),
             std::string(flightPlanData.GetAlternate()),
             std::string(flightPlanData.GetRoute()),
-            std::string(flightPlanData.GetRemarks()),
+            remarks,
             runway,
             std::string(radarPosition.GetSquawk()),
             std::string(controllerAssignedData.GetSquawk()),
@@ -182,6 +196,7 @@ namespace FlightStrips::flightplan {
             controllerAssignedData.GetAssignedHeading(),
             std::string(flightPlanData.GetAircraftInfo()),
             {flightPlanData.GetAircraftWtc()},
+            ResolveSpokenCallsign(callsign, remarks),
             Position{
                 position.m_Latitude, position.m_Longitude, radarPosition.GetPressureAltitude()
             },

--- a/euroscope-plugin/src/plugin/flightplan/FlightPlanService.h
+++ b/euroscope-plugin/src/plugin/flightplan/FlightPlanService.h
@@ -5,6 +5,7 @@
 #include <unordered_set>
 #include <vector>
 #include "handlers/RadarTargetEventHandler.h"
+#include "AirlineCallsignService.h"
 #include "FlightPlan.h"
 #include "handlers/FlightPlanEventHandlers.h"
 #include "stands/StandService.h"
@@ -12,6 +13,7 @@
 #include "websocket/Events.h"
 #include "handlers/TimedEventHandler.h"
 #include "plugin/FlightStripsPlugin.h"
+#include "filesystem/FileSystem.h"
 
 namespace FlightStrips::flightplan {
     std::vector<EcfmpRestriction> ParseEcfmpRestrictions(const std::string& jsonStr);
@@ -22,7 +24,8 @@ class FlightPlanService final : public handlers::FlightPlanEventHandler, public 
     explicit FlightPlanService(const std::shared_ptr<websocket::WebSocketService> &websocketService,
                               const std::shared_ptr<FlightStripsPlugin> &flightStripsPlugin,
                               const std::shared_ptr<stands::StandService>& standService,
-                              const std::shared_ptr<configuration::AppConfig>& appConfig);
+                              const std::shared_ptr<configuration::AppConfig>& appConfig,
+                              filesystem::FileSystem* fileSystem);
 
     void RadarTargetPositionEvent(EuroScopePlugIn::CRadarTarget radarTarget, bool isRangeOnly) override;
     void RadarTargetOutOfRangeEvent(EuroScopePlugIn::CRadarTarget radarTarget) override;
@@ -43,12 +46,14 @@ class FlightPlanService final : public handlers::FlightPlanEventHandler, public 
     void ApplyPdcStateChange(const std::string& callsign, const std::string& state, const std::string& requestRemarks = {});
 
     static std::string GetEstimatedLandingTime(const EuroScopePlugIn::CFlightPlan& flightPlan);
+    [[nodiscard]] std::string ResolveSpokenCallsign(const std::string& callsign, const std::string& remarks) const;
 private:
 
     std::shared_ptr<websocket::WebSocketService> m_websocketService;
     std::shared_ptr<FlightStripsPlugin> m_flightStripsPlugin;
     std::shared_ptr<stands::StandService> m_standService;
     std::shared_ptr<configuration::AppConfig> m_appConfig;
+    std::unique_ptr<AirlineCallsignService> m_airlineCallsignService;
     std::unordered_map<std::string, FlightPlan> m_flightPlans = {};
     std::unordered_map<std::string, PositionEvent> m_pendingPositionUpdates = {};
     std::unordered_set<std::string> m_rangeTrackedCallsigns = {};

--- a/euroscope-plugin/src/plugin/messages/MessageService.cpp
+++ b/euroscope-plugin/src/plugin/messages/MessageService.cpp
@@ -183,6 +183,7 @@ namespace FlightStrips::messages {
             const auto flightPlanData = it.GetFlightPlanData();
 
             const auto callsign = std::string(it.GetCallsign());
+            const auto remarks = std::string(flightPlanData.GetRemarks());
             const auto radarTarget = m_plugin->RadarTargetSelect(callsign.c_str());
             const auto radarPosition = radarTarget.GetPosition();
             const auto hasRadarPosition = radarPosition.IsValid();
@@ -221,7 +222,7 @@ namespace FlightStrips::messages {
                 std::string(flightPlanData.GetDestination()),
                 std::string(flightPlanData.GetAlternate()),
                 std::string(flightPlanData.GetRoute()),
-                std::string(flightPlanData.GetRemarks()),
+                remarks,
                 runway,
                 squawk,
                 std::string(controllerAssignedData.GetSquawk()),
@@ -233,6 +234,7 @@ namespace FlightStrips::messages {
                 controllerAssignedData.GetAssignedHeading(),
                 std::string(flightPlanData.GetAircraftInfo()),
                 {flightPlanData.GetAircraftWtc()},
+                m_flightPlanService->ResolveSpokenCallsign(callsign, remarks),
                 Position{
                     latitude, longitude, altitude
                 },
@@ -278,7 +280,7 @@ namespace FlightStrips::messages {
                 std::string(position.GetSquawk()), "", "",  // squawk, assigned_squawk, sid
                 false, "",   // cleared, ground_state
                 0, 0, 0,    // cleared_altitude, requested_altitude, heading
-                "", "",     // aircraft_type, aircraft_category
+                "", "", "", // aircraft_type, aircraft_category, spoken_callsign
                 Position{pos.m_Latitude, pos.m_Longitude, position.GetPressureAltitude()},
                 stand,
                 "", "", "",  // communication_type, capabilities, eobt

--- a/euroscope-plugin/src/plugin/websocket/Events.h
+++ b/euroscope-plugin/src/plugin/websocket/Events.h
@@ -560,7 +560,7 @@ struct StripUpdateEvent final : Event {
     StripUpdateEvent(std::string callsign, std::string origin, std::string destination, std::string alternate, std::string route,
           std::string remarks, std::string runway, std::string squawk, std::string assigned_squawk, std::string sid,
           bool cleared, std::string ground_state, int cleared_altitude, int requested_altitude, int heading,
-          std::string aircraft_type, std::string aircraft_category, Position position, std::string stand,
+          std::string aircraft_type, std::string aircraft_category, std::string spoken_callsign, Position position, std::string stand,
           std::string communication_type, std::string capabilities, std::string eobt, std::string eldt,
           std::string tracking_controller, std::string engine_type, bool has_fp = true)
         : Event(EVENT_STRIP_UPDATE), callsign(std::move(callsign)),
@@ -580,6 +580,7 @@ struct StripUpdateEvent final : Event {
           heading(heading),
           aircraft_type(std::move(aircraft_type)),
           aircraft_category(std::move(aircraft_category)),
+          spoken_callsign(std::move(spoken_callsign)),
           position(position),
           stand(std::move(stand)),
           communication_type(std::move(communication_type)),
@@ -608,6 +609,7 @@ struct StripUpdateEvent final : Event {
     int heading;
     std::string aircraft_type;
     std::string aircraft_category;
+    std::string spoken_callsign;
     Position position;
     std::string stand;
     std::string communication_type;
@@ -620,7 +622,7 @@ struct StripUpdateEvent final : Event {
 
     NLOHMANN_DEFINE_TYPE_INTRUSIVE(StripUpdateEvent, callsign, origin, destination, alternate, route, remarks, runway, squawk,
                                    assigned_squawk, sid, cleared, ground_state, cleared_altitude, requested_altitude,
-                                   heading, aircraft_type, aircraft_category, position, stand, communication_type,
+                                   heading, aircraft_type, aircraft_category, spoken_callsign, position, stand, communication_type,
                                    capabilities, eobt, eldt, tracking_controller, engine_type, has_fp, type);
 
 };
@@ -677,7 +679,7 @@ struct Strip final {
     Strip(std::string callsign, std::string origin, std::string destination, std::string alternate, std::string route,
           std::string remarks, std::string runway, std::string squawk, std::string assigned_squawk, std::string sid,
           bool cleared, std::string ground_state, int cleared_altitude, int requested_altitude, int heading,
-          std::string aircraft_type, std::string aircraft_category, Position position, std::string stand,
+          std::string aircraft_type, std::string aircraft_category, std::string spoken_callsign, Position position, std::string stand,
           std::string communication_type, std::string capabilities, std::string eobt, std::string eldt,
           std::string tracking_controller, std::string engine_type, bool has_fp = true)
         : callsign(std::move(callsign)),
@@ -697,6 +699,7 @@ struct Strip final {
           heading(heading),
           aircraft_type(std::move(aircraft_type)),
           aircraft_category(std::move(aircraft_category)),
+          spoken_callsign(std::move(spoken_callsign)),
           position(position),
           stand(std::move(stand)),
           communication_type(std::move(communication_type)),
@@ -725,6 +728,7 @@ struct Strip final {
     int heading;
     std::string aircraft_type;
     std::string aircraft_category;
+    std::string spoken_callsign;
     Position position;
     std::string stand;
     std::string communication_type;
@@ -737,7 +741,7 @@ struct Strip final {
 
     NLOHMANN_DEFINE_TYPE_INTRUSIVE(Strip, callsign, origin, destination, alternate, route, remarks, runway, squawk,
                                    assigned_squawk, sid, cleared, ground_state, cleared_altitude, requested_altitude,
-                                   heading, aircraft_type, aircraft_category, position, stand, communication_type,
+                                   heading, aircraft_type, aircraft_category, spoken_callsign, position, stand, communication_type,
                                    capabilities, eobt, eldt, tracking_controller, engine_type, has_fp);
 };
 

--- a/euroscope-plugin/test/plugin/CMakeLists.txt
+++ b/euroscope-plugin/test/plugin/CMakeLists.txt
@@ -23,6 +23,7 @@ set(ALL_FILES
         authentication/AuthenticationServiceTest.cpp
 
         # FlightPlan
+        flightplan/AirlineCallsignServiceTest.cpp
         flightplan/RouteServiceTest.cpp
         flightplan/FlightPlanServiceTest.cpp
 

--- a/euroscope-plugin/test/plugin/configuration/AppConfigTest.cpp
+++ b/euroscope-plugin/test/plugin/configuration/AppConfigTest.cpp
@@ -75,6 +75,11 @@ TEST(AppConfigTest, GetStandsFile_Default_ReturnsGRpluginStands) {
     EXPECT_EQ(cfg.GetStandsFile(), "GRpluginStands.txt");
 }
 
+TEST(AppConfigTest, GetAirlinesFile_Default_ReturnsIcaoAirlinesPath) {
+    auto cfg = MakeDefault();
+    EXPECT_EQ(cfg.GetAirlinesFile(), "../ICAO/ICAO_Airlines.txt");
+}
+
 TEST(AppConfigTest, GetDisconnectOnOutOfRange_Default_ReturnsFalse) {
     auto cfg = MakeDefault();
     EXPECT_FALSE(cfg.GetDisconnectOnOutOfRange());

--- a/euroscope-plugin/test/plugin/flightplan/AirlineCallsignServiceTest.cpp
+++ b/euroscope-plugin/test/plugin/flightplan/AirlineCallsignServiceTest.cpp
@@ -1,0 +1,96 @@
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+
+#include "flightplan/AirlineCallsignService.h"
+
+using FlightStrips::flightplan::AirlineCallsignService;
+
+namespace {
+    std::filesystem::path WriteAirlinesFile(const std::string& name, const std::string& contents) {
+        const auto path = std::filesystem::temp_directory_path() / name;
+        std::ofstream output(path, std::ios::binary | std::ios::trunc);
+        output << contents;
+        output.close();
+        return path;
+    }
+}
+
+TEST(AirlineCallsignServiceTest, MissingFileKeepsEmptyMap) {
+    const auto path = (std::filesystem::temp_directory_path() / "flightstrips-missing-airlines.txt").string();
+    std::filesystem::remove(path);
+
+    const AirlineCallsignService service(path);
+
+    EXPECT_EQ(service.Size(), 0u);
+    EXPECT_EQ(service.ResolveSpokenCallsign("SAS123", ""), "");
+}
+
+TEST(AirlineCallsignServiceTest, ResolvesTelephonyFromAirlineFile) {
+    const auto path = WriteAirlinesFile(
+        "flightstrips-airlines-basic.txt",
+        ";comment\n"
+        "SAS\tSCANDINAVIAN AIRLINES SYSTEM\tSCANDINAVIAN\tDENMARK\n"
+    );
+
+    const AirlineCallsignService service(path.string());
+
+    EXPECT_EQ(service.Size(), 1u);
+    EXPECT_EQ(service.ResolveSpokenCallsign("SAS123", ""), "SCANDINAVIAN");
+}
+
+TEST(AirlineCallsignServiceTest, DoesNotResolveTelephonyForNonNumericFourthCharacter) {
+    const auto path = WriteAirlinesFile(
+        "flightstrips-airlines-nonnumeric.txt",
+        "OYF\tFSR AIR\tFSR AIR\tDENMARK\n"
+    );
+
+    const AirlineCallsignService service(path.string());
+
+    EXPECT_EQ(service.ResolveSpokenCallsign("OYFSR", ""), "");
+}
+
+TEST(AirlineCallsignServiceTest, RemarksOverrideAirlineFile) {
+    const auto path = WriteAirlinesFile(
+        "flightstrips-airlines-override.txt",
+        "TVF\tTRANSAVIA FRANCE\tFRANCE SOLEIL\tFRANCE\n"
+    );
+
+    const AirlineCallsignService service(path.string());
+
+    EXPECT_EQ(service.ResolveSpokenCallsign("TVF123", "RMK/TCAS KLM TRANSAVIA VIRTUAL CS=FRANCE SOLEIL=KLM /V/"),
+              "FRANCE SOLEIL");
+}
+
+TEST(AirlineCallsignServiceTest, ResolvesCallsignBackslashPatternFromRemarks) {
+    const auto path = WriteAirlinesFile(
+        "flightstrips-airlines-backslash.txt",
+        "EAW\tEUROWINGS\tEUROWINGS\tGERMANY\n"
+    );
+
+    const AirlineCallsignService service(path.string());
+
+    EXPECT_EQ(
+        service.ResolveSpokenCallsign(
+            "EAW123",
+            "PBN/A1B1D1L1O1S1 DOF/260618 REG/N537SB EET/EGTT0018 OPR/EAW PER/D RMK/TCAS SIMBRIEF CALLSIGN \\ EXECUTIVE /V/"
+        ),
+        "EXECUTIVE");
+}
+
+TEST(AirlineCallsignServiceTest, ResolvesCallsignEqualsPatternFromRemarks) {
+    const auto path = WriteAirlinesFile(
+        "flightstrips-airlines-equals.txt",
+        "TAX\tAIR TAXI\tAIR TAXI\tPORTUGAL\n"
+    );
+
+    const AirlineCallsignService service(path.string());
+
+    EXPECT_EQ(
+        service.ResolveSpokenCallsign(
+            "TAX123",
+            "PBN/A1B1C1D1O1S1 DOF/260618 REG/CSTCA EET/GMMM0048 OPR/TAX PER/D CALL RMK/CALLSIGN AIRTAXI=AIRTAXI VIRTUAL AIRLINE WEBSITE=AIRTAXI.PT /V/"
+        ),
+        "AIRTAXI");
+}

--- a/euroscope-plugin/test/plugin/flightplan/FlightPlanServiceTest.cpp
+++ b/euroscope-plugin/test/plugin/flightplan/FlightPlanServiceTest.cpp
@@ -107,7 +107,8 @@ TEST(FlightPlanServiceStateTest, ApplyCdmUpdate_PopulatesBackendFields) {
         std::shared_ptr<FlightStrips::websocket::WebSocketService>{},
         std::shared_ptr<FlightStrips::FlightStripsPlugin>{},
         std::shared_ptr<FlightStrips::stands::StandService>{},
-        std::shared_ptr<FlightStrips::configuration::AppConfig>{}
+        std::shared_ptr<FlightStrips::configuration::AppConfig>{},
+        nullptr
     );
 
     CdmUpdateEvent update;
@@ -151,7 +152,8 @@ TEST(FlightPlanServiceStateTest, ApplyBackendSyncCdm_SeedsCdmState) {
         std::shared_ptr<FlightStrips::websocket::WebSocketService>{},
         std::shared_ptr<FlightStrips::FlightStripsPlugin>{},
         std::shared_ptr<FlightStrips::stands::StandService>{},
-        std::shared_ptr<FlightStrips::configuration::AppConfig>{}
+        std::shared_ptr<FlightStrips::configuration::AppConfig>{},
+        nullptr
     );
 
     BackendSyncCdmData syncData;
@@ -179,7 +181,8 @@ TEST(FlightPlanServiceStateTest, ApplyPdcStateChange_SeedsTrackedState) {
         std::shared_ptr<FlightStrips::websocket::WebSocketService>{},
         std::shared_ptr<FlightStrips::FlightStripsPlugin>{},
         std::shared_ptr<FlightStrips::stands::StandService>{},
-        std::shared_ptr<FlightStrips::configuration::AppConfig>{}
+        std::shared_ptr<FlightStrips::configuration::AppConfig>{},
+        nullptr
     );
 
     service.ApplyPdcStateChange("SAS321", "CLEARED");

--- a/euroscope-plugin/test/plugin/websocket/WebSocketServiceTest.cpp
+++ b/euroscope-plugin/test/plugin/websocket/WebSocketServiceTest.cpp
@@ -1259,3 +1259,80 @@ TEST(SyncEventTest, EmptyCollections_SerializesCorrectly) {
     EXPECT_TRUE(j["runways"].is_array());
     EXPECT_TRUE(j["sids"].is_array());
 }
+
+TEST(StripUpdateEventTest, SerializesSpokenCallsignField) {
+    StripUpdateEvent e(
+        "WLF166",
+        "EKCH",
+        "EGLL",
+        "",
+        "",
+        "RMK/CS=WOLFAIR",
+        "22L",
+        "1234",
+        "2345",
+        "BETOS1B",
+        true,
+        "TAXI",
+        5000,
+        7000,
+        180,
+        "B738",
+        "M",
+        "WOLFAIR",
+        Position{55.6181, 12.6560, 1500},
+        "A12",
+        "R",
+        "1",
+        "1200",
+        "",
+        "EKCH_APP",
+        "J"
+    );
+
+    const nlohmann::json j = e;
+    EXPECT_EQ(j["type"], EVENT_STRIP_UPDATE_NAME);
+    EXPECT_EQ(j["spoken_callsign"], "WOLFAIR");
+}
+
+TEST(SyncEventTest, PopulatedStripSerializesSpokenCallsignField) {
+    SyncEvent e(
+        {
+            Strip(
+                "WLF166",
+                "EKCH",
+                "EGLL",
+                "",
+                "",
+                "RMK/CS=WOLFAIR",
+                "22L",
+                "1234",
+                "2345",
+                "BETOS1B",
+                true,
+                "TAXI",
+                5000,
+                7000,
+                180,
+                "B738",
+                "M",
+                "WOLFAIR",
+                Position{55.6181, 12.6560, 1500},
+                "A12",
+                "R",
+                "1",
+                "1200",
+                "",
+                "EKCH_APP",
+                "J"
+            )
+        },
+        {Controller("DEL", "EKCH_DEL")},
+        {Runway{"22L", true, false}},
+        {SidEntry{"BETOS1B", "22L"}}
+    );
+
+    const nlohmann::json j = e;
+    ASSERT_EQ(j["strips"].size(), 1u);
+    EXPECT_EQ(j["strips"][0]["spoken_callsign"], "WOLFAIR");
+}

--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -150,6 +150,7 @@ export interface FrontendStrip {
   position_altitude?: number;
   aircraft_type: string;
   aircraft_category: string;
+  spoken_callsign?: string;
   stand: string;
   capabilities: string;
   communication_type: CommunicationType;
@@ -299,6 +300,7 @@ export interface FrontendStripUpdateEvent {
   heading: number;
   aircraft_type: string;
   aircraft_category: string;
+  spoken_callsign?: string;
   stand: string;
   capabilities: string;
   communication_type: CommunicationType;

--- a/frontend/src/components/FlightPlanDialog.tsx
+++ b/frontend/src/components/FlightPlanDialog.tsx
@@ -597,7 +597,7 @@ export default function FlightPlanDialog({
             <div className="grid items-center" style={gridGroupStyle}>
               <Label className="font-light" style={{ fontSize: FONT_SIZE_LABEL }}>IATA TYPE</Label>
               <Input
-                defaultValue=""
+                value={strip.spoken_callsign ?? ""}
                 disabled
                 className={CLS_BTN_DISABLED}
                 style={fieldStyle(130)}


### PR DESCRIPTION
## Summary
- source spoken callsign resolution in the EuroScope plugin using remarks first and ICAO_Airlines.txt fallback
- persist and forward spoken_callsign through the backend and frontend instead of deriving it server-side
- add regression coverage for remarks parsing, sync persistence, and websocket serialization

## Testing
- go test ./internal/services
- go test ./internal/frontend -run TestMapStripToFrontendModel
- cmake --build euroscope-plugin\\build --config Debug --target FlightStripsCoreTests
- FlightStripsCoreTests.exe spoken callsign coverage