### PR TITLE
Fix failing PDC and CDM tests

### DIFF
--- a/backend/internal/cdm/service_sync_test.go
+++ b/backend/internal/cdm/service_sync_test.go
@@ -404,22 +404,26 @@ func TestSyncCdmData_MasterSession_KeepsFreshCtotWhenEobtNormalizationAlsoRuns(t
 	expectedClamped := truncateCDMClockValue(addMinutes(timeToClock(now), masterEobtClampTarget))
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/ifps/depAirport" {
+		switch r.URL.Path {
+		case "/ifps/depAirport":
+			_, _ = w.Write([]byte(`[{
+				"callsign":"SAS191",
+				"departure":"EKCH",
+				"eobt":"1000",
+				"tobt":"1010",
+				"ctot":"1040",
+				"cdmSts":"REA",
+				"cdmData":{
+					"reqTobt":"1005",
+					"reqTobtType":"PILOT",
+					"reason":"REGUL"
+				}
+			}]`))
+		case "/ifps/dpi", "/ifps/setCdmData":
+			w.WriteHeader(http.StatusOK)
+		default:
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
-		_, _ = w.Write([]byte(`[{
-			"callsign":"SAS191",
-			"departure":"EKCH",
-			"eobt":"1000",
-			"tobt":"1010",
-			"ctot":"1040",
-			"cdmSts":"REA",
-			"cdmData":{
-				"reqTobt":"1005",
-				"reqTobtType":"PILOT",
-				"reason":"REGUL"
-			}
-		}]`))
 	}))
 	defer server.Close()
 
@@ -531,10 +535,14 @@ func TestSyncCdmData_MasterSession_DoesNotOverwriteConfirmedTobtDuringEobtNormal
 	expectedClamped := truncateCDMClockValue(addMinutes(timeToClock(now), masterEobtClampTarget))
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/ifps/depAirport" {
+		switch r.URL.Path {
+		case "/ifps/depAirport":
+			_, _ = w.Write([]byte(`[]`))
+		case "/ifps/dpi", "/ifps/setCdmData":
+			w.WriteHeader(http.StatusOK)
+		default:
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
-		_, _ = w.Write([]byte(`[]`))
 	}))
 	defer server.Close()
 

--- a/backend/internal/pdc/integration_test.go
+++ b/backend/internal/pdc/integration_test.go
@@ -1085,7 +1085,6 @@ func TestProcessPDCRequest_InactiveDepartureRunwayCreatesFault(t *testing.T) {
 }
 
 func TestProcessPDCRequest_MandatoryRouteRequiresManualApprovalWithoutChangingStrip(t *testing.T) {
-	t.Parallel()
 	t.Cleanup(config.SetFeatureFlagsForTest(config.FeatureFlagsConfig{MandatoryRouteClearanceFlow: true}))
 	suite := &PDCIntegrationTestSuite{}
 	suite.SetupTest(t)
@@ -1182,7 +1181,6 @@ func TestProcessPDCRequest_AlreadyCleared(t *testing.T) {
 }
 
 func TestIssueClearance_MandatoryRouteIncludesFullRouteAndCorrectedSid(t *testing.T) {
-	t.Parallel()
 	t.Cleanup(config.SetFeatureFlagsForTest(config.FeatureFlagsConfig{MandatoryRouteClearanceFlow: true}))
 	suite := &PDCIntegrationTestSuite{}
 	suite.SetupTest(t)

--- a/backend/internal/pdc/validation_test.go
+++ b/backend/internal/pdc/validation_test.go
@@ -152,7 +152,6 @@ func TestValidatePDCFlightPlan_FaultsWhenHeadingWithoutAltitude(t *testing.T) {
 }
 
 func TestValidatePDCFlightPlan_MandatoryRouteCreatesManualReviewFault(t *testing.T) {
-	t.Parallel()
 	t.Cleanup(config.SetFeatureFlagsForTest(config.FeatureFlagsConfig{MandatoryRouteClearanceFlow: true}))
 
 	service := &Service{}
@@ -178,7 +177,6 @@ func TestValidatePDCFlightPlan_MandatoryRouteCreatesManualReviewFault(t *testing
 }
 
 func TestValidatePDCFlightPlan_MandatoryRouteResolvedSidAvoidsRoutingFault(t *testing.T) {
-	t.Parallel()
 	t.Cleanup(config.SetFeatureFlagsForTest(config.FeatureFlagsConfig{MandatoryRouteClearanceFlow: true}))
 
 	service := &Service{}


### PR DESCRIPTION
## Summary
- Update CDM test HTTP handlers to accept the extra `/ifps/dpi` and `/ifps/setCdmData` calls made during sync flows
- Remove `t.Parallel()` from PDC tests that mutate feature flags and shared integration state
- Stabilize the affected validation and integration coverage for mandatory-route behavior

## Testing
- Not run (not requested)