### PR TITLE
ci: use Blacksmith Docker builder for layer caching

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -6,11 +6,13 @@ on:
       - 'main'
     paths:
       - 'backend/**'
+      - '.github/workflows/build-backend.yml'
   pull_request:
     branches:
       - 'main'
     paths:
       - 'backend/**'
+      - '.github/workflows/build-backend.yml'
 
 jobs:
   build-backend:

--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -15,14 +15,12 @@ on:
       - '.github/workflows/build-backend.yml'
 
 jobs:
-  build-backend:
-    name: Build backend
+  build:
+    name: Build & test
     runs-on: blacksmith-4vcpu-ubuntu-2404
-
     defaults:
       run:
         working-directory: ./backend
-
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v5
@@ -33,6 +31,11 @@ jobs:
     - name: Test
       run: go test ./...
 
+  docker:
+    name: Docker build
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+    - uses: actions/checkout@v3
     - name: Set up Docker Buildx
       uses: useblacksmith/setup-docker-builder@v1
     - name: Build Docker image (api)

--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -30,3 +30,18 @@ jobs:
       run: go build ./...
     - name: Test
       run: go test ./...
+
+    - name: Set up Docker Buildx
+      uses: useblacksmith/setup-docker-builder@v1
+    - name: Build Docker image (api)
+      uses: useblacksmith/build-push-action@v2
+      with:
+        context: ./backend
+        file: ./backend/Dockerfile
+        push: false
+    - name: Build Docker image (migrate)
+      uses: useblacksmith/build-push-action@v2
+      with:
+        context: ./backend
+        file: ./backend/Dockerfile.Migrate
+        push: false

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,41 @@
+name: Build docs
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'docs/**'
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - 'docs/**'
+
+jobs:
+  build-docs:
+    name: Build docs
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    defaults:
+      run:
+        working-directory: ./docs
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@master
+      with:
+        node-version: 22
+    - name: install dependencies
+      run: npm ci
+    - name: build
+      run: npm run build
+
+    - name: Set up Docker Buildx
+      uses: useblacksmith/setup-docker-builder@v1
+    - name: Build Docker image
+      uses: useblacksmith/build-push-action@v2
+      with:
+        context: ./docs
+        file: ./docs/Dockerfile
+        push: false

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -15,14 +15,12 @@ on:
       - '.github/workflows/build-docs.yml'
 
 jobs:
-  build-docs:
-    name: Build docs
+  build:
+    name: Build & test
     runs-on: blacksmith-4vcpu-ubuntu-2404
-
     defaults:
       run:
         working-directory: ./docs
-
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@master
@@ -33,6 +31,11 @@ jobs:
     - name: build
       run: npm run build
 
+  docker:
+    name: Docker build
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+    - uses: actions/checkout@v3
     - name: Set up Docker Buildx
       uses: useblacksmith/setup-docker-builder@v1
     - name: Build Docker image

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -6,11 +6,13 @@ on:
       - 'main'
     paths:
       - 'docs/**'
+      - '.github/workflows/build-docs.yml'
   pull_request:
     branches:
       - 'main'
     paths:
       - 'docs/**'
+      - '.github/workflows/build-docs.yml'
 
 jobs:
   build-docs:

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -6,11 +6,13 @@ on:
       - 'main'
     paths:
       - 'frontend/**'
+      - '.github/workflows/build-frontend.yml'
   pull_request:
     branches:
       - 'main'
     paths:
       - 'frontend/**'
+      - '.github/workflows/build-frontend.yml'
 
 jobs:
   build-frontend:

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -34,3 +34,12 @@ jobs:
       run: npm ci
     - name: build
       run: npm run build
+
+    - name: Set up Docker Buildx
+      uses: useblacksmith/setup-docker-builder@v1
+    - name: Build Docker image
+      uses: useblacksmith/build-push-action@v2
+      with:
+        context: ./frontend
+        file: ./frontend/Dockerfile
+        push: false

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -15,18 +15,12 @@ on:
       - '.github/workflows/build-frontend.yml'
 
 jobs:
-  build-frontend:
-    name: Build frontend (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [blacksmith-4vcpu-ubuntu-2404]
-
+  build:
+    name: Build & test
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     defaults:
       run:
         working-directory: ./frontend
-
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@master
@@ -37,6 +31,11 @@ jobs:
     - name: build
       run: npm run build
 
+  docker:
+    name: Docker build
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+    - uses: actions/checkout@v3
     - name: Set up Docker Buildx
       uses: useblacksmith/setup-docker-builder@v1
     - name: Build Docker image

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -94,6 +94,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set up Docker Buildx
+        uses: useblacksmith/setup-docker-builder@v1
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -127,6 +130,9 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: useblacksmith/setup-docker-builder@v1
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -246,6 +252,9 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: useblacksmith/setup-docker-builder@v1
 
       - name: Log in to GHCR
         uses: docker/login-action@v3


### PR DESCRIPTION
Leverage Blacksmith Docker layer caching to speed up Docker builds by 40x.

Changes:
- Add useblacksmith/setup-docker-builder@v1 step to all Docker build jobs (release-please.yml)
- Add Docker image builds to PR pipelines (push: false) in build-backend.yml and build-frontend.yml
- Create new build-docs.yml workflow for docs PR pipelines with Docker build
- All PR Docker builds use push: false to verify images without pushing to the registry