### PR TITLE
Reset heading and cleared altitude during strip lifecycle restarts

### DIFF
--- a/backend/internal/services/strip_sync.go
+++ b/backend/internal/services/strip_sync.go
@@ -286,7 +286,12 @@ func (s *StripService) syncEuroscopeStrip(ctx context.Context, session int32, ci
 			existingStrip.Bay != "" &&
 			existingStrip.Bay != shared.BAY_NOT_CLEARED
 
+		updateHeading := strip.Heading
 		updateClearedAlt := strip.ClearedAltitude
+		if restartLifecycle {
+			updateHeading = 0
+			updateClearedAlt = 0
+		}
 		if updateClearedAlt == 0 && bay == shared.BAY_NOT_CLEARED {
 			existingCfl := int32(0)
 			if !restartLifecycle && existingStrip.ClearedAltitude != nil {
@@ -373,7 +378,7 @@ func (s *StripService) syncEuroscopeStrip(ctx context.Context, session int32, ci
 			Squawk:                   &strip.Squawk,
 			Sid:                      &strip.Sid,
 			ClearedAltitude:          &updateClearedAlt,
-			Heading:                  &strip.Heading,
+			Heading:                  &updateHeading,
 			AircraftType:             &strip.AircraftType,
 			Runway:                   runway,
 			RequestedAltitude:        &strip.RequestedAltitude,
@@ -489,6 +494,9 @@ func (s *StripService) syncEuroscopeStrip(ctx context.Context, session int32, ci
 		slog.DebugContext(ctx, "Updated strip", slog.String("callsign", strip.Callsign))
 		if primaryChange && updateClearedAlt != strip.ClearedAltitude && s.esCommander != nil {
 			s.esCommander.SendClearedAltitude(session, cid, strip.Callsign, updateClearedAlt)
+		}
+		if primaryChange && updateHeading != strip.Heading && s.esCommander != nil {
+			s.esCommander.SendHeading(session, cid, strip.Callsign, updateHeading)
 		}
 
 		needsStripBroadcast = true

--- a/backend/internal/services/strip_sync_test.go
+++ b/backend/internal/services/strip_sync_test.go
@@ -285,6 +285,8 @@ func TestSyncEuroscopeStrip_ParkedArrivalRefilesAsDepartureResetsLifecycleState(
 			Active:         true,
 			ActivationKey:  "old-key",
 		},
+		Heading:         func() *int32 { v := int32(195); return &v }(),
+		ClearedAltitude: func() *int32 { v := int32(3000); return &v }(),
 	}
 
 	var updatedStrip *models.Strip
@@ -313,15 +315,17 @@ func TestSyncEuroscopeStrip_ParkedArrivalRefilesAsDepartureResetsLifecycleState(
 	esHub.SetServer(routeServer)
 
 	err := svc.syncEuroscopeStrip(ctx, session, "", euroscope.Strip{
-		Callsign:    callsign,
-		Origin:      "EKCH",
-		Destination: "EGLL",
-		Remarks:     "REG/OYABC",
-		Runway:      "22R",
-		Eobt:        "1230",
-		GroundState: euroscope.GroundStateParked,
-		Stand:       "B7",
-		HasFP:       true,
+		Callsign:        callsign,
+		Origin:          "EKCH",
+		Destination:     "EGLL",
+		Remarks:         "REG/OYABC",
+		Runway:          "04R",
+		Eobt:            "1230",
+		GroundState:     euroscope.GroundStateParked,
+		Stand:           "B7",
+		Heading:         195,
+		ClearedAltitude: 3000,
+		HasFP:           true,
 	}, "EKCH")
 	require.NoError(t, err)
 
@@ -349,7 +353,11 @@ func TestSyncEuroscopeStrip_ParkedArrivalRefilesAsDepartureResetsLifecycleState(
 	assert.Nil(t, updatedStrip.ValidationStatus)
 	assert.False(t, updatedStrip.StartReq)
 	require.NotNil(t, updatedStrip.Runway)
-	assert.Equal(t, "22R", *updatedStrip.Runway)
+	assert.Equal(t, "04R", *updatedStrip.Runway)
+	require.NotNil(t, updatedStrip.Heading)
+	assert.Zero(t, *updatedStrip.Heading)
+	require.NotNil(t, updatedStrip.ClearedAltitude)
+	assert.Equal(t, int32(7000), *updatedStrip.ClearedAltitude)
 	require.NotNil(t, updatedStrip.Registration)
 	assert.Equal(t, "OYABC", *updatedStrip.Registration)
 	require.NotNil(t, updatedStrip.CdmData)
@@ -361,6 +369,12 @@ func TestSyncEuroscopeStrip_ParkedArrivalRefilesAsDepartureResetsLifecycleState(
 	require.NotNil(t, updatedStrip.PdcData)
 	assert.Equal(t, models.PdcStateNone, updatedStrip.PdcData.State)
 	assert.Nil(t, updatedStrip.PdcData.RequestRemarks)
+	require.Len(t, esHub.Headings, 1)
+	assert.Equal(t, callsign, esHub.Headings[0].Callsign)
+	assert.Zero(t, esHub.Headings[0].Heading)
+	require.Len(t, esHub.ClearedAltitudes, 1)
+	assert.Equal(t, callsign, esHub.ClearedAltitudes[0].Callsign)
+	assert.Equal(t, int32(7000), esHub.ClearedAltitudes[0].Altitude)
 	require.Len(t, hub.StripUpdates, 1)
 	assert.Equal(t, callsign, hub.StripUpdates[0].Callsign)
 }

--- a/backend/internal/shared/publisher.go
+++ b/backend/internal/shared/publisher.go
@@ -41,6 +41,7 @@ type EuroscopeStripCommander interface {
 	SendGroundState(session int32, cid string, callsign string, state string)
 	SendClearedFlag(session int32, cid string, callsign string, flag bool)
 	SendClearedAltitude(session int32, cid string, callsign string, altitude int32)
+	SendHeading(session int32, cid string, callsign string, heading int32)
 	SendCoordinationHandover(session int32, cid string, callsign string, targetCallsign string)
 	SendAssumeOnly(session int32, cid string, callsign string)
 	SendDropTracking(session int32, cid string, callsign string)

--- a/backend/internal/testutil/mock_euroscope_hub.go
+++ b/backend/internal/testutil/mock_euroscope_hub.go
@@ -74,6 +74,14 @@ type ClearedAltitudeCall struct {
 	Altitude int32
 }
 
+// HeadingCall records arguments to SendHeading.
+type HeadingCall struct {
+	Session  int32
+	Cid      string
+	Callsign string
+	Heading  int32
+}
+
 type RemarksCall struct {
 	Session  int32
 	Cid      string
@@ -123,6 +131,7 @@ type MockEuroscopeHub struct {
 	GenerateSquawks       []GenerateSquawkCall
 	Eobts                 []EobtCall
 	ClearedAltitudes      []ClearedAltitudeCall
+	Headings              []HeadingCall
 	RemarksUpdates        []RemarksCall
 	AircraftInfoUpdates   []AircraftInfoCall
 	AircraftInfoRemarks   []AircraftInfoRemarksCall
@@ -242,7 +251,9 @@ func (m *MockEuroscopeHub) SendClearedAltitude(session int32, cid string, callsi
 	m.ClearedAltitudes = append(m.ClearedAltitudes, ClearedAltitudeCall{session, cid, callsign, altitude})
 }
 
-func (m *MockEuroscopeHub) SendHeading(session int32, cid string, callsign string, heading int32) {}
+func (m *MockEuroscopeHub) SendHeading(session int32, cid string, callsign string, heading int32) {
+	m.Headings = append(m.Headings, HeadingCall{Session: session, Cid: cid, Callsign: callsign, Heading: heading})
+}
 
 func (m *MockEuroscopeHub) SendCoordinationHandover(session int32, cid string, callsign string, targetCallsign string) {
 	m.CoordinationHandovers = append(m.CoordinationHandovers, CoordinationHandoverCall{session, cid, callsign, targetCallsign})


### PR DESCRIPTION
## Summary
- Reset heading alongside cleared altitude when a strip lifecycle restart is detected
- Propagate the reset heading back through EuroScope for the active client only
- Extend the strip sync test and mock hub to cover the heading reset path

## Testing
- Not run (not requested)