### PR TITLE
Confirm voice clearance and restore pending PDC timeouts

### DIFF
--- a/backend/internal/frontend/handlers.go
+++ b/backend/internal/frontend/handlers.go
@@ -134,6 +134,12 @@ func handleMove(ctx context.Context, client *Client, message Message) error {
 		return nil
 	}
 
+	previousBay := strip.Bay
+	previousCleared := strip.Cleared
+	shouldConfirmVoiceClearance := move.Bay == shared.BAY_CLEARED &&
+		strip.PdcState != "" &&
+		strip.PdcState != internalModels.PdcStateNone
+
 	if move.Bay == shared.BAY_NOT_CLEARED || move.Bay == shared.BAY_CLEARED {
 		isCleared := move.Bay == shared.BAY_CLEARED
 		if err := client.hub.stripService.UpdateClearedFlagForMove(ctx, client.session, move.Callsign, isCleared, move.Bay, client.GetCid()); err != nil {
@@ -147,6 +153,22 @@ func handleMove(ctx context.Context, client *Client, message Message) error {
 
 	if err := client.hub.stripService.MoveToBay(ctx, client.session, move.Callsign, move.Bay, true); err != nil {
 		return err
+	}
+
+	if shouldConfirmVoiceClearance {
+		pdcService := client.hub.server.GetPdcService()
+		if pdcService == nil {
+			return errors.New("PDC service not available")
+		}
+		if err := pdcService.ConfirmVoiceClearance(ctx, move.Callsign, client.session); err != nil {
+			if rollbackErr := client.hub.stripService.UpdateClearedFlagForMove(ctx, client.session, move.Callsign, previousCleared, previousBay, client.GetCid()); rollbackErr != nil {
+				return errors.Join(err, rollbackErr)
+			}
+			if rollbackErr := client.hub.stripService.MoveToBay(ctx, client.session, move.Callsign, previousBay, true); rollbackErr != nil {
+				return errors.Join(err, rollbackErr)
+			}
+			return err
+		}
 	}
 
 	return nil

--- a/backend/internal/frontend/handlers_move_test.go
+++ b/backend/internal/frontend/handlers_move_test.go
@@ -43,6 +43,39 @@ type spyStripService struct {
 	testutil.NoOpStripService
 	autoTransferCalled bool
 	moveToBayCalled    bool
+	moveCalls          []string
+	clearedUpdates     []clearedUpdateCall
+}
+
+type spyPdcService struct {
+	confirmVoiceClearanceCalled bool
+	confirmVoiceCallsign        string
+	confirmVoiceSession         int32
+	confirmVoiceClearanceErr    error
+}
+
+type clearedUpdateCall struct {
+	isCleared bool
+	bay       string
+}
+
+func (s *spyPdcService) IssueClearance(_ context.Context, _ string, _ string, _ string, _ int32) error {
+	return nil
+}
+
+func (s *spyPdcService) ManualStateChange(_ context.Context, _ string, _ int32, _ string) error {
+	return nil
+}
+
+func (s *spyPdcService) ConfirmVoiceClearance(_ context.Context, callsign string, sessionID int32) error {
+	s.confirmVoiceClearanceCalled = true
+	s.confirmVoiceCallsign = callsign
+	s.confirmVoiceSession = sessionID
+	return s.confirmVoiceClearanceErr
+}
+
+func (s *spyPdcService) RevertToVoice(_ context.Context, _ string, _ int32, _ string) error {
+	return nil
 }
 
 func (s *spyStripService) AutoTransferAirborneStrip(_ context.Context, _ int32, _ string) error {
@@ -50,8 +83,9 @@ func (s *spyStripService) AutoTransferAirborneStrip(_ context.Context, _ int32, 
 	return nil
 }
 
-func (s *spyStripService) MoveToBay(_ context.Context, _ int32, _ string, _ string, _ bool) error {
+func (s *spyStripService) MoveToBay(_ context.Context, _ int32, _ string, bay string, _ bool) error {
 	s.moveToBayCalled = true
+	s.moveCalls = append(s.moveCalls, bay)
 	return nil
 }
 
@@ -59,7 +93,11 @@ func (s *spyStripService) UpdateGroundStateForMove(_ context.Context, _ int32, _
 	return nil
 }
 
-func (s *spyStripService) UpdateClearedFlagForMove(_ context.Context, _ int32, _ string, _ bool, _ string, _ string) error {
+func (s *spyStripService) UpdateClearedFlagForMove(_ context.Context, _ int32, _ string, isCleared bool, bay string, _ string) error {
+	s.clearedUpdates = append(s.clearedUpdates, clearedUpdateCall{
+		isCleared: isCleared,
+		bay:       bay,
+	})
 	return nil
 }
 
@@ -252,4 +290,73 @@ func TestHandleMove_OwnedByOther_AllowedWithCoordination(t *testing.T) {
 	err := handleMove(context.Background(), client, msg)
 	require.NoError(t, err)
 	assert.True(t, spy.moveToBayCalled, "Move should succeed when coordination targets this position")
+}
+
+func TestHandleMove_ToClearedWithActivePdcConfirmsVoiceClearance(t *testing.T) {
+	stripRepo := &testutil.MockStripRepository{
+		GetByCallsignFn: func(_ context.Context, _ int32, callsign string) (*models.Strip, error) {
+			return &models.Strip{
+				Callsign:    callsign,
+				Bay:         shared.BAY_NOT_CLEARED,
+				Origin:      "EKCH",
+				Destination: "ESSA",
+				PdcState:    "REQUESTED",
+			}, nil
+		},
+	}
+
+	pdcSpy := &spyPdcService{}
+	ms := mockServerWithStripRepo(stripRepo)
+	ms.PdcServiceVal = pdcSpy
+
+	spy := &spyStripService{}
+	hub := buildFrontendTestHub(ms, spy)
+	client := buildFrontendTestClient(hub, 1, "EKCH")
+
+	msg := marshalMessage(t, frontend.MoveEvent{
+		Callsign: "SAS300",
+		Bay:      shared.BAY_CLEARED,
+	})
+
+	err := handleMove(context.Background(), client, msg)
+	require.NoError(t, err)
+	assert.True(t, spy.moveToBayCalled, "MoveToBay should still be called")
+	assert.True(t, pdcSpy.confirmVoiceClearanceCalled, "voice-clearance confirmation should run for active PDC strips")
+	assert.Equal(t, "SAS300", pdcSpy.confirmVoiceCallsign)
+	assert.Equal(t, int32(1), pdcSpy.confirmVoiceSession)
+}
+
+func TestHandleMove_RevertsClearedMoveWhenVoiceConfirmationFails(t *testing.T) {
+	stripRepo := &testutil.MockStripRepository{
+		GetByCallsignFn: func(_ context.Context, _ int32, callsign string) (*models.Strip, error) {
+			return &models.Strip{
+				Callsign:    callsign,
+				Bay:         shared.BAY_NOT_CLEARED,
+				Origin:      "EKCH",
+				Destination: "ESSA",
+				PdcState:    "REQUESTED",
+				Cleared:     false,
+			}, nil
+		},
+	}
+
+	pdcSpy := &spyPdcService{confirmVoiceClearanceErr: assert.AnError}
+	ms := mockServerWithStripRepo(stripRepo)
+	ms.PdcServiceVal = pdcSpy
+
+	spy := &spyStripService{}
+	hub := buildFrontendTestHub(ms, spy)
+	client := buildFrontendTestClient(hub, 1, "EKCH")
+
+	msg := marshalMessage(t, frontend.MoveEvent{
+		Callsign: "SAS301",
+		Bay:      shared.BAY_CLEARED,
+	})
+
+	err := handleMove(context.Background(), client, msg)
+	require.ErrorIs(t, err, assert.AnError)
+	require.Len(t, spy.clearedUpdates, 2)
+	assert.Equal(t, clearedUpdateCall{isCleared: true, bay: shared.BAY_CLEARED}, spy.clearedUpdates[0])
+	assert.Equal(t, clearedUpdateCall{isCleared: false, bay: shared.BAY_NOT_CLEARED}, spy.clearedUpdates[1])
+	assert.Equal(t, []string{shared.BAY_CLEARED, shared.BAY_NOT_CLEARED}, spy.moveCalls)
 }

--- a/backend/internal/frontend/hub.go
+++ b/backend/internal/frontend/hub.go
@@ -1175,6 +1175,23 @@ func (hub *Hub) SendBroadcast(session int32, message string, from string) {
 	hub.Broadcast(session, event)
 }
 
+func (hub *Hub) SendMessage(session int32, sender, text string, recipients []string) {
+	if recipients == nil {
+		recipients = []string{}
+	}
+
+	msg := frontend.MessageReceivedEvent{
+		ID:          hub.NextMessageID(),
+		Sender:      sender,
+		Text:        text,
+		IsBroadcast: len(recipients) == 0,
+		Recipients:  recipients,
+	}
+
+	hub.storeMessage(session, msg)
+	hub.dispatchMessage(session, msg, "")
+}
+
 func (hub *Hub) SendGoAround(session int32, callsign string) {
 	hub.Broadcast(session, frontend.GoAroundEvent{
 		Callsign: callsign,

--- a/backend/internal/pdc/integration_test.go
+++ b/backend/internal/pdc/integration_test.go
@@ -710,6 +710,103 @@ func TestRevertToVoiceFlow(t *testing.T) {
 	assert.Equal(t, "REVERT_TO_VOICE", readStripPdcState(t, strip))
 }
 
+func TestRestorePendingTimeouts_ExpiresClearedPdcAfterRestart(t *testing.T) {
+	t.Parallel()
+	suite := &PDCIntegrationTestSuite{}
+	suite.SetupTest(t)
+
+	const callsign = "SAS321"
+	const sessionID = int32(1)
+
+	testdata.SeedClearedTestStrip(t, suite.queries, sessionID, callsign)
+
+	requestChannel := models.PdcChannelWeb
+	messageSequence := int32(42)
+	messageSent := time.Now().UTC().Add(-2 * time.Second)
+	issuedByCid := "CID123"
+
+	require.NoError(t, suite.service.stripRepo.SetPdcData(context.Background(), sessionID, callsign, &models.PdcData{
+		State:           string(StateCleared),
+		RequestChannel:  &requestChannel,
+		MessageSequence: &messageSequence,
+		MessageSent:     &messageSent,
+		IssuedByCid:     &issuedByCid,
+		Web:             &models.PdcWebData{},
+	}))
+
+	suite.mockStrip.On("UnclearStrip", mock.Anything, sessionID, callsign, issuedByCid).Return(nil)
+	suite.mockFrontend.On("SendPdcStateChange", sessionID, callsign, "NO_RESPONSE", "").Return()
+
+	restartedService := &Service{
+		client:        &hoppieClientAdapter{HoppieClient: suite.mockHoppie},
+		sessionRepo:   suite.service.sessionRepo,
+		stripRepo:     suite.service.stripRepo,
+		frontendHub:   suite.mockFrontend,
+		stripService:  suite.mockStrip,
+		timeouts:      make(map[string]*timeoutTracker),
+		timeoutConfig: 100 * time.Millisecond,
+	}
+	suite.mockStrip.On("ReevaluatePdcRequestValidations", mock.Anything, sessionID, callsign, true, false).Return(nil).Maybe()
+
+	restored, err := restartedService.restorePendingTimeouts(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, restored)
+
+	require.Eventually(t, func() bool {
+		strip, err := suite.queries.GetStrip(context.Background(), database.GetStripParams{
+			Session:  sessionID,
+			Callsign: callsign,
+		})
+		if err != nil {
+			return false
+		}
+		return readStripPdcState(t, strip) == "NO_RESPONSE"
+	}, time.Second, 25*time.Millisecond)
+}
+
+func TestConfirmVoiceClearance_ClearsPdcStateAndPublishesPdcMessage(t *testing.T) {
+	t.Parallel()
+	suite := &PDCIntegrationTestSuite{}
+	suite.SetupTest(t)
+
+	callsign := "SAS123"
+	sessionID := int32(1)
+	ctx := context.Background()
+
+	requestedAt := time.Now().UTC()
+	requestChannel := models.PdcChannelWeb
+	webAtis := "B"
+	webClearance := "CLRD TO: ESSA"
+
+	require.NoError(t, suite.service.stripRepo.SetPdcData(ctx, sessionID, callsign, &models.PdcData{
+		State:          string(StateRequested),
+		RequestChannel: &requestChannel,
+		RequestedAt:    &requestedAt,
+		Web: &models.PdcWebData{
+			Atis:          &webAtis,
+			ClearanceText: &webClearance,
+		},
+	}))
+
+	suite.mockFrontend.On("SendPdcStateChange", sessionID, callsign, "NONE", "").Return()
+	suite.mockFrontend.On("SendMessage", sessionID, "SYSTEM", "SAS123: CLEARANCE given / confirmed over voice.", []string{"CLR-DEL"}).Return()
+
+	err := suite.service.ConfirmVoiceClearance(ctx, callsign, sessionID)
+	require.NoError(t, err)
+
+	strip, err := suite.queries.GetStrip(context.Background(), database.GetStripParams{
+		Session:  sessionID,
+		Callsign: callsign,
+	})
+	require.NoError(t, err)
+
+	pdcData := readStripPdcData(t, strip)
+	assert.Equal(t, models.PdcStateNone, pdcData.State)
+	assert.Nil(t, pdcData.RequestChannel)
+	assert.Nil(t, pdcData.RequestedAt)
+	assert.Nil(t, pdcData.Web)
+}
+
 // ===== ERROR SCENARIO TESTS =====
 
 func TestProcessPDCRequest_FlightPlanNotHeld(t *testing.T) {

--- a/backend/internal/pdc/mocks/hubs.go
+++ b/backend/internal/pdc/mocks/hubs.go
@@ -160,6 +160,10 @@ func (m *FrontendHub) SendPdcStateChange(session int32, callsign, state, remarks
 	m.Called(session, callsign, state, remarks)
 }
 
+func (m *FrontendHub) SendMessage(session int32, sender, text string, recipients []string) {
+	m.Called(session, sender, text, recipients)
+}
+
 func (m *FrontendHub) SendRunwayConfiguration(session int32, departure, arrival []string, status map[string]string) {
 	m.Called(session, departure, arrival, status)
 }

--- a/backend/internal/pdc/service.go
+++ b/backend/internal/pdc/service.go
@@ -354,6 +354,12 @@ func (s *Service) confirmPilotAcknowledgement(ctx context.Context, sessionID int
 
 // Start begins the background polling loop
 func (s *Service) Start(ctx context.Context) {
+	if restored, err := s.restorePendingTimeouts(ctx); err != nil {
+		slog.ErrorContext(ctx, "PDC Service: Failed to restore pending confirmation timeouts", slog.Any("error", err))
+	} else if restored > 0 {
+		slog.InfoContext(ctx, "PDC Service: Restored pending confirmation timeouts", slog.Int("count", restored))
+	}
+
 	slog.InfoContext(ctx, "PDC Service: Starting Hoppie polling loop")
 
 	for {
@@ -367,6 +373,52 @@ func (s *Service) Start(ctx context.Context) {
 			}
 		}
 	}
+}
+
+func (s *Service) restorePendingTimeouts(ctx context.Context) (int, error) {
+	sessions, err := s.sessionRepo.List(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to list sessions for timeout recovery: %w", err)
+	}
+
+	restored := 0
+	for _, session := range sessions {
+		strips, err := s.stripRepo.List(ctx, session.ID)
+		if err != nil {
+			return restored, fmt.Errorf("failed to list strips for session %d: %w", session.ID, err)
+		}
+
+		sessionInfo := sessionInformation{
+			id:       session.ID,
+			name:     session.Name,
+			airport:  session.Airport,
+			callsign: session.Airport,
+		}
+
+		for _, strip := range strips {
+			if strip == nil || strip.PdcState != string(StateCleared) || strip.PdcData == nil {
+				continue
+			}
+			if strip.PdcData.MessageSent == nil || strip.PdcData.MessageSequence == nil {
+				slog.WarnContext(ctx, "PDC Service: Skipping timeout recovery for cleared strip with incomplete PDC data",
+					slog.String("callsign", strip.Callsign),
+					slog.Int("session", int(session.ID)),
+				)
+				continue
+			}
+
+			remaining := s.timeoutConfig - time.Since(strip.PdcData.MessageSent.UTC())
+			if remaining < 0 {
+				remaining = 0
+			}
+
+			cid := valueOrEmpty(strip.PdcData.IssuedByCid)
+			s.startClearanceTimeoutAfter(ctx, *strip.PdcData.MessageSequence, sessionInfo, strip.Callsign, cid, isWebPDCRequest(strip), remaining)
+			restored++
+		}
+	}
+
+	return restored, nil
 }
 
 func (s *Service) pollAndProcess(ctx context.Context) error {
@@ -747,6 +799,37 @@ func (s *Service) RevertToVoice(ctx context.Context, callsign string, sessionId 
 	return nil
 }
 
+func (s *Service) ConfirmVoiceClearance(ctx context.Context, callsign string, sessionID int32) error {
+	strip, err := s.stripRepo.GetByCallsign(ctx, sessionID, callsign)
+	if err != nil {
+		return fmt.Errorf("failed to get strip: %w", err)
+	}
+
+	if strip.PdcState == "" || strip.PdcState == string(StateNone) {
+		return nil
+	}
+
+	s.CancelTimeout(callsign, sessionID)
+
+	if err := s.stripRepo.SetPdcData(ctx, sessionID, callsign, (&models.PdcData{}).Normalize()); err != nil {
+		return fmt.Errorf("failed to clear PDC state after voice clearance: %w", err)
+	}
+
+	if err := s.notifyStateChange(ctx, sessionID, callsign, StateNone, ""); err != nil {
+		return err
+	}
+
+	if s.frontendHub != nil {
+		recipients := []string{}
+		if _, ok := config.GetMessageAreas()["CLR-DEL"]; ok {
+			recipients = []string{"CLR-DEL"}
+		}
+		s.frontendHub.SendMessage(sessionID, "SYSTEM", fmt.Sprintf("%s: CLEARANCE given / confirmed over voice.", callsign), recipients)
+	}
+
+	return nil
+}
+
 func (s *Service) getNextFrequency(ctx context.Context, sessionID int32) (string, error) {
 	owners, err := s.sectorRepo.ListBySession(ctx, sessionID)
 	if err != nil {
@@ -1054,7 +1137,11 @@ func (s *Service) SendErrorMessage(ctx context.Context, session sessionInformati
 }
 
 // StartClearanceTimeout starts a timeout that reverts cleared flag if pilot doesn't respond
-func (s *Service) StartClearanceTimeout(ctx context.Context, airport, callsign string, messageId int32, session sessionInformation, cid string, web bool) {
+func (s *Service) StartClearanceTimeout(ctx context.Context, _ string, callsign string, messageId int32, session sessionInformation, cid string, web bool) {
+	s.startClearanceTimeoutAfter(ctx, messageId, session, callsign, cid, web, s.timeoutConfig)
+}
+
+func (s *Service) startClearanceTimeoutAfter(ctx context.Context, messageId int32, session sessionInformation, callsign string, cid string, web bool, delay time.Duration) {
 	key := fmt.Sprintf("%s_%d", callsign, session.id)
 
 	// Cancel any existing timeout for this callsign
@@ -1076,9 +1163,9 @@ func (s *Service) StartClearanceTimeout(ctx context.Context, airport, callsign s
 	s.timeoutsMutex.Unlock()
 
 	// Start timeout goroutine
-	go s.handleTimeout(timeoutCtx, airport, callsign, messageId, session)
+	go s.handleTimeout(timeoutCtx, delay, callsign, messageId, session)
 
-	slog.DebugContext(ctx, "PDC Service: Started timeout", slog.Duration("timeout", s.timeoutConfig), slog.String("callsign", callsign))
+	slog.DebugContext(ctx, "PDC Service: Started timeout", slog.Duration("timeout", delay), slog.String("callsign", callsign))
 }
 
 // CancelTimeout cancels an active timeout
@@ -1096,7 +1183,7 @@ func (s *Service) CancelTimeout(callsign string, sessionID int32) {
 }
 
 // handleTimeout waits for timeout and reverts cleared flag if no response
-func (s *Service) handleTimeout(ctx context.Context, airport, callsign string, messageId int32, session sessionInformation) {
+func (s *Service) handleTimeout(ctx context.Context, delay time.Duration, callsign string, messageId int32, session sessionInformation) {
 	key := fmt.Sprintf("%s_%d", callsign, session.id)
 
 	s.timeoutsMutex.RLock()
@@ -1111,7 +1198,7 @@ func (s *Service) handleTimeout(ctx context.Context, airport, callsign string, m
 	case <-ctx.Done():
 		// Timeout was cancelled (pilot responded)
 		return
-	case <-time.After(s.timeoutConfig):
+	case <-time.After(delay):
 		// Timeout expired - revert cleared flag
 		slog.DebugContext(ctx, "PDC Service: Timeout expired - reverting cleared flag", slog.String("callsign", callsign))
 
@@ -1140,7 +1227,7 @@ func (s *Service) handleTimeout(ctx context.Context, airport, callsign string, m
 			if err != nil {
 				slog.ErrorContext(ctx, "PDC Service: Failed to get next message sequence", slog.Any("error", err))
 			} else {
-				msg := buildNoResponseMessage(seq, messageId, airport, callsign)
+				msg := buildNoResponseMessage(seq, messageId, session.airport, callsign)
 				err = s.client.SendCPDLC(ctx, session.callsign, callsign, msg)
 				if err != nil {
 					slog.ErrorContext(ctx, "PDC Service: Failed to send no response message", slog.Any("error", err))

--- a/backend/internal/shared/frontend.go
+++ b/backend/internal/shared/frontend.go
@@ -38,6 +38,7 @@ type FrontendHub interface {
 	SendCdmUpdates(session int32, events []frontend.CdmDataEvent)
 	SendCdmWait(session int32, callsign string)
 	SendPdcStateChange(session int32, callsign, state, remarks string)
+	SendMessage(session int32, sender, text string, recipients []string)
 	SendRunwayConfiguration(session int32, departure, arrival []string, status map[string]string)
 	SendTacticalStripCreated(session int32, strip frontend.TacticalStripPayload)
 	SendTacticalStripDeleted(session int32, id int64, bay string)

--- a/backend/internal/shared/server.go
+++ b/backend/internal/shared/server.go
@@ -21,6 +21,7 @@ type Session struct {
 type PdcService interface {
 	IssueClearance(ctx context.Context, callsign, remarks, cid string, sessionID int32) error
 	ManualStateChange(ctx context.Context, callsign string, sessionID int32, newState string) error
+	ConfirmVoiceClearance(ctx context.Context, callsign string, sessionID int32) error
 	RevertToVoice(ctx context.Context, callsign string, sessionID int32, cid string) error
 }
 

--- a/backend/internal/testutil/mock_frontend_hub.go
+++ b/backend/internal/testutil/mock_frontend_hub.go
@@ -285,6 +285,19 @@ func (m *MockFrontendHub) SendCdmWait(session int32, callsign string) {
 
 func (m *MockFrontendHub) SendPdcStateChange(session int32, callsign, state, remarks string) {}
 
+func (m *MockFrontendHub) SendMessage(session int32, sender, text string, recipients []string) {
+	m.SentMessages = append(m.SentMessages, SentMessageCall{
+		Session: session,
+		Cid:     sender,
+		Message: frontend.MessageReceivedEvent{
+			Sender:      sender,
+			Text:        text,
+			IsBroadcast: len(recipients) == 0,
+			Recipients:  recipients,
+		},
+	})
+}
+
 func (m *MockFrontendHub) SendRunwayConfiguration(session int32, departure, arrival []string, status map[string]string) {
 }
 

--- a/backend/internal/testutil/mock_server.go
+++ b/backend/internal/testutil/mock_server.go
@@ -19,6 +19,7 @@ type MockServer struct {
 	SectorRepoVal     repository.SectorOwnerRepository
 	SessionRepoVal    repository.SessionRepository
 	StripRepoVal      repository.StripRepository
+	PdcServiceVal     shared.PdcService
 
 	GetOrCreateSessionFn                func(airport string, name string) (shared.Session, error)
 	UpdateSectorsFn                     func(sessionId int32) ([]shared.SectorChange, error)
@@ -46,7 +47,7 @@ func (m *MockServer) GetOrCreateSession(airport string, name string) (shared.Ses
 
 func (m *MockServer) GetCdmService() shared.CdmService { return m.CdmServiceVal }
 
-func (m *MockServer) GetPdcService() shared.PdcService { return nil }
+func (m *MockServer) GetPdcService() shared.PdcService { return m.PdcServiceVal }
 
 func (m *MockServer) GetStripRepository() repository.StripRepository { return m.StripRepoVal }
 

--- a/backend/internal/testutil/mock_session_repository.go
+++ b/backend/internal/testutil/mock_session_repository.go
@@ -10,6 +10,7 @@ import (
 // MockSessionRepository is a configurable mock for repository.SessionRepository.
 type MockSessionRepository struct {
 	GetByIDFn             func(ctx context.Context, id int32) (*models.Session, error)
+	GetByNamesFn          func(ctx context.Context, name string) ([]*models.Session, error)
 	ListFn                func(ctx context.Context) ([]*models.Session, error)
 	UpdateActiveRunwaysFn func(ctx context.Context, id int32, activeRunways pkgModels.ActiveRunways) error
 	UpdateCdmMasterFn     func(ctx context.Context, id int32, master bool) error
@@ -35,7 +36,10 @@ func (m *MockSessionRepository) GetByNameAndAirport(ctx context.Context, name st
 }
 
 func (m *MockSessionRepository) GetByNames(ctx context.Context, name string) ([]*models.Session, error) {
-	panic("unexpected call to MockSessionRepository.GetByNames")
+	if m.GetByNamesFn == nil {
+		panic("unexpected call to MockSessionRepository.GetByNames")
+	}
+	return m.GetByNamesFn(ctx, name)
 }
 
 func (m *MockSessionRepository) GetExpiredSessions(ctx context.Context, expiredBefore *time.Time) ([]*models.Session, error) {

--- a/frontend/src/components/FlightPlanDialog.tsx
+++ b/frontend/src/components/FlightPlanDialog.tsx
@@ -20,6 +20,7 @@ import { normalizeCdmTime } from "@/lib/cdmTime";
 import { CDM_RED } from "@/lib/cdmColors";
 import { getCtotSlotDisplay, getEcfmpNitosRemarks, getMandatoryRouteRestriction, getGroundStopRestriction, getProhibitRestriction, isFlightLevelViolated } from "@/lib/ecfmp";
 import { MandatoryRouteDialog } from "@/components/MandatoryRouteDialog";
+import { ManualPdcBypassDialog } from "@/components/ManualPdcBypassDialog";
 
 const FONT_FAMILY = "Arial";
 const FONT_SIZE_FIELD = scalePx(20);
@@ -216,6 +217,7 @@ interface FlightPlanDialogProps {
   onOpenChange?: (open: boolean) => void;
   children?: React.ReactNode;
   mode?: "clearance" | "view";
+  pdcAction?: "default" | "manual";
 }
 
 export default function FlightPlanDialog({
@@ -224,8 +226,10 @@ export default function FlightPlanDialog({
   onOpenChange,
   children,
   mode = "clearance",
+  pdcAction = "default",
 }: FlightPlanDialogProps) {
   const isViewMode = mode === "view";
+  const usesManualPdcBypass = pdcAction === "manual";
   const strip = useStrip(callsign);
   const initialCflByRunway = useInitialCflByRunway();
   const transitionAltitude = useTransitionAltitude();
@@ -272,6 +276,7 @@ export default function FlightPlanDialog({
   const [hdgDialogOpen, setHdgDialogOpen] = useState(false);
   const [altDialogOpen, setAltDialogOpen] = useState(false);
   const [mandatoryRouteDialogOpen, setMandatoryRouteDialogOpen] = useState(false);
+  const [manualPdcBypassDialogOpen, setManualPdcBypassDialogOpen] = useState(false);
   const defaultClearedAltitude = strip?.runway ? initialCflByRunway[strip.runway] : undefined;
   const commitEobt = () => updateStrip(callsign, { eobt: normalizeCdmTime(eobt) });
   const sidFault = hasClxFieldFault(strip, "sid");
@@ -313,6 +318,14 @@ export default function FlightPlanDialog({
     if (!strip) return;
     const update = buildRnavUpdate(strip.aircraft_type ?? "", strip.remarks ?? "", capability);
     updateStrip(callsign, update);
+  };
+
+  const performManualClearance = () => {
+    if (!strip) return;
+
+    moveAction(strip.callsign, Bay.Cleared);
+    setManualPdcBypassDialogOpen(false);
+    setDialogOpen(false);
   };
 
   return (
@@ -802,6 +815,10 @@ export default function FlightPlanDialog({
                         setMandatoryRouteDialogOpen(true);
                         return;
                       }
+                      if ((strip.pdc_state === "REQUESTED" || strip.pdc_state === "REQUESTED_WITH_FAULTS") && usesManualPdcBypass) {
+                        setManualPdcBypassDialogOpen(true);
+                        return;
+                      }
                       if (strip.pdc_state === "REQUESTED" || strip.pdc_state === "REQUESTED_WITH_FAULTS") {
                         clearPdc(strip.callsign, null);
                       } else {
@@ -887,6 +904,15 @@ export default function FlightPlanDialog({
             setMandatoryRouteDialogOpen(false);
             setDialogOpen(false);
           }}
+        />
+      )}
+
+      {strip && (
+        <ManualPdcBypassDialog
+          open={manualPdcBypassDialogOpen}
+          onOpenChange={setManualPdcBypassDialogOpen}
+          callsign={callsign}
+          onConfirm={performManualClearance}
         />
       )}
     </>

--- a/frontend/src/components/ManualPdcBypassDialog.tsx
+++ b/frontend/src/components/ManualPdcBypassDialog.tsx
@@ -1,0 +1,74 @@
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { scalePx } from "@/lib/viewportScale";
+
+const DIALOG_WIDTH = scalePx(500);
+const FONT_SIZE = scalePx(18);
+const FONT_SIZE_BUTTON = scalePx(20);
+
+interface ManualPdcBypassDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  callsign: string;
+  onConfirm: () => void;
+}
+
+export function ManualPdcBypassDialog({
+  open,
+  onOpenChange,
+  callsign,
+  onConfirm,
+}: ManualPdcBypassDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        style={{
+          width: DIALOG_WIDTH,
+          padding: scalePx(20),
+          gap: scalePx(16),
+        }}
+      >
+        <DialogTitle className="sr-only">Manual PDC Bypass Warning</DialogTitle>
+        <div className="flex flex-col gap-4">
+          <div className="text-center" style={{ fontSize: FONT_SIZE, fontWeight: "bold" }}>
+            <span style={{ color: "red" }}>ACTIVE PDC REQUEST</span>
+            <br />
+            <span style={{ color: "red" }}>This strip already has a PDC</span>
+            <br />
+            <span style={{ color: "red" }}>Do you want to give the clearance over voice?</span>
+          </div>
+          <div
+            className="border border-black text-center font-bold"
+            style={{ fontSize: scalePx(16), backgroundColor: "#FFD700", color: "black", padding: scalePx(10) }}
+          >
+            {callsign}: Manual voice clearance
+          </div>
+          <div className="flex justify-center gap-4">
+            <Button
+              onClick={onConfirm}
+              style={{
+                fontSize: FONT_SIZE_BUTTON,
+                padding: `${scalePx(8)}px ${scalePx(24)}px`,
+                backgroundColor: "#3F3F3F",
+                color: "white",
+              }}
+            >
+              YES
+            </Button>
+            <Button
+              onClick={() => onOpenChange(false)}
+              style={{
+                fontSize: FONT_SIZE_BUTTON,
+                padding: `${scalePx(8)}px ${scalePx(24)}px`,
+                backgroundColor: "#3F3F3F",
+                color: "white",
+              }}
+            >
+              NO
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/strip/ApnPushStrip.tsx
+++ b/frontend/src/components/strip/ApnPushStrip.tsx
@@ -29,8 +29,8 @@ import { PushbackMapDialog } from "@/components/map-dialogs/PushbackMapDialog";
 import { ApronTaxiMapDialog } from "@/components/map-dialogs/ApronTaxiMapDialog";
 import { TaxiMapDialog } from "@/components/map-dialogs/TaxiMapDialog";
 import { RunwayDialog } from "./RunwayDialog";
-import FlightPlanDialog from "@/components/FlightPlanDialog";
 import { ValidationStatusDialog } from "./ValidationStatusDialog";
+import { DepartureAwareFlightPlanDialog } from "./DepartureAwareFlightPlanDialog";
 
 // Height: 4.72dvh(51px at 1080p)
 const HALF_H = "2.36dvh";    // half of 4.72dvh for TSAT/CTOT split
@@ -266,7 +266,7 @@ export function ApnPushStrip({
         direction="departure"
         currentRunway={runway}
       />
-      <FlightPlanDialog callsign={callsign} open={fplOpen} onOpenChange={setFplOpen} mode="view" />
+      <DepartureAwareFlightPlanDialog callsign={callsign} open={fplOpen} onOpenChange={setFplOpen} />
       {validationStatus && (
         <ValidationStatusDialog callsign={callsign} status={validationStatus} open={validationDialogOpen} onOpenChange={setValidationDialogOpen} />
       )}

--- a/frontend/src/components/strip/ApnTaxiDepStrip.tsx
+++ b/frontend/src/components/strip/ApnTaxiDepStrip.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import type { StripProps } from "./types";
-import FlightPlanDialog from "@/components/FlightPlanDialog";
 import {
   useStripCallsignInteraction,
   getFramedStripStyle,
@@ -23,6 +22,7 @@ import { useStripTransfers, useWebSocketStore } from "@/store/store-hooks";
 import { ApronTaxiMapDialog } from "@/components/map-dialogs/ApronTaxiMapDialog";
 import { useCTOTColor } from "@/hooks/useCTOTColor";
 import { ValidationStatusDialog } from "./ValidationStatusDialog";
+import { DepartureAwareFlightPlanDialog } from "./DepartureAwareFlightPlanDialog";
 const TOP_H= "3.15dvh";  // 2/3 of 4.72dvh
 const BOT_H  = "1.57dvh";  // 1/3 of 4.72dvh
 const HALF_H = "2.08dvh";  // 1/2 of inner content height (4.72dvh - 2px border - 1px padding each side)
@@ -202,7 +202,7 @@ export function ApnTaxiDepStrip({
         callsign={callsign}
         coordinationMode={isCoordinationMode}
       />
-      <FlightPlanDialog callsign={callsign} open={fplOpen} onOpenChange={setFplOpen} mode="view" />
+      <DepartureAwareFlightPlanDialog callsign={callsign} open={fplOpen} onOpenChange={setFplOpen} />
       {validationStatus && (
         <ValidationStatusDialog callsign={callsign} status={validationStatus} open={validationDialogOpen} onOpenChange={setValidationDialogOpen} />
       )}

--- a/frontend/src/components/strip/ControlzoneStrip.tsx
+++ b/frontend/src/components/strip/ControlzoneStrip.tsx
@@ -2,7 +2,6 @@ import { useMemo, useState } from "react";
 import type { FrontendStrip } from "@/api/models";
 import { useAirport, useMetar } from "@/store/store-hooks";
 import { decodeMetar } from "@/lib/metarDecode";
-import FlightPlanDialog from "@/components/FlightPlanDialog";
 import {
   COLOR_ARR_YELLOW,
   COLOR_MANUAL_BLUE,
@@ -11,6 +10,7 @@ import {
   SELECTION_COLOR,
   useStripSelection,
 } from "./shared";
+import { DepartureAwareFlightPlanDialog } from "./DepartureAwareFlightPlanDialog";
 
 const FULL_H = "4.72dvh";
 const TOP_H = "3.15dvh";
@@ -165,7 +165,7 @@ export function ControlzoneStrip({ strip, selectable }: Props) {
         />
       </div>
     </div>
-    <FlightPlanDialog callsign={strip.callsign} open={fplOpen} onOpenChange={setFplOpen} mode="view" />
+    <DepartureAwareFlightPlanDialog callsign={strip.callsign} open={fplOpen} onOpenChange={setFplOpen} />
     </>
   );
 }

--- a/frontend/src/components/strip/DepartureAwareFlightPlanDialog.tsx
+++ b/frontend/src/components/strip/DepartureAwareFlightPlanDialog.tsx
@@ -1,0 +1,28 @@
+import FlightPlanDialog from "@/components/FlightPlanDialog";
+import { useAirport, useStrip } from "@/store/store-hooks";
+
+interface DepartureAwareFlightPlanDialogProps {
+  callsign: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function DepartureAwareFlightPlanDialog({
+  callsign,
+  open,
+  onOpenChange,
+}: DepartureAwareFlightPlanDialogProps) {
+  const strip = useStrip(callsign);
+  const airport = useAirport();
+  const isDeparture = strip?.origin === airport && strip?.destination !== airport;
+
+  return (
+    <FlightPlanDialog
+      callsign={callsign}
+      open={open}
+      onOpenChange={onOpenChange}
+      mode={isDeparture ? "clearance" : "view"}
+      pdcAction={isDeparture ? "manual" : "default"}
+    />
+  );
+}

--- a/frontend/src/components/strip/TwyDepStrip.tsx
+++ b/frontend/src/components/strip/TwyDepStrip.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { getAircraftTypeWithWtc } from "@/lib/utils";
 import { useStripTransfers, useTransitionAltitude, useWebSocketStore } from "@/store/store-hooks";
 import { formatAltitude } from "@/lib/utils";
-import FlightPlanDialog from "@/components/FlightPlanDialog";
 import { useCTOTColor } from "@/hooks/useCTOTColor";
 import { COLOR_UNEXPECTED_YELLOW, COLOR_TYPE_HEAVY, getValidationBlockedCursor } from "./shared";
 import { getStripBg } from "./types";
@@ -15,6 +14,7 @@ import { TAXI_MAP_POINTS } from "@/config/ekch";
 import { Bay } from "@/api/models";
 import { ValidationStatusDialog } from "./ValidationStatusDialog";
 import { getGroundStopRestriction, isFlightLevelViolated } from "@/lib/ecfmp";
+import { DepartureAwareFlightPlanDialog } from "./DepartureAwareFlightPlanDialog";
 
 // Heights— 4.72dvh total (51px at 1080p), 2/3 top / 1/3 bottom (used by callsign and SID/dest)
 const TOP_H      = "3.15dvh";  // 2/3 of 4.72dvh
@@ -305,7 +305,7 @@ export function TwyDepStrip({
       runway={runway}
       coordinationMode={isCoordinationMode}
     />
-    <FlightPlanDialog callsign={callsign} open={fplOpen} onOpenChange={setFplOpen} mode="view" />
+    <DepartureAwareFlightPlanDialog callsign={callsign} open={fplOpen} onOpenChange={setFplOpen} />
     {validationStatus && (
       <ValidationStatusDialog callsign={callsign} status={validationStatus} open={validationDialogOpen} onOpenChange={setValidationDialogOpen} />
     )}


### PR DESCRIPTION
## Summary
- Confirm voice clearance when a strip is moved to cleared while PDC is active
- Roll back the cleared move if voice confirmation fails
- Restore pending cleared-PDC timeouts on service start after restart
- Add frontend support for manual PDC bypass flow and targeted message sending
- Cover the new backend and frontend paths with unit and integration tests

## Testing
- Added backend unit tests for cleared-move confirmation and rollback behavior
- Added backend integration tests for timeout recovery and voice clearance confirmation
- Not run (not requested)