### PR TITLE
Add tactical strip lookup before confirm and timer mutation

### DIFF
--- a/backend/internal/database/tactical_strips.sql.go
+++ b/backend/internal/database/tactical_strips.sql.go
@@ -100,6 +100,36 @@ func (q *Queries) DeleteTacticalStrip(ctx context.Context, arg DeleteTacticalStr
 	return err
 }
 
+const getTacticalStripByID = `-- name: GetTacticalStripByID :one
+SELECT id, session_id, type, bay, label, aircraft, produced_by, sequence, timer_start, confirmed, confirmed_by, created_at FROM tactical_strips
+WHERE id = $1 AND session_id = $2
+`
+
+type GetTacticalStripByIDParams struct {
+	ID        int64
+	SessionID int32
+}
+
+func (q *Queries) GetTacticalStripByID(ctx context.Context, arg GetTacticalStripByIDParams) (TacticalStrip, error) {
+	row := q.db.QueryRow(ctx, getTacticalStripByID, arg.ID, arg.SessionID)
+	var i TacticalStrip
+	err := row.Scan(
+		&i.ID,
+		&i.SessionID,
+		&i.Type,
+		&i.Bay,
+		&i.Label,
+		&i.Aircraft,
+		&i.ProducedBy,
+		&i.Sequence,
+		&i.TimerStart,
+		&i.Confirmed,
+		&i.ConfirmedBy,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const getTacticalStripSequenceByID = `-- name: GetTacticalStripSequenceByID :one
 SELECT sequence::INT FROM tactical_strips WHERE id = $1 AND session_id = $2
 `

--- a/backend/internal/frontend/handlers.go
+++ b/backend/internal/frontend/handlers.go
@@ -770,16 +770,21 @@ func handleConfirmTacticalStrip(ctx context.Context, client *Client, message Mes
 		return errors.New("tactical strip repository not available")
 	}
 
-	ts, err := tacticalRepo.Confirm(ctx, req.ID, client.session, client.position)
+	ts, err := tacticalRepo.GetByID(ctx, req.ID, client.session)
 	if err != nil {
 		return err
 	}
 
-	if ts.Type != "MEMAID" && ts.Type != "CROSSING" {
+	if ts.Type != internalModels.TacticalStripTypeMemaid && ts.Type != internalModels.TacticalStripTypeCrossing {
 		return errors.New("confirm is only valid for MEMAID and CROSSING strips")
 	}
 	if ts.ProducedBy == client.position {
 		return errors.New("producer cannot confirm their own MEMAID strip")
+	}
+
+	ts, err = tacticalRepo.Confirm(ctx, req.ID, client.session, client.position)
+	if err != nil {
+		return err
 	}
 
 	client.hub.SendTacticalStripUpdated(client.session, MapTacticalStripToPayload(ts))
@@ -797,13 +802,18 @@ func handleStartTacticalTimer(ctx context.Context, client *Client, message Messa
 		return errors.New("tactical strip repository not available")
 	}
 
-	ts, err := tacticalRepo.StartTimer(ctx, req.ID, client.session)
+	ts, err := tacticalRepo.GetByID(ctx, req.ID, client.session)
 	if err != nil {
 		return err
 	}
 
-	if ts.Type != "START" && ts.Type != "LAND" {
+	if ts.Type != internalModels.TacticalStripTypeStart && ts.Type != internalModels.TacticalStripTypeLand {
 		return errors.New("start timer is only valid for START and LAND strips")
+	}
+
+	ts, err = tacticalRepo.StartTimer(ctx, req.ID, client.session)
+	if err != nil {
+		return err
 	}
 
 	client.hub.SendTacticalStripUpdated(client.session, MapTacticalStripToPayload(ts))

--- a/backend/internal/frontend/handlers_tactical_test.go
+++ b/backend/internal/frontend/handlers_tactical_test.go
@@ -1,6 +1,7 @@
 package frontend
 
 import (
+	"FlightStrips/internal/models"
 	"FlightStrips/internal/shared"
 	"FlightStrips/internal/testutil"
 	"FlightStrips/pkg/events/frontend"
@@ -16,6 +17,16 @@ import (
 func buildTacticalTestHub() *Hub {
 	return &Hub{
 		server:       &testutil.MockServer{FrontendHubVal: &testutil.MockFrontendHub{}},
+		stripService: &testutil.NoOpStripService{},
+	}
+}
+
+func buildTacticalRepoHub(repo *testutil.MockTacticalStripRepository) *Hub {
+	return &Hub{
+		server: &testutil.MockServer{
+			FrontendHubVal:       &testutil.MockFrontendHub{},
+			TacticalStripRepoVal: repo,
+		},
 		stripService: &testutil.NoOpStripService{},
 	}
 }
@@ -55,4 +66,84 @@ func TestHandleCreateTacticalStrip_ValidBay_PassesBayValidation(t *testing.T) {
 	// Bay validation passes; fails on nil tactical repo — that is expected.
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not available", "should fail on nil repo, not bay validation")
+}
+
+func TestHandleConfirmTacticalStrip_InvalidTypeRejectedBeforeMutation(t *testing.T) {
+	confirmCalled := false
+	hub := buildTacticalRepoHub(&testutil.MockTacticalStripRepository{
+		GetByIDFn: func(_ context.Context, id int64, sessionID int32) (*models.TacticalStrip, error) {
+			assert.Equal(t, int64(42), id)
+			assert.Equal(t, int32(1), sessionID)
+			return &models.TacticalStrip{
+				ID:        id,
+				SessionID: sessionID,
+				Type:      models.TacticalStripTypeStart,
+			}, nil
+		},
+		ConfirmFn: func(_ context.Context, _ int64, _ int32, _ string) (*models.TacticalStrip, error) {
+			confirmCalled = true
+			return nil, nil
+		},
+	})
+	client := buildFrontendTestClient(hub, 1, "EKCH")
+	client.position = "EKCH_TWR"
+
+	msg := marshalMessage(t, frontend.ConfirmTacticalStripAction{ID: 42})
+
+	err := handleConfirmTacticalStrip(context.Background(), client, msg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "confirm is only valid")
+	assert.False(t, confirmCalled, "Confirm must not be called when the tactical strip type is invalid")
+}
+
+func TestHandleConfirmTacticalStrip_ProducerRejectedBeforeMutation(t *testing.T) {
+	confirmCalled := false
+	hub := buildTacticalRepoHub(&testutil.MockTacticalStripRepository{
+		GetByIDFn: func(_ context.Context, id int64, sessionID int32) (*models.TacticalStrip, error) {
+			return &models.TacticalStrip{
+				ID:         id,
+				SessionID:  sessionID,
+				Type:       models.TacticalStripTypeCrossing,
+				ProducedBy: "EKCH_TWR",
+			}, nil
+		},
+		ConfirmFn: func(_ context.Context, _ int64, _ int32, _ string) (*models.TacticalStrip, error) {
+			confirmCalled = true
+			return nil, nil
+		},
+	})
+	client := buildFrontendTestClient(hub, 1, "EKCH")
+	client.position = "EKCH_TWR"
+
+	msg := marshalMessage(t, frontend.ConfirmTacticalStripAction{ID: 43})
+
+	err := handleConfirmTacticalStrip(context.Background(), client, msg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "producer cannot confirm")
+	assert.False(t, confirmCalled, "Confirm must not be called when the producer is not allowed to confirm")
+}
+
+func TestHandleStartTacticalTimer_InvalidTypeRejectedBeforeMutation(t *testing.T) {
+	startTimerCalled := false
+	hub := buildTacticalRepoHub(&testutil.MockTacticalStripRepository{
+		GetByIDFn: func(_ context.Context, id int64, sessionID int32) (*models.TacticalStrip, error) {
+			return &models.TacticalStrip{
+				ID:        id,
+				SessionID: sessionID,
+				Type:      models.TacticalStripTypeMemaid,
+			}, nil
+		},
+		StartTimerFn: func(_ context.Context, _ int64, _ int32) (*models.TacticalStrip, error) {
+			startTimerCalled = true
+			return nil, nil
+		},
+	})
+	client := buildFrontendTestClient(hub, 1, "EKCH")
+
+	msg := marshalMessage(t, frontend.StartTacticalTimerAction{ID: 99})
+
+	err := handleStartTacticalTimer(context.Background(), client, msg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "start timer is only valid")
+	assert.False(t, startTimerCalled, "StartTimer must not be called when the tactical strip type is invalid")
 }

--- a/backend/internal/repository/postgres/tactical_strip.go
+++ b/backend/internal/repository/postgres/tactical_strip.go
@@ -72,6 +72,17 @@ func (r *tacticalStripRepository) ListBySession(ctx context.Context, sessionID i
 	return result, nil
 }
 
+func (r *tacticalStripRepository) GetByID(ctx context.Context, id int64, sessionID int32) (*models.TacticalStrip, error) {
+	row, err := r.queries.GetTacticalStripByID(ctx, database.GetTacticalStripByIDParams{
+		ID:        id,
+		SessionID: sessionID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return tacticalStripToModel(row), nil
+}
+
 func (r *tacticalStripRepository) Delete(ctx context.Context, id int64, sessionID int32) error {
 	return r.queries.DeleteTacticalStrip(ctx, database.DeleteTacticalStripParams{
 		ID:        id,

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -157,6 +157,7 @@ type SectorOwnerRepository interface {
 type TacticalStripRepository interface {
 	Create(ctx context.Context, sessionID int32, stripType, bay, label string, aircraft *string, producedBy string, sequence int32) (*models.TacticalStrip, error)
 	ListBySession(ctx context.Context, sessionID int32) ([]*models.TacticalStrip, error)
+	GetByID(ctx context.Context, id int64, sessionID int32) (*models.TacticalStrip, error)
 	Delete(ctx context.Context, id int64, sessionID int32) error
 	Confirm(ctx context.Context, id int64, sessionID int32, confirmedBy string) (*models.TacticalStrip, error)
 	StartTimer(ctx context.Context, id int64, sessionID int32) (*models.TacticalStrip, error)

--- a/backend/internal/testutil/mock_server.go
+++ b/backend/internal/testutil/mock_server.go
@@ -11,15 +11,16 @@ import (
 
 // MockServer is a configurable mock for shared.Server.
 type MockServer struct {
-	FrontendHubVal    shared.FrontendHub
-	EuroscopeHubVal   shared.EuroscopeHub
-	CdmServiceVal     shared.CdmService
-	CoordRepoVal      repository.CoordinationRepository
-	ControllerRepoVal repository.ControllerRepository
-	SectorRepoVal     repository.SectorOwnerRepository
-	SessionRepoVal    repository.SessionRepository
-	StripRepoVal      repository.StripRepository
-	PdcServiceVal     shared.PdcService
+	FrontendHubVal       shared.FrontendHub
+	EuroscopeHubVal      shared.EuroscopeHub
+	CdmServiceVal        shared.CdmService
+	CoordRepoVal         repository.CoordinationRepository
+	ControllerRepoVal    repository.ControllerRepository
+	SectorRepoVal        repository.SectorOwnerRepository
+	SessionRepoVal       repository.SessionRepository
+	StripRepoVal         repository.StripRepository
+	TacticalStripRepoVal repository.TacticalStripRepository
+	PdcServiceVal        shared.PdcService
 
 	GetOrCreateSessionFn                func(airport string, name string) (shared.Session, error)
 	UpdateSectorsFn                     func(sessionId int32) ([]shared.SectorChange, error)
@@ -65,7 +66,9 @@ func (m *MockServer) GetCoordinationRepository() repository.CoordinationReposito
 	return m.CoordRepoVal
 }
 
-func (m *MockServer) GetTacticalStripRepository() repository.TacticalStripRepository { return nil }
+func (m *MockServer) GetTacticalStripRepository() repository.TacticalStripRepository {
+	return m.TacticalStripRepoVal
+}
 
 func (m *MockServer) UpdateSectors(sessionId int32) ([]shared.SectorChange, error) {
 	if m.UpdateSectorsFn != nil {

--- a/backend/internal/testutil/mock_tactical_strip_repository.go
+++ b/backend/internal/testutil/mock_tactical_strip_repository.go
@@ -8,6 +8,7 @@ import (
 type MockTacticalStripRepository struct {
 	CreateFn                 func(ctx context.Context, sessionID int32, stripType, bay, label string, aircraft *string, producedBy string, sequence int32) (*models.TacticalStrip, error)
 	ListBySessionFn          func(ctx context.Context, sessionID int32) ([]*models.TacticalStrip, error)
+	GetByIDFn                func(ctx context.Context, id int64, sessionID int32) (*models.TacticalStrip, error)
 	DeleteFn                 func(ctx context.Context, id int64, sessionID int32) error
 	ConfirmFn                func(ctx context.Context, id int64, sessionID int32, confirmedBy string) (*models.TacticalStrip, error)
 	StartTimerFn             func(ctx context.Context, id int64, sessionID int32) (*models.TacticalStrip, error)
@@ -32,6 +33,13 @@ func (m *MockTacticalStripRepository) ListBySession(ctx context.Context, session
 		panic("unexpected call to MockTacticalStripRepository.ListBySession")
 	}
 	return m.ListBySessionFn(ctx, sessionID)
+}
+
+func (m *MockTacticalStripRepository) GetByID(ctx context.Context, id int64, sessionID int32) (*models.TacticalStrip, error) {
+	if m.GetByIDFn == nil {
+		panic("unexpected call to MockTacticalStripRepository.GetByID")
+	}
+	return m.GetByIDFn(ctx, id, sessionID)
 }
 
 func (m *MockTacticalStripRepository) Delete(ctx context.Context, id int64, sessionID int32) error {

--- a/backend/queries/tactical_strips.sql
+++ b/backend/queries/tactical_strips.sql
@@ -13,6 +13,10 @@ SELECT * FROM tactical_strips
 WHERE session_id = $1
 ORDER BY bay, sequence ASC;
 
+-- name: GetTacticalStripByID :one
+SELECT * FROM tactical_strips
+WHERE id = $1 AND session_id = $2;
+
 -- name: DeleteTacticalStrip :exec
 DELETE FROM tactical_strips WHERE id = $1 AND session_id = $2;
 


### PR DESCRIPTION
## Summary
- Added a session-scoped tactical strip lookup by ID in the repository and generated queries.
- Updated tactical strip confirm and timer handlers to validate strip type and ownership before mutating state.
- Expanded tactical strip test coverage with cases that ensure invalid types and producers are rejected before repository mutation.
- Extended test utilities so tactical strip repositories can be injected through the mock server.

## Testing
- Added handler tests covering invalid confirm/start paths and mutation-prevention behavior.
- Not run (not requested).