### PR TITLE
Extract strip update handling into a dedicated service

### DIFF
--- a/backend/internal/frontend/handlers.go
+++ b/backend/internal/frontend/handlers.go
@@ -20,6 +20,7 @@ type Message = shared.Message[frontend.EventType]
 
 type pdcInvalidValidationStripReevaluator interface {
 	ReevaluatePdcInvalidValidationForStrip(ctx context.Context, session int32, strip *internalModels.Strip, activeDepartureRunways []string, publish bool, forceReactivate bool) error
+	ReevaluatePdcInvalidValidation(ctx context.Context, session int32, callsign string, publish bool, forceReactivate bool) error
 }
 
 type departureValidationStripReevaluator interface {
@@ -181,123 +182,17 @@ func handleStripUpdate(ctx context.Context, client *Client, message Message) err
 		return err
 	}
 
-	if event.Route != nil && event.Sid != nil {
-		return errors.New("cannot update both route and sid at the same time")
+	service := client.hub.getStripUpdateService()
+	if service == nil {
+		return errors.New("strip update service not available")
 	}
 
-	s := client.hub.server
-	stripRepo := s.GetStripRepository()
-
-	strip, err := stripRepo.GetByCallsign(ctx, client.session, event.Callsign)
-	if err != nil {
-		return err
-	}
-
-	isOwner := strip.Owner == nil || *strip.Owner == "" || *strip.Owner == client.position
-	if !isOwner {
-		// Non-owners may not modify EuroScope-forwarded fields (SID, route, stand, runway,
-		// altitude, heading, remarks, aircraft info).
-		if event.Sid != nil || event.Route != nil || event.Stand != nil || event.Runway != nil || event.Altitude != nil || event.Heading != nil || event.Remarks != nil || event.Aircraft != nil {
-			return errors.New("non-owner cannot modify strip fields")
-		}
-		return nil
-	}
-
-	if event.Route != nil && stringPtrValue(strip.Route) != *event.Route {
-		s.GetEuroscopeHub().SendRoute(client.session, client.GetCid(), event.Callsign, *event.Route)
-	}
-
-	aircraftChanged := event.Aircraft != nil && stringPtrValue(strip.AircraftType) != *event.Aircraft
-	remarksChanged := event.Remarks != nil && stringPtrValue(strip.Remarks) != *event.Remarks
-	if aircraftChanged && remarksChanged {
-		s.GetEuroscopeHub().SendAircraftInfoAndRemarks(client.session, client.GetCid(), event.Callsign, *event.Aircraft, *event.Remarks)
-	} else if aircraftChanged {
-		s.GetEuroscopeHub().SendAircraftInfo(client.session, client.GetCid(), event.Callsign, *event.Aircraft)
-	} else if remarksChanged {
-		s.GetEuroscopeHub().SendRemarks(client.session, client.GetCid(), event.Callsign, *event.Remarks)
-	}
-
-	if event.Sid != nil && stringPtrValue(strip.Sid) != *event.Sid {
-		s.GetEuroscopeHub().SendSid(client.session, client.GetCid(), event.Callsign, *event.Sid)
-		if err := stripRepo.AppendControllerModifiedField(ctx, client.session, event.Callsign, "sid"); err != nil {
-			return err
-		}
-		if reevaluator, ok := client.hub.stripService.(pdcInvalidValidationStripReevaluator); ok {
-			sessionData, err := s.GetSessionRepository().GetByID(ctx, client.session)
-			if err != nil {
-				return err
-			}
-			updatedStrip := *strip
-			updatedStrip.Sid = event.Sid
-			if err := reevaluator.ReevaluatePdcInvalidValidationForStrip(ctx, client.session, &updatedStrip, sessionData.ActiveRunways.DepartureRunways, true, false); err != nil {
-				return err
-			}
-		}
-	}
-
-	if event.Stand != nil && stringPtrValue(strip.Stand) != *event.Stand {
-		s.GetEuroscopeHub().SendStand(client.session, client.GetCid(), event.Callsign, *event.Stand)
-		if err := stripRepo.AppendControllerModifiedField(ctx, client.session, event.Callsign, "stand"); err != nil {
-			return err
-		}
-		if client.hub.stripService != nil {
-			if err := client.hub.stripService.UpdateStand(ctx, client.session, event.Callsign, *event.Stand); err != nil {
-				return err
-			}
-		}
-	}
-
-	if event.Runway != nil && strip.Runway != event.Runway {
-		s.GetEuroscopeHub().SendRunway(client.session, client.GetCid(), event.Callsign, *event.Runway)
-		if _, err := stripRepo.UpdateRunway(ctx, client.session, event.Callsign, event.Runway, nil); err != nil {
-			return err
-		}
-		if err := stripRepo.AppendControllerModifiedField(ctx, client.session, event.Callsign, "runway"); err != nil {
-			return err
-		}
-		if client.hub.stripService != nil {
-			if err := client.hub.stripService.ReevaluatePdcInvalidValidation(ctx, client.session, event.Callsign, true, false); err != nil {
-				return err
-			}
-			if reevaluator, ok := client.hub.stripService.(departureValidationStripReevaluator); ok {
-				if err := reevaluator.ReevaluateDepartureValidation(ctx, client.session, event.Callsign, true, false); err != nil {
-					return err
-				}
-			}
-		}
-	}
-
-	if event.Eobt != nil && stringPtrValue(strip.EffectiveEobt()) != strings.TrimSpace(*event.Eobt) {
-		eobt := strings.TrimSpace(*event.Eobt)
-		if !isValidFrontendClockValue(eobt) {
-			return errors.New("invalid eobt: expected HHMM")
-		}
-		s.GetEuroscopeHub().SendEobt(client.session, client.GetCid(), event.Callsign, eobt)
-		cdmService := client.hub.server.GetCdmService()
-		if cdmService == nil {
-			return errors.New("CDM service not available")
-		}
-		if err := cdmService.HandleEobtUpdate(ctx, client.session, event.Callsign, eobt, client.position, "ATC"); err != nil {
-			return err
-		}
-		client.hub.SendStripUpdate(client.session, event.Callsign)
-	}
-
-	if event.Altitude != nil && strip.ClearedAltitude != event.Altitude {
-		s.GetEuroscopeHub().SendClearedAltitude(client.session, client.GetCid(), event.Callsign, *event.Altitude)
-		if err := stripRepo.AppendControllerModifiedField(ctx, client.session, event.Callsign, "cleared_altitude"); err != nil {
-			return err
-		}
-	}
-
-	if event.Heading != nil && strip.Heading != event.Heading {
-		s.GetEuroscopeHub().SendHeading(client.session, client.GetCid(), event.Callsign, *event.Heading)
-		if err := stripRepo.AppendControllerModifiedField(ctx, client.session, event.Callsign, "heading"); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return service.UpdateStrip(ctx, FrontendStripUpdateRequest{
+		Session:  client.session,
+		Cid:      client.GetCid(),
+		Position: client.position,
+		Event:    event,
+	})
 }
 
 func stringPtrValue(value *string) string {

--- a/backend/internal/frontend/handlers_test.go
+++ b/backend/internal/frontend/handlers_test.go
@@ -371,59 +371,148 @@ func TestHandleCoordinationTransferRequest_MarkClearFailureDoesNotRejectTransfer
 	assert.True(t, updateMarkedCalled)
 }
 
-func TestHandleStripUpdate_RunwayChangePersistsSelectedRunway(t *testing.T) {
+type recordingStripUpdateUseCase struct {
+	req FrontendStripUpdateRequest
+	err error
+}
+
+func (r *recordingStripUpdateUseCase) UpdateStrip(_ context.Context, req FrontendStripUpdateRequest) error {
+	r.req = req
+	return r.err
+}
+
+func TestHandleStripUpdate_DecodesAndDelegatesToUseCase(t *testing.T) {
+	ctx := context.Background()
+	const session = int32(7)
+	const cid = "123456"
+	const callsign = "SAS123"
+	const position = "EKCH_DEL"
+	route := "NEXIL Z20"
+
+	useCase := &recordingStripUpdateUseCase{}
+	hub := &Hub{stripUpdateService: useCase}
+	client := &Client{
+		session:  session,
+		hub:      hub,
+		position: position,
+	}
+	client.SetUser(shared.NewAuthenticatedUser(cid, 0, nil))
+
+	payload, err := json.Marshal(frontendEvents.UpdateStripDataEvent{
+		Type:     frontendEvents.UpdateStripData,
+		Callsign: callsign,
+		Route:    &route,
+	})
+	require.NoError(t, err)
+
+	err = handleStripUpdate(ctx, client, Message{
+		Type:    frontendEvents.UpdateStripData,
+		Message: payload,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, session, useCase.req.Session)
+	assert.Equal(t, cid, useCase.req.Cid)
+	assert.Equal(t, position, useCase.req.Position)
+	assert.Equal(t, callsign, useCase.req.Event.Callsign)
+	require.NotNil(t, useCase.req.Event.Route)
+	assert.Equal(t, route, *useCase.req.Event.Route)
+}
+
+func TestHandleStripUpdate_UsesHubWiringForServiceDependencies(t *testing.T) {
 	ctx := context.Background()
 	const session = int32(7)
 	const callsign = "SAS123"
-	currentRunway := "22L"
-	selectedRunway := "04R"
+	const cid = "123456"
+	const owner = "EKCH_DEL"
+	currentSid := "MIKRO"
+	selectedSid := "BETUD"
+	currentEobt := "1000"
+	updatedEobt := "1015"
 
-	var updatedRunway *string
-	var markedField string
+	getByCallsignCalls := 0
+	var handledEobt string
+	var reevaluatedSid *string
+	var reevaluatedRunways []string
 
 	stripRepo := &testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, gotSession int32, gotCallsign string) (*models.Strip, error) {
 			assert.Equal(t, session, gotSession)
 			assert.Equal(t, callsign, gotCallsign)
+			getByCallsignCalls++
 			return &models.Strip{
 				Callsign: callsign,
 				Session:  session,
-				Runway:   &currentRunway,
+				Owner:    ptr(owner),
+				Sid:      &currentSid,
+				PdcState: "REQUESTED_WITH_FAULTS",
+				CdmData: &models.CdmData{
+					Eobt: &currentEobt,
+				},
 			}, nil
-		},
-		UpdateRunwayFn: func(_ context.Context, gotSession int32, gotCallsign string, runway *string, version *int32) (int64, error) {
-			assert.Equal(t, session, gotSession)
-			assert.Equal(t, callsign, gotCallsign)
-			assert.Nil(t, version)
-			updatedRunway = runway
-			return 1, nil
 		},
 		AppendControllerModifiedFieldFn: func(_ context.Context, gotSession int32, gotCallsign string, field string) error {
 			assert.Equal(t, session, gotSession)
 			assert.Equal(t, callsign, gotCallsign)
-			markedField = field
+			assert.Contains(t, []string{"sid"}, field)
 			return nil
 		},
 	}
 
-	euroscopeHub := &testutil.MockEuroscopeHub{}
-	server := &testutil.MockServer{
-		StripRepoVal:    stripRepo,
-		EuroscopeHubVal: euroscopeHub,
+	cdmService := &recordingCdmService{
+		handleEobtUpdateFn: func(_ context.Context, gotSession int32, gotCallsign string, eobt string, sourcePosition string, sourceRole string) error {
+			assert.Equal(t, session, gotSession)
+			assert.Equal(t, callsign, gotCallsign)
+			assert.Equal(t, owner, sourcePosition)
+			assert.Equal(t, "ATC", sourceRole)
+			handledEobt = eobt
+			return nil
+		},
 	}
 
-	hub := &Hub{server: server, send: make(chan internalMessage, 1)}
+	server := &testutil.MockServer{
+		StripRepoVal: stripRepo,
+		SessionRepoVal: &testutil.MockSessionRepository{
+			GetByIDFn: func(_ context.Context, id int32) (*models.Session, error) {
+				assert.Equal(t, session, id)
+				return &models.Session{
+					ID: id,
+					ActiveRunways: pkgModels.ActiveRunways{
+						DepartureRunways: []string{"22R"},
+					},
+				}, nil
+			},
+		},
+		CdmServiceVal:   cdmService,
+		EuroscopeHubVal: &testutil.MockEuroscopeHub{},
+	}
+
+	hub := &Hub{
+		server: server,
+		stripService: &stripUpdateValidationReevaluator{
+			reevaluateForStripFn: func(_ context.Context, gotSession int32, strip *models.Strip, activeDepartureRunways []string, publish bool, forceReactivate bool) error {
+				assert.Equal(t, session, gotSession)
+				assert.True(t, publish)
+				assert.False(t, forceReactivate)
+				reevaluatedSid = strip.Sid
+				reevaluatedRunways = activeDepartureRunways
+				return nil
+			},
+		},
+		send:         make(chan internalMessage, 1),
+		clxOverrides: make(map[int32]map[string]bool),
+	}
 	client := &Client{
 		session:  session,
 		hub:      hub,
-		position: "EKCH_DEL",
+		position: owner,
 	}
-	client.SetUser(shared.NewAuthenticatedUser("123456", 0, nil))
+	client.SetUser(shared.NewAuthenticatedUser(cid, 0, nil))
 
 	payload, err := json.Marshal(frontendEvents.UpdateStripDataEvent{
 		Type:     frontendEvents.UpdateStripData,
 		Callsign: callsign,
-		Runway:   &selectedRunway,
+		Sid:      &selectedSid,
+		Eobt:     &updatedEobt,
 	})
 	require.NoError(t, err)
 
@@ -433,9 +522,21 @@ func TestHandleStripUpdate_RunwayChangePersistsSelectedRunway(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.NotNil(t, updatedRunway)
-	assert.Equal(t, selectedRunway, *updatedRunway)
-	assert.Equal(t, "runway", markedField)
+	assert.Equal(t, updatedEobt, handledEobt)
+	require.NotNil(t, reevaluatedSid)
+	assert.Equal(t, selectedSid, *reevaluatedSid)
+	assert.Equal(t, []string{"22R"}, reevaluatedRunways)
+	assert.Equal(t, 2, getByCallsignCalls)
+
+	select {
+	case msg := <-hub.send:
+		assert.Equal(t, session, msg.session)
+		update, ok := msg.message.(frontendEvents.StripUpdateEvent)
+		require.True(t, ok)
+		assert.Equal(t, callsign, update.Callsign)
+	case <-time.After(time.Second):
+		t.Fatal("expected strip update broadcast from hub publisher")
+	}
 }
 
 func TestRoundedClxTobtAddsFifteenMinutesAndRoundsUpToFive(t *testing.T) {
@@ -466,194 +567,6 @@ func TestRoundedClxTobtAddsFifteenMinutesAndRoundsUpToFive(t *testing.T) {
 			assert.Equal(t, tt.want, roundedClxTobt(tt.now))
 		})
 	}
-}
-
-func TestHandleStripUpdate_EobtChangeTriggersCdmRecalculation(t *testing.T) {
-	ctx := context.Background()
-	const session = int32(7)
-	const callsign = "SAS123"
-	currentEobt := "1000"
-	updatedEobt := "1015"
-	tobt := "1020"
-	tsat := "1030"
-	ctot := "1040"
-
-	var handledEobt string
-	getByCallsignCalls := 0
-
-	stripRepo := &testutil.MockStripRepository{
-		GetByCallsignFn: func(_ context.Context, gotSession int32, gotCallsign string) (*models.Strip, error) {
-			assert.Equal(t, session, gotSession)
-			assert.Equal(t, callsign, gotCallsign)
-			getByCallsignCalls++
-			return &models.Strip{
-				Callsign: callsign,
-				Session:  session,
-				Origin:   "EKCH",
-				CdmData: &models.CdmData{
-					Eobt: &currentEobt,
-					Tobt: &tobt,
-					Tsat: &tsat,
-					Ctot: &ctot,
-				},
-			}, nil
-		},
-	}
-
-	cdmService := &recordingCdmService{
-		handleEobtUpdateFn: func(_ context.Context, gotSession int32, gotCallsign string, eobt string, sourcePosition string, sourceRole string) error {
-			assert.Equal(t, session, gotSession)
-			assert.Equal(t, callsign, gotCallsign)
-			assert.Equal(t, "EKCH_DEL", sourcePosition)
-			assert.Equal(t, "ATC", sourceRole)
-			handledEobt = eobt
-			return nil
-		},
-	}
-	euroscopeHub := &testutil.MockEuroscopeHub{}
-
-	server := &testutil.MockServer{
-		StripRepoVal:    stripRepo,
-		CdmServiceVal:   cdmService,
-		EuroscopeHubVal: euroscopeHub,
-	}
-	hub := &Hub{
-		server: server,
-		send:   make(chan internalMessage, 2),
-	}
-	client := &Client{
-		session:  session,
-		hub:      hub,
-		position: "EKCH_DEL",
-	}
-	client.SetUser(shared.NewAuthenticatedUser("123456", 0, nil))
-
-	payload, err := json.Marshal(frontendEvents.UpdateStripDataEvent{
-		Type:     frontendEvents.UpdateStripData,
-		Callsign: callsign,
-		Eobt:     &updatedEobt,
-	})
-	require.NoError(t, err)
-
-	err = handleStripUpdate(ctx, client, Message{
-		Type:    frontendEvents.UpdateStripData,
-		Message: payload,
-	})
-	require.NoError(t, err)
-
-	assert.Equal(t, updatedEobt, handledEobt)
-	require.Len(t, euroscopeHub.Eobts, 1)
-	assert.Equal(t, session, euroscopeHub.Eobts[0].Session)
-	assert.Equal(t, "123456", euroscopeHub.Eobts[0].Cid)
-	assert.Equal(t, callsign, euroscopeHub.Eobts[0].Callsign)
-	assert.Equal(t, updatedEobt, euroscopeHub.Eobts[0].Eobt)
-	assert.Equal(t, 2, getByCallsignCalls)
-}
-
-func TestHandleStripUpdate_OwnerCanUpdateRemarksAndAircraftInfo(t *testing.T) {
-	ctx := context.Background()
-	const session = int32(7)
-	const callsign = "SAS123"
-	const owner = "EKCH_DEL"
-	currentRemarks := "REG/OYABC PBN/A1"
-	currentAircraftInfo := "B738/M-SDE2FGHIWY/LB1"
-	updatedRemarks := "REG/OYABC PBN/A1B1C1D1S1S2"
-	updatedAircraftInfo := "B738/M-SDE2FGHIWYR/LB1"
-
-	stripRepo := &testutil.MockStripRepository{
-		GetByCallsignFn: func(_ context.Context, gotSession int32, gotCallsign string) (*models.Strip, error) {
-			assert.Equal(t, session, gotSession)
-			assert.Equal(t, callsign, gotCallsign)
-			return &models.Strip{
-				Callsign:     callsign,
-				Session:      session,
-				Owner:        ptr(owner),
-				Remarks:      &currentRemarks,
-				AircraftType: &currentAircraftInfo,
-			}, nil
-		},
-	}
-
-	euroscopeHub := &testutil.MockEuroscopeHub{}
-	server := &testutil.MockServer{
-		StripRepoVal:    stripRepo,
-		EuroscopeHubVal: euroscopeHub,
-	}
-
-	hub := &Hub{server: server, send: make(chan internalMessage, 1)}
-	client := &Client{
-		session:  session,
-		hub:      hub,
-		position: owner,
-	}
-	client.SetUser(shared.NewAuthenticatedUser("123456", 0, nil))
-
-	payload, err := json.Marshal(frontendEvents.UpdateStripDataEvent{
-		Type:     frontendEvents.UpdateStripData,
-		Callsign: callsign,
-		Remarks:  &updatedRemarks,
-		Aircraft: &updatedAircraftInfo,
-	})
-	require.NoError(t, err)
-
-	err = handleStripUpdate(ctx, client, Message{
-		Type:    frontendEvents.UpdateStripData,
-		Message: payload,
-	})
-	require.NoError(t, err)
-
-	assert.Empty(t, euroscopeHub.RemarksUpdates)
-	assert.Empty(t, euroscopeHub.AircraftInfoUpdates)
-	require.Len(t, euroscopeHub.AircraftInfoRemarks, 1)
-	assert.Equal(t, updatedRemarks, euroscopeHub.AircraftInfoRemarks[0].Remarks)
-	assert.Equal(t, updatedAircraftInfo, euroscopeHub.AircraftInfoRemarks[0].AircraftType)
-	assert.Equal(t, []string{"aircraft_info_remarks"}, euroscopeHub.FlightPlanUpdateOrder)
-}
-
-func TestHandleStripUpdate_NonOwnerCannotUpdateRemarksOrAircraftInfo(t *testing.T) {
-	ctx := context.Background()
-	const session = int32(7)
-	const callsign = "SAS123"
-	owner := "EKCH_TWR"
-	updatedRemarks := "PBN/A1"
-	updatedAircraftInfo := "B738/M-SR"
-
-	stripRepo := &testutil.MockStripRepository{
-		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
-			return &models.Strip{
-				Callsign: callsign,
-				Session:  session,
-				Owner:    &owner,
-			}, nil
-		},
-	}
-
-	server := &testutil.MockServer{
-		StripRepoVal:    stripRepo,
-		EuroscopeHubVal: &testutil.MockEuroscopeHub{},
-	}
-	hub := &Hub{server: server}
-	client := &Client{
-		session:  session,
-		hub:      hub,
-		position: "EKCH_DEL",
-	}
-	client.SetUser(shared.NewAuthenticatedUser("123456", 0, nil))
-
-	payload, err := json.Marshal(frontendEvents.UpdateStripDataEvent{
-		Type:     frontendEvents.UpdateStripData,
-		Callsign: callsign,
-		Remarks:  &updatedRemarks,
-		Aircraft: &updatedAircraftInfo,
-	})
-	require.NoError(t, err)
-
-	err = handleStripUpdate(ctx, client, Message{
-		Type:    frontendEvents.UpdateStripData,
-		Message: payload,
-	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "non-owner")
 }
 
 func TestHandleUpdateRunwayStatus_SynchronizesAirportLvo(t *testing.T) {
@@ -714,164 +627,6 @@ func TestHandleUpdateRunwayStatus_SynchronizesAirportLvo(t *testing.T) {
 	assert.Equal(t, "LOW_VIS", persisted.RunwayStatus["04L/22L"])
 	assert.Equal(t, "EKCH", syncedAirport)
 	assert.Equal(t, "LOW_VIS", syncedStatus["04L/22L"])
-}
-
-func TestHandleStripUpdate_RunwayChangeReevaluatesDepartureValidation(t *testing.T) {
-	ctx := context.Background()
-	const session = int32(9)
-	const callsign = "SAS123"
-	currentRunway := "22L"
-	selectedRunway := "04R"
-
-	var reevaluatedCallsign string
-	var reevaluatedPublish bool
-	var reevaluatedForce bool
-
-	stripRepo := &testutil.MockStripRepository{
-		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
-			return &models.Strip{
-				Callsign: callsign,
-				Session:  session,
-				Runway:   &currentRunway,
-			}, nil
-		},
-		UpdateRunwayFn: func(_ context.Context, _ int32, _ string, _ *string, _ *int32) (int64, error) {
-			return 1, nil
-		},
-		AppendControllerModifiedFieldFn: func(_ context.Context, _ int32, _ string, _ string) error {
-			return nil
-		},
-	}
-
-	server := &testutil.MockServer{
-		StripRepoVal:    stripRepo,
-		EuroscopeHubVal: &testutil.MockEuroscopeHub{},
-	}
-
-	hub := &Hub{
-		server: server,
-		stripService: &stripUpdateValidationReevaluator{
-			reevaluateDepartureFn: func(_ context.Context, gotSession int32, gotCallsign string, publish bool, forceReactivate bool) error {
-				assert.Equal(t, session, gotSession)
-				reevaluatedCallsign = gotCallsign
-				reevaluatedPublish = publish
-				reevaluatedForce = forceReactivate
-				return nil
-			},
-		},
-	}
-	client := &Client{
-		session:  session,
-		hub:      hub,
-		position: "EKCH_A_GND",
-	}
-	client.SetUser(shared.NewAuthenticatedUser("123456", 0, nil))
-
-	payload, err := json.Marshal(frontendEvents.UpdateStripDataEvent{
-		Type:     frontendEvents.UpdateStripData,
-		Callsign: callsign,
-		Runway:   &selectedRunway,
-	})
-	require.NoError(t, err)
-
-	err = handleStripUpdate(ctx, client, Message{
-		Type:    frontendEvents.UpdateStripData,
-		Message: payload,
-	})
-	require.NoError(t, err)
-	assert.Equal(t, callsign, reevaluatedCallsign)
-	assert.True(t, reevaluatedPublish)
-	assert.False(t, reevaluatedForce)
-}
-
-func TestHandleStripUpdate_SidChangeReevaluatesPdcInvalidValidationUsingSelectedSid(t *testing.T) {
-	ctx := context.Background()
-	const session = int32(8)
-	const callsign = "SAS123"
-	currentSid := "MIKRO"
-	selectedSid := "BETUD"
-	owner := "EKCH_DEL"
-
-	var markedField string
-	var reevaluatedSid *string
-	var reevaluatedRunways []string
-	var reevaluatedPublish bool
-	var reevaluatedForce bool
-
-	stripRepo := &testutil.MockStripRepository{
-		GetByCallsignFn: func(_ context.Context, gotSession int32, gotCallsign string) (*models.Strip, error) {
-			assert.Equal(t, session, gotSession)
-			assert.Equal(t, callsign, gotCallsign)
-			return &models.Strip{
-				Callsign: callsign,
-				Session:  session,
-				Owner:    &owner,
-				Sid:      &currentSid,
-				PdcState: "REQUESTED_WITH_FAULTS",
-			}, nil
-		},
-		AppendControllerModifiedFieldFn: func(_ context.Context, gotSession int32, gotCallsign string, field string) error {
-			assert.Equal(t, session, gotSession)
-			assert.Equal(t, callsign, gotCallsign)
-			markedField = field
-			return nil
-		},
-	}
-
-	euroscopeHub := &testutil.MockEuroscopeHub{}
-	server := &testutil.MockServer{
-		StripRepoVal:    stripRepo,
-		EuroscopeHubVal: euroscopeHub,
-		SessionRepoVal: &testutil.MockSessionRepository{
-			GetByIDFn: func(_ context.Context, id int32) (*models.Session, error) {
-				assert.Equal(t, session, id)
-				return &models.Session{
-					ID: id,
-					ActiveRunways: pkgModels.ActiveRunways{
-						DepartureRunways: []string{"22R"},
-					},
-				}, nil
-			},
-		},
-	}
-
-	stripService := &stripUpdateValidationReevaluator{
-		reevaluateForStripFn: func(_ context.Context, gotSession int32, strip *models.Strip, activeDepartureRunways []string, publish bool, forceReactivate bool) error {
-			assert.Equal(t, session, gotSession)
-			reevaluatedSid = strip.Sid
-			reevaluatedRunways = activeDepartureRunways
-			reevaluatedPublish = publish
-			reevaluatedForce = forceReactivate
-			return nil
-		},
-	}
-	hub := &Hub{server: server, stripService: stripService}
-	client := &Client{
-		session:  session,
-		hub:      hub,
-		position: owner,
-	}
-	client.SetUser(shared.NewAuthenticatedUser("123456", 0, nil))
-
-	payload, err := json.Marshal(frontendEvents.UpdateStripDataEvent{
-		Type:     frontendEvents.UpdateStripData,
-		Callsign: callsign,
-		Sid:      &selectedSid,
-	})
-	require.NoError(t, err)
-
-	err = handleStripUpdate(ctx, client, Message{
-		Type:    frontendEvents.UpdateStripData,
-		Message: payload,
-	})
-	require.NoError(t, err)
-
-	assert.Equal(t, "sid", markedField)
-	require.NotNil(t, reevaluatedSid)
-	assert.Equal(t, selectedSid, *reevaluatedSid)
-	assert.Equal(t, []string{"22R"}, reevaluatedRunways)
-	assert.True(t, reevaluatedPublish)
-	assert.False(t, reevaluatedForce)
 }
 
 func TestHandleReleasePoint_OwnerMarksControllerModified(t *testing.T) {
@@ -1087,72 +842,6 @@ func (s *standUpdateStripService) UpdateStand(ctx context.Context, session int32
 		return nil
 	}
 	return s.updateStandFn(ctx, session, callsign, stand)
-}
-
-func TestHandleStripUpdate_StandChangeTriggersUpdateStand(t *testing.T) {
-	ctx := context.Background()
-	const session = int32(11)
-	const callsign = "SAS123"
-	const owner = "EKCH_A_GND"
-	currentStand := ""
-	selectedStand := "B12"
-
-	var updateStandCallsign string
-	var updateStandValue string
-	var markedField string
-
-	stripRepo := &testutil.MockStripRepository{
-		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
-			return &models.Strip{
-				Callsign: callsign,
-				Session:  session,
-				Owner:    ptr(owner),
-				Stand:    &currentStand,
-			}, nil
-		},
-		AppendControllerModifiedFieldFn: func(_ context.Context, _ int32, _ string, field string) error {
-			markedField = field
-			return nil
-		},
-	}
-
-	server := &testutil.MockServer{
-		StripRepoVal:    stripRepo,
-		EuroscopeHubVal: &testutil.MockEuroscopeHub{},
-	}
-
-	stripService := &standUpdateStripService{
-		updateStandFn: func(_ context.Context, _ int32, cs string, stand string) error {
-			updateStandCallsign = cs
-			updateStandValue = stand
-			return nil
-		},
-	}
-
-	hub := &Hub{server: server, stripService: stripService}
-	client := &Client{
-		session:  session,
-		hub:      hub,
-		position: owner,
-	}
-	client.SetUser(shared.NewAuthenticatedUser("123456", 0, nil))
-
-	payload, err := json.Marshal(frontendEvents.UpdateStripDataEvent{
-		Type:     frontendEvents.UpdateStripData,
-		Callsign: callsign,
-		Stand:    &selectedStand,
-	})
-	require.NoError(t, err)
-
-	err = handleStripUpdate(ctx, client, Message{
-		Type:    frontendEvents.UpdateStripData,
-		Message: payload,
-	})
-	require.NoError(t, err)
-
-	assert.Equal(t, "stand", markedField)
-	assert.Equal(t, callsign, updateStandCallsign)
-	assert.Equal(t, selectedStand, updateStandValue)
 }
 
 func ptr(s string) *string { return &s }

--- a/backend/internal/frontend/hub.go
+++ b/backend/internal/frontend/hub.go
@@ -52,6 +52,7 @@ type cidDisconnectMessage struct {
 type Hub struct {
 	server                shared.Server
 	stripService          shared.StripService
+	stripUpdateService    frontendStripUpdateUseCase
 	authenticationService shared.AuthenticationService
 	clients               map[*Client]bool
 
@@ -180,6 +181,47 @@ func (hub *Hub) GetServer() shared.Server {
 
 func (hub *Hub) SetServer(server shared.Server) {
 	hub.server = server
+	hub.stripUpdateService = hub.newStripUpdateService()
+}
+
+func (hub *Hub) getStripUpdateService() frontendStripUpdateUseCase {
+	if hub.stripUpdateService != nil {
+		return hub.stripUpdateService
+	}
+	hub.stripUpdateService = hub.newStripUpdateService()
+	return hub.stripUpdateService
+}
+
+func (hub *Hub) newStripUpdateService() frontendStripUpdateUseCase {
+	if hub.server == nil {
+		return nil
+	}
+
+	var standUpdater frontendStripUpdateStandUpdater
+	if hub.stripService != nil {
+		standUpdater = hub.stripService
+	}
+
+	var pdcReevaluator pdcInvalidValidationStripReevaluator
+	if reevaluator, ok := hub.stripService.(pdcInvalidValidationStripReevaluator); ok {
+		pdcReevaluator = reevaluator
+	}
+
+	var departureReevaluator departureValidationStripReevaluator
+	if reevaluator, ok := hub.stripService.(departureValidationStripReevaluator); ok {
+		departureReevaluator = reevaluator
+	}
+
+	return NewFrontendStripUpdateService(
+		hub.server.GetStripRepository(),
+		hub.server.GetSessionRepository(),
+		hub.server.GetEuroscopeHub(),
+		hub.server.GetCdmService(),
+		standUpdater,
+		pdcReevaluator,
+		departureReevaluator,
+		hub,
+	)
 }
 
 func (hub *Hub) HandleNewConnection(conn *gorilla.Conn, user shared.AuthenticatedUser, authenticationEvent events.AuthenticationEvent) (*Client, error) {

--- a/backend/internal/frontend/strip_update_service.go
+++ b/backend/internal/frontend/strip_update_service.go
@@ -1,0 +1,263 @@
+package frontend
+
+import (
+	frontendEvents "FlightStrips/pkg/events/frontend"
+	"context"
+	"errors"
+	"strings"
+
+	internalModels "FlightStrips/internal/models"
+	"FlightStrips/internal/repository"
+	"FlightStrips/internal/shared"
+)
+
+type frontendStripUpdateUseCase interface {
+	UpdateStrip(ctx context.Context, req FrontendStripUpdateRequest) error
+}
+
+type FrontendStripUpdateRequest struct {
+	Session  int32
+	Cid      string
+	Position string
+	Event    frontendEvents.UpdateStripDataEvent
+}
+
+type frontendStripUpdatePublisher interface {
+	SendStripUpdate(session int32, callsign string)
+}
+
+type frontendStripUpdateStandUpdater interface {
+	UpdateStand(ctx context.Context, session int32, callsign string, stand string) error
+}
+
+type frontendStripUpdateEuroscopeSender interface {
+	SendRoute(session int32, cid string, callsign string, route string)
+	SendAircraftInfoAndRemarks(session int32, cid string, callsign string, aircraftType string, remarks string)
+	SendAircraftInfo(session int32, cid string, callsign string, aircraftType string)
+	SendRemarks(session int32, cid string, callsign string, remarks string)
+	SendSid(session int32, cid string, callsign string, sid string)
+	SendStand(session int32, cid string, callsign string, stand string)
+	SendRunway(session int32, cid string, callsign string, runway string)
+	SendEobt(session int32, cid string, callsign string, eobt string)
+	SendClearedAltitude(session int32, cid string, callsign string, altitude int32)
+	SendHeading(session int32, cid string, callsign string, heading int32)
+}
+
+type FrontendStripUpdateService struct {
+	stripRepo            repository.StripRepository
+	sessionRepo          repository.SessionRepository
+	euroscopeSender      frontendStripUpdateEuroscopeSender
+	cdmService           shared.CdmService
+	standUpdater         frontendStripUpdateStandUpdater
+	pdcReevaluator       pdcInvalidValidationStripReevaluator
+	departureReevaluator departureValidationStripReevaluator
+	stripUpdatePublisher frontendStripUpdatePublisher
+}
+
+func NewFrontendStripUpdateService(
+	stripRepo repository.StripRepository,
+	sessionRepo repository.SessionRepository,
+	euroscopeSender frontendStripUpdateEuroscopeSender,
+	cdmService shared.CdmService,
+	standUpdater frontendStripUpdateStandUpdater,
+	pdcReevaluator pdcInvalidValidationStripReevaluator,
+	departureReevaluator departureValidationStripReevaluator,
+	stripUpdatePublisher frontendStripUpdatePublisher,
+) *FrontendStripUpdateService {
+	return &FrontendStripUpdateService{
+		stripRepo:            stripRepo,
+		sessionRepo:          sessionRepo,
+		euroscopeSender:      euroscopeSender,
+		cdmService:           cdmService,
+		standUpdater:         standUpdater,
+		pdcReevaluator:       pdcReevaluator,
+		departureReevaluator: departureReevaluator,
+		stripUpdatePublisher: stripUpdatePublisher,
+	}
+}
+
+func (s *FrontendStripUpdateService) UpdateStrip(ctx context.Context, req FrontendStripUpdateRequest) error {
+	if req.Event.Route != nil && req.Event.Sid != nil {
+		return errors.New("cannot update both route and sid at the same time")
+	}
+
+	strip, err := s.stripRepo.GetByCallsign(ctx, req.Session, req.Event.Callsign)
+	if err != nil {
+		return err
+	}
+
+	isOwner := strip.Owner == nil || *strip.Owner == "" || *strip.Owner == req.Position
+	if !isOwner {
+		if req.Event.Sid != nil || req.Event.Route != nil || req.Event.Stand != nil || req.Event.Runway != nil || req.Event.Altitude != nil || req.Event.Heading != nil || req.Event.Remarks != nil || req.Event.Aircraft != nil {
+			return errors.New("non-owner cannot modify strip fields")
+		}
+		return nil
+	}
+
+	if err := s.handleRouteUpdate(req, strip); err != nil {
+		return err
+	}
+	if err := s.handleAircraftAndRemarksUpdate(req, strip); err != nil {
+		return err
+	}
+	if err := s.handleSidUpdate(ctx, req, strip); err != nil {
+		return err
+	}
+	if err := s.handleStandUpdate(ctx, req, strip); err != nil {
+		return err
+	}
+	if err := s.handleRunwayUpdate(ctx, req, strip); err != nil {
+		return err
+	}
+	if err := s.handleEobtUpdate(ctx, req, strip); err != nil {
+		return err
+	}
+	if err := s.handleAltitudeUpdate(ctx, req, strip); err != nil {
+		return err
+	}
+	if err := s.handleHeadingUpdate(ctx, req, strip); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *FrontendStripUpdateService) handleRouteUpdate(req FrontendStripUpdateRequest, strip *internalModels.Strip) error {
+	if req.Event.Route == nil || stringPtrValue(strip.Route) == *req.Event.Route {
+		return nil
+	}
+
+	s.euroscopeSender.SendRoute(req.Session, req.Cid, req.Event.Callsign, *req.Event.Route)
+	return nil
+}
+
+func (s *FrontendStripUpdateService) handleAircraftAndRemarksUpdate(req FrontendStripUpdateRequest, strip *internalModels.Strip) error {
+	aircraftChanged := req.Event.Aircraft != nil && stringPtrValue(strip.AircraftType) != *req.Event.Aircraft
+	remarksChanged := req.Event.Remarks != nil && stringPtrValue(strip.Remarks) != *req.Event.Remarks
+
+	switch {
+	case aircraftChanged && remarksChanged:
+		s.euroscopeSender.SendAircraftInfoAndRemarks(req.Session, req.Cid, req.Event.Callsign, *req.Event.Aircraft, *req.Event.Remarks)
+	case aircraftChanged:
+		s.euroscopeSender.SendAircraftInfo(req.Session, req.Cid, req.Event.Callsign, *req.Event.Aircraft)
+	case remarksChanged:
+		s.euroscopeSender.SendRemarks(req.Session, req.Cid, req.Event.Callsign, *req.Event.Remarks)
+	}
+
+	return nil
+}
+
+func (s *FrontendStripUpdateService) handleSidUpdate(ctx context.Context, req FrontendStripUpdateRequest, strip *internalModels.Strip) error {
+	if req.Event.Sid == nil || stringPtrValue(strip.Sid) == *req.Event.Sid {
+		return nil
+	}
+
+	s.euroscopeSender.SendSid(req.Session, req.Cid, req.Event.Callsign, *req.Event.Sid)
+	if err := s.stripRepo.AppendControllerModifiedField(ctx, req.Session, req.Event.Callsign, "sid"); err != nil {
+		return err
+	}
+	if s.pdcReevaluator == nil {
+		return nil
+	}
+
+	sessionData, err := s.sessionRepo.GetByID(ctx, req.Session)
+	if err != nil {
+		return err
+	}
+	updatedStrip := *strip
+	updatedStrip.Sid = req.Event.Sid
+
+	return s.pdcReevaluator.ReevaluatePdcInvalidValidationForStrip(ctx, req.Session, &updatedStrip, sessionData.ActiveRunways.DepartureRunways, true, false)
+}
+
+func (s *FrontendStripUpdateService) handleStandUpdate(ctx context.Context, req FrontendStripUpdateRequest, strip *internalModels.Strip) error {
+	if req.Event.Stand == nil || stringPtrValue(strip.Stand) == *req.Event.Stand {
+		return nil
+	}
+
+	s.euroscopeSender.SendStand(req.Session, req.Cid, req.Event.Callsign, *req.Event.Stand)
+	if err := s.stripRepo.AppendControllerModifiedField(ctx, req.Session, req.Event.Callsign, "stand"); err != nil {
+		return err
+	}
+	if s.standUpdater != nil {
+		return s.standUpdater.UpdateStand(ctx, req.Session, req.Event.Callsign, *req.Event.Stand)
+	}
+
+	return nil
+}
+
+func (s *FrontendStripUpdateService) handleRunwayUpdate(ctx context.Context, req FrontendStripUpdateRequest, strip *internalModels.Strip) error {
+	if req.Event.Runway == nil || stringPtrValue(strip.Runway) == *req.Event.Runway {
+		return nil
+	}
+
+	s.euroscopeSender.SendRunway(req.Session, req.Cid, req.Event.Callsign, *req.Event.Runway)
+	if _, err := s.stripRepo.UpdateRunway(ctx, req.Session, req.Event.Callsign, req.Event.Runway, nil); err != nil {
+		return err
+	}
+	if err := s.stripRepo.AppendControllerModifiedField(ctx, req.Session, req.Event.Callsign, "runway"); err != nil {
+		return err
+	}
+	if s.pdcReevaluator != nil {
+		if err := s.pdcReevaluator.ReevaluatePdcInvalidValidation(ctx, req.Session, req.Event.Callsign, true, false); err != nil {
+			return err
+		}
+	}
+	if s.departureReevaluator != nil {
+		return s.departureReevaluator.ReevaluateDepartureValidation(ctx, req.Session, req.Event.Callsign, true, false)
+	}
+
+	return nil
+}
+
+func (s *FrontendStripUpdateService) handleEobtUpdate(ctx context.Context, req FrontendStripUpdateRequest, strip *internalModels.Strip) error {
+	if req.Event.Eobt == nil {
+		return nil
+	}
+
+	eobt := strings.TrimSpace(*req.Event.Eobt)
+	if stringPtrValue(strip.EffectiveEobt()) == eobt {
+		return nil
+	}
+	if !isValidFrontendClockValue(eobt) {
+		return errors.New("invalid eobt: expected HHMM")
+	}
+
+	s.euroscopeSender.SendEobt(req.Session, req.Cid, req.Event.Callsign, eobt)
+	if s.cdmService == nil {
+		return errors.New("CDM service not available")
+	}
+	if err := s.cdmService.HandleEobtUpdate(ctx, req.Session, req.Event.Callsign, eobt, req.Position, "ATC"); err != nil {
+		return err
+	}
+	if s.stripUpdatePublisher != nil {
+		s.stripUpdatePublisher.SendStripUpdate(req.Session, req.Event.Callsign)
+	}
+
+	return nil
+}
+
+func (s *FrontendStripUpdateService) handleAltitudeUpdate(ctx context.Context, req FrontendStripUpdateRequest, strip *internalModels.Strip) error {
+	if req.Event.Altitude == nil || int32PointerEquals(strip.ClearedAltitude, req.Event.Altitude) {
+		return nil
+	}
+
+	s.euroscopeSender.SendClearedAltitude(req.Session, req.Cid, req.Event.Callsign, *req.Event.Altitude)
+	return s.stripRepo.AppendControllerModifiedField(ctx, req.Session, req.Event.Callsign, "cleared_altitude")
+}
+
+func (s *FrontendStripUpdateService) handleHeadingUpdate(ctx context.Context, req FrontendStripUpdateRequest, strip *internalModels.Strip) error {
+	if req.Event.Heading == nil || int32PointerEquals(strip.Heading, req.Event.Heading) {
+		return nil
+	}
+
+	s.euroscopeSender.SendHeading(req.Session, req.Cid, req.Event.Callsign, *req.Event.Heading)
+	return s.stripRepo.AppendControllerModifiedField(ctx, req.Session, req.Event.Callsign, "heading")
+}
+
+func int32PointerEquals(left *int32, right *int32) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
+}

--- a/backend/internal/frontend/strip_update_service_test.go
+++ b/backend/internal/frontend/strip_update_service_test.go
@@ -1,0 +1,596 @@
+package frontend
+
+import (
+	"context"
+	"testing"
+
+	"FlightStrips/internal/models"
+	"FlightStrips/internal/testutil"
+	frontendEvents "FlightStrips/pkg/events/frontend"
+	pkgModels "FlightStrips/pkg/models"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingStripUpdatePublisher struct {
+	session  int32
+	callsign string
+	calls    int
+}
+
+func (p *recordingStripUpdatePublisher) SendStripUpdate(session int32, callsign string) {
+	p.session = session
+	p.callsign = callsign
+	p.calls++
+}
+
+type recordingStripUpdateEuroscopeSender struct {
+	runways          []string
+	clearedAltitudes []int32
+	headings         []int32
+}
+
+func (s *recordingStripUpdateEuroscopeSender) SendRoute(_ int32, _ string, _ string, _ string) {}
+func (s *recordingStripUpdateEuroscopeSender) SendAircraftInfoAndRemarks(_ int32, _ string, _ string, _ string, _ string) {
+}
+func (s *recordingStripUpdateEuroscopeSender) SendAircraftInfo(_ int32, _ string, _ string, _ string) {
+}
+func (s *recordingStripUpdateEuroscopeSender) SendRemarks(_ int32, _ string, _ string, _ string) {}
+func (s *recordingStripUpdateEuroscopeSender) SendSid(_ int32, _ string, _ string, _ string)     {}
+func (s *recordingStripUpdateEuroscopeSender) SendStand(_ int32, _ string, _ string, _ string)   {}
+func (s *recordingStripUpdateEuroscopeSender) SendRunway(_ int32, _ string, _ string, runway string) {
+	s.runways = append(s.runways, runway)
+}
+func (s *recordingStripUpdateEuroscopeSender) SendEobt(_ int32, _ string, _ string, _ string) {}
+func (s *recordingStripUpdateEuroscopeSender) SendClearedAltitude(_ int32, _ string, _ string, altitude int32) {
+	s.clearedAltitudes = append(s.clearedAltitudes, altitude)
+}
+func (s *recordingStripUpdateEuroscopeSender) SendHeading(_ int32, _ string, _ string, heading int32) {
+	s.headings = append(s.headings, heading)
+}
+
+func TestFrontendStripUpdateService_RunwayChangePersistsSelectedRunway(t *testing.T) {
+	ctx := context.Background()
+	const session = int32(7)
+	const callsign = "SAS123"
+	currentRunway := "22L"
+	selectedRunway := "04R"
+
+	var updatedRunway *string
+	var markedField string
+
+	stripRepo := &testutil.MockStripRepository{
+		GetByCallsignFn: func(_ context.Context, gotSession int32, gotCallsign string) (*models.Strip, error) {
+			assert.Equal(t, session, gotSession)
+			assert.Equal(t, callsign, gotCallsign)
+			return &models.Strip{
+				Callsign: callsign,
+				Session:  session,
+				Runway:   &currentRunway,
+			}, nil
+		},
+		UpdateRunwayFn: func(_ context.Context, gotSession int32, gotCallsign string, runway *string, version *int32) (int64, error) {
+			assert.Equal(t, session, gotSession)
+			assert.Equal(t, callsign, gotCallsign)
+			assert.Nil(t, version)
+			updatedRunway = runway
+			return 1, nil
+		},
+		AppendControllerModifiedFieldFn: func(_ context.Context, gotSession int32, gotCallsign string, field string) error {
+			assert.Equal(t, session, gotSession)
+			assert.Equal(t, callsign, gotCallsign)
+			markedField = field
+			return nil
+		},
+	}
+
+	service := NewFrontendStripUpdateService(
+		stripRepo,
+		nil,
+		&testutil.MockEuroscopeHub{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	err := service.UpdateStrip(ctx, FrontendStripUpdateRequest{
+		Session:  session,
+		Cid:      "123456",
+		Position: "EKCH_DEL",
+		Event: frontendEvents.UpdateStripDataEvent{
+			Callsign: callsign,
+			Runway:   &selectedRunway,
+		},
+	})
+	require.NoError(t, err)
+
+	require.NotNil(t, updatedRunway)
+	assert.Equal(t, selectedRunway, *updatedRunway)
+	assert.Equal(t, "runway", markedField)
+}
+
+func TestFrontendStripUpdateService_EobtChangeTriggersCdmRecalculation(t *testing.T) {
+	ctx := context.Background()
+	const session = int32(7)
+	const callsign = "SAS123"
+	currentEobt := "1000"
+	updatedEobt := "1015"
+	tobt := "1020"
+	tsat := "1030"
+	ctot := "1040"
+
+	var handledEobt string
+
+	stripRepo := &testutil.MockStripRepository{
+		GetByCallsignFn: func(_ context.Context, gotSession int32, gotCallsign string) (*models.Strip, error) {
+			assert.Equal(t, session, gotSession)
+			assert.Equal(t, callsign, gotCallsign)
+			return &models.Strip{
+				Callsign: callsign,
+				Session:  session,
+				Origin:   "EKCH",
+				CdmData: &models.CdmData{
+					Eobt: &currentEobt,
+					Tobt: &tobt,
+					Tsat: &tsat,
+					Ctot: &ctot,
+				},
+			}, nil
+		},
+	}
+
+	cdmService := &recordingCdmService{
+		handleEobtUpdateFn: func(_ context.Context, gotSession int32, gotCallsign string, eobt string, sourcePosition string, sourceRole string) error {
+			assert.Equal(t, session, gotSession)
+			assert.Equal(t, callsign, gotCallsign)
+			assert.Equal(t, "EKCH_DEL", sourcePosition)
+			assert.Equal(t, "ATC", sourceRole)
+			handledEobt = eobt
+			return nil
+		},
+	}
+	euroscopeHub := &testutil.MockEuroscopeHub{}
+	publisher := &recordingStripUpdatePublisher{}
+
+	service := NewFrontendStripUpdateService(
+		stripRepo,
+		nil,
+		euroscopeHub,
+		cdmService,
+		nil,
+		nil,
+		nil,
+		publisher,
+	)
+
+	err := service.UpdateStrip(ctx, FrontendStripUpdateRequest{
+		Session:  session,
+		Cid:      "123456",
+		Position: "EKCH_DEL",
+		Event: frontendEvents.UpdateStripDataEvent{
+			Callsign: callsign,
+			Eobt:     &updatedEobt,
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, updatedEobt, handledEobt)
+	require.Len(t, euroscopeHub.Eobts, 1)
+	assert.Equal(t, session, euroscopeHub.Eobts[0].Session)
+	assert.Equal(t, "123456", euroscopeHub.Eobts[0].Cid)
+	assert.Equal(t, callsign, euroscopeHub.Eobts[0].Callsign)
+	assert.Equal(t, updatedEobt, euroscopeHub.Eobts[0].Eobt)
+	assert.Equal(t, 1, publisher.calls)
+	assert.Equal(t, session, publisher.session)
+	assert.Equal(t, callsign, publisher.callsign)
+}
+
+func TestFrontendStripUpdateService_OwnerCanUpdateRemarksAndAircraftInfo(t *testing.T) {
+	ctx := context.Background()
+	const session = int32(7)
+	const callsign = "SAS123"
+	const owner = "EKCH_DEL"
+	currentRemarks := "REG/OYABC PBN/A1"
+	currentAircraftInfo := "B738/M-SDE2FGHIWY/LB1"
+	updatedRemarks := "REG/OYABC PBN/A1B1C1D1S1S2"
+	updatedAircraftInfo := "B738/M-SDE2FGHIWYR/LB1"
+
+	stripRepo := &testutil.MockStripRepository{
+		GetByCallsignFn: func(_ context.Context, gotSession int32, gotCallsign string) (*models.Strip, error) {
+			assert.Equal(t, session, gotSession)
+			assert.Equal(t, callsign, gotCallsign)
+			return &models.Strip{
+				Callsign:     callsign,
+				Session:      session,
+				Owner:        ptr(owner),
+				Remarks:      &currentRemarks,
+				AircraftType: &currentAircraftInfo,
+			}, nil
+		},
+	}
+
+	euroscopeHub := &testutil.MockEuroscopeHub{}
+	service := NewFrontendStripUpdateService(
+		stripRepo,
+		nil,
+		euroscopeHub,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	err := service.UpdateStrip(ctx, FrontendStripUpdateRequest{
+		Session:  session,
+		Cid:      "123456",
+		Position: owner,
+		Event: frontendEvents.UpdateStripDataEvent{
+			Callsign: callsign,
+			Remarks:  &updatedRemarks,
+			Aircraft: &updatedAircraftInfo,
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Empty(t, euroscopeHub.RemarksUpdates)
+	assert.Empty(t, euroscopeHub.AircraftInfoUpdates)
+	require.Len(t, euroscopeHub.AircraftInfoRemarks, 1)
+	assert.Equal(t, updatedRemarks, euroscopeHub.AircraftInfoRemarks[0].Remarks)
+	assert.Equal(t, updatedAircraftInfo, euroscopeHub.AircraftInfoRemarks[0].AircraftType)
+	assert.Equal(t, []string{"aircraft_info_remarks"}, euroscopeHub.FlightPlanUpdateOrder)
+}
+
+func TestFrontendStripUpdateService_NonOwnerCannotUpdateRemarksOrAircraftInfo(t *testing.T) {
+	ctx := context.Background()
+	const session = int32(7)
+	const callsign = "SAS123"
+	owner := "EKCH_TWR"
+	updatedRemarks := "PBN/A1"
+	updatedAircraftInfo := "B738/M-SR"
+
+	stripRepo := &testutil.MockStripRepository{
+		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
+			return &models.Strip{
+				Callsign: callsign,
+				Session:  session,
+				Owner:    &owner,
+			}, nil
+		},
+	}
+
+	service := NewFrontendStripUpdateService(
+		stripRepo,
+		nil,
+		&testutil.MockEuroscopeHub{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	err := service.UpdateStrip(ctx, FrontendStripUpdateRequest{
+		Session:  session,
+		Cid:      "123456",
+		Position: "EKCH_DEL",
+		Event: frontendEvents.UpdateStripDataEvent{
+			Callsign: callsign,
+			Remarks:  &updatedRemarks,
+			Aircraft: &updatedAircraftInfo,
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-owner")
+}
+
+func TestFrontendStripUpdateService_RunwayChangeReevaluatesDepartureValidation(t *testing.T) {
+	ctx := context.Background()
+	const session = int32(9)
+	const callsign = "SAS123"
+	currentRunway := "22L"
+	selectedRunway := "04R"
+
+	var reevaluatedCallsign string
+	var reevaluatedPublish bool
+	var reevaluatedForce bool
+
+	stripRepo := &testutil.MockStripRepository{
+		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
+			return &models.Strip{
+				Callsign: callsign,
+				Session:  session,
+				Runway:   &currentRunway,
+			}, nil
+		},
+		UpdateRunwayFn: func(_ context.Context, _ int32, _ string, _ *string, _ *int32) (int64, error) {
+			return 1, nil
+		},
+		AppendControllerModifiedFieldFn: func(_ context.Context, _ int32, _ string, _ string) error {
+			return nil
+		},
+	}
+
+	service := NewFrontendStripUpdateService(
+		stripRepo,
+		nil,
+		&testutil.MockEuroscopeHub{},
+		nil,
+		nil,
+		nil,
+		&stripUpdateValidationReevaluator{
+			reevaluateDepartureFn: func(_ context.Context, gotSession int32, gotCallsign string, publish bool, forceReactivate bool) error {
+				assert.Equal(t, session, gotSession)
+				reevaluatedCallsign = gotCallsign
+				reevaluatedPublish = publish
+				reevaluatedForce = forceReactivate
+				return nil
+			},
+		},
+		nil,
+	)
+
+	err := service.UpdateStrip(ctx, FrontendStripUpdateRequest{
+		Session:  session,
+		Cid:      "123456",
+		Position: "EKCH_A_GND",
+		Event: frontendEvents.UpdateStripDataEvent{
+			Callsign: callsign,
+			Runway:   &selectedRunway,
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, callsign, reevaluatedCallsign)
+	assert.True(t, reevaluatedPublish)
+	assert.False(t, reevaluatedForce)
+}
+
+func TestFrontendStripUpdateService_SidChangeReevaluatesPdcInvalidValidationUsingSelectedSid(t *testing.T) {
+	ctx := context.Background()
+	const session = int32(8)
+	const callsign = "SAS123"
+	currentSid := "MIKRO"
+	selectedSid := "BETUD"
+	owner := "EKCH_DEL"
+
+	var markedField string
+	var reevaluatedSid *string
+	var reevaluatedRunways []string
+	var reevaluatedPublish bool
+	var reevaluatedForce bool
+
+	stripRepo := &testutil.MockStripRepository{
+		GetByCallsignFn: func(_ context.Context, gotSession int32, gotCallsign string) (*models.Strip, error) {
+			assert.Equal(t, session, gotSession)
+			assert.Equal(t, callsign, gotCallsign)
+			return &models.Strip{
+				Callsign: callsign,
+				Session:  session,
+				Owner:    &owner,
+				Sid:      &currentSid,
+				PdcState: "REQUESTED_WITH_FAULTS",
+			}, nil
+		},
+		AppendControllerModifiedFieldFn: func(_ context.Context, gotSession int32, gotCallsign string, field string) error {
+			assert.Equal(t, session, gotSession)
+			assert.Equal(t, callsign, gotCallsign)
+			markedField = field
+			return nil
+		},
+	}
+
+	service := NewFrontendStripUpdateService(
+		stripRepo,
+		&testutil.MockSessionRepository{
+			GetByIDFn: func(_ context.Context, id int32) (*models.Session, error) {
+				assert.Equal(t, session, id)
+				return &models.Session{
+					ID: id,
+					ActiveRunways: pkgModels.ActiveRunways{
+						DepartureRunways: []string{"22R"},
+					},
+				}, nil
+			},
+		},
+		&testutil.MockEuroscopeHub{},
+		nil,
+		nil,
+		&stripUpdateValidationReevaluator{
+			reevaluateForStripFn: func(_ context.Context, gotSession int32, strip *models.Strip, activeDepartureRunways []string, publish bool, forceReactivate bool) error {
+				assert.Equal(t, session, gotSession)
+				reevaluatedSid = strip.Sid
+				reevaluatedRunways = activeDepartureRunways
+				reevaluatedPublish = publish
+				reevaluatedForce = forceReactivate
+				return nil
+			},
+		},
+		nil,
+		nil,
+	)
+
+	err := service.UpdateStrip(ctx, FrontendStripUpdateRequest{
+		Session:  session,
+		Cid:      "123456",
+		Position: owner,
+		Event: frontendEvents.UpdateStripDataEvent{
+			Callsign: callsign,
+			Sid:      &selectedSid,
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "sid", markedField)
+	require.NotNil(t, reevaluatedSid)
+	assert.Equal(t, selectedSid, *reevaluatedSid)
+	assert.Equal(t, []string{"22R"}, reevaluatedRunways)
+	assert.True(t, reevaluatedPublish)
+	assert.False(t, reevaluatedForce)
+}
+
+func TestFrontendStripUpdateService_StandChangeTriggersUpdateStand(t *testing.T) {
+	ctx := context.Background()
+	const session = int32(11)
+	const callsign = "SAS123"
+	const owner = "EKCH_A_GND"
+	currentStand := ""
+	selectedStand := "B12"
+
+	var updateStandCallsign string
+	var updateStandValue string
+	var markedField string
+
+	stripRepo := &testutil.MockStripRepository{
+		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
+			return &models.Strip{
+				Callsign: callsign,
+				Session:  session,
+				Owner:    ptr(owner),
+				Stand:    &currentStand,
+			}, nil
+		},
+		AppendControllerModifiedFieldFn: func(_ context.Context, _ int32, _ string, field string) error {
+			markedField = field
+			return nil
+		},
+	}
+
+	stripService := &standUpdateStripService{
+		updateStandFn: func(_ context.Context, _ int32, cs string, stand string) error {
+			updateStandCallsign = cs
+			updateStandValue = stand
+			return nil
+		},
+	}
+
+	service := NewFrontendStripUpdateService(
+		stripRepo,
+		nil,
+		&testutil.MockEuroscopeHub{},
+		nil,
+		stripService,
+		nil,
+		nil,
+		nil,
+	)
+
+	err := service.UpdateStrip(ctx, FrontendStripUpdateRequest{
+		Session:  session,
+		Cid:      "123456",
+		Position: owner,
+		Event: frontendEvents.UpdateStripDataEvent{
+			Callsign: callsign,
+			Stand:    &selectedStand,
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "stand", markedField)
+	assert.Equal(t, callsign, updateStandCallsign)
+	assert.Equal(t, selectedStand, updateStandValue)
+}
+
+func TestFrontendStripUpdateService_ValueMatchedRunwayAltitudeAndHeadingAreNoOps(t *testing.T) {
+	ctx := context.Background()
+	const session = int32(5)
+	const callsign = "SAS123"
+	runway := "22L"
+	altitude := int32(5000)
+	heading := int32(220)
+
+	stripRepo := &testutil.MockStripRepository{
+		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
+			return &models.Strip{
+				Callsign:        callsign,
+				Session:         session,
+				Runway:          ptr(runway),
+				ClearedAltitude: &altitude,
+				Heading:         &heading,
+			}, nil
+		},
+	}
+	sender := &recordingStripUpdateEuroscopeSender{}
+
+	sameRunway := "22L"
+	sameAltitude := int32(5000)
+	sameHeading := int32(220)
+
+	service := NewFrontendStripUpdateService(
+		stripRepo,
+		nil,
+		sender,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	err := service.UpdateStrip(ctx, FrontendStripUpdateRequest{
+		Session:  session,
+		Cid:      "123456",
+		Position: "EKCH_DEL",
+		Event: frontendEvents.UpdateStripDataEvent{
+			Callsign: callsign,
+			Runway:   &sameRunway,
+			Altitude: &sameAltitude,
+			Heading:  &sameHeading,
+		},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, sender.runways)
+	assert.Empty(t, sender.clearedAltitudes)
+	assert.Empty(t, sender.headings)
+}
+
+func TestFrontendStripUpdateService_NilStoredAltitudeAndHeadingStillForwardExplicitZero(t *testing.T) {
+	ctx := context.Background()
+	const session = int32(6)
+	const callsign = "SAS321"
+	zero := int32(0)
+
+	var markedFields []string
+
+	stripRepo := &testutil.MockStripRepository{
+		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
+			return &models.Strip{
+				Callsign: callsign,
+				Session:  session,
+			}, nil
+		},
+		AppendControllerModifiedFieldFn: func(_ context.Context, _ int32, _ string, fieldName string) error {
+			markedFields = append(markedFields, fieldName)
+			return nil
+		},
+	}
+	sender := &recordingStripUpdateEuroscopeSender{}
+
+	service := NewFrontendStripUpdateService(
+		stripRepo,
+		nil,
+		sender,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	err := service.UpdateStrip(ctx, FrontendStripUpdateRequest{
+		Session:  session,
+		Cid:      "123456",
+		Position: "EKCH_DEL",
+		Event: frontendEvents.UpdateStripDataEvent{
+			Callsign: callsign,
+			Altitude: &zero,
+			Heading:  &zero,
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []int32{0}, sender.clearedAltitudes)
+	assert.Equal(t, []int32{0}, sender.headings)
+	assert.Equal(t, []string{"cleared_altitude", "heading"}, markedFields)
+}


### PR DESCRIPTION
## Summary
- Move strip update logic out of the frontend handlers into a dedicated service
- Keep websocket hub interactions focused on routing and delivery
- Add and update tests around strip update handling and service behavior

## Testing
- Not run (not requested)