### PR TITLE
chore(strip): remove shared server service locator

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -158,15 +158,19 @@ func main() {
 	tacticalStripRepo := postgres.NewTacticalStripRepository(dbpool)
 
 	// Initialize services
-	stripService := services.NewStripService(stripRepo)
+	stripService := services.NewStripService(
+		stripRepo,
+		services.WithTacticalStripRepository(tacticalStripRepo),
+		services.WithCoordinationStore(coordRepo),
+		services.WithControllerReader(controllerRepo),
+		services.WithSessionReader(sessionRepo),
+		services.WithSectorOwnerRepository(sectorRepo),
+	)
 	controllerService := services.NewControllerService(controllerRepo)
 	cdmService := cdm.NewCdmService(cdmClient, stripRepo, sessionRepo, controllerRepo)
 	ecfmpBaseURL := getEnv("ECFMP_BASE_URL", ecfmp.DefaultBaseURL)
 	ecfmpClient := ecfmp.NewClient(ecfmp.WithBaseURL(ecfmpBaseURL))
 
-	stripService.SetTacticalStripRepo(tacticalStripRepo)
-	stripService.SetCoordinationRepo(coordRepo)
-	stripService.SetControllerRepo(controllerRepo)
 	stripService.SetCdmService(cdmService)
 	cdmService.SetValidationReevaluator(stripService)
 
@@ -268,6 +272,7 @@ func main() {
 	slog.Info("CDM local calculation enabled", slog.String("rateUri", resolveURI(cdmCfg.RateUri)))
 
 	if pdcService != nil {
+		stripService.SetPdcService(pdcService)
 		pdcService.SetFrontendHub(frontendHub)
 		pdcService.SetEuroscopeHub(euroscopeHub)
 	}
@@ -276,7 +281,9 @@ func main() {
 
 	frontendHub.SetServer(fsServer)
 	euroscopeHub.SetServer(fsServer)
-	controllerService.SetServer(fsServer)
+	stripService.SetRouteRecalculator(fsServer)
+	controllerService.SetFrontendNotifier(frontendHub)
+	controllerService.SetSessionRecalculator(fsServer)
 	controllerService.SetStripService(stripService)
 
 	frontendUpgrader := websocket.NewConnectionUpgrader[pkgFrontend.EventType, *frontend.Client](frontendHub, authenticationService)

--- a/backend/internal/euroscope/handlers_login_test.go
+++ b/backend/internal/euroscope/handlers_login_test.go
@@ -520,7 +520,7 @@ func TestHandleLoginEvent_ThenControllerOnline_ForcesOrchestrationForSamePositio
 	}
 
 	controllerService := services.NewControllerService(controllerRepo)
-	controllerService.SetServer(server)
+	controllerService.SetSessionRecalculator(server)
 
 	hub := &Hub{
 		server:                      server,

--- a/backend/internal/services/controller.go
+++ b/backend/internal/services/controller.go
@@ -14,23 +14,32 @@ import (
 
 // ControllerService owns all controller online/offline business logic.
 type ControllerService struct {
-	controllerRepo repository.ControllerRepository
-	server         shared.Server
-	stripService   shared.StripService
+	controllerRepo      repository.ControllerRepository
+	frontendNotifier    FrontendNotifier
+	sessionRecalculator SessionRecalculator
+	stripService        shared.StripService
 }
 
-func NewControllerService(controllerRepo repository.ControllerRepository) *ControllerService {
-	return &ControllerService{
+func NewControllerService(controllerRepo repository.ControllerRepository, options ...ControllerServiceOption) *ControllerService {
+	service := &ControllerService{
 		controllerRepo: controllerRepo,
 	}
-}
-
-func (cs *ControllerService) SetServer(server shared.Server) {
-	cs.server = server
+	for _, option := range options {
+		option(service)
+	}
+	return service
 }
 
 func (cs *ControllerService) SetStripService(stripService shared.StripService) {
 	cs.stripService = stripService
+}
+
+func (cs *ControllerService) SetFrontendNotifier(frontendNotifier FrontendNotifier) {
+	cs.frontendNotifier = frontendNotifier
+}
+
+func (cs *ControllerService) SetSessionRecalculator(sessionRecalculator SessionRecalculator) {
+	cs.sessionRecalculator = sessionRecalculator
 }
 
 // ControllerOnline handles all database mutations and orchestration for a
@@ -40,7 +49,6 @@ func (cs *ControllerService) ControllerOnline(ctx context.Context, session int32
 }
 
 func (cs *ControllerService) ControllerOnlineWithOptions(ctx context.Context, session int32, callsign, position, positionName string, options shared.ControllerOnlineOptions) (shared.ControllerOnlineResult, error) {
-	s := cs.server
 	controller, err := cs.controllerRepo.GetByCallsign(ctx, session, callsign)
 
 	// Case A: new controller (not in database).
@@ -112,7 +120,7 @@ func (cs *ControllerService) ControllerOnlineWithOptions(ctx context.Context, se
 		slog.String("callsign", callsign),
 		slog.String("position", position),
 		slog.String("trigger", "position_changed"))
-	changes, err := s.RecalculateSessionContext(ctx, session, true)
+	changes, err := cs.sessionRecalculator.RecalculateSessionContext(ctx, session, true)
 	if err != nil {
 		return shared.ControllerOnlineResult{}, err
 	}
@@ -151,8 +159,6 @@ func (cs *ControllerService) ControllerOnlineWithOptions(ctx context.Context, se
 // performOnlineOrchestration is the common path for a newly-created controller.
 // It auto-assumes cleared strips, then recalculates sectors, layouts, and routes as one session update.
 func (cs *ControllerService) performOnlineOrchestration(ctx context.Context, session int32, position, positionName string) (shared.ControllerOnlineResult, error) {
-	s := cs.server
-
 	if cs.stripService != nil {
 		if err := cs.stripService.AutoAssumeForControllerOnline(ctx, session, position); err != nil {
 			slog.ErrorContext(ctx, "Failed to auto-assume strips on controller online",
@@ -164,7 +170,7 @@ func (cs *ControllerService) performOnlineOrchestration(ctx context.Context, ses
 		slog.Int("session", int(session)),
 		slog.String("position", position),
 		slog.String("trigger", "new_controller"))
-	changes, err := s.RecalculateSessionContext(ctx, session, true)
+	changes, err := cs.sessionRecalculator.RecalculateSessionContext(ctx, session, true)
 	if err != nil {
 		return shared.ControllerOnlineResult{}, err
 	}
@@ -210,7 +216,9 @@ func (cs *ControllerService) ControllerOffline(ctx context.Context, session int3
 	// If the controller is not in the database, send the notification immediately.
 	if errors.Is(err, pgx.ErrNoRows) {
 		slog.DebugContext(ctx, "Controller going offline does not exist in database", slog.String("callsign", callsign))
-		cs.server.GetFrontendHub().SendControllerOffline(session, callsign, "", "")
+		if cs.frontendNotifier != nil {
+			cs.frontendNotifier.SendControllerOffline(session, callsign, "", "")
+		}
 		return shared.ControllerOfflineResult{ShouldScheduleTimer: false}, nil
 	}
 
@@ -219,7 +227,9 @@ func (cs *ControllerService) ControllerOffline(ctx context.Context, session int3
 	if configErr != nil {
 		// Unknown position — immediate offline handling (no timer).
 		_ = cs.controllerRepo.Delete(ctx, session, callsign)
-		cs.server.GetFrontendHub().SendControllerOffline(session, callsign, controller.Position, "")
+		if cs.frontendNotifier != nil {
+			cs.frontendNotifier.SendControllerOffline(session, callsign, controller.Position, "")
+		}
 		return shared.ControllerOfflineResult{ShouldScheduleTimer: false}, nil
 	}
 	positionName := posConfig.Name

--- a/backend/internal/services/controller_options.go
+++ b/backend/internal/services/controller_options.go
@@ -1,0 +1,23 @@
+package services
+
+import "FlightStrips/internal/shared"
+
+type ControllerServiceOption func(*ControllerService)
+
+func WithFrontendNotifier(frontendNotifier FrontendNotifier) ControllerServiceOption {
+	return func(cs *ControllerService) {
+		cs.frontendNotifier = frontendNotifier
+	}
+}
+
+func WithSessionRecalculator(sessionRecalculator SessionRecalculator) ControllerServiceOption {
+	return func(cs *ControllerService) {
+		cs.sessionRecalculator = sessionRecalculator
+	}
+}
+
+func WithControllerStripService(stripService shared.StripService) ControllerServiceOption {
+	return func(cs *ControllerService) {
+		cs.stripService = stripService
+	}
+}

--- a/backend/internal/services/controller_test.go
+++ b/backend/internal/services/controller_test.go
@@ -38,7 +38,8 @@ func TestControllerOnline_CreatesIfNotExists(t *testing.T) {
 
 	mockServer := &testutil.MockServer{}
 	svc := NewControllerService(ctrlRepo)
-	svc.SetServer(mockServer)
+	svc.SetFrontendNotifier(mockServer.FrontendHubVal)
+	svc.SetSessionRecalculator(mockServer)
 
 	result, err := svc.ControllerOnline(ctx, session, callsign, position, "")
 	require.NoError(t, err)
@@ -75,7 +76,8 @@ func TestControllerOnline_UpdatesExisting(t *testing.T) {
 
 	mockServer := &testutil.MockServer{}
 	svc := NewControllerService(ctrlRepo)
-	svc.SetServer(mockServer)
+	svc.SetFrontendNotifier(mockServer.FrontendHubVal)
+	svc.SetSessionRecalculator(mockServer)
 
 	_, err := svc.ControllerOnline(ctx, session, callsign, newPosition, "")
 	require.NoError(t, err)
@@ -137,7 +139,8 @@ func TestControllerOnline_SamePosition_ForceOrchestrationRunsUpdates(t *testing.
 	}
 
 	svc := NewControllerService(ctrlRepo)
-	svc.SetServer(mockServer)
+	svc.SetFrontendNotifier(mockServer.FrontendHubVal)
+	svc.SetSessionRecalculator(mockServer)
 
 	result, err := svc.ControllerOnlineWithOptions(ctx, session, callsign, position, "", shared.ControllerOnlineOptions{
 		ForceOrchestration: true,
@@ -165,7 +168,8 @@ func TestControllerOffline_ControllerNotFound(t *testing.T) {
 	hub := &testutil.MockFrontendHub{}
 	mockServer := &testutil.MockServer{FrontendHubVal: hub}
 	svc := NewControllerService(ctrlRepo)
-	svc.SetServer(mockServer)
+	svc.SetFrontendNotifier(mockServer.FrontendHubVal)
+	svc.SetSessionRecalculator(mockServer)
 
 	result, err := svc.ControllerOffline(ctx, session, callsign)
 	require.NoError(t, err)
@@ -200,7 +204,8 @@ func TestControllerOffline_UnknownPosition_DeletesImmediately(t *testing.T) {
 	hub := &testutil.MockFrontendHub{}
 	mockServer := &testutil.MockServer{FrontendHubVal: hub}
 	svc := NewControllerService(ctrlRepo)
-	svc.SetServer(mockServer)
+	svc.SetFrontendNotifier(mockServer.FrontendHubVal)
+	svc.SetSessionRecalculator(mockServer)
 
 	result, err := svc.ControllerOffline(ctx, session, callsign)
 	require.NoError(t, err)
@@ -246,7 +251,8 @@ func TestControllerOffline_PositionAlreadyCovered_DeletesStaleRowWithoutOfflineE
 	hub := &testutil.MockFrontendHub{}
 	mockServer := &testutil.MockServer{FrontendHubVal: hub}
 	svc := NewControllerService(ctrlRepo)
-	svc.SetServer(mockServer)
+	svc.SetFrontendNotifier(mockServer.FrontendHubVal)
+	svc.SetSessionRecalculator(mockServer)
 
 	result, err := svc.ControllerOffline(ctx, session, callsign)
 	require.NoError(t, err)
@@ -287,7 +293,8 @@ func TestControllerOffline_ObserverCoverageDoesNotSuppressOfflineHandling(t *tes
 	hub := &testutil.MockFrontendHub{}
 	mockServer := &testutil.MockServer{FrontendHubVal: hub}
 	svc := NewControllerService(ctrlRepo)
-	svc.SetServer(mockServer)
+	svc.SetFrontendNotifier(mockServer.FrontendHubVal)
+	svc.SetSessionRecalculator(mockServer)
 
 	result, err := svc.ControllerOffline(ctx, session, callsign)
 	require.NoError(t, err)
@@ -327,7 +334,8 @@ func TestControllerOffline_MismatchedPrefixCoverageDoesNotSuppressOfflineHandlin
 	hub := &testutil.MockFrontendHub{}
 	mockServer := &testutil.MockServer{FrontendHubVal: hub}
 	svc := NewControllerService(ctrlRepo)
-	svc.SetServer(mockServer)
+	svc.SetFrontendNotifier(mockServer.FrontendHubVal)
+	svc.SetSessionRecalculator(mockServer)
 
 	result, err := svc.ControllerOffline(ctx, session, callsign)
 	require.NoError(t, err)
@@ -360,7 +368,8 @@ func TestControllerOnline_New_IgnoresObserverCoverageForSingleOnPosition(t *test
 
 	mockServer := &testutil.MockServer{}
 	svc := NewControllerService(ctrlRepo)
-	svc.SetServer(mockServer)
+	svc.SetFrontendNotifier(mockServer.FrontendHubVal)
+	svc.SetSessionRecalculator(mockServer)
 
 	result, err := svc.ControllerOnline(ctx, session, callsign, position, "EKCH_TWR")
 	require.NoError(t, err)
@@ -392,7 +401,8 @@ func TestControllerOnline_New_IgnoresMismatchedPrefixCoverageForSingleOnPosition
 
 	mockServer := &testutil.MockServer{}
 	svc := NewControllerService(ctrlRepo)
-	svc.SetServer(mockServer)
+	svc.SetFrontendNotifier(mockServer.FrontendHubVal)
+	svc.SetSessionRecalculator(mockServer)
 
 	result, err := svc.ControllerOnline(ctx, session, callsign, position, "EKCH_TWR")
 	require.NoError(t, err)
@@ -415,7 +425,8 @@ func TestControllerOnline_New_SendsOnlineEvent(t *testing.T) {
 	hub := &testutil.MockFrontendHub{}
 	mockServer := &testutil.MockServer{FrontendHubVal: hub}
 	svc := NewControllerService(ctrlRepo)
-	svc.SetServer(mockServer)
+	svc.SetFrontendNotifier(mockServer.FrontendHubVal)
+	svc.SetSessionRecalculator(mockServer)
 
 	result, err := svc.ControllerOnline(ctx, session, callsign, position, "")
 	require.NoError(t, err)
@@ -459,7 +470,8 @@ func TestControllerOnline_PositionChanged_SendsOnlineEvent(t *testing.T) {
 	hub := &testutil.MockFrontendHub{}
 	mockServer := &testutil.MockServer{FrontendHubVal: hub}
 	svc := NewControllerService(ctrlRepo)
-	svc.SetServer(mockServer)
+	svc.SetFrontendNotifier(mockServer.FrontendHubVal)
+	svc.SetSessionRecalculator(mockServer)
 
 	result, err := svc.ControllerOnline(ctx, session, callsign, newPosition, "")
 	require.NoError(t, err)
@@ -480,7 +492,8 @@ func TestControllerOffline_NotFound_SendsOfflineEvent(t *testing.T) {
 	hub := &testutil.MockFrontendHub{}
 	mockServer := &testutil.MockServer{FrontendHubVal: hub}
 	svc := NewControllerService(ctrlRepo)
-	svc.SetServer(mockServer)
+	svc.SetFrontendNotifier(mockServer.FrontendHubVal)
+	svc.SetSessionRecalculator(mockServer)
 
 	result, err := svc.ControllerOffline(ctx, session, callsign)
 	require.NoError(t, err)

--- a/backend/internal/services/dependencies.go
+++ b/backend/internal/services/dependencies.go
@@ -1,0 +1,42 @@
+package services
+
+import (
+	internalModels "FlightStrips/internal/models"
+	"FlightStrips/internal/shared"
+	"context"
+)
+
+type RouteRecalculator interface {
+	UpdateRouteForStrip(callsign string, sessionID int32, sendUpdate bool) error
+	UpdateRouteForStripContext(ctx context.Context, callsign string, sessionID int32, sendUpdate bool) error
+}
+
+type StripRouteComputer interface {
+	ComputeNextOwnersForStripContext(ctx context.Context, strip *internalModels.Strip, sessionID int32) ([]string, bool, error)
+}
+
+type SessionReader interface {
+	GetByID(ctx context.Context, id int32) (*internalModels.Session, error)
+}
+
+type ControllerReader interface {
+	GetByCid(ctx context.Context, cid string) (*internalModels.Controller, error)
+	GetByCallsign(ctx context.Context, session int32, callsign string) (*internalModels.Controller, error)
+	GetByPosition(ctx context.Context, session int32, position string) ([]*internalModels.Controller, error)
+	ListBySession(ctx context.Context, session int32) ([]*internalModels.Controller, error)
+}
+
+type CoordinationStore interface {
+	Create(ctx context.Context, coordination *internalModels.Coordination) error
+	GetByStripID(ctx context.Context, session int32, stripID int32) (*internalModels.Coordination, error)
+	GetByStripCallsign(ctx context.Context, session int32, callsign string) (*internalModels.Coordination, error)
+	Delete(ctx context.Context, id int32) error
+}
+
+type FrontendNotifier interface {
+	SendControllerOffline(session int32, callsign string, position string, identifier string)
+}
+
+type SessionRecalculator interface {
+	RecalculateSessionContext(ctx context.Context, sessionID int32, sendUpdate bool) ([]shared.SectorChange, error)
+}

--- a/backend/internal/services/strip.go
+++ b/backend/internal/services/strip.go
@@ -14,20 +14,28 @@ const (
 )
 
 type StripService struct {
-	stripRepo       repository.StripRepository
-	tacticalRepo    repository.TacticalStripRepository
-	sectorOwnerRepo repository.SectorOwnerRepository
-	publisher       shared.StripEventPublisher
-	esCommander     shared.EuroscopeStripCommander
-	coordRepo       repository.CoordinationRepository
-	controllerRepo  repository.ControllerRepository
-	cdmService      shared.CdmService
+	stripRepo         repository.StripRepository
+	tacticalRepo      repository.TacticalStripRepository
+	sectorOwnerRepo   repository.SectorOwnerRepository
+	publisher         shared.StripEventPublisher
+	esCommander       shared.EuroscopeStripCommander
+	coordRepo         CoordinationStore
+	controllerRepo    ControllerReader
+	sessionRepo       SessionReader
+	routeRecalculator RouteRecalculator
+	routeComputer     StripRouteComputer
+	pdcService        shared.PdcService
+	cdmService        shared.CdmService
 }
 
-func NewStripService(stripRepo repository.StripRepository) *StripService {
-	return &StripService{
+func NewStripService(stripRepo repository.StripRepository, options ...StripServiceOption) *StripService {
+	service := &StripService{
 		stripRepo: stripRepo,
 	}
+	for _, option := range options {
+		option(service)
+	}
+	return service
 }
 
 func (s *StripService) SetFrontendHub(publisher shared.StripEventPublisher) {
@@ -46,72 +54,64 @@ func (s *StripService) SetTacticalStripRepo(tacticalRepo repository.TacticalStri
 	s.tacticalRepo = tacticalRepo
 }
 
-func (s *StripService) SetCoordinationRepo(coordRepo repository.CoordinationRepository) {
+func (s *StripService) SetCoordinationRepo(coordRepo CoordinationStore) {
 	s.coordRepo = coordRepo
 }
 
-func (s *StripService) SetControllerRepo(controllerRepo repository.ControllerRepository) {
+func (s *StripService) SetControllerRepo(controllerRepo ControllerReader) {
 	s.controllerRepo = controllerRepo
 }
 
-func (s *StripService) getControllerRepository() repository.ControllerRepository {
-	if s.controllerRepo != nil {
-		return s.controllerRepo
-	}
-	if s.publisher == nil {
-		return nil
-	}
-	server := s.publisher.GetServer()
-	if server == nil {
-		return nil
-	}
-	return server.GetControllerRepository()
+func (s *StripService) SetSessionRepo(sessionRepo SessionReader) {
+	s.sessionRepo = sessionRepo
 }
 
-func (s *StripService) getSessionRepository() repository.SessionRepository {
-	if s.publisher == nil {
-		return nil
+func (s *StripService) SetRouteRecalculator(routeRecalculator RouteRecalculator) {
+	s.routeRecalculator = routeRecalculator
+	if routeComputer, ok := routeRecalculator.(StripRouteComputer); ok {
+		s.routeComputer = routeComputer
 	}
-	server := s.publisher.GetServer()
-	if server == nil {
-		return nil
-	}
-	return server.GetSessionRepository()
 }
 
-func (s *StripService) getServer() shared.Server {
-	if s.publisher == nil {
-		return nil
-	}
-	return s.publisher.GetServer()
+func (s *StripService) SetRouteComputer(routeComputer StripRouteComputer) {
+	s.routeComputer = routeComputer
 }
 
-func (s *StripService) getCoordinationRepository() repository.CoordinationRepository {
-	if s.coordRepo != nil {
-		return s.coordRepo
-	}
-	server := s.getServer()
-	if server == nil {
-		return nil
-	}
-	return server.GetCoordinationRepository()
+func (s *StripService) SetPdcService(pdcService shared.PdcService) {
+	s.pdcService = pdcService
+}
+
+func (s *StripService) getControllerRepository() ControllerReader {
+	return s.controllerRepo
+}
+
+func (s *StripService) getSessionRepository() SessionReader {
+	return s.sessionRepo
+}
+
+func (s *StripService) getCoordinationRepository() CoordinationStore {
+	return s.coordRepo
 }
 
 func (s *StripService) getPdcService() shared.PdcService {
-	server := s.getServer()
-	if server == nil {
-		return nil
-	}
-	return server.GetPdcService()
+	return s.pdcService
+}
+
+func (s *StripService) getRouteRecalculator() RouteRecalculator {
+	return s.routeRecalculator
+}
+
+func (s *StripService) getRouteComputer() StripRouteComputer {
+	return s.routeComputer
 }
 
 func (s *StripService) recalculateRouteForStrip(ctx context.Context, session int32, callsign string) error {
-	server := s.getServer()
-	if server == nil {
+	routeRecalculator := s.getRouteRecalculator()
+	if routeRecalculator == nil {
 		return nil
 	}
 
-	return server.UpdateRouteForStripContext(ctx, callsign, session, false)
+	return routeRecalculator.UpdateRouteForStripContext(ctx, callsign, session, false)
 }
 
 func (s *StripService) SetCdmService(cdmService shared.CdmService) {

--- a/backend/internal/services/strip_airborne_test.go
+++ b/backend/internal/services/strip_airborne_test.go
@@ -49,7 +49,6 @@ func TestResolveAirborneController_UnknownSID(t *testing.T) {
 // the AIRBORNE bay is skipped without error.
 func TestAutoTransferAirborneStrip_SkipsWhenNotAirborneBay(t *testing.T) {
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{})
 
 	svc := NewStripService(&testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -66,7 +65,6 @@ func TestAutoTransferAirborneStrip_SkipsWhenNotAirborneBay(t *testing.T) {
 // no owner is skipped without error.
 func TestAutoTransferAirborneStrip_SkipsWhenNoOwner(t *testing.T) {
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{})
 
 	svc := NewStripService(&testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -88,15 +86,13 @@ func TestAutoTransferAirborneStrip_SkipsWhenOwnerCidMissing(t *testing.T) {
 	// the skip-when-no-owner path as a proxy; the CID guard is exercised in integration
 	// tests where a SID route is configured.
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{
-		ControllerRepoVal: &testutil.MockControllerRepository{
-			ListBySessionFn: func(_ context.Context, _ int32) ([]*models.Controller, error) {
-				// Owner controller present but no CID set.
-				owner := "EKCH_TWR"
-				return []*models.Controller{{Position: owner, Cid: nil}}, nil
-			},
+	controllerRepo := &testutil.MockControllerRepository{
+		ListBySessionFn: func(_ context.Context, _ int32) ([]*models.Controller, error) {
+			// Owner controller present but no CID set.
+			owner := "EKCH_TWR"
+			return []*models.Controller{{Position: owner, Cid: nil}}, nil
 		},
-	})
+	}
 
 	owner := "EKCH_TWR"
 	svc := NewStripService(&testutil.MockStripRepository{
@@ -105,6 +101,7 @@ func TestAutoTransferAirborneStrip_SkipsWhenOwnerCidMissing(t *testing.T) {
 		},
 	})
 	svc.SetFrontendHub(hub)
+	svc.SetControllerRepo(controllerRepo)
 
 	// With no SID the function exits before the CID check — no error expected.
 	err := svc.AutoTransferAirborneStrip(context.Background(), 1, "SAS001")
@@ -159,10 +156,10 @@ func TestUpdateAircraftPosition_AutoHandoverTriggeredFromDepartBay(t *testing.T)
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{ControllerRepoVal: controllerRepo})
 
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
+	svc.SetControllerRepo(controllerRepo)
 
 	// EKCH coordinates, altitude 250 ft — above the configured 200 ft airborne threshold.
 	err := svc.UpdateAircraftPosition(ctx, session, callsign,
@@ -235,16 +232,14 @@ func TestCreateCoordinationTransfer_EsHandoverSentWhenTargetHasNoEsConnection(t 
 	esHub := &testutil.MockEuroscopeHub{}
 
 	frontendHub := &testutil.MockFrontendHub{}
-	frontendHub.SetServer(&testutil.MockServer{
-		CoordRepoVal: &testutil.MockCoordinationRepository{
-			CreateFn: func(_ context.Context, _ *models.Coordination) error { return nil },
+	coordRepo := &testutil.MockCoordinationRepository{
+		CreateFn: func(_ context.Context, _ *models.Coordination) error { return nil },
+	}
+	controllerRepo := &testutil.MockControllerRepository{
+		ListBySessionFn: func(_ context.Context, _ int32) ([]*models.Controller, error) {
+			return controllers, nil
 		},
-		ControllerRepoVal: &testutil.MockControllerRepository{
-			ListBySessionFn: func(_ context.Context, _ int32) ([]*models.Controller, error) {
-				return controllers, nil
-			},
-		},
-	})
+	}
 
 	stripRepo := &testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -255,6 +250,8 @@ func TestCreateCoordinationTransfer_EsHandoverSentWhenTargetHasNoEsConnection(t 
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(frontendHub)
 	svc.SetEuroscopeHub(esHub)
+	svc.SetCoordinationRepo(coordRepo)
+	svc.SetControllerRepo(controllerRepo)
 
 	err := svc.CreateCoordinationTransfer(ctx, session, callsign, "EKCH_TWR", "EKCH_APP")
 	require.NoError(t, err)
@@ -296,10 +293,10 @@ func TestUpdateAircraftPosition_NoAutoHandoverWhenAlreadyAirborne(t *testing.T) 
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{ControllerRepoVal: controllerRepo})
 
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
+	svc.SetControllerRepo(controllerRepo)
 
 	err := svc.UpdateAircraftPosition(ctx, session, callsign,
 		shared.AirportLatitude, shared.AirportLongitude, 1000, "EKCH")

--- a/backend/internal/services/strip_arrival.go
+++ b/backend/internal/services/strip_arrival.go
@@ -193,10 +193,10 @@ func (s *StripService) handleArrivalPositionUpdate(ctx context.Context, session 
 // HandleTrackingControllerChanged processes a tracking controller change event,
 // potentially accepting a coordination and moving the strip if it becomes airborne.
 func (s *StripService) HandleTrackingControllerChanged(ctx context.Context, session int32, callsign string, trackingController string) error {
-	if s.controllerRepo == nil {
+	if s.getControllerRepository() == nil {
 		return errors.New("controller repository not configured")
 	}
-	if s.coordRepo == nil {
+	if s.getCoordinationRepository() == nil {
 		return errors.New("coordination repository not configured")
 	}
 
@@ -263,11 +263,9 @@ func (s *StripService) HandleTrackingControllerChanged(ctx context.Context, sess
 	// work them again. For missed-approach TWR->APP assumptions, restore the strip to
 	// FINAL so TWR becomes the next controller again. Departures use the regular HIDDEN bay.
 	targetBay := shared.BAY_HIDDEN
-	if s.publisher != nil {
-		if srv := s.publisher.GetServer(); srv != nil {
-			if sess, sessErr := s.getCachedSession(ctx, session); sessErr == nil && sess != nil && strip.Destination == sess.Airport {
-				targetBay = shared.BAY_ARR_HIDDEN
-			}
+	if s.getSessionRepository() != nil {
+		if sess, sessErr := s.getCachedSession(ctx, session); sessErr == nil && sess != nil && strip.Destination == sess.Airport {
+			targetBay = shared.BAY_ARR_HIDDEN
 		}
 	}
 	if targetBay == shared.BAY_ARR_HIDDEN && coordFromPosition != "" && isMissedApproachReturn(coordFromPosition, assumingPosition) {

--- a/backend/internal/services/strip_arrival_landing_test.go
+++ b/backend/internal/services/strip_arrival_landing_test.go
@@ -216,9 +216,6 @@ func buildLandingDetectionSvc(
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	if coordRepo != nil {
-		hub.SetServer(&testutil.MockServer{CoordRepoVal: coordRepo})
-	}
 
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
@@ -480,8 +477,6 @@ func TestHandleArrivalPositionUpdate_AutoAcceptsCoordinationOnTouchdown(t *testi
 	}
 
 	svc, hub, _ := buildLandingDetectionSvc(t, strip, coordRepo)
-	// AcceptCoordination also calls GetByStripID via the server's coord repo.
-	hub.SetServer(&testutil.MockServer{CoordRepoVal: coordRepo})
 
 	// Capture SetOwner to verify the strip is assumed by toPos.
 	svc.stripRepo.(*testutil.MockStripRepository).SetOwnerFn = func(_ context.Context, _ int32, _ string, o *string, _ int32) (int64, error) {
@@ -567,7 +562,6 @@ func TestHandleArrivalPositionUpdate_AutoAcceptsEsArrivalCoordinationWithAssumeO
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{CoordRepoVal: coordRepo})
 	esHub := &testutil.MockEuroscopeHub{}
 
 	svc := NewStripService(stripRepo)
@@ -637,7 +631,6 @@ func TestAssumeStripCoordination_EsArrivalUsesAssumeOnly(t *testing.T) {
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{CoordRepoVal: coordRepo})
 	esHub := &testutil.MockEuroscopeHub{}
 
 	svc := NewStripService(stripRepo)

--- a/backend/internal/services/strip_auto_assume.go
+++ b/backend/internal/services/strip_auto_assume.go
@@ -88,14 +88,12 @@ func (s *StripService) autoAssumeForClearedStrip(ctx context.Context, session in
 	}
 
 	if count == 1 {
-		if s.publisher != nil {
-			if server := s.publisher.GetServer(); server != nil {
-				if err := server.UpdateRouteForStripContext(ctx, callsign, session, false); err != nil {
-					slog.ErrorContext(ctx, "Error updating route after auto-assume", slog.String("callsign", callsign), slog.Any("error", err))
-				}
-				if refreshed, err := s.syncStripByCallsign(ctx, session, callsign); err == nil {
-					nextOwners = refreshed.NextOwners
-				}
+		if routeRecalculator := s.getRouteRecalculator(); routeRecalculator != nil {
+			if err := routeRecalculator.UpdateRouteForStripContext(ctx, callsign, session, false); err != nil {
+				slog.ErrorContext(ctx, "Error updating route after auto-assume", slog.String("callsign", callsign), slog.Any("error", err))
+			}
+			if refreshed, err := s.syncStripByCallsign(ctx, session, callsign); err == nil {
+				nextOwners = refreshed.NextOwners
 			}
 		}
 		s.publisher.SendOwnersUpdate(session, callsign, sqPosition, nextOwners, previousOwners, nil)
@@ -109,12 +107,7 @@ func (s *StripService) resolveControllerPositionByCid(ctx context.Context, cid s
 		return "", nil
 	}
 
-	controllerRepo := s.controllerRepo
-	if controllerRepo == nil && s.publisher != nil {
-		if server := s.publisher.GetServer(); server != nil {
-			controllerRepo = server.GetControllerRepository()
-		}
-	}
+	controllerRepo := s.getControllerRepository()
 	if controllerRepo == nil {
 		return "", nil
 	}
@@ -137,14 +130,7 @@ func (s *StripService) shouldAutoAssumeClearedDeparture(ctx context.Context, ses
 	if shared.IsArrivalBay(strip.Bay) {
 		return false
 	}
-	if s.publisher == nil {
-		return true
-	}
-	server := s.publisher.GetServer()
-	if server == nil {
-		return true
-	}
-	sessionRepo := server.GetSessionRepository()
+	sessionRepo := s.getSessionRepository()
 	if sessionRepo == nil {
 		return true
 	}
@@ -222,14 +208,12 @@ func (s *StripService) AutoAssumeForControllerOnline(ctx context.Context, sessio
 				slog.String("callsign", strip.Callsign),
 				slog.String("position", controllerPosition))
 			nextOwners := strip.NextOwners
-			if s.publisher != nil {
-				if server := s.publisher.GetServer(); server != nil {
-					if err := server.UpdateRouteForStripContext(ctx, strip.Callsign, session, false); err != nil {
-						slog.ErrorContext(ctx, "Error updating route after auto-assume on controller online", slog.String("callsign", strip.Callsign), slog.Any("error", err))
-					}
-					if refreshed, err := s.syncStripByCallsign(ctx, session, strip.Callsign); err == nil {
-						nextOwners = refreshed.NextOwners
-					}
+			if routeRecalculator := s.getRouteRecalculator(); routeRecalculator != nil {
+				if err := routeRecalculator.UpdateRouteForStripContext(ctx, strip.Callsign, session, false); err != nil {
+					slog.ErrorContext(ctx, "Error updating route after auto-assume on controller online", slog.String("callsign", strip.Callsign), slog.Any("error", err))
+				}
+				if refreshed, err := s.syncStripByCallsign(ctx, session, strip.Callsign); err == nil {
+					nextOwners = refreshed.NextOwners
 				}
 			}
 			s.publisher.SendOwnersUpdate(session, strip.Callsign, controllerPosition, nextOwners, strip.PreviousOwners, nil)

--- a/backend/internal/services/strip_controller_modified_test.go
+++ b/backend/internal/services/strip_controller_modified_test.go
@@ -8,8 +8,8 @@ import (
 	"FlightStrips/internal/models"
 	"FlightStrips/internal/shared"
 	"FlightStrips/internal/testutil"
-	pkgModels "FlightStrips/pkg/models"
 	euroscopeEvents "FlightStrips/pkg/events/euroscope"
+	pkgModels "FlightStrips/pkg/models"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -76,12 +76,7 @@ func TestHandleStripUpdate_EuroscopeClient_StandChange_NoControllerModified(t *t
 		},
 	}
 
-	mockServer := &testutil.MockServer{
-		SessionRepoVal: sessionRepo,
-	}
-
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(mockServer)
 
 	if stripRepo.GetMaxSequenceInBayFn == nil {
 		stripRepo.GetMaxSequenceInBayFn = func(_ context.Context, _ int32, _ string) (int32, error) {
@@ -101,6 +96,7 @@ func TestHandleStripUpdate_EuroscopeClient_StandChange_NoControllerModified(t *t
 
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
+	svc.SetSessionRepo(sessionRepo)
 
 	esStrip := euroscopeEvents.Strip{
 		Callsign: callsign,

--- a/backend/internal/services/strip_coordination.go
+++ b/backend/internal/services/strip_coordination.go
@@ -65,10 +65,9 @@ func (s *StripService) CreateCoordinationTransfer(ctx context.Context, session i
 	if s.publisher == nil {
 		return errors.New("frontend hub not configured")
 	}
-
-	server := s.publisher.GetServer()
-	if server == nil {
-		return errors.New("server not configured")
+	coordRepo := s.getCoordinationRepository()
+	if coordRepo == nil {
+		return errors.New("coordination store not configured")
 	}
 
 	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
@@ -83,7 +82,7 @@ func (s *StripService) CreateCoordinationTransfer(ctx context.Context, session i
 		ToPosition:   to,
 	}
 
-	if err := server.GetCoordinationRepository().Create(ctx, coord); err != nil {
+	if err := coordRepo.Create(ctx, coord); err != nil {
 		return err
 	}
 
@@ -98,7 +97,11 @@ func (s *StripService) CreateCoordinationTransfer(ctx context.Context, session i
 	// For strips in the AIRBORNE bay, also send an ES handover so the owning
 	// EuroScope client initiates the transfer to the target controller.
 	if strip.Bay == shared.BAY_AIRBORNE && s.esCommander != nil {
-		controllers, err := server.GetControllerRepository().ListBySession(ctx, session)
+		controllerRepo := s.getControllerRepository()
+		if controllerRepo == nil {
+			return nil
+		}
+		controllers, err := controllerRepo.ListBySession(ctx, session)
 		if err == nil {
 			var ownerCid *string
 			var targetCallsign string
@@ -123,10 +126,9 @@ func (s *StripService) CreateEsArrivalCoordination(ctx context.Context, session 
 	if s.publisher == nil {
 		return errors.New("frontend hub not configured")
 	}
-
-	server := s.publisher.GetServer()
-	if server == nil {
-		return errors.New("server not configured")
+	coordRepo := s.getCoordinationRepository()
+	if coordRepo == nil {
+		return errors.New("coordination store not configured")
 	}
 
 	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
@@ -143,7 +145,7 @@ func (s *StripService) CreateEsArrivalCoordination(ctx context.Context, session 
 		EsHandoverCid: esHandoverCid,
 	}
 
-	if err := server.GetCoordinationRepository().Create(ctx, coord); err != nil {
+	if err := coordRepo.Create(ctx, coord); err != nil {
 		return err
 	}
 
@@ -158,9 +160,9 @@ func (s *StripService) AcceptCoordination(ctx context.Context, session int32, ca
 	if s.publisher == nil {
 		return errors.New("frontend hub not configured")
 	}
-	server := s.publisher.GetServer()
-	if server == nil {
-		return errors.New("server not configured")
+	coordRepo := s.getCoordinationRepository()
+	if coordRepo == nil {
+		return errors.New("coordination store not configured")
 	}
 
 	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
@@ -168,7 +170,7 @@ func (s *StripService) AcceptCoordination(ctx context.Context, session int32, ca
 		return err
 	}
 
-	coordination, err := server.GetCoordinationRepository().GetByStripID(ctx, session, strip.ID)
+	coordination, err := coordRepo.GetByStripID(ctx, session, strip.ID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil
 	}
@@ -176,7 +178,7 @@ func (s *StripService) AcceptCoordination(ctx context.Context, session int32, ca
 		return err
 	}
 
-	if err := server.GetCoordinationRepository().Delete(ctx, coordination.ID); err != nil {
+	if err := coordRepo.Delete(ctx, coordination.ID); err != nil {
 		return err
 	}
 
@@ -211,11 +213,6 @@ func (s *StripService) AutoTransferAirborneStrip(ctx context.Context, session in
 		return errors.New("frontend hub not configured")
 	}
 
-	server := s.publisher.GetServer()
-	if server == nil {
-		return errors.New("server not configured")
-	}
-
 	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		return err
@@ -231,8 +228,13 @@ func (s *StripService) AutoTransferAirborneStrip(ctx context.Context, session in
 		return nil
 	}
 
+	controllerRepo := s.getControllerRepository()
+	if controllerRepo == nil {
+		return errors.New("controller reader not configured")
+	}
+
 	// fetch controllers once
-	controllers, err := server.GetControllerRepository().ListBySession(ctx, session)
+	controllers, err := controllerRepo.ListBySession(ctx, session)
 	if err != nil {
 		return err
 	}
@@ -264,7 +266,12 @@ func (s *StripService) AutoTransferAirborneStrip(ctx context.Context, session in
 		return nil
 	}
 
-	coordination, err := server.GetCoordinationRepository().GetByStripID(ctx, session, strip.ID)
+	coordRepo := s.getCoordinationRepository()
+	if coordRepo == nil {
+		return errors.New("coordination store not configured")
+	}
+
+	coordination, err := coordRepo.GetByStripID(ctx, session, strip.ID)
 	if err == nil {
 		slog.DebugContext(ctx, "Skipping automatic AIRBORNE transfer because coordination already exists",
 			slog.String("callsign", callsign),
@@ -360,10 +367,11 @@ func prepareOwnersForAutomaticTransfer(strip *internalModels.Strip, newOwner str
 // autoAcceptPendingCoordination accepts any pending coordination for the strip automatically,
 // e.g. when the aircraft is detected landing on the runway.
 func (s *StripService) autoAcceptPendingCoordination(ctx context.Context, session int32, strip *internalModels.Strip) {
-	if s.coordRepo == nil {
+	coordRepo := s.getCoordinationRepository()
+	if coordRepo == nil {
 		return
 	}
-	coordination, err := s.coordRepo.GetByStripID(ctx, session, strip.ID)
+	coordination, err := coordRepo.GetByStripID(ctx, session, strip.ID)
 	if err != nil {
 		return // no coordination pending
 	}
@@ -465,7 +473,8 @@ func (s *StripService) HandleCoordinationReceived(ctx context.Context, session i
 // AssumeStripCoordination handles the full frontend assume flow:
 // accepts a pending coordination, or directly assumes an unowned strip.
 func (s *StripService) AssumeStripCoordination(ctx context.Context, session int32, callsign string, position string) error {
-	if s.coordRepo == nil {
+	coordRepo := s.getCoordinationRepository()
+	if coordRepo == nil {
 		return errors.New("coordination repository not configured")
 	}
 
@@ -475,7 +484,7 @@ func (s *StripService) AssumeStripCoordination(ctx context.Context, session int3
 	}
 
 	// Check for a pending coordination first.
-	coordination, err := s.coordRepo.GetByStripID(ctx, session, strip.ID)
+	coordination, err := coordRepo.GetByStripID(ctx, session, strip.ID)
 	if err == nil {
 		// Coordination exists — validate it targets this position.
 		if coordination.ToPosition != position {
@@ -483,7 +492,7 @@ func (s *StripService) AssumeStripCoordination(ctx context.Context, session int3
 			// The coordination is stale (e.g. from an ES arrival push to a different position).
 			// Delete it and allow direct assumption.
 			if (strip.Owner == nil || *strip.Owner == "") && slices.Contains(strip.NextOwners, position) {
-				_ = s.coordRepo.Delete(ctx, coordination.ID)
+				_ = coordRepo.Delete(ctx, coordination.ID)
 
 				nextOwners := strip.NextOwners
 				index := slices.Index(nextOwners, position)
@@ -553,14 +562,12 @@ func (s *StripService) AssumeStripCoordination(ctx context.Context, session int3
 
 		s.publisher.SendCoordinationAssume(session, callsign, position)
 
-		if s.publisher != nil {
-			if server := s.publisher.GetServer(); server != nil {
-				if err := server.UpdateRouteForStrip(callsign, session, false); err != nil {
-					slog.ErrorContext(ctx, "Error updating route after direct assume", slog.String("callsign", callsign), slog.Any("error", err))
-				}
-				if refreshed, err := s.stripRepo.GetByCallsign(ctx, session, callsign); err == nil {
-					nextOwners = refreshed.NextOwners
-				}
+		if routeRecalculator := s.getRouteRecalculator(); routeRecalculator != nil {
+			if err := routeRecalculator.UpdateRouteForStrip(callsign, session, false); err != nil {
+				slog.ErrorContext(ctx, "Error updating route after direct assume", slog.String("callsign", callsign), slog.Any("error", err))
+			}
+			if refreshed, err := s.stripRepo.GetByCallsign(ctx, session, callsign); err == nil {
+				nextOwners = refreshed.NextOwners
 			}
 		}
 
@@ -645,14 +652,12 @@ func (s *StripService) ForceAssumeStrip(ctx context.Context, session int32, call
 	// Recalculate the route starting from the new owner. This updates NextOwners in the
 	// DB. We pass sendUpdate=false because we send the owners update ourselves below with
 	// the fully cleaned previous owners.
-	if s.publisher != nil {
-		if server := s.publisher.GetServer(); server != nil {
-			_ = server.UpdateRouteForStrip(callsign, session, false)
+	if routeRecalculator := s.getRouteRecalculator(); routeRecalculator != nil {
+		_ = routeRecalculator.UpdateRouteForStrip(callsign, session, false)
 
-			// Re-read to pick up the recalculated NextOwners.
-			if updated, err := s.stripRepo.GetByCallsign(ctx, session, callsign); err == nil {
-				nextOwners = updated.NextOwners
-			}
+		// Re-read to pick up the recalculated NextOwners.
+		if updated, err := s.stripRepo.GetByCallsign(ctx, session, callsign); err == nil {
+			nextOwners = updated.NextOwners
 		}
 	}
 
@@ -678,11 +683,12 @@ func (s *StripService) ForceAssumeStrip(ctx context.Context, session int32, call
 
 // RejectCoordination rejects a pending coordination transfer.
 func (s *StripService) RejectCoordination(ctx context.Context, session int32, callsign string, position string) error {
-	if s.coordRepo == nil {
+	coordRepo := s.getCoordinationRepository()
+	if coordRepo == nil {
 		return errors.New("coordination repository not configured")
 	}
 
-	coordination, err := s.coordRepo.GetByStripCallsign(ctx, session, callsign)
+	coordination, err := coordRepo.GetByStripCallsign(ctx, session, callsign)
 	if err != nil {
 		return err
 	}
@@ -691,7 +697,7 @@ func (s *StripService) RejectCoordination(ctx context.Context, session int32, ca
 		return errors.New("cannot reject strip which is not transferred to you")
 	}
 
-	if err = s.coordRepo.Delete(ctx, coordination.ID); err != nil {
+	if err = coordRepo.Delete(ctx, coordination.ID); err != nil {
 		return err
 	}
 	s.publisher.SendCoordinationReject(session, callsign, position)
@@ -702,10 +708,6 @@ func (s *StripService) RejectCoordination(ctx context.Context, session int32, ca
 func (s *StripService) CreateTagRequest(ctx context.Context, session int32, callsign string, requesterPosition string) error {
 	if s.publisher == nil {
 		return errors.New("frontend hub not configured")
-	}
-	server := s.publisher.GetServer()
-	if server == nil {
-		return errors.New("server not configured")
 	}
 
 	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
@@ -721,7 +723,10 @@ func (s *StripService) CreateTagRequest(ctx context.Context, session int32, call
 		return errors.New("cannot request tag of a strip you already own")
 	}
 
-	coordRepo := server.GetCoordinationRepository()
+	coordRepo := s.getCoordinationRepository()
+	if coordRepo == nil {
+		return errors.New("coordination store not configured")
+	}
 
 	// Check no active coordination already exists
 	if _, err := coordRepo.GetByStripCallsign(ctx, session, callsign); err == nil {
@@ -749,10 +754,6 @@ func (s *StripService) AcceptTagRequest(ctx context.Context, session int32, call
 	if s.publisher == nil {
 		return errors.New("frontend hub not configured")
 	}
-	server := s.publisher.GetServer()
-	if server == nil {
-		return errors.New("server not configured")
-	}
 
 	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
 	if err != nil {
@@ -763,7 +764,11 @@ func (s *StripService) AcceptTagRequest(ctx context.Context, session int32, call
 		return errors.New("only the strip owner can accept a tag request")
 	}
 
-	coordRepo := server.GetCoordinationRepository()
+	coordRepo := s.getCoordinationRepository()
+	if coordRepo == nil {
+		return errors.New("coordination store not configured")
+	}
+
 	coordination, err := coordRepo.GetByStripCallsign(ctx, session, callsign)
 	if err != nil {
 		return err
@@ -813,8 +818,8 @@ func (s *StripService) AcceptTagRequest(ctx context.Context, session int32, call
 	}
 
 	// Recalculate route from the new owner (same as ForceAssumeStrip).
-	if server := s.publisher.GetServer(); server != nil {
-		_ = server.UpdateRouteForStrip(callsign, session, false)
+	if routeRecalculator := s.getRouteRecalculator(); routeRecalculator != nil {
+		_ = routeRecalculator.UpdateRouteForStrip(callsign, session, false)
 
 		if updated, err := s.stripRepo.GetByCallsign(ctx, session, callsign); err == nil {
 			nextOwners = updated.NextOwners
@@ -842,11 +847,12 @@ func (s *StripService) AcceptTagRequest(ctx context.Context, session int32, call
 
 // CancelCoordinationTransfer cancels a pending coordination transfer initiated by the caller.
 func (s *StripService) CancelCoordinationTransfer(ctx context.Context, session int32, callsign string, position string) error {
-	if s.coordRepo == nil {
+	coordRepo := s.getCoordinationRepository()
+	if coordRepo == nil {
 		return errors.New("coordination repository not configured")
 	}
 
-	coordination, err := s.coordRepo.GetByStripCallsign(ctx, session, callsign)
+	coordination, err := coordRepo.GetByStripCallsign(ctx, session, callsign)
 	if err != nil {
 		return err
 	}
@@ -855,7 +861,7 @@ func (s *StripService) CancelCoordinationTransfer(ctx context.Context, session i
 		return errors.New("cannot cancel a transfer that you did not initiate")
 	}
 
-	if err := s.coordRepo.Delete(ctx, coordination.ID); err != nil {
+	if err := coordRepo.Delete(ctx, coordination.ID); err != nil {
 		return err
 	}
 	s.publisher.SendCoordinationReject(session, callsign, position)

--- a/backend/internal/services/strip_fields.go
+++ b/backend/internal/services/strip_fields.go
@@ -290,9 +290,8 @@ func (s *StripService) UpdateStand(ctx context.Context, session int32, callsign 
 		}
 	}
 
-	server := s.publisher.GetServer()
-	if server != nil {
-		if err := server.UpdateRouteForStripContext(ctx, callsign, session, true); err != nil {
+	if routeRecalculator := s.getRouteRecalculator(); routeRecalculator != nil {
+		if err := routeRecalculator.UpdateRouteForStripContext(ctx, callsign, session, true); err != nil {
 			slog.ErrorContext(ctx, "Error updating route after stand assignment", slog.String("callsign", callsign), slog.Any("error", err))
 		}
 	}

--- a/backend/internal/services/strip_force_assume_test.go
+++ b/backend/internal/services/strip_force_assume_test.go
@@ -110,7 +110,6 @@ func TestForceAssumeStrip_RouteRecalculated(t *testing.T) {
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(mockServer)
 
 	svc := NewStripService(&testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -124,6 +123,7 @@ func TestForceAssumeStrip_RouteRecalculated(t *testing.T) {
 		},
 	})
 	svc.SetFrontendHub(hub)
+	svc.SetRouteRecalculator(mockServer)
 
 	err := svc.ForceAssumeStrip(context.Background(), 1, "SAS123", "EKCH_D_TWR")
 	require.NoError(t, err)
@@ -160,7 +160,6 @@ func TestForceAssumeStrip_NextOwnersFilteredFromPrevious(t *testing.T) {
 	mockServer := &testutil.MockServer{
 		UpdateRouteForStripFn: func(_ string, _ int32, _ bool) error { return nil },
 	}
-	hub.SetServer(mockServer)
 
 	svc := NewStripService(&testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -182,6 +181,7 @@ func TestForceAssumeStrip_NextOwnersFilteredFromPrevious(t *testing.T) {
 		},
 	})
 	svc.SetFrontendHub(hub)
+	svc.SetRouteRecalculator(mockServer)
 
 	err := svc.ForceAssumeStrip(context.Background(), 1, "SAS123", "EKCH_D_TWR")
 	require.NoError(t, err)

--- a/backend/internal/services/strip_frontend_move_test.go
+++ b/backend/internal/services/strip_frontend_move_test.go
@@ -45,7 +45,6 @@ type frontendMoveFixture struct {
 	repo                 *testutil.MockStripRepository
 	hub                  *testutil.MockFrontendHub
 	esHub                *testutil.MockEuroscopeHub
-	server               *testutil.MockServer
 	strip                *internalModels.Strip
 	ctx                  context.Context
 	updateClearedBays    []string
@@ -145,22 +144,18 @@ func newFrontendMoveFixture(strip *internalModels.Strip) *frontendMoveFixture {
 		},
 	}
 
-	fixture.server = &testutil.MockServer{
-		FrontendHubVal:  fixture.hub,
-		EuroscopeHubVal: fixture.esHub,
-		StripRepoVal:    fixture.repo,
-		PdcServiceVal:   fixture.pdcSpy,
+	routeRecalculator := &testutil.MockServer{
 		UpdateRouteForStripCtxFn: func(_ context.Context, _ string, _ int32, _ bool) error {
 			fixture.routeUpdates++
 			return nil
 		},
 	}
-	fixture.hub.SetServer(fixture.server)
-	fixture.esHub.SetServer(fixture.server)
 
 	fixture.svc = NewStripService(fixture.repo)
 	fixture.svc.SetFrontendHub(fixture.hub)
 	fixture.svc.SetEuroscopeHub(fixture.esHub)
+	fixture.svc.SetPdcService(fixture.pdcSpy)
+	fixture.svc.SetRouteRecalculator(routeRecalculator)
 	fixture.ctx = shared.WithSyncState(context.Background(), &shared.SyncState{
 		ExistingStrips: map[string]*internalModels.Strip{
 			strip.Callsign: strip,

--- a/backend/internal/services/strip_landing_clearance_validation_test.go
+++ b/backend/internal/services/strip_landing_clearance_validation_test.go
@@ -42,12 +42,11 @@ func buildLandingClearanceValidationSvc(t *testing.T, repo *testutil.MockStripRe
 			}, nil
 		},
 	}
-	server := &testutil.MockServer{SessionRepoVal: sessionRepo}
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(server)
 
 	svc := NewStripService(repo)
 	svc.SetFrontendHub(hub)
+	svc.SetSessionRepo(sessionRepo)
 	return svc
 }
 

--- a/backend/internal/services/strip_lifecycle_test.go
+++ b/backend/internal/services/strip_lifecycle_test.go
@@ -222,18 +222,19 @@ func TestUnclearStrip_MovesToNotClearedBay(t *testing.T) {
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{
+	routeRecalculator := &testutil.MockServer{
 		UpdateRouteForStripFn: func(cs string, sess int32, sendUpdate bool) error {
 			routeUpdateCallsign = cs
 			routeUpdateSession = sess
 			routeUpdateSendUpdate = sendUpdate
 			return nil
 		},
-	})
+	}
 	esHub := &testutil.MockEuroscopeHub{}
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
 	svc.SetEuroscopeHub(esHub)
+	svc.SetRouteRecalculator(routeRecalculator)
 
 	err := svc.UnclearStrip(ctx, session, callsign, cid)
 	require.NoError(t, err)
@@ -521,8 +522,7 @@ func TestAssumeStripCoordination_DirectAssume_UnownedStrip(t *testing.T) {
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{
-		CoordRepoVal: coordRepo,
+	routeRecalculator := &testutil.MockServer{
 		UpdateRouteForStripFn: func(cs string, sess int32, sendUpdate bool) error {
 			assert.Equal(t, callsign, cs)
 			assert.Equal(t, session, sess)
@@ -530,10 +530,11 @@ func TestAssumeStripCoordination_DirectAssume_UnownedStrip(t *testing.T) {
 			routeRecalculated = true
 			return nil
 		},
-	})
+	}
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
 	svc.SetCoordinationRepo(coordRepo)
+	svc.SetRouteRecalculator(routeRecalculator)
 
 	err := svc.AssumeStripCoordination(ctx, session, callsign, position)
 	require.NoError(t, err)
@@ -590,7 +591,6 @@ func TestAssumeStripCoordination_WithCoordination_AcceptsIt(t *testing.T) {
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{CoordRepoVal: coordRepo})
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
 	svc.SetCoordinationRepo(coordRepo)
@@ -654,7 +654,6 @@ func TestAssumeStripCoordination_WithTowerCoordination_DoesNotMoveToLowerTaxiBay
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{CoordRepoVal: coordRepo})
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
 	svc.SetCoordinationRepo(coordRepo)
@@ -689,7 +688,6 @@ func TestAssumeStripCoordination_AlreadyOwned_ReturnsError(t *testing.T) {
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{CoordRepoVal: coordRepo})
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
 	svc.SetCoordinationRepo(coordRepo)
@@ -1394,18 +1392,19 @@ func TestUpdateClearedFlagForMove_ToNotCleared_ClearsOwner(t *testing.T) {
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{
+	routeRecalculator := &testutil.MockServer{
 		UpdateRouteForStripFn: func(cs string, sess int32, sendUpdate bool) error {
 			routeUpdateCallsign = cs
 			routeUpdateSession = sess
 			routeUpdateSendUpdate = sendUpdate
 			return nil
 		},
-	})
+	}
 	esHub := &testutil.MockEuroscopeHub{}
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
 	svc.SetEuroscopeHub(esHub)
+	svc.SetRouteRecalculator(routeRecalculator)
 
 	err := svc.UpdateClearedFlagForMove(ctx, session, callsign, false, shared.BAY_NOT_CLEARED, "CID")
 	require.NoError(t, err)

--- a/backend/internal/services/strip_manual_fpl_test.go
+++ b/backend/internal/services/strip_manual_fpl_test.go
@@ -159,7 +159,7 @@ func TestCreateManualFPL_RecalculatesRouteAfterStandAssignment(t *testing.T) {
 	esHub := &testutil.MockEuroscopeHub{}
 	fHub := &testutil.MockFrontendHub{}
 	routeRecalculated := false
-	fHub.SetServer(&testutil.MockServer{
+	routeRecalculator := &testutil.MockServer{
 		UpdateRouteForStripFn: func(cs string, sess int32, sendUpdate bool) error {
 			assert.Equal(t, callsign, cs)
 			assert.Equal(t, session, sess)
@@ -167,8 +167,9 @@ func TestCreateManualFPL_RecalculatesRouteAfterStandAssignment(t *testing.T) {
 			routeRecalculated = true
 			return nil
 		},
-	})
+	}
 	svc := buildManualFPLService(t, stripRepo, esHub, fHub)
+	svc.SetRouteRecalculator(routeRecalculator)
 
 	err := svc.CreateManualFPL(context.Background(), session, frontend.CreateManualFPLAction{
 		Callsign: callsign,

--- a/backend/internal/services/strip_missed_approach.go
+++ b/backend/internal/services/strip_missed_approach.go
@@ -38,8 +38,8 @@ func (s *StripService) applyMissedApproachOwnerFix(ctx context.Context, session 
 		}
 	}
 
-	if srv := s.publisher.GetServer(); srv != nil {
-		_ = srv.UpdateRouteForStrip(callsign, session, true)
+	if routeRecalculator := s.getRouteRecalculator(); routeRecalculator != nil {
+		_ = routeRecalculator.UpdateRouteForStrip(callsign, session, true)
 	}
 }
 
@@ -64,13 +64,13 @@ func (s *StripService) MissedApproach(ctx context.Context, session int32, callsi
 	if s.publisher == nil {
 		return errors.New("missed approach: frontend hub not configured")
 	}
-	server := s.publisher.GetServer()
-	if server == nil {
-		return errors.New("missed approach: server not configured")
+	sessionRepo := s.getSessionRepository()
+	if sessionRepo == nil {
+		return errors.New("missed approach: session reader not configured")
 	}
 
 	// Get the active arrival runway from the session.
-	sessionObj, err := server.GetSessionRepository().GetByID(ctx, session)
+	sessionObj, err := sessionRepo.GetByID(ctx, session)
 	if err != nil {
 		return fmt.Errorf("missed approach: failed to get session: %w", err)
 	}
@@ -87,6 +87,15 @@ func (s *StripService) MissedApproach(ctx context.Context, session int32, callsi
 		return errors.New("missed approach: no approach controller configured for the active arrival runway")
 	}
 
+	controllerRepo := s.getControllerRepository()
+	if controllerRepo == nil {
+		return errors.New("missed approach: controller reader not configured")
+	}
+	coordRepo := s.getCoordinationRepository()
+	if coordRepo == nil {
+		return errors.New("missed approach: coordination store not configured")
+	}
+
 	// Convert the configured position name to its frequency.
 	posConfig, configErr := config.GetPositionByName(toPositionName)
 	if configErr != nil {
@@ -97,7 +106,7 @@ func (s *StripService) MissedApproach(ctx context.Context, session int32, callsi
 	// Look up online controllers to resolve the actual handover target.
 	// The configured controller may not be staffed, so fall back through the
 	// airborne_owners priority list (same order used for departure airborne transfers).
-	controllers, err := server.GetControllerRepository().ListBySession(ctx, session)
+	controllers, err := controllerRepo.ListBySession(ctx, session)
 	if err != nil {
 		return fmt.Errorf("missed approach: failed to list controllers: %w", err)
 	}
@@ -152,7 +161,7 @@ func (s *StripService) MissedApproach(ctx context.Context, session int32, callsi
 		FromPosition: position,
 		ToPosition:   toPosition,
 	}
-	if err := server.GetCoordinationRepository().Create(ctx, coord); err != nil {
+	if err := coordRepo.Create(ctx, coord); err != nil {
 		return fmt.Errorf("missed approach: failed to create coordination record: %w", err)
 	}
 	s.publisher.SendCoordinationTransfer(session, callsign, position, toPosition)

--- a/backend/internal/services/strip_missed_approach_assume_test.go
+++ b/backend/internal/services/strip_missed_approach_assume_test.go
@@ -73,17 +73,17 @@ func buildAssumeAfterMissedSvc(
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{
-		CoordRepoVal: coordRepo,
+	routeRecalculator := &testutil.MockServer{
 		UpdateRouteForStripFn: func(_ string, _ int32, _ bool) error {
 			res.routeRecalcCount++
 			return nil
 		},
-	})
+	}
 
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
 	svc.SetCoordinationRepo(coordRepo)
+	svc.SetRouteRecalculator(routeRecalculator)
 
 	return svc, hub, res
 }
@@ -299,23 +299,24 @@ func buildTrackingChangedSvc(
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{
-		CoordRepoVal: coordRepo,
-		SessionRepoVal: &testutil.MockSessionRepository{
-			GetByIDFn: func(_ context.Context, _ int32) (*models.Session, error) {
-				return &models.Session{ID: 1, Airport: airport}, nil
-			},
+	sessionRepo := &testutil.MockSessionRepository{
+		GetByIDFn: func(_ context.Context, _ int32) (*models.Session, error) {
+			return &models.Session{ID: 1, Airport: airport}, nil
 		},
+	}
+	routeRecalculator := &testutil.MockServer{
 		UpdateRouteForStripFn: func(_ string, _ int32, _ bool) error {
 			res.routeRecalcCount++
 			return nil
 		},
-	})
+	}
 
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
 	svc.SetCoordinationRepo(coordRepo)
 	svc.SetControllerRepo(controllerRepo)
+	svc.SetSessionRepo(sessionRepo)
+	svc.SetRouteRecalculator(routeRecalculator)
 
 	return svc, res
 }
@@ -387,23 +388,24 @@ func buildTrackingChangedSvcWithCoord(
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{
-		CoordRepoVal: coordRepo,
-		SessionRepoVal: &testutil.MockSessionRepository{
-			GetByIDFn: func(_ context.Context, _ int32) (*models.Session, error) {
-				return &models.Session{ID: 1, Airport: airport}, nil
-			},
+	sessionRepo := &testutil.MockSessionRepository{
+		GetByIDFn: func(_ context.Context, _ int32) (*models.Session, error) {
+			return &models.Session{ID: 1, Airport: airport}, nil
 		},
+	}
+	routeRecalculator := &testutil.MockServer{
 		UpdateRouteForStripFn: func(_ string, _ int32, _ bool) error {
 			res.routeRecalcCount++
 			return nil
 		},
-	})
+	}
 
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
 	svc.SetCoordinationRepo(coordRepo)
 	svc.SetControllerRepo(controllerRepo)
+	svc.SetSessionRepo(sessionRepo)
+	svc.SetRouteRecalculator(routeRecalculator)
 
 	return svc, res
 }
@@ -470,9 +472,6 @@ func buildCoordinationReceivedSvc(
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{
-		CoordRepoVal: coordRepo,
-	})
 	esHub := &testutil.MockEuroscopeHub{}
 
 	svc := NewStripService(stripRepo)
@@ -581,19 +580,17 @@ func TestHandleTrackingControllerChanged_TopDownDepartureStillHides(t *testing.T
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{
-		CoordRepoVal: coordRepo,
-		SessionRepoVal: &testutil.MockSessionRepository{
-			GetByIDFn: func(_ context.Context, _ int32) (*models.Session, error) {
-				return &models.Session{ID: 1, Airport: "EKCH"}, nil
-			},
+	sessionRepo := &testutil.MockSessionRepository{
+		GetByIDFn: func(_ context.Context, _ int32) (*models.Session, error) {
+			return &models.Session{ID: 1, Airport: "EKCH"}, nil
 		},
-	})
+	}
 
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
 	svc.SetCoordinationRepo(coordRepo)
 	svc.SetControllerRepo(controllerRepo)
+	svc.SetSessionRepo(sessionRepo)
 
 	require.NoError(t, svc.HandleTrackingControllerChanged(context.Background(), 1, "SAS002", "EKCH_APP_ES"))
 	assert.Equal(t, shared.BAY_HIDDEN, res.updateBayArg)

--- a/backend/internal/services/strip_missed_approach_test.go
+++ b/backend/internal/services/strip_missed_approach_test.go
@@ -32,27 +32,23 @@ func buildMissedApproachSvc(
 		CreateFn: func(_ context.Context, _ *models.Coordination) error { return nil },
 	}
 
-	mockServer := &testutil.MockServer{
-		SessionRepoVal: &testutil.MockSessionRepository{
-			GetByIDFn: func(_ context.Context, _ int32) (*models.Session, error) {
-				return &models.Session{
-					ID: 1,
-					ActiveRunways: pkgModels.ActiveRunways{
-						ArrivalRunways: []string{"04L"},
-					},
-				}, nil
-			},
+	sessionRepo := &testutil.MockSessionRepository{
+		GetByIDFn: func(_ context.Context, _ int32) (*models.Session, error) {
+			return &models.Session{
+				ID: 1,
+				ActiveRunways: pkgModels.ActiveRunways{
+					ArrivalRunways: []string{"04L"},
+				},
+			}, nil
 		},
-		ControllerRepoVal: &testutil.MockControllerRepository{
-			ListBySessionFn: func(_ context.Context, _ int32) ([]*models.Controller, error) {
-				return controllers, nil
-			},
+	}
+	controllerRepo := &testutil.MockControllerRepository{
+		ListBySessionFn: func(_ context.Context, _ int32) ([]*models.Controller, error) {
+			return controllers, nil
 		},
-		CoordRepoVal: coordRepo,
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(mockServer)
 
 	svc := NewStripService(&testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -67,6 +63,8 @@ func buildMissedApproachSvc(
 	})
 	svc.SetFrontendHub(hub)
 	svc.SetCoordinationRepo(coordRepo)
+	svc.SetSessionRepo(sessionRepo)
+	svc.SetControllerRepo(controllerRepo)
 	if esHub != nil {
 		svc.SetEuroscopeHub(esHub)
 	}
@@ -108,18 +106,15 @@ func TestMissedApproach_NoRunwayMapping(t *testing.T) {
 		{Name: "EKCH_W_APP", Frequency: "119.805"},
 	}))
 
-	mockServer := &testutil.MockServer{
-		SessionRepoVal: &testutil.MockSessionRepository{
-			GetByIDFn: func(_ context.Context, _ int32) (*models.Session, error) {
-				return &models.Session{
-					ID:            1,
-					ActiveRunways: pkgModels.ActiveRunways{ArrivalRunways: []string{"04L"}},
-				}, nil
-			},
+	sessionRepo := &testutil.MockSessionRepository{
+		GetByIDFn: func(_ context.Context, _ int32) (*models.Session, error) {
+			return &models.Session{
+				ID:            1,
+				ActiveRunways: pkgModels.ActiveRunways{ArrivalRunways: []string{"04L"}},
+			}, nil
 		},
 	}
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(mockServer)
 
 	svc := NewStripService(&testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -127,6 +122,7 @@ func TestMissedApproach_NoRunwayMapping(t *testing.T) {
 		},
 	})
 	svc.SetFrontendHub(hub)
+	svc.SetSessionRepo(sessionRepo)
 
 	err := svc.MissedApproach(context.Background(), 1, "SAS001", "118.105")
 	require.Error(t, err)

--- a/backend/internal/services/strip_no_stand_validation_test.go
+++ b/backend/internal/services/strip_no_stand_validation_test.go
@@ -244,7 +244,6 @@ func TestUpdateStand_ReevaluatesNoStandValidation(t *testing.T) {
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{})
 	svc := NewStripService(repo)
 	svc.SetFrontendHub(hub)
 

--- a/backend/internal/services/strip_options.go
+++ b/backend/internal/services/strip_options.go
@@ -1,0 +1,77 @@
+package services
+
+import (
+	"FlightStrips/internal/repository"
+	"FlightStrips/internal/shared"
+)
+
+type StripServiceOption func(*StripService)
+
+func WithStripEventPublisher(publisher shared.StripEventPublisher) StripServiceOption {
+	return func(s *StripService) {
+		s.publisher = publisher
+	}
+}
+
+func WithEuroscopeCommander(esCommander shared.EuroscopeStripCommander) StripServiceOption {
+	return func(s *StripService) {
+		s.esCommander = esCommander
+	}
+}
+
+func WithSectorOwnerRepository(sectorOwnerRepo repository.SectorOwnerRepository) StripServiceOption {
+	return func(s *StripService) {
+		s.sectorOwnerRepo = sectorOwnerRepo
+	}
+}
+
+func WithTacticalStripRepository(tacticalRepo repository.TacticalStripRepository) StripServiceOption {
+	return func(s *StripService) {
+		s.tacticalRepo = tacticalRepo
+	}
+}
+
+func WithCoordinationStore(coordStore CoordinationStore) StripServiceOption {
+	return func(s *StripService) {
+		s.coordRepo = coordStore
+	}
+}
+
+func WithControllerReader(controllerReader ControllerReader) StripServiceOption {
+	return func(s *StripService) {
+		s.controllerRepo = controllerReader
+	}
+}
+
+func WithSessionReader(sessionReader SessionReader) StripServiceOption {
+	return func(s *StripService) {
+		s.sessionRepo = sessionReader
+	}
+}
+
+func WithRouteRecalculator(routeRecalculator RouteRecalculator) StripServiceOption {
+	return func(s *StripService) {
+		s.routeRecalculator = routeRecalculator
+		if routeComputer, ok := routeRecalculator.(StripRouteComputer); ok {
+			s.routeComputer = routeComputer
+		}
+	}
+}
+
+func WithRouteComputer(routeComputer StripRouteComputer) StripServiceOption {
+	return func(s *StripService) {
+		s.routeComputer = routeComputer
+	}
+}
+
+func WithPdcService(pdcService shared.PdcService) StripServiceOption {
+	return func(s *StripService) {
+		s.pdcService = pdcService
+	}
+}
+
+func WithCdmService(cdmService shared.CdmService) StripServiceOption {
+	return func(s *StripService) {
+		s.cdmService = cdmService
+	}
+}

--- a/backend/internal/services/strip_pdc_invalid_validation_test.go
+++ b/backend/internal/services/strip_pdc_invalid_validation_test.go
@@ -16,21 +16,20 @@ import (
 
 func newPdcInvalidValidationFixture(stripRepo *testutil.MockStripRepository, departureRunways ...string) (*StripService, *testutil.MockFrontendHub) {
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{
-		SessionRepoVal: &testutil.MockSessionRepository{
-			GetByIDFn: func(_ context.Context, id int32) (*models.Session, error) {
-				return &models.Session{
-					ID: id,
-					ActiveRunways: pkgModels.ActiveRunways{
-						DepartureRunways: departureRunways,
-					},
-				}, nil
-			},
+	sessionRepo := &testutil.MockSessionRepository{
+		GetByIDFn: func(_ context.Context, id int32) (*models.Session, error) {
+			return &models.Session{
+				ID: id,
+				ActiveRunways: pkgModels.ActiveRunways{
+					DepartureRunways: departureRunways,
+				},
+			}, nil
 		},
-	})
+	}
 
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
+	svc.SetSessionRepo(sessionRepo)
 	return svc, hub
 }
 

--- a/backend/internal/services/strip_sync.go
+++ b/backend/internal/services/strip_sync.go
@@ -36,11 +36,8 @@ type syncRouteComputer interface {
 }
 
 func (s *StripService) syncEuroscopeStrip(ctx context.Context, session int32, cid string, strip euroscope.Strip, airport string) error {
-	server := s.publisher.GetServer()
-	if server == nil {
-		return errors.New("server not configured")
-	}
-	routeComputer, _ := server.(syncRouteComputer)
+	routeRecalculator := s.getRouteRecalculator()
+	routeComputer := s.getRouteComputer()
 
 	syncState := shared.GetSyncState(ctx)
 
@@ -523,8 +520,10 @@ func (s *StripService) syncEuroscopeStrip(ctx context.Context, session int32, ci
 	}
 
 	if routeNeedsUpdate {
-		if err := server.UpdateRouteForStripContext(ctx, strip.Callsign, session, false); err != nil {
-			slog.ErrorContext(ctx, "Error updating route for strip", slog.String("callsign", strip.Callsign), slog.Any("error", err))
+		if routeRecalculator != nil {
+			if err := routeRecalculator.UpdateRouteForStripContext(ctx, strip.Callsign, session, false); err != nil {
+				slog.ErrorContext(ctx, "Error updating route for strip", slog.String("callsign", strip.Callsign), slog.Any("error", err))
+			}
 		}
 	}
 

--- a/backend/internal/services/strip_sync_test.go
+++ b/backend/internal/services/strip_sync_test.go
@@ -124,24 +124,21 @@ func TestSyncEuroscopeStrip_ExistingStripWritesRouteAndHasFPInPrimaryUpdate(t *t
 		},
 	}
 
-	svc, hub, esHub := newSyncTestFixture(t, existingStrip, stripRepo)
-	mockServer, ok := hub.GetServer().(*testutil.MockServer)
-	require.True(t, ok)
-	mockServer.UpdateRouteForStripFn = func(_ string, _ int32, _ bool) error {
-		routeUpdateCalls++
-		return nil
-	}
-
+	svc, _, _ := newSyncTestFixture(t, existingStrip, stripRepo)
 	routeServer := &syncRouteComputerTestServer{
-		MockServer: mockServer,
+		MockServer: &testutil.MockServer{
+			UpdateRouteForStripFn: func(_ string, _ int32, _ bool) error {
+				routeUpdateCalls++
+				return nil
+			},
+		},
 		computeNextOwnersFn: func(_ context.Context, strip *models.Strip, sessionId int32) ([]string, bool, error) {
 			require.Equal(t, session, sessionId)
 			require.Equal(t, callsign, strip.Callsign)
 			return []string{"EKCH_TWR"}, true, nil
 		},
 	}
-	hub.SetServer(routeServer)
-	esHub.SetServer(routeServer)
+	svc.SetRouteRecalculator(routeServer)
 
 	err := svc.syncEuroscopeStrip(ctx, session, "", euroscope.Strip{
 		Callsign:    callsign,
@@ -301,18 +298,15 @@ func TestSyncEuroscopeStrip_ParkedArrivalRefilesAsDepartureResetsLifecycleState(
 	}
 
 	svc, hub, esHub := newSyncTestFixture(t, existingStrip, stripRepo)
-	mockServer, ok := hub.GetServer().(*testutil.MockServer)
-	require.True(t, ok)
 	routeServer := &syncRouteComputerTestServer{
-		MockServer: mockServer,
+		MockServer: &testutil.MockServer{},
 		computeNextOwnersFn: func(_ context.Context, strip *models.Strip, sessionID int32) ([]string, bool, error) {
 			require.Equal(t, session, sessionID)
 			require.Equal(t, callsign, strip.Callsign)
 			return []string{"EKCH_DEL"}, true, nil
 		},
 	}
-	hub.SetServer(routeServer)
-	esHub.SetServer(routeServer)
+	svc.SetRouteRecalculator(routeServer)
 
 	err := svc.syncEuroscopeStrip(ctx, session, "", euroscope.Strip{
 		Callsign:        callsign,
@@ -1256,14 +1250,14 @@ func TestSyncEuroscopeStrip_MoveBackToNotCleared_ClearsOwner(t *testing.T) {
 	}
 
 	svc, hub, _ := newSyncTestFixture(t, existingStrip, stripRepo)
-	mockServer, ok := hub.GetServer().(*testutil.MockServer)
-	require.True(t, ok)
-	mockServer.UpdateRouteForStripFn = func(cs string, sess int32, sendUpdate bool) error {
-		routeUpdateCallsign = cs
-		routeUpdateSession = sess
-		routeUpdateSendUpdate = sendUpdate
-		return nil
-	}
+	svc.SetRouteRecalculator(&testutil.MockServer{
+		UpdateRouteForStripFn: func(cs string, sess int32, sendUpdate bool) error {
+			routeUpdateCallsign = cs
+			routeUpdateSession = sess
+			routeUpdateSendUpdate = sendUpdate
+			return nil
+		},
+	})
 
 	err := svc.syncEuroscopeStrip(ctx, session, "", euroscope.Strip{
 		Callsign: callsign,

--- a/backend/internal/services/strip_tag_request_test.go
+++ b/backend/internal/services/strip_tag_request_test.go
@@ -36,15 +36,13 @@ func TestCreateTagRequest_Success(t *testing.T) {
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	mockServer := &testutil.MockServer{CoordRepoVal: coordRepo}
-	hub.SetServer(mockServer)
-
 	svc := NewStripService(&testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
 			return strip, nil
 		},
 	})
 	svc.SetFrontendHub(hub)
+	svc.SetCoordinationRepo(coordRepo)
 
 	err := svc.CreateTagRequest(context.Background(), 1, "SAS123", "EKCH_D_TWR")
 	require.NoError(t, err)
@@ -65,7 +63,6 @@ func TestCreateTagRequest_UnownedStrip(t *testing.T) {
 	strip := &models.Strip{ID: 1, Callsign: "SAS123", Owner: nil}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{})
 
 	svc := NewStripService(&testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -85,7 +82,6 @@ func TestCreateTagRequest_AlreadyOwner(t *testing.T) {
 	strip := &models.Strip{ID: 1, Callsign: "SAS123", Owner: &owner}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{})
 
 	svc := NewStripService(&testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -112,7 +108,6 @@ func TestCreateTagRequest_ActiveCoordinationExists(t *testing.T) {
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{CoordRepoVal: coordRepo})
 
 	svc := NewStripService(&testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -120,6 +115,8 @@ func TestCreateTagRequest_ActiveCoordinationExists(t *testing.T) {
 		},
 	})
 	svc.SetFrontendHub(hub)
+	svc.SetCoordinationRepo(coordRepo)
+	svc.SetCoordinationRepo(coordRepo)
 
 	err := svc.CreateTagRequest(context.Background(), 1, "SAS123", "EKCH_GND")
 	require.Error(t, err)
@@ -129,7 +126,6 @@ func TestCreateTagRequest_ActiveCoordinationExists(t *testing.T) {
 // TestCreateTagRequest_StripNotFound verifies that a repository error is propagated.
 func TestCreateTagRequest_StripNotFound(t *testing.T) {
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{})
 
 	svc := NewStripService(&testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -174,7 +170,6 @@ func TestAcceptTagRequest_Success(t *testing.T) {
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{CoordRepoVal: coordRepo})
 
 	svc := NewStripService(&testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -189,6 +184,7 @@ func TestAcceptTagRequest_Success(t *testing.T) {
 		},
 	})
 	svc.SetFrontendHub(hub)
+	svc.SetCoordinationRepo(coordRepo)
 
 	err := svc.AcceptTagRequest(context.Background(), 1, "SAS123", "EKCH_A_TWR")
 	require.NoError(t, err)
@@ -213,7 +209,6 @@ func TestAcceptTagRequest_NotOwner(t *testing.T) {
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{CoordRepoVal: coordRepo})
 
 	svc := NewStripService(&testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -221,6 +216,7 @@ func TestAcceptTagRequest_NotOwner(t *testing.T) {
 		},
 	})
 	svc.SetFrontendHub(hub)
+	svc.SetCoordinationRepo(coordRepo)
 
 	err := svc.AcceptTagRequest(context.Background(), 1, "SAS123", "EKCH_D_TWR")
 	require.Error(t, err)
@@ -240,7 +236,6 @@ func TestAcceptTagRequest_NotTagRequest(t *testing.T) {
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{CoordRepoVal: coordRepo})
 
 	svc := NewStripService(&testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -248,6 +243,7 @@ func TestAcceptTagRequest_NotTagRequest(t *testing.T) {
 		},
 	})
 	svc.SetFrontendHub(hub)
+	svc.SetCoordinationRepo(coordRepo)
 
 	err := svc.AcceptTagRequest(context.Background(), 1, "SAS123", "EKCH_A_TWR")
 	require.Error(t, err)
@@ -283,7 +279,6 @@ func TestAcceptTagRequest_DisplacedOwnerRemovedFromPrevious(t *testing.T) {
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{CoordRepoVal: coordRepo})
 
 	svc := NewStripService(&testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -298,6 +293,7 @@ func TestAcceptTagRequest_DisplacedOwnerRemovedFromPrevious(t *testing.T) {
 		},
 	})
 	svc.SetFrontendHub(hub)
+	svc.SetCoordinationRepo(coordRepo)
 
 	err := svc.AcceptTagRequest(context.Background(), 1, "SAS123", "EKCH_A_TWR")
 	require.NoError(t, err)
@@ -325,13 +321,13 @@ func TestAcceptTagRequest_RouteRecalculated(t *testing.T) {
 	}
 
 	routeRecalculated := false
-	mockServer := &testutil.MockServer{
-		CoordRepoVal: &testutil.MockCoordinationRepository{
-			GetByStripCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Coordination, error) {
-				return coord, nil
-			},
-			DeleteFn: func(_ context.Context, _ int32) error { return nil },
+	coordRepo := &testutil.MockCoordinationRepository{
+		GetByStripCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Coordination, error) {
+			return coord, nil
 		},
+		DeleteFn: func(_ context.Context, _ int32) error { return nil },
+	}
+	routeRecalculator := &testutil.MockServer{
 		UpdateRouteForStripFn: func(callsign string, sessionId int32, sendUpdate bool) error {
 			assert.Equal(t, "SAS123", callsign)
 			assert.Equal(t, int32(1), sessionId)
@@ -342,7 +338,6 @@ func TestAcceptTagRequest_RouteRecalculated(t *testing.T) {
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(mockServer)
 
 	svc := NewStripService(&testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -356,6 +351,8 @@ func TestAcceptTagRequest_RouteRecalculated(t *testing.T) {
 		},
 	})
 	svc.SetFrontendHub(hub)
+	svc.SetCoordinationRepo(coordRepo)
+	svc.SetRouteRecalculator(routeRecalculator)
 
 	err := svc.AcceptTagRequest(context.Background(), 1, "SAS123", "EKCH_A_TWR")
 	require.NoError(t, err)
@@ -395,18 +392,14 @@ func TestAcceptTagRequest_NextOwnersFilteredFromPrevious(t *testing.T) {
 	callCount := 0
 	var savedPrevious []string
 
-	mockServer := &testutil.MockServer{
-		CoordRepoVal: &testutil.MockCoordinationRepository{
-			GetByStripCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Coordination, error) {
-				return coord, nil
-			},
-			DeleteFn: func(_ context.Context, _ int32) error { return nil },
+	coordRepo := &testutil.MockCoordinationRepository{
+		GetByStripCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Coordination, error) {
+			return coord, nil
 		},
-		UpdateRouteForStripFn: func(_ string, _ int32, _ bool) error { return nil },
+		DeleteFn: func(_ context.Context, _ int32) error { return nil },
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(mockServer)
 
 	svc := NewStripService(&testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -428,6 +421,10 @@ func TestAcceptTagRequest_NextOwnersFilteredFromPrevious(t *testing.T) {
 		},
 	})
 	svc.SetFrontendHub(hub)
+	svc.SetCoordinationRepo(coordRepo)
+	svc.SetRouteRecalculator(&testutil.MockServer{
+		UpdateRouteForStripFn: func(_ string, _ int32, _ bool) error { return nil },
+	})
 
 	err := svc.AcceptTagRequest(context.Background(), 1, "SAS123", "EKCH_A_TWR")
 	require.NoError(t, err)
@@ -473,7 +470,6 @@ func TestAcceptTagRequest_CoordinationDeleted(t *testing.T) {
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{CoordRepoVal: coordRepo})
 
 	svc := NewStripService(&testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -487,6 +483,7 @@ func TestAcceptTagRequest_CoordinationDeleted(t *testing.T) {
 		},
 	})
 	svc.SetFrontendHub(hub)
+	svc.SetCoordinationRepo(coordRepo)
 
 	err := svc.AcceptTagRequest(context.Background(), 1, "SAS123", "EKCH_A_TWR")
 	require.NoError(t, err)
@@ -520,7 +517,6 @@ func TestAcceptTagRequest_SetOwnerFails(t *testing.T) {
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{CoordRepoVal: coordRepo})
 
 	svc := NewStripService(&testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -534,6 +530,7 @@ func TestAcceptTagRequest_SetOwnerFails(t *testing.T) {
 		},
 	})
 	svc.SetFrontendHub(hub)
+	svc.SetCoordinationRepo(coordRepo)
 
 	err := svc.AcceptTagRequest(context.Background(), 1, "SAS123", "EKCH_A_TWR")
 	require.Error(t, err)
@@ -563,7 +560,6 @@ func TestAcceptTagRequest_RequesterInNextList_OwnerAppendedToPrevious(t *testing
 
 	var savedPreviousOwners []string
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{CoordRepoVal: coordRepo})
 
 	svc := NewStripService(&testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -578,6 +574,7 @@ func TestAcceptTagRequest_RequesterInNextList_OwnerAppendedToPrevious(t *testing
 		},
 	})
 	svc.SetFrontendHub(hub)
+	svc.SetCoordinationRepo(coordRepo)
 
 	err := svc.AcceptTagRequest(context.Background(), 1, "SAS123", "EKCH_A_TWR")
 	require.NoError(t, err)
@@ -609,7 +606,6 @@ func TestAcceptTagRequest_RequesterNotInNextList_OwnerNotAppendedToPrevious(t *t
 
 	var savedPreviousOwners []string
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{CoordRepoVal: coordRepo})
 
 	svc := NewStripService(&testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -624,6 +620,7 @@ func TestAcceptTagRequest_RequesterNotInNextList_OwnerNotAppendedToPrevious(t *t
 		},
 	})
 	svc.SetFrontendHub(hub)
+	svc.SetCoordinationRepo(coordRepo)
 
 	err := svc.AcceptTagRequest(context.Background(), 1, "SAS123", "EKCH_A_TWR")
 	require.NoError(t, err)

--- a/backend/internal/services/strip_test.go
+++ b/backend/internal/services/strip_test.go
@@ -203,17 +203,18 @@ func TestAutoAssume_ClearedStrip(t *testing.T) {
 	var routeUpdateSession int32
 	var routeUpdateSendUpdate bool
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{
+	routeRecalculator := &testutil.MockServer{
 		UpdateRouteForStripFn: func(cs string, sess int32, sendUpdate bool) error {
 			routeUpdateCallsign = cs
 			routeUpdateSession = sess
 			routeUpdateSendUpdate = sendUpdate
 			return nil
 		},
-	})
+	}
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
 	svc.SetSectorOwnerRepo(sectorRepo)
+	svc.SetRouteRecalculator(routeRecalculator)
 
 	err := svc.AutoAssumeForClearedStrip(ctx, session, callsign)
 	require.NoError(t, err)
@@ -356,17 +357,18 @@ func TestAutoAssume_FallbackToDel(t *testing.T) {
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{
+	routeRecalculator := &testutil.MockServer{
 		UpdateRouteForStripFn: func(cs string, sess int32, sendUpdate bool) error {
 			assert.Equal(t, callsign, cs)
 			assert.Equal(t, session, sess)
 			assert.False(t, sendUpdate)
 			return nil
 		},
-	})
+	}
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
 	svc.SetSectorOwnerRepo(sectorRepo)
+	svc.SetRouteRecalculator(routeRecalculator)
 
 	err := svc.AutoAssumeForClearedStrip(ctx, session, callsign)
 	require.NoError(t, err)
@@ -399,18 +401,17 @@ func TestAutoAssume_ClearedArrivalStrip_IsIgnored(t *testing.T) {
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{
-		SessionRepoVal: &testutil.MockSessionRepository{
-			GetByIDFn: func(_ context.Context, id int32) (*models.Session, error) {
-				assert.Equal(t, session, id)
-				return &models.Session{ID: session, Airport: "EKCH"}, nil
-			},
+	sessionRepo := &testutil.MockSessionRepository{
+		GetByIDFn: func(_ context.Context, id int32) (*models.Session, error) {
+			assert.Equal(t, session, id)
+			return &models.Session{ID: session, Airport: "EKCH"}, nil
 		},
-	})
+	}
 
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
 	svc.SetSectorOwnerRepo(sectorRepo)
+	svc.SetSessionRepo(sessionRepo)
 
 	err := svc.AutoAssumeForClearedStrip(ctx, session, callsign)
 	require.NoError(t, err)
@@ -466,16 +467,17 @@ func TestAutoAssumeForControllerOnline_AssumesMatchingStrip(t *testing.T) {
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{
+	routeRecalculator := &testutil.MockServer{
 		UpdateRouteForStripFn: func(cs string, sess int32, sendUpdate bool) error {
 			assert.Equal(t, "SAS100", cs)
 			assert.Equal(t, session, sess)
 			assert.False(t, sendUpdate)
 			return nil
 		},
-	})
+	}
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
+	svc.SetRouteRecalculator(routeRecalculator)
 
 	err := svc.AutoAssumeForControllerOnline(ctx, session, position)
 	require.NoError(t, err)
@@ -540,17 +542,16 @@ func TestAutoAssumeForControllerOnline_IgnoresArrivalStrip(t *testing.T) {
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(&testutil.MockServer{
-		SessionRepoVal: &testutil.MockSessionRepository{
-			GetByIDFn: func(_ context.Context, id int32) (*models.Session, error) {
-				assert.Equal(t, session, id)
-				return &models.Session{ID: session, Airport: "EKCH"}, nil
-			},
+	sessionRepo := &testutil.MockSessionRepository{
+		GetByIDFn: func(_ context.Context, id int32) (*models.Session, error) {
+			assert.Equal(t, session, id)
+			return &models.Session{ID: session, Airport: "EKCH"}, nil
 		},
-	})
+	}
 
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
+	svc.SetSessionRepo(sessionRepo)
 
 	err := svc.AutoAssumeForControllerOnline(ctx, session, position)
 	require.NoError(t, err)
@@ -579,9 +580,7 @@ func TestCreateCoordinationTransfer_Success(t *testing.T) {
 		},
 	}
 
-	mockServer := &testutil.MockServer{CoordRepoVal: coordRepo}
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(mockServer)
 
 	stripRepo := &testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -597,6 +596,7 @@ func TestCreateCoordinationTransfer_Success(t *testing.T) {
 
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
+	svc.SetCoordinationRepo(coordRepo)
 
 	err := svc.CreateCoordinationTransfer(ctx, session, callsign, fromPos, toPos)
 	require.NoError(t, err)
@@ -664,17 +664,13 @@ func TestCreateCoordinationTransfer_TaxiBayToTower_MovesToLowerTaxiBay(t *testin
 		},
 	}
 
-	mockServer := &testutil.MockServer{
-		CoordRepoVal: coordRepo,
-		SessionRepoVal: &testutil.MockSessionRepository{
-			GetByIDFn: func(_ context.Context, id int32) (*models.Session, error) {
-				assert.Equal(t, session, id)
-				return &models.Session{ID: session, Airport: "EKCH"}, nil
-			},
+	sessionRepo := &testutil.MockSessionRepository{
+		GetByIDFn: func(_ context.Context, id int32) (*models.Session, error) {
+			assert.Equal(t, session, id)
+			return &models.Session{ID: session, Airport: "EKCH"}, nil
 		},
 	}
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(mockServer)
 
 	stripRepo := &testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -696,6 +692,8 @@ func TestCreateCoordinationTransfer_TaxiBayToTower_MovesToLowerTaxiBay(t *testin
 
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
+	svc.SetCoordinationRepo(coordRepo)
+	svc.SetSessionRepo(sessionRepo)
 
 	err := svc.CreateCoordinationTransfer(ctx, session, callsign, fromPos, toPos)
 	require.NoError(t, err)
@@ -719,17 +717,13 @@ func TestCreateCoordinationTransfer_ArrivalTaxiBayToTower_DoesNotMoveToLowerTaxi
 		CreateFn: func(_ context.Context, _ *models.Coordination) error { return nil },
 	}
 
-	mockServer := &testutil.MockServer{
-		CoordRepoVal: coordRepo,
-		SessionRepoVal: &testutil.MockSessionRepository{
-			GetByIDFn: func(_ context.Context, id int32) (*models.Session, error) {
-				assert.Equal(t, session, id)
-				return &models.Session{ID: session, Airport: "EKCH"}, nil
-			},
+	sessionRepo := &testutil.MockSessionRepository{
+		GetByIDFn: func(_ context.Context, id int32) (*models.Session, error) {
+			assert.Equal(t, session, id)
+			return &models.Session{ID: session, Airport: "EKCH"}, nil
 		},
 	}
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(mockServer)
 
 	stripRepo := &testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -747,6 +741,8 @@ func TestCreateCoordinationTransfer_ArrivalTaxiBayToTower_DoesNotMoveToLowerTaxi
 
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
+	svc.SetCoordinationRepo(coordRepo)
+	svc.SetSessionRepo(sessionRepo)
 
 	err := svc.CreateCoordinationTransfer(ctx, session, callsign, fromPos, toPos)
 	require.NoError(t, err)
@@ -767,9 +763,7 @@ func TestCreateCoordinationTransfer_TaxiBayToNonTower_DoesNotMoveToLowerTaxiBay(
 		CreateFn: func(_ context.Context, _ *models.Coordination) error { return nil },
 	}
 
-	mockServer := &testutil.MockServer{CoordRepoVal: coordRepo}
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(mockServer)
 
 	stripRepo := &testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
@@ -779,6 +773,7 @@ func TestCreateCoordinationTransfer_TaxiBayToNonTower_DoesNotMoveToLowerTaxiBay(
 
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
+	svc.SetCoordinationRepo(coordRepo)
 
 	err := svc.CreateCoordinationTransfer(ctx, session, callsign, fromPos, toPos)
 	require.NoError(t, err)
@@ -796,12 +791,11 @@ func TestCreateCoordinationTransfer_StripNotFound(t *testing.T) {
 	}
 
 	coordRepo := &testutil.MockCoordinationRepository{}
-	mockServer := &testutil.MockServer{CoordRepoVal: coordRepo}
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(mockServer)
 
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
+	svc.SetCoordinationRepo(coordRepo)
 
 	err := svc.CreateCoordinationTransfer(ctx, 1, "UNKNOWN", "DEL_N", "GND_N")
 	require.Error(t, err)
@@ -833,9 +827,7 @@ func TestCreateCoordinationTransfer_AirborneBay_SendsEsHandover(t *testing.T) {
 		},
 	}
 
-	mockServer := &testutil.MockServer{CoordRepoVal: coordRepo, ControllerRepoVal: controllerRepo}
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(mockServer)
 
 	esHub := &testutil.MockEuroscopeHub{}
 
@@ -848,6 +840,8 @@ func TestCreateCoordinationTransfer_AirborneBay_SendsEsHandover(t *testing.T) {
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
 	svc.SetEuroscopeHub(esHub)
+	svc.SetCoordinationRepo(coordRepo)
+	svc.SetControllerRepo(controllerRepo)
 
 	err := svc.CreateCoordinationTransfer(ctx, session, callsign, fromPos, toPos)
 	require.NoError(t, err)
@@ -873,9 +867,7 @@ func TestCreateCoordinationTransfer_NonAirborneBay_NoEsHandover(t *testing.T) {
 		CreateFn: func(_ context.Context, _ *models.Coordination) error { return nil },
 	}
 
-	mockServer := &testutil.MockServer{CoordRepoVal: coordRepo}
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(mockServer)
 
 	esHub := &testutil.MockEuroscopeHub{}
 
@@ -888,6 +880,7 @@ func TestCreateCoordinationTransfer_NonAirborneBay_NoEsHandover(t *testing.T) {
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
 	svc.SetEuroscopeHub(esHub)
+	svc.SetCoordinationRepo(coordRepo)
 
 	err := svc.CreateCoordinationTransfer(ctx, session, callsign, fromPos, toPos)
 	require.NoError(t, err)
@@ -950,12 +943,11 @@ func TestAcceptCoordination_UpdatesOwner(t *testing.T) {
 		},
 	}
 
-	mockServer := &testutil.MockServer{CoordRepoVal: coordRepo}
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(mockServer)
 
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
+	svc.SetCoordinationRepo(coordRepo)
 
 	err := svc.AcceptCoordination(ctx, session, callsign, assumingPos)
 	require.NoError(t, err)
@@ -1121,12 +1113,11 @@ func TestAcceptCoordination_NoCoordination(t *testing.T) {
 		},
 	}
 
-	mockServer := &testutil.MockServer{CoordRepoVal: coordRepo}
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(mockServer)
 
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
+	svc.SetCoordinationRepo(coordRepo)
 
 	err := svc.AcceptCoordination(ctx, session, callsign, "GND_N")
 	require.NoError(t, err) // no coordination is not an error
@@ -1233,9 +1224,9 @@ func TestUpdateStand_TriggersRouteRecalculation(t *testing.T) {
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(mockServer)
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
+	svc.SetRouteRecalculator(mockServer)
 
 	err := svc.UpdateStand(ctx, session, callsign, stand)
 	require.NoError(t, err)
@@ -1275,9 +1266,7 @@ func TestUpdateStand_StandChangeClearsStartReq(t *testing.T) {
 		},
 	}
 
-	mockServer := &testutil.MockServer{}
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(mockServer)
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
 
@@ -1309,9 +1298,9 @@ func TestUpdateStand_NoRouteUpdateWhenStripNotFound(t *testing.T) {
 	}
 
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(mockServer)
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
+	svc.SetRouteRecalculator(mockServer)
 
 	err := svc.UpdateStand(ctx, 1, "SAS999", "B5")
 	require.NoError(t, err)

--- a/backend/internal/services/strip_unexpected_change_test.go
+++ b/backend/internal/services/strip_unexpected_change_test.go
@@ -25,16 +25,8 @@ func newSyncTestFixture(t *testing.T, _ *models.Strip, stripRepo *testutil.MockS
 			return &models.Session{ActiveRunways: pkgModels.ActiveRunways{}}, nil
 		},
 	}
-
-	mockServer := &testutil.MockServer{
-		SessionRepoVal: sessionRepo,
-	}
-
 	hub := &testutil.MockFrontendHub{}
-	hub.SetServer(mockServer)
-
 	esHub := &testutil.MockEuroscopeHub{}
-	esHub.SetServer(mockServer)
 
 	// MoveToBay needs GetMaxSequenceInBayFn; provide a safe default.
 	if stripRepo.GetMaxSequenceInBayFn == nil {
@@ -72,6 +64,7 @@ func newSyncTestFixture(t *testing.T, _ *models.Strip, stripRepo *testutil.MockS
 	svc := NewStripService(stripRepo)
 	svc.SetFrontendHub(hub)
 	svc.SetEuroscopeHub(esHub)
+	svc.SetSessionRepo(sessionRepo)
 
 	return svc, hub, esHub
 }

--- a/backend/internal/shared/publisher.go
+++ b/backend/internal/shared/publisher.go
@@ -11,8 +11,6 @@ import (
 // automatically satisfies it; services depend on this narrow view to make
 // their event surface explicit.
 type StripEventPublisher interface {
-	ServerInjectable
-
 	Broadcast(session int32, message frontend.OutgoingMessage)
 	SendStripUpdate(session int32, callsign string)
 	SendAssignedSquawkEvent(session int32, callsign string, squawk string)
@@ -51,8 +49,6 @@ type EuroscopeStripCommander interface {
 // CdmEventPublisher is the narrow frontend-broadcast interface the CDM service
 // uses. It is a subset of FrontendHub.
 type CdmEventPublisher interface {
-	ServerInjectable
-
 	SendCdmUpdate(session int32, event frontend.CdmDataEvent)
 	SendCdmUpdates(session int32, events []frontend.CdmDataEvent)
 	SendCdmWait(session int32, callsign string)

--- a/backend/internal/testing/e2e/server.go
+++ b/backend/internal/testing/e2e/server.go
@@ -116,14 +116,17 @@ func StartTestServer() (*TestServer, error) {
 	coordRepo := postgres.NewCoordinationRepository(dbpool)
 
 	// Initialize services
-	stripService := services.NewStripService(stripRepo)
+	stripService := services.NewStripService(
+		stripRepo,
+		services.WithCoordinationStore(coordRepo),
+		services.WithControllerReader(controllerRepo),
+		services.WithSessionReader(sessionRepo),
+		services.WithSectorOwnerRepository(sectorRepo),
+	)
 	controllerService := services.NewControllerService(controllerRepo)
 	cdmClient := cdm.NewClient(cdm.WithAPIKey(""))
 	cdmService := cdm.NewCdmService(cdmClient, stripRepo, sessionRepo, controllerRepo)
 	cdmService.SetValidationReevaluator(stripService)
-
-	stripService.SetCoordinationRepo(coordRepo)
-	stripService.SetControllerRepo(controllerRepo)
 
 	// Initialize hubs
 	frontendHub := frontend.NewHub(stripService, authService)
@@ -140,7 +143,9 @@ func StartTestServer() (*TestServer, error) {
 
 	frontendHub.SetServer(fsServer)
 	euroscopeHub.SetServer(fsServer)
-	controllerService.SetServer(fsServer)
+	stripService.SetRouteRecalculator(fsServer)
+	controllerService.SetFrontendNotifier(frontendHub)
+	controllerService.SetSessionRecalculator(fsServer)
 	controllerService.SetStripService(stripService)
 
 	// Create WebSocket upgraders


### PR DESCRIPTION
## Summary
- remove the shared server service-locator fallback from strip and controller services
- add explicit dependency interfaces and constructor options for service wiring
- update service, hub, and e2e tests to inject narrow dependencies directly

## Testing
- go test ./...