### PR TITLE
chore(app): extract application bootstrap

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -1,57 +1,25 @@
 package main
 
 import (
-	"FlightStrips/internal/alb"
-	"FlightStrips/internal/cdm"
+	"FlightStrips/internal/app"
 	"FlightStrips/internal/config"
-	"FlightStrips/internal/database"
-	"FlightStrips/internal/ecfmp"
-	ecfmpWebAPI "FlightStrips/internal/ecfmp/webapi"
-	"FlightStrips/internal/euroscope"
-	"FlightStrips/internal/frontend"
-	"FlightStrips/internal/metar"
-	"FlightStrips/internal/pdc"
-	"FlightStrips/internal/pilot"
-	"FlightStrips/internal/repository/postgres"
-	"FlightStrips/internal/server"
-	"FlightStrips/internal/services"
 	"FlightStrips/internal/telemetry"
-	"FlightStrips/internal/vatsim"
-	"FlightStrips/internal/websocket"
-	pkgEuroscope "FlightStrips/pkg/events/euroscope"
-	pkgFrontend "FlightStrips/pkg/events/frontend"
 	"context"
-	_ "database/sql"
 	"flag"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
 	"time"
 
-	"github.com/exaring/otelpgx"
-	_ "github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
-
-	_ "embed"
-
-	_ "github.com/jackc/pgx/v5/pgtype"
-
 	"github.com/joho/godotenv"
 	"github.com/lmittmann/tint"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-	"go.opentelemetry.io/otel"
 )
 
 var addr = flag.String("addr", "", "http service address (overrides SERVER_ADDR env var)")
-
-func healthz(w http.ResponseWriter, _ *http.Request) {
-	w.WriteHeader(http.StatusOK)
-}
 
 func main() {
 	flag.Parse()
@@ -60,40 +28,20 @@ func main() {
 		*addr = getEnv("SERVER_ADDR", "127.0.0.1:8090")
 	}
 
-	var logLevel slog.LevelVar
-	switch strings.ToUpper(os.Getenv("LOG_LEVEL")) {
-	case "DEBUG":
-		logLevel.Set(slog.LevelDebug)
-	case "WARN":
-		logLevel.Set(slog.LevelWarn)
-	case "ERROR":
-		logLevel.Set(slog.LevelError)
-	default: // "INFO" or unset
-		logLevel.Set(slog.LevelInfo)
-	}
-	logger := slog.New(tint.NewHandler(os.Stdout, &tint.Options{Level: &logLevel}))
-	slog.SetDefault(logger)
+	configureLogging()
+	loadEnvFiles()
 
-	var err error
-	for _, envFile := range []string{".env", ".env.dev"} {
-		err = godotenv.Load(envFile)
-		if err != nil && !os.IsNotExist(err) {
-			slog.Error("Error loading env file", slog.String("file", envFile), slog.Any("error", err))
-			os.Exit(1)
-		}
-	}
+	ctx, cancelWorkers := context.WithCancel(context.Background())
+	defer cancelWorkers()
 
-	ctx := context.Background()
 	if err := config.InitConfig(); err != nil {
 		slog.Error("Failed to initialize config", slog.Any("error", err))
 		os.Exit(1)
 	}
 
-	// Initialize OpenTelemetry if endpoint is configured
 	otlpEndpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
-	var tel *telemetry.Telemetry
 	if otlpEndpoint != "" {
-		tel, err = telemetry.Initialize(ctx, telemetry.Config{
+		tel, err := telemetry.Initialize(ctx, telemetry.Config{
 			ServiceName:    "flightstrips-backend",
 			ServiceVersion: "1.0.0",
 			Environment:    getEnv("ENVIRONMENT", "development"),
@@ -108,240 +56,62 @@ func main() {
 			}
 		}()
 
-		// Setup dual logger (stdout + OTEL)
 		telemetry.SetupDualLogger()
 		slog.Info("OpenTelemetry initialized", slog.String("endpoint", otlpEndpoint))
 	}
 
-	// Configure pgxpool with OTEL tracing
-	poolConfig, err := pgxpool.ParseConfig(os.Getenv("DATABASE_CONNECTIONSTRING"))
-	if err != nil {
-		slog.Error("Failed to parse database connection string", slog.Any("error", err))
-		os.Exit(1)
-	}
-
-	if otlpEndpoint != "" {
-		poolConfig.ConnConfig.Tracer = otelpgx.NewTracer(
-			otelpgx.WithTracerProvider(otel.GetTracerProvider()),
-			otelpgx.WithTrimSQLInSpanName(),
-		)
-	}
-
-	dbpool, err := pgxpool.NewWithConfig(ctx, poolConfig)
-	if err != nil {
-		slog.Error("Failed to connect to database", slog.Any("error", err))
-		os.Exit(1)
-	}
-	defer dbpool.Close()
-
-	if otlpEndpoint != "" {
-		if err := otelpgx.RecordStats(dbpool); err != nil {
-			slog.Warn("Failed to record database stats", slog.Any("error", err))
-		}
-	}
-
-	authenticationService, err := services.NewAuthenticationService(os.Getenv("OIDC_SIGNING_ALGO"), os.Getenv("OIDC_AUTHORITY"), getEnv("OIDC_AUDIENCE", "backend-dev"))
-	if err != nil {
-		slog.Error("Failed to initialize authentication service", slog.Any("error", err))
-		os.Exit(1)
-	}
-
-	cdmKey := os.Getenv("CDM_KEY")
-	cdmClient := cdm.NewClient(cdm.WithAPIKey(cdmKey))
-
-	// Initialize repositories
-	stripRepo := postgres.NewStripRepository(dbpool)
-	controllerRepo := postgres.NewControllerRepository(dbpool)
-	sessionRepo := postgres.NewSessionRepository(dbpool)
-	sectorRepo := postgres.NewSectorOwnerRepository(dbpool)
-	coordRepo := postgres.NewCoordinationRepository(dbpool)
-	tacticalStripRepo := postgres.NewTacticalStripRepository(dbpool)
-
-	// Initialize services
-	stripService := services.NewStripService(
-		stripRepo,
-		services.WithTacticalStripRepository(tacticalStripRepo),
-		services.WithCoordinationStore(coordRepo),
-		services.WithControllerReader(controllerRepo),
-		services.WithSessionReader(sessionRepo),
-		services.WithSectorOwnerRepository(sectorRepo),
-	)
-	controllerService := services.NewControllerService(controllerRepo)
-	cdmService := cdm.NewCdmService(cdmClient, stripRepo, sessionRepo, controllerRepo)
-	ecfmpBaseURL := getEnv("ECFMP_BASE_URL", ecfmp.DefaultBaseURL)
-	ecfmpClient := ecfmp.NewClient(ecfmp.WithBaseURL(ecfmpBaseURL))
-
-	stripService.SetCdmService(cdmService)
-	cdmService.SetValidationReevaluator(stripService)
-
-	// Initialize PDC Service
-	hoppieLogon := os.Getenv("HOPPIE_LOGON")
-	pdcClient := pdc.HoppieClientInterface(pdc.NoopHoppieClient{})
-	if hoppieLogon != "" {
-		pdcClient = pdc.NewClient(hoppieLogon)
-		slog.Info("PDC Hoppie client initialized")
-	} else {
-		slog.Warn("PDC Hoppie client disabled - HOPPIE_LOGON not set")
-	}
-	pdcService := pdc.NewPDCService(pdcClient, sessionRepo, stripRepo, sectorRepo, controllerRepo)
-	pdcService.SetStripService(stripService)
-	pdcService.SetWebLookupLiveOnly(envBool("PDC_WEB_LOOKUP_LIVE_ONLY", isLiveEnvironment(getEnv("ENVIRONMENT", "development"))))
-
-	requireLiveCIDVerification := isLiveEnvironment(getEnv("ENVIRONMENT", "development"))
-	var vatsimCache *vatsim.Cache
-	if requireLiveCIDVerification {
-		vatsimCache = vatsim.NewCache(
-			getEnv("VATSIM_STATUS_URL", ""),
-			envDuration("VATSIM_POLL_INTERVAL", 30*time.Second),
-			nil,
-		)
-		slog.Info("VATSIM cache enabled for live web PDC ownership verification")
-	}
-
-	var fsServer *server.Server
-	transceiverCache := vatsim.NewTransceiverCache(
-		getEnv("VATSIM_TRANSCEIVERS_URL", ""),
-		envDuration("VATSIM_TRANSCEIVER_POLL_INTERVAL", 30*time.Second),
-		nil,
-		func(ctx context.Context) error {
-			if fsServer == nil {
-				return nil
-			}
-			return fsServer.RefreshAllSectors(ctx)
-		},
-	)
-	slog.Info("VATSIM transceiver cache enabled for sector ownership refresh")
-	pdcService.SetTransceiverLookup(transceiverCache)
-
-	frontendHub := frontend.NewHub(stripService, authenticationService)
-	euroscopeHub := euroscope.NewHub(stripService, controllerService, authenticationService)
-	albHub := alb.NewHub()
-	ecfmpService := ecfmp.NewService(ecfmpClient, stripRepo, sessionRepo, frontendHub, euroscopeHub)
-
-	stripService.SetFrontendHub(frontendHub)
-	stripService.SetEuroscopeHub(euroscopeHub)
-	stripService.SetSectorOwnerRepo(sectorRepo)
-	cdmService.SetFrontendHub(frontendHub)
-	cdmService.SetEuroscopeHub(euroscopeHub)
-
-	cdmCfg := config.GetCdmConfig()
-	resolveURI := func(uri string) string {
-		if uri == "" || strings.HasPrefix(uri, "http://") || strings.HasPrefix(uri, "https://") {
-			return uri
-		}
-		return filepath.Join(config.GetConfigDir(), uri)
-	}
-	configStore := cdm.NewCdmConfigStore(
-		resolveURI(cdmCfg.RateUri),
-		resolveURI(cdmCfg.SidIntervalUri),
-		resolveURI(cdmCfg.TaxizonesUri),
-		envDuration("CDM_CONFIG_REFRESH_INTERVAL", 15*time.Minute),
-		cdm.CdmConfigDefaults{
-			Rate:        cdmCfg.Rate,
-			RateLvo:     cdmCfg.RateLvo,
-			TaxiMinutes: cdm.DefaultCDMTaxiMinutes,
-		},
-		nil,
-	)
-	// Seed deice config and default rates from YAML before first refresh.
-	configStore.SeedAirportConfig("EKCH", cdmCfg.Rate, cdmCfg.RateLvo, cdm.CdmDeiceConfig{
-		Light:  cdmCfg.Deice.Light,
-		Medium: cdmCfg.Deice.Medium,
-		Heavy:  cdmCfg.Deice.Heavy,
-		Super:  cdmCfg.Deice.Super,
-		Platform: func() []cdm.CdmDeicePlatformConfig {
-			platforms := make([]cdm.CdmDeicePlatformConfig, len(cdmCfg.Deice.Platform))
-			for i, p := range cdmCfg.Deice.Platform {
-				platforms[i] = cdm.CdmDeicePlatformConfig{Name: p.Name, Time: p.Time}
-			}
-			return platforms
-		}(),
+	application, err := app.Build(ctx, app.Config{
+		DatabaseConnectionString: os.Getenv("DATABASE_CONNECTIONSTRING"),
+		OIDCSigningAlgorithm:     os.Getenv("OIDC_SIGNING_ALGO"),
+		OIDCAuthority:            os.Getenv("OIDC_AUTHORITY"),
+		OIDCAudience:             getEnv("OIDC_AUDIENCE", "backend-dev"),
+		Environment:              getEnv("ENVIRONMENT", "development"),
+		EnablePostgresTracing:    otlpEndpoint != "",
+		EnableHTTPTracing:        otlpEndpoint != "",
+		CDMKey:                   os.Getenv("CDM_KEY"),
+		CDMConfigRefreshInterval: envDuration("CDM_CONFIG_REFRESH_INTERVAL", 15*time.Minute),
+		EnableCDMConfigStore:     true,
+		HoppieLogon:              os.Getenv("HOPPIE_LOGON"),
+		PDCWebLookupLiveOnly:     envBool("PDC_WEB_LOOKUP_LIVE_ONLY", isLiveEnvironment(getEnv("ENVIRONMENT", "development"))),
+		EnablePDC:                true,
+		ECFMPBaseURL:             getEnv("ECFMP_BASE_URL", ""),
+		EnableECFMP:              true,
+		EnableECFMPAPI:           !isLiveEnvironment(getEnv("ENVIRONMENT", "development")),
+		EnablePilotAPI:           true,
+		EnableALB:                true,
+		EnableMetar:              true,
+		EnableVATSIM:             true,
+		EnableTransceivers:       true,
+		EnableTraffic:            true,
+		EnableDBSeed:             true,
+	}, app.Dependencies{
+		VATSIMStatusURL:      getEnv("VATSIM_STATUS_URL", ""),
+		VATSIMPollInterval:   envDuration("VATSIM_POLL_INTERVAL", 30*time.Second),
+		TransceiversURL:      getEnv("VATSIM_TRANSCEIVERS_URL", ""),
+		TransceiversInterval: envDuration("VATSIM_TRANSCEIVER_POLL_INTERVAL", 30*time.Second),
 	})
-	sequenceService := cdm.NewSequenceService(stripRepo, sessionRepo, configStore, frontendHub, euroscopeHub)
-	cdmService.SetConfigProvider(configStore)
-	cdmService.SetSequenceService(sequenceService)
-	configStore.SetOnAirportConfigChanged(func(airport string) {
-		if err := cdmService.TriggerRecalculateForAirport(context.Background(), airport); err != nil {
-			slog.Warn("CDM config change recalculation failed",
-				slog.String("airport", airport),
-				slog.Any("error", err),
-			)
+	if err != nil {
+		slog.Error("Failed to build application", slog.Any("error", err))
+		os.Exit(1)
+	}
+	defer func() {
+		if err := application.Close(context.Background()); err != nil {
+			slog.Error("Failed to close application", slog.Any("error", err))
 		}
-	})
-	go configStore.Start(ctx)
-	slog.Info("CDM local calculation enabled", slog.String("rateUri", resolveURI(cdmCfg.RateUri)))
+	}()
+	application.StartWorkers(ctx)
 
-	if pdcService != nil {
-		stripService.SetPdcService(pdcService)
-		pdcService.SetFrontendHub(frontendHub)
-		pdcService.SetEuroscopeHub(euroscopeHub)
-	}
-
-	fsServer = server.NewServer(dbpool, euroscopeHub, frontendHub, cdmService, pdcService, transceiverCache, stripRepo, controllerRepo, sessionRepo, sectorRepo, coordRepo, tacticalStripRepo)
-
-	frontendHub.SetServer(fsServer)
-	euroscopeHub.SetServer(fsServer)
-	stripService.SetRouteRecalculator(fsServer)
-	controllerService.SetFrontendNotifier(frontendHub)
-	controllerService.SetSessionRecalculator(fsServer)
-	controllerService.SetStripService(stripService)
-
-	frontendUpgrader := websocket.NewConnectionUpgrader[pkgFrontend.EventType, *frontend.Client](frontendHub, authenticationService)
-	euroscopeUpgrader := websocket.NewConnectionUpgrader[pkgEuroscope.EventType, *euroscope.Client](euroscopeHub, authenticationService)
-
-	go ecfmpService.Start(ctx)
-	go cdmService.Start(ctx)
-	go pdcService.Start(ctx)
-	if vatsimCache != nil {
-		go vatsimCache.Start(ctx)
-	}
-	go transceiverCache.Start(ctx)
-	go albHub.Run()
-
-	metarPoller := metar.NewPoller(sessionRepo, frontendHub)
-	go metarPoller.Start(ctx)
-
-	trafficMetrics := services.NewTrafficMetricsService(sessionRepo, stripRepo)
-	go trafficMetrics.Start(ctx)
-
-	// TODO remove
-	db := database.New(dbpool)
-	_ = db.InsertAirport(context.Background(), "EKCH")
-
-	// Health Function for local Dev
-	http.HandleFunc("/healthz", healthz)
-	http.HandleFunc("/euroscopeEvents", euroscopeUpgrader.Upgrade)
-	http.HandleFunc("/frontEndEvents", frontendUpgrader.Upgrade)
-	http.HandleFunc("/albEvents", albHub.Upgrade)
-	apiMux := http.NewServeMux()
-	flightLookup := pdc.NewFlightLookupAdapter(pdcService, sessionRepo)
-	cdm.NewWebAPI(authenticationService, sessionRepo, sequenceService).RegisterRoutes(apiMux)
-	if !isLiveEnvironment(getEnv("ENVIRONMENT", "development")) {
-		ecfmpWebAPI.NewWebAPI(ecfmpService).RegisterRoutes(apiMux)
-	}
-	pilot.NewWebAPI(authenticationService, vatsimCache, flightLookup, requireLiveCIDVerification).RegisterRoutes(apiMux)
-	pdc.NewWebAPI(authenticationService, pdcService, vatsimCache, requireLiveCIDVerification).RegisterRoutes(apiMux)
-	http.Handle("/api/", server.APIMiddleware(http.StripPrefix("/api", apiMux)))
-
-	// Wrap with OTEL HTTP instrumentation
-	var handler http.Handler = http.DefaultServeMux
-	if otlpEndpoint != "" {
-		handler = otelhttp.NewHandler(http.DefaultServeMux, "http.server")
-	}
-
-	// Setup graceful shutdown
-	server := &http.Server{
+	httpServer := &http.Server{
 		Addr:    *addr,
-		Handler: handler,
+		Handler: application.Handler(),
 	}
 
-	// Handle shutdown signals
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 
 	go func() {
 		slog.Info("Server started", slog.String("address", *addr))
-		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			slog.Error("Server failed", slog.Any("error", err))
 			os.Exit(1)
 		}
@@ -349,16 +119,44 @@ func main() {
 
 	<-sigChan
 	slog.Info("Shutting down server...")
+	cancelWorkers()
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	if err := server.Shutdown(shutdownCtx); err != nil {
+	if err := httpServer.Shutdown(shutdownCtx); err != nil {
 		slog.Error("Server shutdown failed", slog.Any("error", err))
 		os.Exit(1)
 	}
 
 	slog.Info("Server shutdown complete")
+}
+
+func configureLogging() {
+	var logLevel slog.LevelVar
+	switch strings.ToUpper(os.Getenv("LOG_LEVEL")) {
+	case "DEBUG":
+		logLevel.Set(slog.LevelDebug)
+	case "WARN":
+		logLevel.Set(slog.LevelWarn)
+	case "ERROR":
+		logLevel.Set(slog.LevelError)
+	default:
+		logLevel.Set(slog.LevelInfo)
+	}
+
+	logger := slog.New(tint.NewHandler(os.Stdout, &tint.Options{Level: &logLevel}))
+	slog.SetDefault(logger)
+}
+
+func loadEnvFiles() {
+	for _, envFile := range []string{".env", ".env.dev"} {
+		err := godotenv.Load(envFile)
+		if err != nil && !os.IsNotExist(err) {
+			slog.Error("Error loading env file", slog.String("file", envFile), slog.Any("error", err))
+			os.Exit(1)
+		}
+	}
 }
 
 func getEnv(key, fallback string) string {

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -1,0 +1,499 @@
+package app
+
+import (
+	"FlightStrips/internal/alb"
+	"FlightStrips/internal/cdm"
+	appconfig "FlightStrips/internal/config"
+	"FlightStrips/internal/database"
+	"FlightStrips/internal/ecfmp"
+	ecfmpWebAPI "FlightStrips/internal/ecfmp/webapi"
+	"FlightStrips/internal/euroscope"
+	"FlightStrips/internal/frontend"
+	"FlightStrips/internal/metar"
+	"FlightStrips/internal/pdc"
+	"FlightStrips/internal/pilot"
+	"FlightStrips/internal/repository"
+	"FlightStrips/internal/repository/postgres"
+	"FlightStrips/internal/server"
+	"FlightStrips/internal/services"
+	"FlightStrips/internal/shared"
+	"FlightStrips/internal/vatsim"
+	"FlightStrips/internal/websocket"
+	pkgEuroscope "FlightStrips/pkg/events/euroscope"
+	pkgFrontend "FlightStrips/pkg/events/frontend"
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/exaring/otelpgx"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+)
+
+type Config struct {
+	DatabaseConnectionString string
+	OIDCSigningAlgorithm     string
+	OIDCAuthority            string
+	OIDCAudience             string
+	Environment              string
+	EnablePostgresTracing    bool
+	EnableHTTPTracing        bool
+
+	CDMKey                   string
+	CDMConfigDir             string
+	CDMConfigRefreshInterval time.Duration
+	EnableCDMConfigStore     bool
+
+	HoppieLogon          string
+	PDCWebLookupLiveOnly bool
+	EnablePDC            bool
+
+	ECFMPBaseURL       string
+	EnableECFMP        bool
+	EnableECFMPAPI     bool
+	EnablePilotAPI     bool
+	EnableALB          bool
+	EnableMetar        bool
+	EnableVATSIM       bool
+	EnableTransceivers bool
+	EnableTraffic      bool
+	EnableDBSeed       bool
+	CloseDBOnClose     bool
+}
+
+type Dependencies struct {
+	DBPool                *pgxpool.Pool
+	AuthenticationService shared.AuthenticationService
+	PDCClient             pdc.HoppieClientInterface
+	VATSIMStatusURL       string
+	VATSIMPollInterval    time.Duration
+	TransceiversURL       string
+	TransceiversInterval  time.Duration
+}
+
+type App struct {
+	dbpool       *pgxpool.Pool
+	closeDB      bool
+	handler      http.Handler
+	workers      []func(context.Context)
+	startWorkers sync.Once
+}
+
+func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
+	cfg = cfg.withDefaults()
+
+	dbpool, closeDB, err := buildDBPool(ctx, cfg, deps.DBPool)
+	if err != nil {
+		return nil, err
+	}
+
+	authService, err := buildAuthenticationService(cfg, deps.AuthenticationService)
+	if err != nil {
+		if closeDB {
+			dbpool.Close()
+		}
+		return nil, err
+	}
+
+	stripRepo := postgres.NewStripRepository(dbpool)
+	controllerRepo := postgres.NewControllerRepository(dbpool)
+	sessionRepo := postgres.NewSessionRepository(dbpool)
+	sectorRepo := postgres.NewSectorOwnerRepository(dbpool)
+	coordRepo := postgres.NewCoordinationRepository(dbpool)
+	tacticalStripRepo := postgres.NewTacticalStripRepository(dbpool)
+
+	stripService := services.NewStripService(
+		stripRepo,
+		services.WithTacticalStripRepository(tacticalStripRepo),
+		services.WithCoordinationStore(coordRepo),
+		services.WithControllerReader(controllerRepo),
+		services.WithSessionReader(sessionRepo),
+		services.WithSectorOwnerRepository(sectorRepo),
+	)
+	controllerService := services.NewControllerService(controllerRepo)
+	cdmClient := cdm.NewClient(cdm.WithAPIKey(cfg.CDMKey))
+	cdmService := cdm.NewCdmService(cdmClient, stripRepo, sessionRepo, controllerRepo)
+	stripService.SetCdmService(cdmService)
+	cdmService.SetValidationReevaluator(stripService)
+
+	pdcService := buildPDCService(cfg, deps.PDCClient, sessionRepo, stripRepo, sectorRepo, controllerRepo)
+	requireLiveCIDVerification := isLiveEnvironment(cfg.Environment)
+	vatsimCache := buildVATSIMCache(cfg, deps, requireLiveCIDVerification)
+
+	var fsServer *server.Server
+	var transceiverCache *vatsim.TransceiverCache
+	var transceiverLookup server.TransceiverLookup = noopTransceiverLookup{}
+	if cfg.EnableTransceivers {
+		transceiverCache = vatsim.NewTransceiverCache(
+			deps.TransceiversURL,
+			deps.TransceiversInterval,
+			nil,
+			func(ctx context.Context) error {
+				if fsServer == nil {
+					return nil
+				}
+				return fsServer.RefreshAllSectors(ctx)
+			},
+		)
+		transceiverLookup = transceiverCache
+		slog.Info("VATSIM transceiver cache enabled for sector ownership refresh")
+	}
+
+	frontendHub := frontend.NewHub(stripService, authService)
+	euroscopeHub := euroscope.NewHub(stripService, controllerService, authService)
+	albHub := alb.NewHub()
+	ecfmpService := ecfmp.NewService(ecfmp.NewClient(ecfmp.WithBaseURL(cfg.ECFMPBaseURL)), stripRepo, sessionRepo, frontendHub, euroscopeHub)
+
+	stripService.SetFrontendHub(frontendHub)
+	stripService.SetEuroscopeHub(euroscopeHub)
+	stripService.SetSectorOwnerRepo(sectorRepo)
+	cdmService.SetFrontendHub(frontendHub)
+	cdmService.SetEuroscopeHub(euroscopeHub)
+
+	sequenceService, configStore := configureCDM(cfg, cdmClient, cdmService, stripRepo, sessionRepo, frontendHub, euroscopeHub)
+
+	if pdcService != nil {
+		stripService.SetPdcService(pdcService)
+		pdcService.SetFrontendHub(frontendHub)
+		pdcService.SetEuroscopeHub(euroscopeHub)
+		pdcService.SetTransceiverLookup(transceiverLookup)
+	}
+
+	fsServer = server.NewServer(dbpool, euroscopeHub, frontendHub, cdmService, pdcService, transceiverLookup, stripRepo, controllerRepo, sessionRepo, sectorRepo, coordRepo, tacticalStripRepo)
+
+	frontendHub.SetServer(fsServer)
+	euroscopeHub.SetServer(fsServer)
+	stripService.SetRouteRecalculator(fsServer)
+	controllerService.SetFrontendNotifier(frontendHub)
+	controllerService.SetSessionRecalculator(fsServer)
+	controllerService.SetStripService(stripService)
+
+	if cfg.EnableDBSeed {
+		db := database.New(dbpool)
+		_ = db.InsertAirport(context.Background(), "EKCH")
+	}
+
+	app := &App{
+		dbpool:  dbpool,
+		closeDB: closeDB,
+		handler: buildHandler(buildHandlerConfig{
+			authService:                authService,
+			frontendHub:                frontendHub,
+			euroscopeHub:               euroscopeHub,
+			albHub:                     albHub,
+			pdcService:                 pdcService,
+			sessionRepo:                sessionRepo,
+			sequenceService:            sequenceService,
+			vatsimCache:                vatsimCache,
+			requireLiveCIDVerification: requireLiveCIDVerification,
+			enableHTTPTracing:          cfg.EnableHTTPTracing,
+			enableALB:                  cfg.EnableALB,
+			enableCDMAPI:               sequenceService != nil,
+			enableECFMPAPI:             cfg.EnableECFMPAPI,
+			enablePilotAPI:             cfg.EnablePilotAPI,
+			enablePDCAPI:               pdcService != nil,
+			ecfmpService:               ecfmpService,
+		}),
+	}
+
+	app.addWorker(cdmService.Start)
+	if configStore != nil {
+		app.addWorker(configStore.Start)
+	}
+	if cfg.EnablePDC && pdcService != nil {
+		app.addWorker(pdcService.Start)
+	}
+	if cfg.EnableVATSIM && vatsimCache != nil {
+		app.addWorker(vatsimCache.Start)
+	}
+	if transceiverCache != nil {
+		app.addWorker(transceiverCache.Start)
+	}
+	if cfg.EnableECFMP {
+		app.addWorker(ecfmpService.Start)
+	}
+	if cfg.EnableALB {
+		app.addWorker(func(context.Context) { albHub.Run() })
+	}
+	if cfg.EnableMetar {
+		metarPoller := metar.NewPoller(sessionRepo, frontendHub)
+		app.addWorker(metarPoller.Start)
+	}
+	if cfg.EnableTraffic {
+		trafficMetrics := services.NewTrafficMetricsService(sessionRepo, stripRepo)
+		app.addWorker(trafficMetrics.Start)
+	}
+
+	return app, nil
+}
+
+func (a *App) Handler() http.Handler {
+	return a.handler
+}
+
+func (a *App) StartWorkers(ctx context.Context) {
+	a.startWorkers.Do(func() {
+		for _, worker := range a.workers {
+			go worker(ctx)
+		}
+	})
+}
+
+func (a *App) Close(context.Context) error {
+	if a.closeDB && a.dbpool != nil {
+		a.dbpool.Close()
+	}
+	return nil
+}
+
+func (a *App) DBPool() *pgxpool.Pool {
+	return a.dbpool
+}
+
+func (a *App) addWorker(worker func(context.Context)) {
+	if worker != nil {
+		a.workers = append(a.workers, worker)
+	}
+}
+
+func buildDBPool(ctx context.Context, cfg Config, dbpool *pgxpool.Pool) (*pgxpool.Pool, bool, error) {
+	if dbpool != nil {
+		return dbpool, cfg.CloseDBOnClose, nil
+	}
+
+	poolConfig, err := pgxpool.ParseConfig(cfg.DatabaseConnectionString)
+	if err != nil {
+		return nil, false, fmt.Errorf("parse database connection string: %w", err)
+	}
+
+	if cfg.EnablePostgresTracing {
+		poolConfig.ConnConfig.Tracer = otelpgx.NewTracer(
+			otelpgx.WithTracerProvider(otel.GetTracerProvider()),
+			otelpgx.WithTrimSQLInSpanName(),
+		)
+	}
+
+	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
+	if err != nil {
+		return nil, false, fmt.Errorf("connect to database: %w", err)
+	}
+
+	if cfg.EnablePostgresTracing {
+		if err := otelpgx.RecordStats(pool); err != nil {
+			slog.Warn("Failed to record database stats", slog.Any("error", err))
+		}
+	}
+
+	return pool, true, nil
+}
+
+func buildAuthenticationService(cfg Config, dependency shared.AuthenticationService) (shared.AuthenticationService, error) {
+	if dependency != nil {
+		return dependency, nil
+	}
+
+	authService, err := services.NewAuthenticationService(cfg.OIDCSigningAlgorithm, cfg.OIDCAuthority, cfg.OIDCAudience)
+	if err != nil {
+		return nil, fmt.Errorf("initialize authentication service: %w", err)
+	}
+	return authService, nil
+}
+
+func buildPDCService(
+	cfg Config,
+	client pdc.HoppieClientInterface,
+	sessionRepo repository.SessionRepository,
+	stripRepo repository.StripRepository,
+	sectorRepo repository.SectorOwnerRepository,
+	controllerRepo repository.ControllerRepository,
+) *pdc.Service {
+	if !cfg.EnablePDC {
+		return nil
+	}
+
+	if client == nil {
+		if cfg.HoppieLogon != "" {
+			client = pdc.NewClient(cfg.HoppieLogon)
+			slog.Info("PDC Hoppie client initialized")
+		} else {
+			client = pdc.NoopHoppieClient{}
+			slog.Warn("PDC Hoppie client disabled - HOPPIE_LOGON not set")
+		}
+	}
+
+	service := pdc.NewPDCService(client, sessionRepo, stripRepo, sectorRepo, controllerRepo)
+	service.SetWebLookupLiveOnly(cfg.PDCWebLookupLiveOnly)
+	return service
+}
+
+func buildVATSIMCache(cfg Config, deps Dependencies, requireLiveCIDVerification bool) *vatsim.Cache {
+	if !cfg.EnableVATSIM || !requireLiveCIDVerification {
+		return nil
+	}
+
+	cache := vatsim.NewCache(deps.VATSIMStatusURL, deps.VATSIMPollInterval, nil)
+	slog.Info("VATSIM cache enabled for live web PDC ownership verification")
+	return cache
+}
+
+func configureCDM(
+	cfg Config,
+	cdmClient *cdm.Client,
+	cdmService *cdm.Service,
+	stripRepo repository.StripRepository,
+	sessionRepo repository.SessionRepository,
+	frontendHub *frontend.Hub,
+	euroscopeHub *euroscope.Hub,
+) (*cdm.SequenceService, *cdm.CdmConfigStore) {
+	if !cfg.EnableCDMConfigStore {
+		return nil, nil
+	}
+
+	cdmCfg := appconfig.GetCdmConfig()
+	resolveURI := func(uri string) string {
+		if uri == "" || strings.HasPrefix(uri, "http://") || strings.HasPrefix(uri, "https://") {
+			return uri
+		}
+		return filepath.Join(cfg.CDMConfigDir, uri)
+	}
+	configStore := cdm.NewCdmConfigStore(
+		resolveURI(cdmCfg.RateUri),
+		resolveURI(cdmCfg.SidIntervalUri),
+		resolveURI(cdmCfg.TaxizonesUri),
+		cfg.CDMConfigRefreshInterval,
+		cdm.CdmConfigDefaults{
+			Rate:        cdmCfg.Rate,
+			RateLvo:     cdmCfg.RateLvo,
+			TaxiMinutes: cdm.DefaultCDMTaxiMinutes,
+		},
+		nil,
+	)
+	configStore.SetCdmClient(cdmClient)
+	configStore.SeedAirportConfig("EKCH", cdmCfg.Rate, cdmCfg.RateLvo, cdm.CdmDeiceConfig{
+		Light:  cdmCfg.Deice.Light,
+		Medium: cdmCfg.Deice.Medium,
+		Heavy:  cdmCfg.Deice.Heavy,
+		Super:  cdmCfg.Deice.Super,
+		Platform: func() []cdm.CdmDeicePlatformConfig {
+			platforms := make([]cdm.CdmDeicePlatformConfig, len(cdmCfg.Deice.Platform))
+			for i, p := range cdmCfg.Deice.Platform {
+				platforms[i] = cdm.CdmDeicePlatformConfig{Name: p.Name, Time: p.Time}
+			}
+			return platforms
+		}(),
+	})
+	sequenceService := cdm.NewSequenceService(stripRepo, sessionRepo, configStore, frontendHub, euroscopeHub)
+	cdmService.SetConfigProvider(configStore)
+	cdmService.SetSequenceService(sequenceService)
+	configStore.SetOnAirportConfigChanged(func(airport string) {
+		if err := cdmService.TriggerRecalculateForAirport(context.Background(), airport); err != nil {
+			slog.Warn("CDM config change recalculation failed",
+				slog.String("airport", airport),
+				slog.Any("error", err),
+			)
+		}
+	})
+	slog.Info("CDM local calculation enabled", slog.String("rateUri", resolveURI(cdmCfg.RateUri)))
+
+	return sequenceService, configStore
+}
+
+type buildHandlerConfig struct {
+	authService                shared.AuthenticationService
+	frontendHub                *frontend.Hub
+	euroscopeHub               *euroscope.Hub
+	albHub                     *alb.Hub
+	pdcService                 *pdc.Service
+	sessionRepo                repository.SessionRepository
+	sequenceService            *cdm.SequenceService
+	vatsimCache                *vatsim.Cache
+	requireLiveCIDVerification bool
+	enableHTTPTracing          bool
+	enableALB                  bool
+	enableCDMAPI               bool
+	enableECFMPAPI             bool
+	enablePilotAPI             bool
+	enablePDCAPI               bool
+	ecfmpService               *ecfmp.Service
+}
+
+func buildHandler(cfg buildHandlerConfig) http.Handler {
+	mux := http.NewServeMux()
+	frontendUpgrader := websocket.NewConnectionUpgrader[pkgFrontend.EventType, *frontend.Client](cfg.frontendHub, cfg.authService)
+	euroscopeUpgrader := websocket.NewConnectionUpgrader[pkgEuroscope.EventType, *euroscope.Client](cfg.euroscopeHub, cfg.authService)
+
+	mux.HandleFunc("/healthz", healthz)
+	mux.HandleFunc("/euroscopeEvents", euroscopeUpgrader.Upgrade)
+	mux.HandleFunc("/frontEndEvents", frontendUpgrader.Upgrade)
+	if cfg.enableALB {
+		mux.HandleFunc("/albEvents", cfg.albHub.Upgrade)
+	}
+
+	apiMux := http.NewServeMux()
+	if cfg.enableCDMAPI {
+		cdm.NewWebAPI(cfg.authService, cfg.sessionRepo, cfg.sequenceService).RegisterRoutes(apiMux)
+	}
+	if cfg.enableECFMPAPI {
+		ecfmpWebAPI.NewWebAPI(cfg.ecfmpService).RegisterRoutes(apiMux)
+	}
+	if cfg.enablePilotAPI {
+		flightLookup := pdc.NewFlightLookupAdapter(cfg.pdcService, cfg.sessionRepo)
+		pilot.NewWebAPI(cfg.authService, cfg.vatsimCache, flightLookup, cfg.requireLiveCIDVerification).RegisterRoutes(apiMux)
+	}
+	if cfg.enablePDCAPI {
+		pdc.NewWebAPI(cfg.authService, cfg.pdcService, cfg.vatsimCache, cfg.requireLiveCIDVerification).RegisterRoutes(apiMux)
+	}
+	if cfg.enableCDMAPI || cfg.enableECFMPAPI || cfg.enablePilotAPI || cfg.enablePDCAPI {
+		mux.Handle("/api/", server.APIMiddleware(http.StripPrefix("/api", apiMux)))
+	}
+
+	var handler http.Handler = mux
+	if cfg.enableHTTPTracing {
+		handler = otelhttp.NewHandler(handler, "http.server")
+	}
+	return handler
+}
+
+func healthz(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+type noopTransceiverLookup struct{}
+
+func (noopTransceiverLookup) GetFrequencies(string) []string {
+	return nil
+}
+
+func (cfg Config) withDefaults() Config {
+	if cfg.OIDCAudience == "" {
+		cfg.OIDCAudience = "backend-dev"
+	}
+	if cfg.Environment == "" {
+		cfg.Environment = "development"
+	}
+	if cfg.CDMConfigDir == "" {
+		cfg.CDMConfigDir = appconfig.GetConfigDir()
+	}
+	if cfg.CDMConfigRefreshInterval <= 0 {
+		cfg.CDMConfigRefreshInterval = 15 * time.Minute
+	}
+	if cfg.ECFMPBaseURL == "" {
+		cfg.ECFMPBaseURL = ecfmp.DefaultBaseURL
+	}
+	return cfg
+}
+
+func isLiveEnvironment(environment string) bool {
+	switch strings.ToLower(strings.TrimSpace(environment)) {
+	case "live", "prod", "production":
+		return true
+	default:
+		return false
+	}
+}

--- a/backend/internal/testing/e2e/server.go
+++ b/backend/internal/testing/e2e/server.go
@@ -10,17 +10,10 @@ import (
 	"runtime"
 	"time"
 
-	"FlightStrips/internal/cdm"
+	"FlightStrips/internal/app"
 	"FlightStrips/internal/config"
 	"FlightStrips/internal/database"
-	"FlightStrips/internal/euroscope"
-	"FlightStrips/internal/frontend"
-	"FlightStrips/internal/repository/postgres"
-	"FlightStrips/internal/server"
 	"FlightStrips/internal/services"
-	"FlightStrips/internal/websocket"
-	pkgEuroscope "FlightStrips/pkg/events/euroscope"
-	pkgFrontend "FlightStrips/pkg/events/frontend"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/testcontainers/testcontainers-go"
@@ -31,6 +24,7 @@ import (
 // TestServer wraps the FlightStrips server for testing
 type TestServer struct {
 	Server            *http.Server
+	App               *app.App
 	DBPool            *pgxpool.Pool
 	Queries           *database.Queries
 	ServerAddr        string
@@ -105,68 +99,35 @@ func StartTestServer() (*TestServer, error) {
 		return nil, fmt.Errorf("failed to connect to database: %w", err)
 	}
 
-	// Initialize services
-	authService := services.NewTestAuthenticationService()
-
-	// Initialize repositories
-	stripRepo := postgres.NewStripRepository(dbpool)
-	controllerRepo := postgres.NewControllerRepository(dbpool)
-	sessionRepo := postgres.NewSessionRepository(dbpool)
-	sectorRepo := postgres.NewSectorOwnerRepository(dbpool)
-	coordRepo := postgres.NewCoordinationRepository(dbpool)
-
-	// Initialize services
-	stripService := services.NewStripService(
-		stripRepo,
-		services.WithCoordinationStore(coordRepo),
-		services.WithControllerReader(controllerRepo),
-		services.WithSessionReader(sessionRepo),
-		services.WithSectorOwnerRepository(sectorRepo),
-	)
-	controllerService := services.NewControllerService(controllerRepo)
-	cdmClient := cdm.NewClient(cdm.WithAPIKey(""))
-	cdmService := cdm.NewCdmService(cdmClient, stripRepo, sessionRepo, controllerRepo)
-	cdmService.SetValidationReevaluator(stripService)
-
-	// Initialize hubs
-	frontendHub := frontend.NewHub(stripService, authService)
-	euroscopeHub := euroscope.NewHub(stripService, controllerService, authService)
-
-	stripService.SetFrontendHub(frontendHub)
-	stripService.SetEuroscopeHub(euroscopeHub)
-	stripService.SetSectorOwnerRepo(sectorRepo)
-	cdmService.SetFrontendHub(frontendHub)
-	cdmService.SetEuroscopeHub(euroscopeHub)
-
-	// Initialize server
-	fsServer := server.NewServer(dbpool, euroscopeHub, frontendHub, cdmService, nil, nil, stripRepo, controllerRepo, sessionRepo, sectorRepo, coordRepo, nil)
-
-	frontendHub.SetServer(fsServer)
-	euroscopeHub.SetServer(fsServer)
-	stripService.SetRouteRecalculator(fsServer)
-	controllerService.SetFrontendNotifier(frontendHub)
-	controllerService.SetSessionRecalculator(fsServer)
-	controllerService.SetStripService(stripService)
-
-	// Create WebSocket upgraders
-	frontendUpgrader := websocket.NewConnectionUpgrader[pkgFrontend.EventType, *frontend.Client](frontendHub, authService)
-	euroscopeUpgrader := websocket.NewConnectionUpgrader[pkgEuroscope.EventType, *euroscope.Client](euroscopeHub, authService)
-
-	// Start services
-	go cdmService.Start(ctx)
-
-	// Setup HTTP handlers
-	mux := http.NewServeMux()
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
+	application, err := app.Build(ctx, app.Config{
+		Environment:    "test",
+		CloseDBOnClose: true,
+		EnablePDC:      false,
+		EnableECFMP:    false,
+		EnableECFMPAPI: false,
+		EnablePilotAPI: false,
+		EnableALB:      false,
+		EnableMetar:    false,
+		EnableVATSIM:   false,
+		EnableTraffic:  false,
+		EnableDBSeed:   false,
+	}, app.Dependencies{
+		DBPool:                dbpool,
+		AuthenticationService: services.NewTestAuthenticationService(),
+		TransceiversInterval:  30 * time.Second,
 	})
-	mux.HandleFunc("/euroscopeEvents", euroscopeUpgrader.Upgrade)
-	mux.HandleFunc("/frontEndEvents", frontendUpgrader.Upgrade)
+	if err != nil {
+		dbpool.Close()
+		testcontainers.TerminateContainer(postgresContainer)
+		cancel()
+		return nil, fmt.Errorf("failed to build app: %w", err)
+	}
+	application.StartWorkers(ctx)
 
 	// Bind on :0 so the OS assigns a free port, avoiding conflicts when tests run in parallel.
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		dbpool.Close()
+		_ = application.Close(context.Background())
 		cancel()
 		return nil, fmt.Errorf("failed to bind listener: %w", err)
 	}
@@ -174,7 +135,7 @@ func StartTestServer() (*TestServer, error) {
 
 	httpServer := &http.Server{
 		Addr:    addr,
-		Handler: mux,
+		Handler: application.Handler(),
 	}
 
 	// Start server in background
@@ -189,7 +150,7 @@ func StartTestServer() (*TestServer, error) {
 	// Check if server started successfully (non-blocking — Serve returns immediately on error)
 	select {
 	case err := <-serverErr:
-		dbpool.Close()
+		_ = application.Close(context.Background())
 		cancel()
 		return nil, fmt.Errorf("server failed to start: %w", err)
 	default:
@@ -200,6 +161,7 @@ func StartTestServer() (*TestServer, error) {
 
 	testServer := &TestServer{
 		Server:            httpServer,
+		App:               application,
 		DBPool:            dbpool,
 		Queries:           queries,
 		ServerAddr:        addr,
@@ -228,8 +190,9 @@ func (ts *TestServer) Stop() error {
 		slog.Error("Failed to shutdown server gracefully", slog.Any("error", err))
 	}
 
-	// Close database pool
-	ts.DBPool.Close()
+	if err := ts.App.Close(context.Background()); err != nil {
+		slog.Error("Failed to close app", slog.Any("error", err))
+	}
 
 	// Terminate PostgreSQL container
 	if err := testcontainers.TerminateContainer(ts.postgresContainer); err != nil {


### PR DESCRIPTION
## Summary
- Add a shared internal app builder for backend dependency composition, handlers, workers, and app cleanup
- Move production server startup to process concerns: env/logging, telemetry, signal handling, listen, and shutdown
- Reuse the shared builder from the e2e test server with test-specific dependencies and disabled optional workers

## Verification
- go test ./cmd/server ./internal/app ./internal/testing/e2e
- go test ./...