### PR TITLE
fix(ecfmp): clear mandatory route restriction after strip is cleared

### DIFF
--- a/backend/internal/pdc/integration_test.go
+++ b/backend/internal/pdc/integration_test.go
@@ -107,6 +107,7 @@ func (suite *PDCIntegrationTestSuite) SetupTest(t *testing.T) {
 		timeoutConfig: 30 * time.Second, // Long timeout to prevent firing during test
 	}
 	suite.mockStrip.On("ReevaluatePdcRequestValidations", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	suite.mockStrip.On("ClearMandatoryRouteCdm", mock.Anything, mock.Anything, mock.Anything).Maybe()
 
 	// Seed test data
 	sessionID := testdata.SeedTestSession(t, queries)

--- a/backend/internal/pdc/mocks/strip_service.go
+++ b/backend/internal/pdc/mocks/strip_service.go
@@ -24,6 +24,10 @@ func (m *StripService) UnclearStrip(ctx context.Context, session int32, callsign
 	return args.Error(0)
 }
 
+func (m *StripService) ClearMandatoryRouteCdm(ctx context.Context, session int32, callsign string) {
+	m.Called(ctx, session, callsign)
+}
+
 func (m *StripService) MoveToBay(ctx context.Context, session int32, callsign string, bay string, sendNotification bool) error {
 	args := m.Called(ctx, session, callsign, bay, sendNotification)
 	return args.Error(0)

--- a/backend/internal/pdc/service.go
+++ b/backend/internal/pdc/service.go
@@ -750,6 +750,7 @@ func (s *Service) IssueClearance(ctx context.Context, callsign, remarks, cid str
 		if err := s.stripService.MoveToBay(ctx, sessionInfo.id, callsign, shared.BAY_CLEARED, true); err != nil {
 			slog.ErrorContext(ctx, "PDC Service: Warning - failed to move strip to cleared bay", slog.Any("error", err))
 		}
+		s.stripService.ClearMandatoryRouteCdm(ctx, sessionInfo.id, callsign)
 	}
 
 	s.StartClearanceTimeout(ctx, strip.Origin, callsign, nextSeq, sessionInfo, cid, webDelivery)

--- a/backend/internal/pdc/webapi_handler_test.go
+++ b/backend/internal/pdc/webapi_handler_test.go
@@ -62,6 +62,7 @@ func setupHandlerTest(t *testing.T) *handlerTestSetup {
 		timeoutConfig: 30 * time.Second,
 	}
 	mockStrip.On("ReevaluatePdcInvalidValidation", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockStrip.On("ClearMandatoryRouteCdm", mock.Anything, mock.Anything, mock.Anything).Maybe()
 
 	sessionID := testdata.SeedTestSession(t, queries)
 	webapi := NewWebAPI(pdcAuthStub{}, service, nil, false)

--- a/backend/internal/services/strip.go
+++ b/backend/internal/services/strip.go
@@ -4,6 +4,9 @@ import (
 	"FlightStrips/internal/repository"
 	"FlightStrips/internal/shared"
 	"context"
+	"log/slog"
+
+	internalModels "FlightStrips/internal/models"
 )
 
 const (
@@ -116,6 +119,54 @@ func (s *StripService) recalculateRouteForStrip(ctx context.Context, session int
 
 func (s *StripService) SetCdmService(cdmService shared.CdmService) {
 	s.cdmService = cdmService
+}
+
+func (s *StripService) ClearMandatoryRouteCdm(ctx context.Context, sessionID int32, callsign string) {
+	strip, err := s.stripRepo.GetByCallsign(ctx, sessionID, callsign)
+	if err != nil {
+		slog.WarnContext(ctx, "Failed to get strip for mandatory route CDM clearing",
+			slog.String("callsign", callsign), slog.Any("error", err))
+		return
+	}
+
+	cdm := strip.CdmData
+	if cdm == nil {
+		return
+	}
+
+	hadMandatoryRoute := false
+	for _, r := range cdm.EcfmpRestrictions {
+		if r.Type == "mandatory_route" {
+			hadMandatoryRoute = true
+			break
+		}
+	}
+	if !hadMandatoryRoute {
+		return
+	}
+
+	cdmUpdated := cdm.Clone()
+	filtered := make([]internalModels.EcfmpRestriction, 0, len(cdmUpdated.EcfmpRestrictions))
+	for _, r := range cdmUpdated.EcfmpRestrictions {
+		if r.Type == "mandatory_route" {
+			continue
+		}
+		filtered = append(filtered, r)
+	}
+	cdmUpdated.EcfmpRestrictions = filtered
+	if len(filtered) == 0 {
+		cdmUpdated.EcfmpRestrictions = nil
+	}
+
+	if _, err := s.stripRepo.SetCdmData(ctx, sessionID, callsign, cdmUpdated); err != nil {
+		slog.WarnContext(ctx, "Failed to clear mandatory route restriction from CDM data",
+			slog.String("callsign", callsign), slog.Any("error", err))
+		return
+	}
+
+	if s.publisher != nil {
+		s.publisher.Broadcast(sessionID, shared.BuildFrontendCdmDataEvent(callsign, cdmUpdated))
+	}
 }
 
 func (s *StripService) queueOrSendStripUpdate(ctx context.Context, session int32, callsign string, publish bool) {

--- a/backend/internal/services/strip_frontend_move.go
+++ b/backend/internal/services/strip_frontend_move.go
@@ -71,6 +71,10 @@ func (s *StripService) MoveFrontendStrip(ctx context.Context, session int32, cal
 		return err
 	}
 
+	if targetBay == shared.BAY_CLEARED {
+		s.ClearMandatoryRouteCdm(ctx, session, callsign)
+	}
+
 	if !shouldConfirmVoiceClearance {
 		return nil
 	}

--- a/backend/internal/shared/services.go
+++ b/backend/internal/shared/services.go
@@ -75,6 +75,7 @@ type StripService interface {
 	// Cleared bay operations
 	ClearStrip(ctx context.Context, session int32, callsign string, cid string) error
 	UnclearStrip(ctx context.Context, session int32, callsign string, cid string) error
+	ClearMandatoryRouteCdm(ctx context.Context, session int32, callsign string)
 
 	// Auto-assumption
 	AutoAssumeForClearedStrip(ctx context.Context, session int32, callsign string) error

--- a/backend/internal/testutil/noop_strip_service.go
+++ b/backend/internal/testutil/noop_strip_service.go
@@ -173,3 +173,5 @@ func (s *NoOpStripService) ReevaluatePdcInvalidValidation(_ context.Context, _ i
 func (s *NoOpStripService) ReevaluatePdcRequestValidations(_ context.Context, _ int32, _ string, _ bool, _ bool) error {
 	return nil
 }
+
+func (s *NoOpStripService) ClearMandatoryRouteCdm(_ context.Context, _ int32, _ string) {}

--- a/frontend/src/components/FlightPlanDialog.tsx
+++ b/frontend/src/components/FlightPlanDialog.tsx
@@ -249,7 +249,9 @@ export default function FlightPlanDialog({
   const displayedEobt = normalizeCdmTime(strip?.eobt);
   const displayedTobt = normalizeCdmTime(strip?.tobt);
   const displayedTsat = normalizeCdmTime(strip?.tsat);
-  const hasMandatoryRoute = !!getMandatoryRouteRestriction(strip?.ecfmp_restrictions);
+  const mandatoryRoute = getMandatoryRouteRestriction(strip?.ecfmp_restrictions);
+  const mandatoryRouteToClear = selectMandatoryRoute(strip?.route, mandatoryRoute?.routes ?? []);
+  const hasMandatoryRoute = !!mandatoryRoute;
   const hasGroundStop = !!getGroundStopRestriction(strip?.ecfmp_restrictions);
   const hasProhibit = !!getProhibitRestriction(strip?.ecfmp_restrictions);
   const flViolated = isFlightLevelViolated(strip?.ecfmp_restrictions, strip?.requested_altitude);
@@ -262,6 +264,10 @@ export default function FlightPlanDialog({
   const [rnavDialogOpen, setRnavDialogOpen] = useState(false);
   const [rwyDialogOpen, setRwyDialogOpen] = useState(false);
   const availableSids = useAvailableSids();
+  const mandatoryRouteSid = strip
+    ? resolveMandatoryRouteSid(mandatoryRouteToClear, strip.runway, strip.sid, availableSids)
+    : "";
+  const mandatoryRouteSidMismatch = !!mandatoryRouteSid && mandatoryRouteSid !== (strip?.sid?.trim().toUpperCase() ?? "");
   const [ssrGenerating, setSsrGenerating] = useState(false);
   const [standOpen, setStandOpen] = useState(false);
   const [eobt, setEobt, _eobtFocused, setEobtFocused] = useEditableField(displayedEobt);
@@ -287,12 +293,6 @@ export default function FlightPlanDialog({
   const sidOverride = sidOverrideKey(strip);
   const nitosRemarks = clxNitosRemarks(strip);
   const nitosRemarksFit = fittedNitosRemarksStyle(nitosRemarks);
-  const mandatoryRoute = getMandatoryRouteRestriction(strip?.ecfmp_restrictions);
-  const mandatoryRouteToClear = selectMandatoryRoute(strip?.route, mandatoryRoute?.routes ?? []);
-  const mandatoryRouteSid = strip
-    ? resolveMandatoryRouteSid(mandatoryRouteToClear, strip.runway, strip.sid, availableSids)
-    : "";
-  const mandatoryRouteSidMismatch = !!mandatoryRouteSid && mandatoryRouteSid !== (strip?.sid?.trim().toUpperCase() ?? "");
   const isPdcRequest = strip?.pdc_state === "REQUESTED" || strip?.pdc_state === "REQUESTED_WITH_FAULTS";
   const fieldStyle = (width: number) => ({
     width: scalePx(width),
@@ -561,7 +561,7 @@ export default function FlightPlanDialog({
           <div className="flex flex-col" style={{ width: CONTENT_WIDTH, gap: FIELD_GAP }}>
             <Label className="font-light" style={{ fontSize: FONT_SIZE_LABEL }}>ROUTE</Label>
             <textarea
-              value={route}
+              value={hasMandatoryRoute && mandatoryRouteToClear ? mandatoryRouteToClear : route}
               onChange={(event) => setRoute(event.target.value)}
               onFocus={() => setRouteFocused(true)}
               onBlur={() => {
@@ -570,6 +570,7 @@ export default function FlightPlanDialog({
               }}
               onKeyDown={(event) => event.key === "Enter" && !event.shiftKey && updateStrip(callsign, { route })}
               className={CLS_TEXTAREA_EDITABLE}
+              disabled={hasMandatoryRoute}
               style={{ height: TEXTAREA_HEIGHT, fontFamily: FONT_FAMILY, fontSize: FONT_SIZE_FIELD, ...(hasMandatoryRoute ? { backgroundColor: COLOR_ECFMP_YELLOW } : {}) }}
             />
           </div>

--- a/frontend/src/components/MandatoryRouteDialog.tsx
+++ b/frontend/src/components/MandatoryRouteDialog.tsx
@@ -1,10 +1,11 @@
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
 import { scalePx } from "@/lib/viewportScale";
 
-const DIALOG_WIDTH = scalePx(500);
-const FONT_SIZE = scalePx(18);
-const FONT_SIZE_BUTTON = scalePx(20);
+const DIALOG_WIDTH = scalePx(485);
+const INNER_PADDING = scalePx(20);
+const BUTTON_WIDTH = scalePx(191);
+const BUTTON_HEIGHT = scalePx(70);
+const BUTTON_GAP = scalePx(21);
 
 interface MandatoryRouteDialogProps {
   open: boolean;
@@ -22,80 +23,91 @@ interface MandatoryRouteDialogProps {
 export function MandatoryRouteDialog({
   open,
   onOpenChange,
-  callsign,
-  route,
-  filedSid,
-  mandatorySid,
-  sidMismatch,
-  pdcRequested,
+  callsign: _callsign,
+  route: _route,
+  filedSid: _filedSid,
+  mandatorySid: _mandatorySid,
+  sidMismatch: _sidMismatch,
+  pdcRequested: _pdcRequested,
   onConfirm,
   onCancel,
 }: MandatoryRouteDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
+        className="border border-black rounded-none"
         style={{
           width: DIALOG_WIDTH,
-          padding: scalePx(20),
-          gap: scalePx(16),
+          maxWidth: DIALOG_WIDTH,
+          padding: 0,
+          gap: 0,
+          backgroundColor: "#E4E4E4",
         }}
       >
         <DialogTitle className="sr-only">Mandatory Route Confirmation</DialogTitle>
-        <div className="flex flex-col gap-4">
-          <div className="text-center" style={{ fontSize: FONT_SIZE, fontWeight: "bold" }}>
-            <span style={{ color: "red" }}>MANDATORY ROUTE</span>
-            <br />
-            <span style={{ color: "red" }}>will be sent on clearance</span>
-            <br />
-            <span style={{ color: "red" }}>{pdcRequested ? "via PDC" : "via private message"}</span>
-          </div>
+        <div
+          className="border border-black m-[20px] flex flex-col items-center"
+          style={{
+            paddingTop: scalePx(33),
+            paddingBottom: scalePx(29),
+            paddingInline: INNER_PADDING,
+            color: "black",
+          }}
+        >
           <div
-            className="border border-black text-center font-bold"
-            style={{ fontSize: scalePx(16), backgroundColor: "#FFD700", color: "black", padding: scalePx(10) }}
+            style={{
+              fontFamily: "Rubik, Arial, sans-serif",
+              fontSize: scalePx(32),
+              fontWeight: 400,
+              color: "#FF0000",
+              textAlign: "center",
+              lineHeight: 1.2,
+              marginBottom: scalePx(19),
+            }}
           >
-            {callsign}: {route || "NO MANDATORY ROUTE"}
+            Would you like
+            <br />
+            MANDATORY ROUTE
+            <br />
+            to be send via PM or PDC?
           </div>
-          {mandatorySid && (
-            <div className="flex flex-col gap-2 text-center" style={{ fontSize: scalePx(14) }}>
-              <div
-                className="border border-black"
-                style={{
-                  backgroundColor: sidMismatch ? "#FF0000" : "#B3B3B3",
-                  color: sidMismatch ? "white" : "black",
-                  padding: scalePx(8),
-                  fontWeight: "bold",
-                }}
-              >
-                FILED SID: {filedSid || "NONE"}
-              </div>
-              <div className="border border-black bg-[#D6D6D6] text-black font-bold" style={{ padding: scalePx(8) }}>
-                MANDATORY SID: {mandatorySid}
-              </div>
-            </div>
-          )}
-          <div className="flex justify-center gap-4">
-            <Button
-              onClick={onConfirm}
-              style={{
-                fontSize: FONT_SIZE_BUTTON,
-                padding: `${scalePx(8)}px ${scalePx(24)}px`,
-                backgroundColor: "#3F3F3F",
-                color: "white",
-              }}
-            >
-              CLR
-            </Button>
-            <Button
+          <div className="flex" style={{ gap: BUTTON_GAP }}>
+            <button
+              type="button"
               onClick={onCancel}
               style={{
-                fontSize: FONT_SIZE_BUTTON,
-                padding: `${scalePx(8)}px ${scalePx(24)}px`,
+                width: BUTTON_WIDTH,
+                height: BUTTON_HEIGHT,
                 backgroundColor: "#3F3F3F",
                 color: "white",
+                fontFamily: "Rubik, Arial, sans-serif",
+                fontSize: scalePx(32),
+                fontWeight: 600,
+                textAlign: "center",
+                border: "none",
+                cursor: "pointer",
               }}
             >
-              CANCEL
-            </Button>
+              NO
+            </button>
+            <button
+              type="button"
+              onClick={onConfirm}
+              style={{
+                width: BUTTON_WIDTH,
+                height: BUTTON_HEIGHT,
+                backgroundColor: "#3F3F3F",
+                color: "white",
+                fontFamily: "Rubik, Arial, sans-serif",
+                fontSize: scalePx(32),
+                fontWeight: 600,
+                textAlign: "center",
+                border: "none",
+                cursor: "pointer",
+              }}
+            >
+              YES
+            </button>
           </div>
         </div>
       </DialogContent>

--- a/frontend/src/components/clxbtn.tsx
+++ b/frontend/src/components/clxbtn.tsx
@@ -2,9 +2,9 @@ import React from "react";
 
 import FlightPlanDialog from "@/components/FlightPlanDialog";
 
-export function CLXBtn({ callsign, children }: { callsign: string; children?: React.ReactNode }) {
+export function CLXBtn({ callsign, mode, children }: { callsign: string; mode?: "clearance" | "view"; children?: React.ReactNode }) {
   return (
-    <FlightPlanDialog callsign={callsign}>
+    <FlightPlanDialog callsign={callsign} mode={mode}>
       <div className="px-0 flex flex-col" style={{ flex: "1 0 0%", height: "100%", minWidth: 0, cursor: "pointer" }}>
         {children}
       </div>

--- a/frontend/src/components/strip/ClxClearedStrip.tsx
+++ b/frontend/src/components/strip/ClxClearedStrip.tsx
@@ -157,7 +157,7 @@ export function ClxClearedStrip({
           className="flex flex-col overflow-hidden border-r-2"
           style={{ flex: `${F_DEST} 0 0%`, height: "100%", minWidth: 0, borderRightColor: cellBorderColor }}
         >
-          <CLXBtn callsign={callsign}>
+          <CLXBtn callsign={callsign} mode="view">
             <div className="flex items-center justify-center border-b-2 overflow-hidden" style={{ height: HALF_H, fontFamily: FONT, fontWeight: "bold", fontSize: "0.73vw", color: manualBlue, borderBottomColor: "transparent" }}>
               {destination}
             </div>

--- a/frontend/src/components/strip/DepartureAwareFlightPlanDialog.tsx
+++ b/frontend/src/components/strip/DepartureAwareFlightPlanDialog.tsx
@@ -1,5 +1,6 @@
 import FlightPlanDialog from "@/components/FlightPlanDialog";
 import { useAirport, useStrip } from "@/store/store-hooks";
+import { Bay } from "@/api/models";
 
 interface DepartureAwareFlightPlanDialogProps {
   callsign: string;
@@ -15,14 +16,16 @@ export function DepartureAwareFlightPlanDialog({
   const strip = useStrip(callsign);
   const airport = useAirport();
   const isDeparture = strip?.origin === airport && strip?.destination !== airport;
+  const isNotCleared = strip?.bay === Bay.NotCleared;
+  const clearanceMode = isDeparture && isNotCleared;
 
   return (
     <FlightPlanDialog
       callsign={callsign}
       open={open}
       onOpenChange={onOpenChange}
-      mode={isDeparture ? "clearance" : "view"}
-      pdcAction={isDeparture ? "manual" : "default"}
+      mode={clearanceMode ? "clearance" : "view"}
+      pdcAction={clearanceMode ? "manual" : "default"}
     />
   );
 }


### PR DESCRIPTION
## Summary

- Show the mandatory route in the clearance screen route field instead of the filed route when a restriction exists
- Redesign the mandatory route confirmation dialog with YES/NO buttons
- Open flight plan dialog in view mode for strips already in cleared bays
- Move mandatory route CDM clearing from PDC service into StripService
- Clear the restriction whenever a strip moves to the Cleared bay, covering both PDC and voice clearances