### PR TITLE
chore(cdm): centralize outbound DTO mapping

### DIFF
--- a/backend/internal/cdm/cdm_broadcaster.go
+++ b/backend/internal/cdm/cdm_broadcaster.go
@@ -61,7 +61,7 @@ func (c *CdmBroadcaster) broadcastIfChanged(session int32, callsign string, befo
 	if s.euroscopeHub != nil {
 		data, err := s.stripRepo.GetCdmDataForCallsign(context.Background(), session, callsign)
 		if err == nil {
-			s.euroscopeHub.BroadcastCdmUpdates(session, []euroscopeEvents.CdmUpdateEvent{buildCdmUpdateEvent(callsign, data)})
+			s.euroscopeHub.BroadcastCdmUpdates(session, []euroscopeEvents.CdmUpdateEvent{shared.BuildEuroscopeCdmUpdateEvent(callsign, data)})
 		}
 	}
 }

--- a/backend/internal/cdm/master_viff_sync.go
+++ b/backend/internal/cdm/master_viff_sync.go
@@ -130,7 +130,7 @@ func (c *MasterViffSync) pushCdmDataAfterRecalc(ctx context.Context, session int
 		s.publisher.SendCdmUpdates(session, []frontendEvents.CdmDataEvent{shared.BuildFrontendCdmDataEvent(callsign, data)})
 	}
 	if s.euroscopeHub != nil {
-		s.euroscopeHub.BroadcastCdmUpdates(session, []euroscopeEvents.CdmUpdateEvent{buildCdmUpdateEvent(callsign, data)})
+		s.euroscopeHub.BroadcastCdmUpdates(session, []euroscopeEvents.CdmUpdateEvent{shared.BuildEuroscopeCdmUpdateEvent(callsign, data)})
 	}
 
 	if !s.client.isValid || !s.usesViffSession(session) {

--- a/backend/internal/cdm/sequence.go
+++ b/backend/internal/cdm/sequence.go
@@ -7,7 +7,6 @@ import (
 	euroscopeEvents "FlightStrips/pkg/events/euroscope"
 	frontendEvents "FlightStrips/pkg/events/frontend"
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -207,7 +206,7 @@ func (s *SequenceService) recalculateAirport(ctx context.Context, session int32,
 				strip.CdmData = updated
 				if notify {
 					frontendUpdates = append(frontendUpdates, shared.BuildFrontendCdmDataEvent(strip.Callsign, updated))
-					euroscopeUpdates = append(euroscopeUpdates, buildCdmUpdateEvent(strip.Callsign, updated))
+					euroscopeUpdates = append(euroscopeUpdates, shared.BuildEuroscopeCdmUpdateEvent(strip.Callsign, updated))
 				}
 				if notify && s.afterPersist != nil {
 					afterPersistCallsigns = append(afterPersistCallsigns, strip.Callsign)
@@ -247,7 +246,7 @@ func (s *SequenceService) recalculateAirport(ctx context.Context, session int32,
 			strip.CdmData = updated
 			if notify {
 				frontendUpdates = append(frontendUpdates, shared.BuildFrontendCdmDataEvent(strip.Callsign, updated))
-				euroscopeUpdates = append(euroscopeUpdates, buildCdmUpdateEvent(strip.Callsign, updated))
+				euroscopeUpdates = append(euroscopeUpdates, shared.BuildEuroscopeCdmUpdateEvent(strip.Callsign, updated))
 			}
 			if notify && s.afterPersist != nil {
 				afterPersistCallsigns = append(afterPersistCallsigns, strip.Callsign)
@@ -557,73 +556,6 @@ func (s *SequenceService) broadcastBatch(session int32, frontendUpdates []fronte
 	if s.euroscopeHub != nil {
 		s.euroscopeHub.BroadcastCdmUpdates(session, euroscopeUpdates)
 	}
-}
-
-func buildCdmUpdateEvent(callsign string, data *models.CdmData) euroscopeEvents.CdmUpdateEvent {
-	if data == nil {
-		data = (&models.CdmData{}).Normalize()
-	}
-	return euroscopeEvents.CdmUpdateEvent{
-		Callsign:                 callsign,
-		Eobt:                     truncateCDMClockValue(valueOrEmpty(data.EffectiveEobt())),
-		Tobt:                     truncateCDMClockValue(valueOrEmpty(data.EffectiveTobt())),
-		TobtSetBy:                valueOrEmpty(data.TobtSetBy),
-		TobtConfirmedBy:          valueOrEmpty(data.TobtConfirmedBy),
-		ReqTobt:                  truncateCDMClockValue(valueOrEmpty(data.EffectiveReqTobt())),
-		ReqTobtType:              valueOrEmpty(data.EffectiveReqTobtType()),
-		Tsat:                     truncateToHHMM(valueOrEmpty(data.EffectiveTsat())),
-		Ttot:                     truncateToHHMM(valueOrEmpty(data.EffectiveTtot())),
-		Ctot:                     truncateCDMClockValue(valueOrEmpty(data.EffectiveCtot())),
-		CtotSource:               valueOrEmpty(data.CtotSource),
-		Asat:                     truncateCDMClockValue(valueOrEmpty(data.EffectiveAsat())),
-		Asrt:                     truncateCDMClockValue(valueOrEmpty(data.Asrt)),
-		Tsac:                     valueOrEmpty(data.Tsac),
-		Status:                   valueOrEmpty(data.EffectiveStatus()),
-		EcfmpID:                  valueOrEmpty(data.EcfmpID),
-		Phase:                    valueOrEmpty(data.EffectivePhase()),
-		EcfmpRestrictionsJSON:    serializeEcfmpRestrictionsJSON(data.EcfmpRestrictions),
-	}
-}
-
-func serializeEcfmpRestrictionsJSON(restrictions []models.EcfmpRestriction) string {
-	if len(restrictions) == 0 {
-		return ""
-	}
-	dtos := convertEcfmpRestrictionsEuroscope(restrictions)
-	b, err := json.Marshal(dtos)
-	if err != nil {
-		return ""
-	}
-	return string(b)
-}
-
-func convertEcfmpRestrictionsEuroscope(restrictions []models.EcfmpRestriction) []euroscopeEvents.EcfmpRestrictionDTO {
-	if len(restrictions) == 0 {
-		return nil
-	}
-	result := make([]euroscopeEvents.EcfmpRestrictionDTO, len(restrictions))
-	for i, r := range restrictions {
-		result[i] = euroscopeEvents.EcfmpRestrictionDTO{
-			MeasureID:   r.MeasureID,
-			Ident:       r.Ident,
-			Type:        r.Type,
-			Reason:      r.Reason,
-			Routes:      r.Routes,
-			Destination: r.Destination,
-			MaxLevel:    r.MaxLevel,
-			MinLevel:    r.MinLevel,
-			ExactLevels: r.ExactLevels,
-			HasCtot:     r.HasCtot,
-		}
-	}
-	return result
-}
-
-func truncateToHHMM(value string) string {
-	if len(value) > 4 {
-		return value[:4]
-	}
-	return value
 }
 
 func valueOrEmpty(value *string) string {

--- a/backend/internal/cdm/sequence_test.go
+++ b/backend/internal/cdm/sequence_test.go
@@ -127,7 +127,7 @@ func TestSequenceService_RecalculateAirportPersistsAndBroadcasts(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected second broadcast to be CdmUpdateEvent, got %T", euroscopeHub.Broadcasts[1])
 	}
-	if event.Tsat != truncateToHHMM(secondTsat) || event.Ttot != truncateToHHMM(secondTtot) {
+	if event.Tsat != truncateCDMClockValue(secondTsat) || event.Ttot != truncateCDMClockValue(secondTtot) {
 		t.Fatalf("unexpected broadcast event timings: %#v", event)
 	}
 	if event.EcfmpID != "REGUL" {

--- a/backend/internal/euroscope/hub.go
+++ b/backend/internal/euroscope/hub.go
@@ -254,25 +254,7 @@ func (hub *Hub) sendBackendSyncIfNeeded(client *Client) {
 			entry.PdcRequestRemarks = *strip.PdcRequestRemarks
 		}
 		if strip.CdmData != nil {
-			entry.Cdm = euroscope.BackendSyncCdmData{
-				Eobt:              valueOrEmpty(strip.CdmData.EffectiveEobt()),
-				Tobt:              valueOrEmpty(strip.CdmData.EffectiveTobt()),
-				TobtSetBy:         valueOrEmpty(strip.CdmData.TobtSetBy),
-				TobtConfirmedBy:   valueOrEmpty(strip.CdmData.TobtConfirmedBy),
-				ReqTobt:           valueOrEmpty(strip.CdmData.EffectiveReqTobt()),
-				ReqTobtType:       valueOrEmpty(strip.CdmData.EffectiveReqTobtType()),
-				Tsat:              truncateCDMClockValue(valueOrEmpty(strip.CdmData.EffectiveTsat())),
-				Ttot:              truncateCDMClockValue(valueOrEmpty(strip.CdmData.EffectiveTtot())),
-				Ctot:              valueOrEmpty(strip.CdmData.EffectiveCtot()),
-				CtotSource:        valueOrEmpty(strip.CdmData.CtotSource),
-				Asat:              valueOrEmpty(strip.CdmData.EffectiveAsat()),
-				Asrt:              valueOrEmpty(strip.CdmData.Asrt),
-				Tsac:              valueOrEmpty(strip.CdmData.Tsac),
-				Status:            valueOrEmpty(strip.CdmData.EffectiveStatus()),
-				EcfmpID:           valueOrEmpty(strip.CdmData.EcfmpID),
-				Phase:             valueOrEmpty(strip.CdmData.EffectivePhase()),
-				EcfmpRestrictionsJSON: serializeEcfmpRestrictionsSyncJSON(strip.CdmData.EcfmpRestrictions),
-			}
+			entry.Cdm = shared.BuildEuroscopeBackendSyncCdmData(strip.CdmData)
 		}
 		if strip.PdcState != "" {
 			entry.PdcState = strip.PdcState
@@ -313,46 +295,6 @@ func backendSyncGroundState(strip *internalModels.Strip) string {
 		return *strip.State
 	}
 	return euroscope.GroundStateUnknown
-}
-
-func valueOrEmpty(value *string) string {
-	if value == nil {
-		return ""
-	}
-	return *value
-}
-
-func truncateCDMClockValue(value string) string {
-	if len(value) > 4 {
-		return value[:4]
-	}
-	return value
-}
-
-func serializeEcfmpRestrictionsSyncJSON(restrictions []internalModels.EcfmpRestriction) string {
-	if len(restrictions) == 0 {
-		return ""
-	}
-	dtos := make([]euroscope.EcfmpRestrictionDTO, len(restrictions))
-	for i, r := range restrictions {
-		dtos[i] = euroscope.EcfmpRestrictionDTO{
-			MeasureID:   r.MeasureID,
-			Ident:       r.Ident,
-			Type:        r.Type,
-			Reason:      r.Reason,
-			Routes:      r.Routes,
-			Destination: r.Destination,
-			MaxLevel:    r.MaxLevel,
-			MinLevel:    r.MinLevel,
-			ExactLevels: r.ExactLevels,
-			HasCtot:     r.HasCtot,
-		}
-	}
-	b, err := json.Marshal(dtos)
-	if err != nil {
-		return ""
-	}
-	return string(b)
 }
 
 func (hub *Hub) GetMessageHandlers() shared.MessageHandlers[euroscope.EventType, *Client] {

--- a/backend/internal/frontend/hub.go
+++ b/backend/internal/frontend/hub.go
@@ -359,7 +359,7 @@ func MapStripToFrontendModelWithClx(strip *internalModels.Strip, clxContext clx.
 	if cdm == nil {
 		cdm = (&internalModels.CdmData{}).Normalize()
 	}
-	ecfmpRestrictions := filterFrontendEcfmpRestrictions(cdm.EcfmpRestrictions)
+	cdmEvent := shared.BuildFrontendCdmDataEvent(strip.Callsign, cdm)
 
 	return frontend.Strip{
 		Callsign:                 strip.Callsign,
@@ -390,24 +390,24 @@ func MapStripToFrontendModelWithClx(strip *internalModels.Strip, clxContext clx.
 		PreviousControllers:      strip.PreviousOwners,
 		NextDisplay:              mapNextDisplayToDTO(strip.NextDisplay),
 		Owner:                    helpers.ValueOrDefault(strip.Owner),
-		Eobt:                     truncateFrontendClockValue(helpers.ValueOrDefault(strip.EffectiveEobt())),
-		Tobt:                     truncateFrontendClockValue(helpers.ValueOrDefault(strip.EffectiveTobt())),
-		ReqTobt:                  truncateFrontendClockValue(helpers.ValueOrDefault(cdm.EffectiveReqTobt())),
-		ReqTobtType:              helpers.ValueOrDefault(cdm.EffectiveReqTobtType()),
-		TobtSetBy:                helpers.ValueOrDefault(cdm.TobtSetBy),
-		Tsat:                     truncateFrontendClockValue(helpers.ValueOrDefault(strip.EffectiveTsat())),
-		Ttot:                     truncateFrontendClockValue(helpers.ValueOrDefault(strip.EffectiveTtot())),
-		Ctot:                     effectiveFrontendStripCtot(strip),
-		Aobt:                     truncateFrontendClockValue(helpers.ValueOrDefault(strip.EffectiveAobt())),
-		Asat:                     truncateFrontendClockValue(helpers.ValueOrDefault(strip.EffectiveAsat())),
-		Asrt:                     truncateFrontendClockValue(helpers.ValueOrDefault(cdm.Asrt)),
-		Tsac:                     truncateFrontendClockValue(helpers.ValueOrDefault(cdm.Tsac)),
-		Status:                   helpers.ValueOrDefault(strip.EffectiveCdmStatus()),
-		MostPenalizingAirspace:   helpers.ValueOrDefault(cdm.MostPenalizingAirspace),
-		EcfmpID:                  helpers.ValueOrDefault(cdm.EcfmpID),
-		CtotSource:               helpers.ValueOrDefault(cdm.CtotSource),
-		Phase:                    helpers.ValueOrDefault(cdm.EffectivePhase()),
-		EcfmpRestrictions:        mapEcfmpRestrictionsToDTO(ecfmpRestrictions),
+		Eobt:                     cdmEvent.Eobt,
+		Tobt:                     cdmEvent.Tobt,
+		ReqTobt:                  cdmEvent.ReqTobt,
+		ReqTobtType:              cdmEvent.ReqTobtType,
+		TobtSetBy:                cdmEvent.TobtSetBy,
+		Tsat:                     cdmEvent.Tsat,
+		Ttot:                     cdmEvent.Ttot,
+		Ctot:                     cdmEvent.Ctot,
+		Aobt:                     cdmEvent.Aobt,
+		Asat:                     cdmEvent.Asat,
+		Asrt:                     cdmEvent.Asrt,
+		Tsac:                     cdmEvent.Tsac,
+		Status:                   cdmEvent.Status,
+		MostPenalizingAirspace:   cdmEvent.MostPenalizingAirspace,
+		EcfmpID:                  cdmEvent.EcfmpID,
+		CtotSource:               cdmEvent.CtotSource,
+		Phase:                    cdmEvent.Phase,
+		EcfmpRestrictions:        cdmEvent.EcfmpRestrictions,
 		PdcState:                 strip.PdcState,
 		PdcRequestRemarks:        helpers.ValueOrDefault(strip.PdcRequestRemarks),
 		StartReq:                 strip.StartReq,
@@ -427,50 +427,6 @@ func MapStripToFrontendModelWithClx(strip *internalModels.Strip, clxContext clx.
 		ValidationStatus:         mapValidationStatusToDTO(strip.ValidationStatus),
 		ClxValidation:            mapClxValidationToDTO(clx.Validate(strip, clxContext)),
 	}
-}
-
-func filterFrontendEcfmpRestrictions(restrictions []internalModels.EcfmpRestriction) []internalModels.EcfmpRestriction {
-	if len(restrictions) == 0 {
-		return nil
-	}
-	if config.IsMandatoryRouteClearanceFlowEnabled() {
-		return restrictions
-	}
-
-	filtered := make([]internalModels.EcfmpRestriction, 0, len(restrictions))
-	for _, restriction := range restrictions {
-		if restriction.Type == "mandatory_route" {
-			continue
-		}
-		filtered = append(filtered, restriction)
-	}
-	if len(filtered) == 0 {
-		return nil
-	}
-	return filtered
-}
-
-func mapEcfmpRestrictionsToDTO(restrictions []internalModels.EcfmpRestriction) []frontend.EcfmpRestrictionDTO {
-	if len(restrictions) == 0 {
-		return nil
-	}
-
-	result := make([]frontend.EcfmpRestrictionDTO, len(restrictions))
-	for i, restriction := range restrictions {
-		result[i] = frontend.EcfmpRestrictionDTO{
-			MeasureID:   restriction.MeasureID,
-			Ident:       restriction.Ident,
-			Type:        restriction.Type,
-			Reason:      restriction.Reason,
-			Routes:      restriction.Routes,
-			Destination: restriction.Destination,
-			MaxLevel:    restriction.MaxLevel,
-			MinLevel:    restriction.MinLevel,
-			ExactLevels: restriction.ExactLevels,
-			HasCtot:     restriction.HasCtot,
-		}
-	}
-	return result
 }
 
 func mapClxValidationToDTO(validation *clx.Validation) *frontend.ClxValidation {
@@ -516,18 +472,6 @@ func truncateFrontendClockValue(value string) string {
 		return value[:4]
 	}
 	return value
-}
-
-func effectiveFrontendStripCtot(strip *internalModels.Strip) string {
-	if strip == nil || strip.CdmData == nil {
-		return ""
-	}
-
-	if ctot := truncateFrontendClockValue(helpers.ValueOrDefault(strip.EffectiveCtot())); ctot != "" {
-		return ctot
-	}
-
-	return ""
 }
 
 func (hub *Hub) CidOnline(session int32, cid string) {

--- a/backend/internal/frontend/hub_cdm_test.go
+++ b/backend/internal/frontend/hub_cdm_test.go
@@ -3,6 +3,7 @@ package frontend
 import (
 	"FlightStrips/internal/config"
 	internalModels "FlightStrips/internal/models"
+	"FlightStrips/internal/shared"
 	frontendEvents "FlightStrips/pkg/events/frontend"
 	"testing"
 
@@ -52,6 +53,61 @@ func TestMapStripToFrontendModel_TruncatesCdmTimes(t *testing.T) {
 	assert.Equal(t, "REGUL", model.EcfmpID)
 	assert.Equal(t, "ATFCM", model.CtotSource)
 	assert.Equal(t, "I", model.Phase)
+}
+
+func TestMapStripToFrontendModel_CdmFieldsMatchSharedCdmEvent(t *testing.T) {
+	t.Cleanup(config.SetFeatureFlagsForTest(config.FeatureFlagsConfig{MandatoryRouteClearanceFlow: true}))
+
+	strip := &internalModels.Strip{
+		Callsign: "SAS123",
+		CdmData: (&internalModels.CdmData{
+			Eobt:                   testStringPointer("101500"),
+			Tobt:                   testStringPointer("102000"),
+			ReqTobt:                testStringPointer("102500"),
+			ReqTobtType:            testStringPointer("PILOT"),
+			TobtSetBy:              testStringPointer("EKCH_DEL"),
+			Tsat:                   testStringPointer("103000"),
+			Ttot:                   testStringPointer("104000"),
+			Ctot:                   testStringPointer("104500"),
+			Aobt:                   testStringPointer("105000"),
+			Asat:                   testStringPointer("105500"),
+			Asrt:                   testStringPointer("103500"),
+			Tsac:                   testStringPointer("103700"),
+			Status:                 testStringPointer("READY"),
+			MostPenalizingAirspace: testStringPointer("DK-E"),
+			EcfmpID:                testStringPointer("REGUL"),
+			CtotSource:             testStringPointer("ATFCM"),
+			Phase:                  testStringPointer("I"),
+			EcfmpRestrictions: []internalModels.EcfmpRestriction{
+				{MeasureID: 12, Ident: "REGUL", Type: "mandatory_route", Routes: []string{"VEDAR DCT"}, HasCtot: true},
+			},
+		}).Normalize(),
+	}
+
+	model := MapStripToFrontendModel(strip)
+	actual := frontendEvents.CdmDataEvent{
+		Callsign:               model.Callsign,
+		Eobt:                   model.Eobt,
+		Tobt:                   model.Tobt,
+		ReqTobt:                model.ReqTobt,
+		ReqTobtType:            model.ReqTobtType,
+		TobtSetBy:              model.TobtSetBy,
+		Tsat:                   model.Tsat,
+		Ttot:                   model.Ttot,
+		Ctot:                   model.Ctot,
+		Aobt:                   model.Aobt,
+		Asat:                   model.Asat,
+		Asrt:                   model.Asrt,
+		Tsac:                   model.Tsac,
+		Status:                 model.Status,
+		MostPenalizingAirspace: model.MostPenalizingAirspace,
+		EcfmpID:                model.EcfmpID,
+		CtotSource:             model.CtotSource,
+		Phase:                  model.Phase,
+		EcfmpRestrictions:      model.EcfmpRestrictions,
+	}
+
+	assert.Equal(t, shared.BuildFrontendCdmDataEvent(strip.Callsign, strip.CdmData), actual)
 }
 
 func TestMapStripToFrontendModel_TruncatesCtot(t *testing.T) {

--- a/backend/internal/shared/cdm_euroscope.go
+++ b/backend/internal/shared/cdm_euroscope.go
@@ -33,6 +33,29 @@ func BuildEuroscopeCdmUpdateEvent(callsign string, data *models.CdmData) eurosco
 	}
 }
 
+func BuildEuroscopeBackendSyncCdmData(data *models.CdmData) euroscopeEvents.BackendSyncCdmData {
+	update := BuildEuroscopeCdmUpdateEvent("", data)
+	return euroscopeEvents.BackendSyncCdmData{
+		Eobt:                  update.Eobt,
+		Tobt:                  update.Tobt,
+		TobtSetBy:             update.TobtSetBy,
+		TobtConfirmedBy:       update.TobtConfirmedBy,
+		ReqTobt:               update.ReqTobt,
+		ReqTobtType:           update.ReqTobtType,
+		Tsat:                  update.Tsat,
+		Ttot:                  update.Ttot,
+		Ctot:                  update.Ctot,
+		CtotSource:            update.CtotSource,
+		Asat:                  update.Asat,
+		Asrt:                  update.Asrt,
+		Tsac:                  update.Tsac,
+		Status:                update.Status,
+		EcfmpID:               update.EcfmpID,
+		Phase:                 update.Phase,
+		EcfmpRestrictionsJSON: update.EcfmpRestrictionsJSON,
+	}
+}
+
 func serializeEcfmpRestrictionsJSON(restrictions []models.EcfmpRestriction) string {
 	if len(restrictions) == 0 {
 		return ""

--- a/backend/internal/shared/cdm_euroscope_test.go
+++ b/backend/internal/shared/cdm_euroscope_test.go
@@ -1,0 +1,60 @@
+package shared
+
+import (
+	"FlightStrips/internal/models"
+	euroscopeEvents "FlightStrips/pkg/events/euroscope"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildEuroscopeBackendSyncCdmData_MatchesCdmUpdateFields(t *testing.T) {
+	data := (&models.CdmData{
+		Eobt:            testStringPointer("101500"),
+		Tobt:            testStringPointer("102000"),
+		TobtSetBy:       testStringPointer("EKCH_DEL"),
+		TobtConfirmedBy: testStringPointer("ATC"),
+		ReqTobt:         testStringPointer("102500"),
+		ReqTobtType:     testStringPointer("PILOT"),
+		Tsat:            testStringPointer("103000"),
+		Ttot:            testStringPointer("104000"),
+		Ctot:            testStringPointer("104500"),
+		CtotSource:      testStringPointer("ATFCM"),
+		Asat:            testStringPointer("105500"),
+		Asrt:            testStringPointer("103500"),
+		Tsac:            testStringPointer("103700"),
+		Status:          testStringPointer("READY"),
+		EcfmpID:         testStringPointer("REGUL"),
+		Phase:           testStringPointer("I"),
+		EcfmpRestrictions: []models.EcfmpRestriction{
+			{MeasureID: 12, Ident: "REGUL", Type: "ground_stop", Reason: "Weather", Routes: []string{"VEDAR DCT"}, HasCtot: true},
+		},
+	}).Normalize()
+
+	update := BuildEuroscopeCdmUpdateEvent("SAS123", data)
+	sync := BuildEuroscopeBackendSyncCdmData(data)
+
+	assert.Equal(t, euroscopeEvents.BackendSyncCdmData{
+		Eobt:                  update.Eobt,
+		Tobt:                  update.Tobt,
+		TobtSetBy:             update.TobtSetBy,
+		TobtConfirmedBy:       update.TobtConfirmedBy,
+		ReqTobt:               update.ReqTobt,
+		ReqTobtType:           update.ReqTobtType,
+		Tsat:                  update.Tsat,
+		Ttot:                  update.Ttot,
+		Ctot:                  update.Ctot,
+		CtotSource:            update.CtotSource,
+		Asat:                  update.Asat,
+		Asrt:                  update.Asrt,
+		Tsac:                  update.Tsac,
+		Status:                update.Status,
+		EcfmpID:               update.EcfmpID,
+		Phase:                 update.Phase,
+		EcfmpRestrictionsJSON: update.EcfmpRestrictionsJSON,
+	}, sync)
+}
+
+func testStringPointer(value string) *string {
+	return &value
+}


### PR DESCRIPTION
## Summary
- reuse shared frontend CDM mapping for strip snapshots
- route EuroScope CDM backend sync and CDM sequence broadcasts through shared builders
- add consistency tests for snapshot and incremental CDM DTO fields

## Verification
- go test ./internal/shared ./internal/frontend ./internal/euroscope ./internal/cdm
- go test ./...