### PR TITLE
fix(strip): correct default airlines file path for spoken callsign resolution

### DIFF
--- a/euroscope-plugin/src/plugin/configuration/AppConfig.cpp
+++ b/euroscope-plugin/src/plugin/configuration/AppConfig.cpp
@@ -124,7 +124,7 @@ namespace FlightStrips::configuration {
     }
 
     std::string AppConfig::GetAirlinesFile() {
-        return std::string(ini["files"]["airlines"] | "../ICAO/ICAO_Airlines.txt");
+        return std::string(ini["files"]["airlines"] | "../../ICAO/ICAO_Airlines.txt");
     }
 
     bool AppConfig::GetDisconnectOnOutOfRange() {

--- a/euroscope-plugin/test/plugin/configuration/AppConfigTest.cpp
+++ b/euroscope-plugin/test/plugin/configuration/AppConfigTest.cpp
@@ -77,7 +77,7 @@ TEST(AppConfigTest, GetStandsFile_Default_ReturnsGRpluginStands) {
 
 TEST(AppConfigTest, GetAirlinesFile_Default_ReturnsIcaoAirlinesPath) {
     auto cfg = MakeDefault();
-    EXPECT_EQ(cfg.GetAirlinesFile(), "../ICAO/ICAO_Airlines.txt");
+    EXPECT_EQ(cfg.GetAirlinesFile(), "../../ICAO/ICAO_Airlines.txt");
 }
 
 TEST(AppConfigTest, GetDisconnectOnOutOfRange_Default_ReturnsFalse) {


### PR DESCRIPTION
The default fallback path for the airlines file (../ICAO/ICAO_Airlines.txt) resolved to EKDK/Plugins/ICAO/ which does not exist. The actual ICAO folder is at EKDK/ICAO/, one level higher. Changed the default to ../../ICAO/ICAO_Airlines.txt.

This caused spoken_callsign to remain empty in the database when the config file omitted the \irlines\ key.