### PR TITLE
chore(strip): narrow repository interfaces

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -116,6 +116,7 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 		services.WithSessionReader(sessionRepo),
 		services.WithSectorOwnerRepository(sectorRepo),
 	)
+	stripValidationService := services.NewStripValidationService(stripRepo, stripRepo)
 	controllerService := services.NewControllerService(controllerRepo)
 	cdmClient := cdm.NewClient(cdm.WithAPIKey(cfg.CDMKey))
 	cdmService := cdm.NewCdmService(cdmClient, stripRepo, sessionRepo, controllerRepo)
@@ -151,6 +152,8 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	ecfmpService := ecfmp.NewService(ecfmp.NewClient(ecfmp.WithBaseURL(cfg.ECFMPBaseURL)), stripRepo, sessionRepo, frontendHub, euroscopeHub)
 
 	stripService.SetFrontendHub(frontendHub)
+	stripValidationService.SetFrontendHub(frontendHub)
+	frontendHub.SetValidationService(stripValidationService)
 	stripService.SetEuroscopeHub(euroscopeHub)
 	stripService.SetSectorOwnerRepo(sectorRepo)
 	cdmService.SetFrontendHub(frontendHub)

--- a/backend/internal/cdm/sequence.go
+++ b/backend/internal/cdm/sequence.go
@@ -32,7 +32,7 @@ type sequencingCandidate struct {
 }
 
 type SequenceService struct {
-	stripRepo      repository.StripRepository
+	stripRepo      CdmSequenceStripStore
 	sessionRepo    repository.SessionRepository
 	configProvider ConfigProvider
 	frontendHub    shared.FrontendHub
@@ -40,7 +40,7 @@ type SequenceService struct {
 	afterPersist   func(ctx context.Context, session int32, callsign string)
 }
 
-func NewSequenceService(stripRepo repository.StripRepository, sessionRepo repository.SessionRepository, configProvider ConfigProvider, frontendHub shared.FrontendHub, euroscopeHub shared.EuroscopeHub) *SequenceService {
+func NewSequenceService(stripRepo CdmSequenceStripStore, sessionRepo repository.SessionRepository, configProvider ConfigProvider, frontendHub shared.FrontendHub, euroscopeHub shared.EuroscopeHub) *SequenceService {
 	return &SequenceService{
 		stripRepo:      stripRepo,
 		sessionRepo:    sessionRepo,

--- a/backend/internal/cdm/service.go
+++ b/backend/internal/cdm/service.go
@@ -19,7 +19,7 @@ type Service struct {
 	broadcaster            *CdmBroadcaster
 	recalculationScheduler *RecalculationScheduler
 	client                 *Client
-	stripRepo              repository.StripRepository
+	stripRepo              CdmStripStore
 	sessionRepo            repository.SessionRepository
 	controllerRepo         repository.ControllerRepository
 	publisher              shared.CdmEventPublisher
@@ -52,7 +52,7 @@ const (
 	masterEobtClampTarget     = 30.0
 )
 
-func NewCdmService(client *Client, stripRepo repository.StripRepository, sessionRepo repository.SessionRepository, controllerRepo repository.ControllerRepository) *Service {
+func NewCdmService(client *Client, stripRepo CdmStripStore, sessionRepo repository.SessionRepository, controllerRepo repository.ControllerRepository) *Service {
 	service := &Service{
 		client:         client,
 		stripRepo:      stripRepo,

--- a/backend/internal/cdm/strip_store.go
+++ b/backend/internal/cdm/strip_store.go
@@ -1,0 +1,21 @@
+package cdm
+
+import (
+	"FlightStrips/internal/models"
+	"context"
+)
+
+// CdmStripStore is the strip persistence surface needed by CDM actions and sync.
+type CdmStripStore interface {
+	GetByCallsign(ctx context.Context, session int32, callsign string) (*models.Strip, error)
+	ListByOrigin(ctx context.Context, session int32, origin string) ([]*models.Strip, error)
+	GetCdmData(ctx context.Context, session int32) ([]*models.CdmDataRow, error)
+	GetCdmDataForCallsign(ctx context.Context, session int32, callsign string) (*models.CdmData, error)
+	SetCdmData(ctx context.Context, session int32, callsign string, data *models.CdmData) (int64, error)
+}
+
+// CdmSequenceStripStore is the strip persistence surface needed by CDM sequencing.
+type CdmSequenceStripStore interface {
+	ListByOrigin(ctx context.Context, session int32, origin string) ([]*models.Strip, error)
+	SetCdmData(ctx context.Context, session int32, callsign string, data *models.CdmData) (int64, error)
+}

--- a/backend/internal/ecfmp/service.go
+++ b/backend/internal/ecfmp/service.go
@@ -16,13 +16,13 @@ const refreshInterval = time.Minute
 
 type Service struct {
 	client       *Client
-	stripRepo    repository.StripRepository
+	stripRepo    StripStore
 	sessionRepo  repository.SessionRepository
 	publisher    shared.CdmEventPublisher
 	euroscopeHub shared.EuroscopeHub
 }
 
-func NewService(client *Client, stripRepo repository.StripRepository, sessionRepo repository.SessionRepository, publisher shared.CdmEventPublisher, euroscopeHub shared.EuroscopeHub) *Service {
+func NewService(client *Client, stripRepo StripStore, sessionRepo repository.SessionRepository, publisher shared.CdmEventPublisher, euroscopeHub shared.EuroscopeHub) *Service {
 	return &Service{
 		client:       client,
 		stripRepo:    stripRepo,

--- a/backend/internal/ecfmp/strip_store.go
+++ b/backend/internal/ecfmp/strip_store.go
@@ -1,0 +1,13 @@
+package ecfmp
+
+import (
+	"FlightStrips/internal/models"
+	"context"
+)
+
+// StripStore is the strip persistence surface needed to apply ECFMP restrictions.
+type StripStore interface {
+	List(ctx context.Context, session int32) ([]*models.Strip, error)
+	GetCdmData(ctx context.Context, session int32) ([]*models.CdmDataRow, error)
+	SetCdmData(ctx context.Context, session int32, callsign string, data *models.CdmData) (int64, error)
+}

--- a/backend/internal/frontend/handlers.go
+++ b/backend/internal/frontend/handlers.go
@@ -753,7 +753,10 @@ func handleAcknowledgeValidationStatus(ctx context.Context, client *Client, mess
 	if err := message.JsonUnmarshal(&req); err != nil {
 		return err
 	}
-	return client.hub.stripService.AcknowledgeValidationStatus(ctx, client.session, req.Callsign, req.ActivationKey, client.position)
+	if client.hub.validationService == nil {
+		return errors.New("acknowledge_validation_status: validation service is not configured")
+	}
+	return client.hub.validationService.AcknowledgeValidationStatus(ctx, client.session, req.Callsign, req.ActivationKey, client.position)
 }
 
 func handleSendPrivateMessage(ctx context.Context, client *Client, message Message) error {

--- a/backend/internal/frontend/hub.go
+++ b/backend/internal/frontend/hub.go
@@ -52,6 +52,7 @@ type cidDisconnectMessage struct {
 type Hub struct {
 	server                shared.Server
 	stripService          shared.StripService
+	validationService     validationStatusAcknowledger
 	stripUpdateService    frontendStripUpdateUseCase
 	authenticationService shared.AuthenticationService
 	clients               map[*Client]bool
@@ -87,6 +88,10 @@ type nextDisplayComputer interface {
 
 type nextDisplayBatchComputer interface {
 	ComputeNextDisplaysForStripsContext(ctx context.Context, strips []*internalModels.Strip, sessionId int32) error
+}
+
+type validationStatusAcknowledger interface {
+	AcknowledgeValidationStatus(ctx context.Context, session int32, callsign string, activationKey string, requestingPosition string) error
 }
 
 func NewHub(stripService shared.StripService, authenticationService shared.AuthenticationService) *Hub {
@@ -185,6 +190,10 @@ func (hub *Hub) SetServer(server shared.Server) {
 	hub.server = server
 	hub.snapshotBuilder = nil
 	hub.stripUpdateService = hub.newStripUpdateService()
+}
+
+func (hub *Hub) SetValidationService(validationService validationStatusAcknowledger) {
+	hub.validationService = validationService
 }
 
 func (hub *Hub) getStripUpdateService() frontendStripUpdateUseCase {

--- a/backend/internal/frontend/snapshot_builder.go
+++ b/backend/internal/frontend/snapshot_builder.go
@@ -24,7 +24,7 @@ type InitialSnapshotRequest struct {
 
 type SnapshotBuilderDependencies struct {
 	ControllerRepo     repository.ControllerRepository
-	StripRepo          repository.StripRepository
+	StripRepo          SnapshotStripStore
 	SectorRepo         repository.SectorOwnerRepository
 	SessionRepo        repository.SessionRepository
 	CoordinationRepo   repository.CoordinationRepository
@@ -38,7 +38,7 @@ type SnapshotBuilderDependencies struct {
 
 type SnapshotBuilder struct {
 	controllerRepo     repository.ControllerRepository
-	stripRepo          repository.StripRepository
+	stripRepo          SnapshotStripStore
 	sectorRepo         repository.SectorOwnerRepository
 	sessionRepo        repository.SessionRepository
 	coordinationRepo   repository.CoordinationRepository

--- a/backend/internal/frontend/strip_stores.go
+++ b/backend/internal/frontend/strip_stores.go
@@ -1,0 +1,18 @@
+package frontend
+
+import (
+	internalModels "FlightStrips/internal/models"
+	"context"
+)
+
+// FrontendStripUpdateStore is the strip persistence surface needed by frontend field updates.
+type FrontendStripUpdateStore interface {
+	GetByCallsign(ctx context.Context, session int32, callsign string) (*internalModels.Strip, error)
+	AppendControllerModifiedField(ctx context.Context, session int32, callsign string, fieldName string) error
+	UpdateRunway(ctx context.Context, session int32, callsign string, runway *string, version *int32) (int64, error)
+}
+
+// SnapshotStripStore is the strip persistence surface needed to build initial snapshots.
+type SnapshotStripStore interface {
+	List(ctx context.Context, session int32) ([]*internalModels.Strip, error)
+}

--- a/backend/internal/frontend/strip_update_service.go
+++ b/backend/internal/frontend/strip_update_service.go
@@ -44,7 +44,7 @@ type frontendStripUpdateEuroscopeSender interface {
 }
 
 type FrontendStripUpdateService struct {
-	stripRepo            repository.StripRepository
+	stripRepo            FrontendStripUpdateStore
 	sessionRepo          repository.SessionRepository
 	euroscopeSender      frontendStripUpdateEuroscopeSender
 	cdmService           shared.CdmService
@@ -55,7 +55,7 @@ type FrontendStripUpdateService struct {
 }
 
 func NewFrontendStripUpdateService(
-	stripRepo repository.StripRepository,
+	stripRepo FrontendStripUpdateStore,
 	sessionRepo repository.SessionRepository,
 	euroscopeSender frontendStripUpdateEuroscopeSender,
 	cdmService shared.CdmService,

--- a/backend/internal/frontend/strip_update_service_test.go
+++ b/backend/internal/frontend/strip_update_service_test.go
@@ -25,6 +25,33 @@ func (p *recordingStripUpdatePublisher) SendStripUpdate(session int32, callsign 
 	p.calls++
 }
 
+type stripUpdateStoreFake struct {
+	getByCallsignFn                 func(ctx context.Context, session int32, callsign string) (*models.Strip, error)
+	appendControllerModifiedFieldFn func(ctx context.Context, session int32, callsign string, fieldName string) error
+	updateRunwayFn                  func(ctx context.Context, session int32, callsign string, runway *string, version *int32) (int64, error)
+}
+
+func (f *stripUpdateStoreFake) GetByCallsign(ctx context.Context, session int32, callsign string) (*models.Strip, error) {
+	if f.getByCallsignFn == nil {
+		panic("unexpected call to stripUpdateStoreFake.GetByCallsign")
+	}
+	return f.getByCallsignFn(ctx, session, callsign)
+}
+
+func (f *stripUpdateStoreFake) AppendControllerModifiedField(ctx context.Context, session int32, callsign string, fieldName string) error {
+	if f.appendControllerModifiedFieldFn == nil {
+		panic("unexpected call to stripUpdateStoreFake.AppendControllerModifiedField")
+	}
+	return f.appendControllerModifiedFieldFn(ctx, session, callsign, fieldName)
+}
+
+func (f *stripUpdateStoreFake) UpdateRunway(ctx context.Context, session int32, callsign string, runway *string, version *int32) (int64, error) {
+	if f.updateRunwayFn == nil {
+		panic("unexpected call to stripUpdateStoreFake.UpdateRunway")
+	}
+	return f.updateRunwayFn(ctx, session, callsign, runway, version)
+}
+
 type recordingStripUpdateEuroscopeSender struct {
 	runways          []string
 	clearedAltitudes []int32
@@ -60,8 +87,8 @@ func TestFrontendStripUpdateService_RunwayChangePersistsSelectedRunway(t *testin
 	var updatedRunway *string
 	var markedField string
 
-	stripRepo := &testutil.MockStripRepository{
-		GetByCallsignFn: func(_ context.Context, gotSession int32, gotCallsign string) (*models.Strip, error) {
+	stripRepo := &stripUpdateStoreFake{
+		getByCallsignFn: func(_ context.Context, gotSession int32, gotCallsign string) (*models.Strip, error) {
 			assert.Equal(t, session, gotSession)
 			assert.Equal(t, callsign, gotCallsign)
 			return &models.Strip{
@@ -70,14 +97,14 @@ func TestFrontendStripUpdateService_RunwayChangePersistsSelectedRunway(t *testin
 				Runway:   &currentRunway,
 			}, nil
 		},
-		UpdateRunwayFn: func(_ context.Context, gotSession int32, gotCallsign string, runway *string, version *int32) (int64, error) {
+		updateRunwayFn: func(_ context.Context, gotSession int32, gotCallsign string, runway *string, version *int32) (int64, error) {
 			assert.Equal(t, session, gotSession)
 			assert.Equal(t, callsign, gotCallsign)
 			assert.Nil(t, version)
 			updatedRunway = runway
 			return 1, nil
 		},
-		AppendControllerModifiedFieldFn: func(_ context.Context, gotSession int32, gotCallsign string, field string) error {
+		appendControllerModifiedFieldFn: func(_ context.Context, gotSession int32, gotCallsign string, field string) error {
 			assert.Equal(t, session, gotSession)
 			assert.Equal(t, callsign, gotCallsign)
 			markedField = field
@@ -124,8 +151,8 @@ func TestFrontendStripUpdateService_EobtChangeTriggersCdmRecalculation(t *testin
 
 	var handledEobt string
 
-	stripRepo := &testutil.MockStripRepository{
-		GetByCallsignFn: func(_ context.Context, gotSession int32, gotCallsign string) (*models.Strip, error) {
+	stripRepo := &stripUpdateStoreFake{
+		getByCallsignFn: func(_ context.Context, gotSession int32, gotCallsign string) (*models.Strip, error) {
 			assert.Equal(t, session, gotSession)
 			assert.Equal(t, callsign, gotCallsign)
 			return &models.Strip{
@@ -198,8 +225,8 @@ func TestFrontendStripUpdateService_OwnerCanUpdateRemarksAndAircraftInfo(t *test
 	updatedRemarks := "REG/OYABC PBN/A1B1C1D1S1S2"
 	updatedAircraftInfo := "B738/M-SDE2FGHIWYR/LB1"
 
-	stripRepo := &testutil.MockStripRepository{
-		GetByCallsignFn: func(_ context.Context, gotSession int32, gotCallsign string) (*models.Strip, error) {
+	stripRepo := &stripUpdateStoreFake{
+		getByCallsignFn: func(_ context.Context, gotSession int32, gotCallsign string) (*models.Strip, error) {
 			assert.Equal(t, session, gotSession)
 			assert.Equal(t, callsign, gotCallsign)
 			return &models.Strip{
@@ -252,8 +279,8 @@ func TestFrontendStripUpdateService_NonOwnerCannotUpdateRemarksOrAircraftInfo(t 
 	updatedRemarks := "PBN/A1"
 	updatedAircraftInfo := "B738/M-SR"
 
-	stripRepo := &testutil.MockStripRepository{
-		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
+	stripRepo := &stripUpdateStoreFake{
+		getByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
 			return &models.Strip{
 				Callsign: callsign,
 				Session:  session,
@@ -298,18 +325,18 @@ func TestFrontendStripUpdateService_RunwayChangeReevaluatesDepartureValidation(t
 	var reevaluatedPublish bool
 	var reevaluatedForce bool
 
-	stripRepo := &testutil.MockStripRepository{
-		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
+	stripRepo := &stripUpdateStoreFake{
+		getByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
 			return &models.Strip{
 				Callsign: callsign,
 				Session:  session,
 				Runway:   &currentRunway,
 			}, nil
 		},
-		UpdateRunwayFn: func(_ context.Context, _ int32, _ string, _ *string, _ *int32) (int64, error) {
+		updateRunwayFn: func(_ context.Context, _ int32, _ string, _ *string, _ *int32) (int64, error) {
 			return 1, nil
 		},
-		AppendControllerModifiedFieldFn: func(_ context.Context, _ int32, _ string, _ string) error {
+		appendControllerModifiedFieldFn: func(_ context.Context, _ int32, _ string, _ string) error {
 			return nil
 		},
 	}
@@ -362,8 +389,8 @@ func TestFrontendStripUpdateService_SidChangeReevaluatesPdcInvalidValidationUsin
 	var reevaluatedPublish bool
 	var reevaluatedForce bool
 
-	stripRepo := &testutil.MockStripRepository{
-		GetByCallsignFn: func(_ context.Context, gotSession int32, gotCallsign string) (*models.Strip, error) {
+	stripRepo := &stripUpdateStoreFake{
+		getByCallsignFn: func(_ context.Context, gotSession int32, gotCallsign string) (*models.Strip, error) {
 			assert.Equal(t, session, gotSession)
 			assert.Equal(t, callsign, gotCallsign)
 			return &models.Strip{
@@ -374,7 +401,7 @@ func TestFrontendStripUpdateService_SidChangeReevaluatesPdcInvalidValidationUsin
 				PdcState: "REQUESTED_WITH_FAULTS",
 			}, nil
 		},
-		AppendControllerModifiedFieldFn: func(_ context.Context, gotSession int32, gotCallsign string, field string) error {
+		appendControllerModifiedFieldFn: func(_ context.Context, gotSession int32, gotCallsign string, field string) error {
 			assert.Equal(t, session, gotSession)
 			assert.Equal(t, callsign, gotCallsign)
 			markedField = field
@@ -443,8 +470,8 @@ func TestFrontendStripUpdateService_StandChangeTriggersUpdateStand(t *testing.T)
 	var updateStandValue string
 	var markedField string
 
-	stripRepo := &testutil.MockStripRepository{
-		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
+	stripRepo := &stripUpdateStoreFake{
+		getByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
 			return &models.Strip{
 				Callsign: callsign,
 				Session:  session,
@@ -452,7 +479,7 @@ func TestFrontendStripUpdateService_StandChangeTriggersUpdateStand(t *testing.T)
 				Stand:    &currentStand,
 			}, nil
 		},
-		AppendControllerModifiedFieldFn: func(_ context.Context, _ int32, _ string, field string) error {
+		appendControllerModifiedFieldFn: func(_ context.Context, _ int32, _ string, field string) error {
 			markedField = field
 			return nil
 		},
@@ -501,8 +528,8 @@ func TestFrontendStripUpdateService_ValueMatchedRunwayAltitudeAndHeadingAreNoOps
 	altitude := int32(5000)
 	heading := int32(220)
 
-	stripRepo := &testutil.MockStripRepository{
-		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
+	stripRepo := &stripUpdateStoreFake{
+		getByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
 			return &models.Strip{
 				Callsign:        callsign,
 				Session:         session,
@@ -554,14 +581,14 @@ func TestFrontendStripUpdateService_NilStoredAltitudeAndHeadingStillForwardExpli
 
 	var markedFields []string
 
-	stripRepo := &testutil.MockStripRepository{
-		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
+	stripRepo := &stripUpdateStoreFake{
+		getByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
 			return &models.Strip{
 				Callsign: callsign,
 				Session:  session,
 			}, nil
 		},
-		AppendControllerModifiedFieldFn: func(_ context.Context, _ int32, _ string, fieldName string) error {
+		appendControllerModifiedFieldFn: func(_ context.Context, _ int32, _ string, fieldName string) error {
 			markedFields = append(markedFields, fieldName)
 			return nil
 		},

--- a/backend/internal/pdc/service.go
+++ b/backend/internal/pdc/service.go
@@ -64,7 +64,7 @@ type PdcRequestOutcome struct {
 type Service struct {
 	client            HoppieClientInterface
 	sessionRepo       repository.SessionRepository
-	stripRepo         repository.StripRepository
+	stripRepo         PdcStripStore
 	sectorRepo        repository.SectorOwnerRepository
 	controllerRepo    repository.ControllerRepository
 	frontendHub       shared.FrontendHub
@@ -77,7 +77,7 @@ type Service struct {
 	webLookupLiveOnly bool
 }
 
-func NewPDCService(client HoppieClientInterface, sessionRepo repository.SessionRepository, stripRepo repository.StripRepository, sectorRepo repository.SectorOwnerRepository, controllerRepo repository.ControllerRepository) *Service {
+func NewPDCService(client HoppieClientInterface, sessionRepo repository.SessionRepository, stripRepo PdcStripStore, sectorRepo repository.SectorOwnerRepository, controllerRepo repository.ControllerRepository) *Service {
 	return &Service{
 		client:         client,
 		sessionRepo:    sessionRepo,

--- a/backend/internal/pdc/strip_store.go
+++ b/backend/internal/pdc/strip_store.go
@@ -1,0 +1,18 @@
+package pdc
+
+import (
+	"FlightStrips/internal/models"
+	"context"
+	"time"
+)
+
+// PdcStripStore is the strip persistence surface needed by the PDC workflow.
+type PdcStripStore interface {
+	GetByCallsign(ctx context.Context, session int32, callsign string) (*models.Strip, error)
+	List(ctx context.Context, session int32) ([]*models.Strip, error)
+	Update(ctx context.Context, strip *models.Strip) (int64, error)
+	SetPdcData(ctx context.Context, session int32, callsign string, data *models.PdcData) error
+	SetPdcRequested(ctx context.Context, session int32, callsign string, pdcState string, pdcRequestedAt *time.Time, pdcRequestRemarks *string) error
+	SetPdcMessageSent(ctx context.Context, session int32, callsign string, pdcState string, pdcMessageSequence *int32, pdcMessageSent *time.Time) error
+	UpdatePdcStatus(ctx context.Context, session int32, callsign string, pdcState string) error
+}

--- a/backend/internal/repository/postgres/interface_checks_test.go
+++ b/backend/internal/repository/postgres/interface_checks_test.go
@@ -1,0 +1,28 @@
+package postgres_test
+
+import (
+	"FlightStrips/internal/cdm"
+	"FlightStrips/internal/ecfmp"
+	"FlightStrips/internal/frontend"
+	"FlightStrips/internal/pdc"
+	"FlightStrips/internal/repository/postgres"
+	"FlightStrips/internal/services"
+)
+
+var (
+	_ pdc.PdcStripStore                   = postgres.NewStripRepository(nil)
+	_ cdm.CdmStripStore                   = postgres.NewStripRepository(nil)
+	_ cdm.CdmSequenceStripStore           = postgres.NewStripRepository(nil)
+	_ ecfmp.StripStore                    = postgres.NewStripRepository(nil)
+	_ frontend.FrontendStripUpdateStore   = postgres.NewStripRepository(nil)
+	_ frontend.SnapshotStripStore         = postgres.NewStripRepository(nil)
+	_ services.StripLifecycleStore        = postgres.NewStripRepository(nil)
+	_ services.StripReader                = postgres.NewStripRepository(nil)
+	_ services.StripOrderingStore         = postgres.NewStripRepository(nil)
+	_ services.StripFieldStore            = postgres.NewStripRepository(nil)
+	_ services.StripOwnerStore            = postgres.NewStripRepository(nil)
+	_ services.StripCdmStore              = postgres.NewStripRepository(nil)
+	_ services.StripValidationStatusStore = postgres.NewStripRepository(nil)
+	_ services.StripManualFplStore        = postgres.NewStripRepository(nil)
+	_ services.TrafficMetricsStripStore   = postgres.NewStripRepository(nil)
+)

--- a/backend/internal/server/route.go
+++ b/backend/internal/server/route.go
@@ -545,7 +545,11 @@ func nextDisplaysEqual(left, right *models.NextDisplay) bool {
 	return left.Label == right.Label && left.Frequency == right.Frequency
 }
 
-func routeStripForCallsign(ctx context.Context, stripRepo repository.StripRepository, sessionId int32, callsign string) (*models.Strip, error) {
+type routeStripReader interface {
+	GetByCallsign(ctx context.Context, session int32, callsign string) (*models.Strip, error)
+}
+
+func routeStripForCallsign(ctx context.Context, stripRepo routeStripReader, sessionId int32, callsign string) (*models.Strip, error) {
 	if syncState := shared.GetSyncState(ctx); syncState != nil && syncState.ExistingStrips != nil {
 		if strip := syncState.ExistingStrips[callsign]; strip != nil {
 			return strip, nil

--- a/backend/internal/services/dependencies.go
+++ b/backend/internal/services/dependencies.go
@@ -6,6 +6,71 @@ import (
 	"context"
 )
 
+type StripLifecycleStore interface {
+	Create(ctx context.Context, strip *internalModels.Strip) error
+	Update(ctx context.Context, strip *internalModels.Strip) (int64, error)
+	Delete(ctx context.Context, session int32, callsign string) error
+}
+
+type StripReader interface {
+	GetByCallsign(ctx context.Context, session int32, callsign string) (*internalModels.Strip, error)
+	List(ctx context.Context, session int32) ([]*internalModels.Strip, error)
+}
+
+type StripOrderingStore interface {
+	UpdateBayAndSequence(ctx context.Context, session int32, callsign string, bay string, sequence int32) (int64, error)
+	UpdateSequenceBulk(ctx context.Context, session int32, callsigns []string, sequences []int32) error
+	RecalculateSequences(ctx context.Context, session int32, bay string, spacing int32) error
+	ListSequences(ctx context.Context, session int32, bay string) ([]*internalModels.StripSequence, error)
+	GetSequence(ctx context.Context, session int32, callsign string, bay string) (int32, error)
+	GetMaxSequenceInBay(ctx context.Context, session int32, bay string) (int32, error)
+	GetNextSequence(ctx context.Context, session int32, bay string, sequence int32) (int32, error)
+}
+
+type StripFieldStore interface {
+	UpdateSquawk(ctx context.Context, session int32, callsign string, squawk *string, version *int32) (int64, error)
+	UpdateAssignedSquawk(ctx context.Context, session int32, callsign string, assignedSquawk *string, version *int32) (int64, error)
+	UpdateClearedAltitude(ctx context.Context, session int32, callsign string, altitude *int32, version *int32) (int64, error)
+	UpdateRequestedAltitude(ctx context.Context, session int32, callsign string, altitude *int32, version *int32) (int64, error)
+	UpdateCommunicationType(ctx context.Context, session int32, callsign string, commType *string, version *int32) (int64, error)
+	UpdateGroundState(ctx context.Context, session int32, callsign string, state *string, bay string, version *int32) (int64, error)
+	UpdateClearedFlag(ctx context.Context, session int32, callsign string, cleared bool, bay string, version *int32) (int64, error)
+	UpdateAircraftPosition(ctx context.Context, session int32, callsign string, lat *float64, lon *float64, alt *int32, bay string, version *int32) (int64, error)
+	UpdateBay(ctx context.Context, session int32, callsign string, bay string, version *int32) (int64, error)
+	UpdateHeading(ctx context.Context, session int32, callsign string, heading *int32, version *int32) (int64, error)
+	UpdateStand(ctx context.Context, session int32, callsign string, stand *string, version *int32) (int64, error)
+	UpdateRunway(ctx context.Context, session int32, callsign string, runway *string, version *int32) (int64, error)
+	UpdateStartReq(ctx context.Context, session int32, callsign string, startReq bool, version *int32) (int64, error)
+	UpdateMarked(ctx context.Context, session int32, callsign string, marked bool, version *int32) (int64, error)
+	UpdateTrackingController(ctx context.Context, session int32, callsign string, trackingController string) (int64, error)
+	UpdateRunwayClearance(ctx context.Context, session int32, callsign string) (int64, error)
+	UpdateRunwayConfirmation(ctx context.Context, session int32, callsign string) (int64, error)
+	ResetRunwayClearance(ctx context.Context, session int32, callsign string) (int64, error)
+	UpdateReleasePoint(ctx context.Context, session int32, callsign string, releasePoint *string) (int64, error)
+	AppendUnexpectedChangeField(ctx context.Context, session int32, callsign string, fieldName string) error
+}
+
+type StripOwnerStore interface {
+	SetOwner(ctx context.Context, session int32, callsign string, owner *string, version int32) (int64, error)
+	SetPreviousOwners(ctx context.Context, session int32, callsign string, previousOwners []string) error
+	SetNextAndPreviousOwners(ctx context.Context, session int32, callsign string, nextOwners []string, previousOwners []string) error
+}
+
+type StripCdmStore interface {
+	SetCdmData(ctx context.Context, session int32, callsign string, data *internalModels.CdmData) (int64, error)
+}
+
+type StripValidationStatusStore interface {
+	SetValidationStatus(ctx context.Context, session int32, callsign string, status *internalModels.ValidationStatus) error
+	AcknowledgeValidationStatus(ctx context.Context, session int32, callsign string, activationKey string) (int64, error)
+	ClearValidationStatus(ctx context.Context, session int32, callsign string) error
+}
+
+type StripManualFplStore interface {
+	UpdateIFRManualFPLFields(ctx context.Context, session int32, callsign string, destination string, sid *string, assignedSquawk *string, eobt *string, aircraftType *string, requestedAltitude *int32, route *string, stand *string, runway *string) (int64, error)
+	UpdateVFRManualFPLFields(ctx context.Context, session int32, callsign string, aircraftType *string, personsOnBoard *int32, assignedSquawk string, fplType *string, language *string, remarks *string, bay string) (int64, error)
+}
+
 type RouteRecalculator interface {
 	UpdateRouteForStrip(callsign string, sessionID int32, sendUpdate bool) error
 	UpdateRouteForStripContext(ctx context.Context, callsign string, sessionID int32, sendUpdate bool) error

--- a/backend/internal/services/strip.go
+++ b/backend/internal/services/strip.go
@@ -17,7 +17,14 @@ const (
 )
 
 type StripService struct {
-	stripRepo         repository.StripRepository
+	stripReader       StripReader
+	lifecycleStore    StripLifecycleStore
+	orderingStore     StripOrderingStore
+	fieldStore        StripFieldStore
+	ownerStore        StripOwnerStore
+	cdmStore          StripCdmStore
+	validationStore   StripValidationStatusStore
+	manualFplStore    StripManualFplStore
 	tacticalRepo      repository.TacticalStripRepository
 	sectorOwnerRepo   repository.SectorOwnerRepository
 	publisher         shared.StripEventPublisher
@@ -31,14 +38,40 @@ type StripService struct {
 	cdmService        shared.CdmService
 }
 
-func NewStripService(stripRepo repository.StripRepository, options ...StripServiceOption) *StripService {
-	service := &StripService{
-		stripRepo: stripRepo,
+func NewStripService(stripReader StripReader, options ...StripServiceOption) *StripService {
+	service := &StripService{}
+	if stripReader != nil {
+		service.stripReader = stripReader
+		service.configureStripStores(stripReader)
 	}
 	for _, option := range options {
 		option(service)
 	}
 	return service
+}
+
+func (s *StripService) configureStripStores(store any) {
+	if lifecycleStore, ok := store.(StripLifecycleStore); ok {
+		s.lifecycleStore = lifecycleStore
+	}
+	if orderingStore, ok := store.(StripOrderingStore); ok {
+		s.orderingStore = orderingStore
+	}
+	if fieldStore, ok := store.(StripFieldStore); ok {
+		s.fieldStore = fieldStore
+	}
+	if ownerStore, ok := store.(StripOwnerStore); ok {
+		s.ownerStore = ownerStore
+	}
+	if cdmStore, ok := store.(StripCdmStore); ok {
+		s.cdmStore = cdmStore
+	}
+	if validationStore, ok := store.(StripValidationStatusStore); ok {
+		s.validationStore = validationStore
+	}
+	if manualFplStore, ok := store.(StripManualFplStore); ok {
+		s.manualFplStore = manualFplStore
+	}
 }
 
 func (s *StripService) SetFrontendHub(publisher shared.StripEventPublisher) {
@@ -122,7 +155,7 @@ func (s *StripService) SetCdmService(cdmService shared.CdmService) {
 }
 
 func (s *StripService) ClearMandatoryRouteCdm(ctx context.Context, sessionID int32, callsign string) {
-	strip, err := s.stripRepo.GetByCallsign(ctx, sessionID, callsign)
+	strip, err := s.stripReader.GetByCallsign(ctx, sessionID, callsign)
 	if err != nil {
 		slog.WarnContext(ctx, "Failed to get strip for mandatory route CDM clearing",
 			slog.String("callsign", callsign), slog.Any("error", err))
@@ -158,7 +191,7 @@ func (s *StripService) ClearMandatoryRouteCdm(ctx context.Context, sessionID int
 		cdmUpdated.EcfmpRestrictions = nil
 	}
 
-	if _, err := s.stripRepo.SetCdmData(ctx, sessionID, callsign, cdmUpdated); err != nil {
+	if _, err := s.cdmStore.SetCdmData(ctx, sessionID, callsign, cdmUpdated); err != nil {
 		slog.WarnContext(ctx, "Failed to clear mandatory route restriction from CDM data",
 			slog.String("callsign", callsign), slog.Any("error", err))
 		return

--- a/backend/internal/services/strip_arrival.go
+++ b/backend/internal/services/strip_arrival.go
@@ -55,7 +55,7 @@ func (s *StripService) maybeDropArrivalTrackingInEuroscope(ctx context.Context, 
 
 // UpdateAircraftPosition updates the aircraft position and moves the strip to a new bay if needed.
 func (s *StripService) UpdateAircraftPosition(ctx context.Context, session int32, callsign string, lat, lon float64, altitude int32, airport string) error {
-	existingStrip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+	existingStrip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			slog.DebugContext(ctx, "Strip being updated does not exist in database", slog.String("callsign", callsign), slog.String("event", "FlightStripOffline"))
@@ -86,7 +86,7 @@ func (s *StripService) UpdateAircraftPosition(ctx context.Context, session int32
 		slog.String("computed_bay", bay),
 	)
 
-	_, err = s.stripRepo.UpdateAircraftPosition(ctx, session, callsign, &lat, &lon, &altitude, bay, nil)
+	_, err = s.fieldStore.UpdateAircraftPosition(ctx, session, callsign, &lat, &lon, &altitude, bay, nil)
 	if err != nil {
 		return err
 	}
@@ -165,7 +165,7 @@ func (s *StripService) handleArrivalPositionUpdate(ctx context.Context, session 
 		aldt := time.Now().UTC().Format("1504")
 		newCdm := strip.CdmData.Clone()
 		newCdm.Aldt = &aldt
-		if _, err := s.stripRepo.SetCdmData(ctx, session, callsign, newCdm); err != nil {
+		if _, err := s.cdmStore.SetCdmData(ctx, session, callsign, newCdm); err != nil {
 			slog.ErrorContext(ctx, logPrefix+": failed to set ALDT", slog.String("callsign", callsign), slog.Any("error", err))
 		} else {
 			slog.InfoContext(ctx, "ALDT recorded", slog.String("callsign", callsign), slog.String("aldt", aldt), slog.String("runway", runwayRegion.Name))
@@ -200,7 +200,7 @@ func (s *StripService) HandleTrackingControllerChanged(ctx context.Context, sess
 		return errors.New("coordination repository not configured")
 	}
 
-	if _, err := s.stripRepo.UpdateTrackingController(ctx, session, callsign, trackingController); err != nil {
+	if _, err := s.fieldStore.UpdateTrackingController(ctx, session, callsign, trackingController); err != nil {
 		return err
 	}
 	shared.AddDBOperations(ctx, 1)
@@ -272,7 +272,7 @@ func (s *StripService) HandleTrackingControllerChanged(ctx context.Context, sess
 		targetBay = shared.BAY_FINAL
 	}
 
-	count, err := s.stripRepo.UpdateBay(ctx, session, callsign, targetBay, nil)
+	count, err := s.fieldStore.UpdateBay(ctx, session, callsign, targetBay, nil)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/services/strip_arrival_landing_test.go
+++ b/backend/internal/services/strip_arrival_landing_test.go
@@ -479,7 +479,7 @@ func TestHandleArrivalPositionUpdate_AutoAcceptsCoordinationOnTouchdown(t *testi
 	svc, hub, _ := buildLandingDetectionSvc(t, strip, coordRepo)
 
 	// Capture SetOwner to verify the strip is assumed by toPos.
-	svc.stripRepo.(*testutil.MockStripRepository).SetOwnerFn = func(_ context.Context, _ int32, _ string, o *string, _ int32) (int64, error) {
+	svc.ownerStore.(*testutil.MockStripRepository).SetOwnerFn = func(_ context.Context, _ int32, _ string, o *string, _ int32) (int64, error) {
 		ownerSet = o
 		return 1, nil
 	}

--- a/backend/internal/services/strip_auto_assume.go
+++ b/backend/internal/services/strip_auto_assume.go
@@ -78,7 +78,7 @@ func (s *StripService) autoAssumeForClearedStrip(ctx context.Context, session in
 
 	nextOwners, previousOwners := prepareOwnersForAutomaticTransfer(strip, sqPosition, actingPosition)
 
-	if err := s.stripRepo.SetNextAndPreviousOwners(ctx, session, callsign, nextOwners, previousOwners); err != nil {
+	if err := s.ownerStore.SetNextAndPreviousOwners(ctx, session, callsign, nextOwners, previousOwners); err != nil {
 		return err
 	}
 
@@ -230,7 +230,7 @@ func (s *StripService) syncStripByCallsign(ctx context.Context, session int32, c
 		}
 		return nil, pgx.ErrNoRows
 	}
-	return s.stripRepo.GetByCallsign(ctx, session, callsign)
+	return s.stripReader.GetByCallsign(ctx, session, callsign)
 }
 
 func (s *StripService) syncStrips(ctx context.Context, session int32) ([]*models.Strip, error) {
@@ -241,7 +241,7 @@ func (s *StripService) syncStrips(ctx context.Context, session int32) ([]*models
 		}
 		return strips, nil
 	}
-	return s.stripRepo.List(ctx, session)
+	return s.stripReader.List(ctx, session)
 }
 
 func (s *StripService) syncSession(ctx context.Context, session int32) *models.Session {

--- a/backend/internal/services/strip_cleared_bay.go
+++ b/backend/internal/services/strip_cleared_bay.go
@@ -17,7 +17,7 @@ func (s *StripService) scheduleStandAutoHide(session int32, callsign string) {
 
 		ctx := context.Background()
 
-		strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+		strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 		if err != nil {
 			// Strip was deleted while we were waiting — nothing to do.
 			slog.DebugContext(ctx, "Auto-hide from STAND: strip not found, skipping",
@@ -53,7 +53,7 @@ func (s *StripService) ClearStrip(ctx context.Context, session int32, callsign s
 		return fmt.Errorf("failed to move strip to cleared bay: %w", err)
 	}
 
-	if _, err := s.stripRepo.UpdateClearedFlag(ctx, session, callsign, true, shared.BAY_CLEARED, nil); err != nil {
+	if _, err := s.fieldStore.UpdateClearedFlag(ctx, session, callsign, true, shared.BAY_CLEARED, nil); err != nil {
 		slog.ErrorContext(ctx, "ClearStrip: failed to update cleared flag", slog.Any("error", err))
 	}
 
@@ -70,7 +70,7 @@ func (s *StripService) UnclearStrip(ctx context.Context, session int32, callsign
 		return fmt.Errorf("failed to move strip to not-cleared bay: %w", err)
 	}
 
-	if _, err := s.stripRepo.UpdateClearedFlag(ctx, session, callsign, false, shared.BAY_NOT_CLEARED, nil); err != nil {
+	if _, err := s.fieldStore.UpdateClearedFlag(ctx, session, callsign, false, shared.BAY_NOT_CLEARED, nil); err != nil {
 		slog.ErrorContext(ctx, "UnclearStrip: failed to update cleared flag", slog.Any("error", err))
 	}
 
@@ -91,7 +91,7 @@ func (s *StripService) clearOwnerForNotCleared(ctx context.Context, session int3
 		return fmt.Errorf("failed to get strip for owner reset: %w", err)
 	}
 
-	if err := s.stripRepo.SetPreviousOwners(ctx, session, callsign, []string{}); err != nil {
+	if err := s.ownerStore.SetPreviousOwners(ctx, session, callsign, []string{}); err != nil {
 		return fmt.Errorf("failed to persist previous owners: %w", err)
 	}
 	if syncState := shared.GetSyncState(ctx); syncState != nil && syncState.ExistingStrips != nil {
@@ -101,7 +101,7 @@ func (s *StripService) clearOwnerForNotCleared(ctx context.Context, session int3
 	}
 
 	if strip.Owner != nil && *strip.Owner != "" {
-		count, err := s.stripRepo.SetOwner(ctx, session, callsign, nil, strip.Version)
+		count, err := s.ownerStore.SetOwner(ctx, session, callsign, nil, strip.Version)
 		if err != nil {
 			return fmt.Errorf("failed to clear strip owner: %w", err)
 		}
@@ -133,7 +133,7 @@ func (s *StripService) clearOwnerForNotCleared(ctx context.Context, session int3
 
 // DeleteStrip removes a strip from the database and notifies the frontend.
 func (s *StripService) DeleteStrip(ctx context.Context, session int32, callsign string) error {
-	err := s.stripRepo.Delete(ctx, session, callsign)
+	err := s.lifecycleStore.Delete(ctx, session, callsign)
 	s.publisher.SendAircraftDisconnect(session, callsign)
 	return err
 }

--- a/backend/internal/services/strip_coordination.go
+++ b/backend/internal/services/strip_coordination.go
@@ -41,7 +41,7 @@ func (s *StripService) maybeAcceptOwnedEsArrivalCoordination(ctx context.Context
 }
 
 func (s *StripService) clearOwnerForOwnedEsArrivalCoordination(ctx context.Context, session int32, callsign string) error {
-	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		return err
 	}
@@ -70,7 +70,7 @@ func (s *StripService) CreateCoordinationTransfer(ctx context.Context, session i
 		return errors.New("coordination store not configured")
 	}
 
-	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		return err
 	}
@@ -131,7 +131,7 @@ func (s *StripService) CreateEsArrivalCoordination(ctx context.Context, session 
 		return errors.New("coordination store not configured")
 	}
 
-	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		return err
 	}
@@ -165,7 +165,7 @@ func (s *StripService) AcceptCoordination(ctx context.Context, session int32, ca
 		return errors.New("coordination store not configured")
 	}
 
-	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		return err
 	}
@@ -190,7 +190,7 @@ func (s *StripService) AcceptCoordination(ctx context.Context, session int32, ca
 
 	previousOwners := append(strip.PreviousOwners, coordination.FromPosition)
 
-	if err := s.stripRepo.SetNextAndPreviousOwners(ctx, session, callsign, nextOwners, previousOwners); err != nil {
+	if err := s.ownerStore.SetNextAndPreviousOwners(ctx, session, callsign, nextOwners, previousOwners); err != nil {
 		return err
 	}
 
@@ -213,7 +213,7 @@ func (s *StripService) AutoTransferAirborneStrip(ctx context.Context, session in
 		return errors.New("frontend hub not configured")
 	}
 
-	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		return err
 	}
@@ -392,7 +392,7 @@ func (s *StripService) HandleCoordinationReceived(ctx context.Context, session i
 		return errors.New("controller repository not configured")
 	}
 
-	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			slog.DebugContext(ctx, "Strip not found for coordination_received event", slog.String("callsign", callsign))
@@ -417,7 +417,7 @@ func (s *StripService) HandleCoordinationReceived(ctx context.Context, session i
 
 	originalBay := strip.Bay
 	if strip.Bay == shared.BAY_ARR_HIDDEN {
-		if _, err := s.stripRepo.UpdateBay(ctx, session, callsign, shared.BAY_FINAL, nil); err != nil {
+		if _, err := s.fieldStore.UpdateBay(ctx, session, callsign, shared.BAY_FINAL, nil); err != nil {
 			return err
 		}
 
@@ -478,7 +478,7 @@ func (s *StripService) AssumeStripCoordination(ctx context.Context, session int3
 		return errors.New("coordination repository not configured")
 	}
 
-	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		return err
 	}
@@ -500,7 +500,7 @@ func (s *StripService) AssumeStripCoordination(ctx context.Context, session int3
 					nextOwners = nextOwners[index+1:]
 				}
 
-				if err := s.stripRepo.SetNextAndPreviousOwners(ctx, session, callsign, nextOwners, strip.PreviousOwners); err != nil {
+				if err := s.ownerStore.SetNextAndPreviousOwners(ctx, session, callsign, nextOwners, strip.PreviousOwners); err != nil {
 					return err
 				}
 
@@ -548,7 +548,7 @@ func (s *StripService) AssumeStripCoordination(ctx context.Context, session int3
 			nextOwners = nextOwners[index+1:]
 		}
 
-		if err := s.stripRepo.SetNextAndPreviousOwners(ctx, session, callsign, nextOwners, strip.PreviousOwners); err != nil {
+		if err := s.ownerStore.SetNextAndPreviousOwners(ctx, session, callsign, nextOwners, strip.PreviousOwners); err != nil {
 			return err
 		}
 
@@ -566,7 +566,7 @@ func (s *StripService) AssumeStripCoordination(ctx context.Context, session int3
 			if err := routeRecalculator.UpdateRouteForStrip(callsign, session, false); err != nil {
 				slog.ErrorContext(ctx, "Error updating route after direct assume", slog.String("callsign", callsign), slog.Any("error", err))
 			}
-			if refreshed, err := s.stripRepo.GetByCallsign(ctx, session, callsign); err == nil {
+			if refreshed, err := s.stripReader.GetByCallsign(ctx, session, callsign); err == nil {
 				nextOwners = refreshed.NextOwners
 			}
 		}
@@ -587,7 +587,7 @@ func (s *StripService) AssumeStripCoordination(ctx context.Context, session int3
 //   - The displaced owner is removed from previous controllers.
 //   - Any controllers that appear in the recalculated next owners are removed from previous controllers.
 func (s *StripService) ForceAssumeStrip(ctx context.Context, session int32, callsign string, position string) error {
-	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		return err
 	}
@@ -637,7 +637,7 @@ func (s *StripService) ForceAssumeStrip(ctx context.Context, session int32, call
 		previousOwners = append(previousOwners, *strip.Owner)
 	}
 
-	if err := s.stripRepo.SetNextAndPreviousOwners(ctx, session, callsign, nextOwners, previousOwners); err != nil {
+	if err := s.ownerStore.SetNextAndPreviousOwners(ctx, session, callsign, nextOwners, previousOwners); err != nil {
 		return err
 	}
 
@@ -656,7 +656,7 @@ func (s *StripService) ForceAssumeStrip(ctx context.Context, session int32, call
 		_ = routeRecalculator.UpdateRouteForStrip(callsign, session, false)
 
 		// Re-read to pick up the recalculated NextOwners.
-		if updated, err := s.stripRepo.GetByCallsign(ctx, session, callsign); err == nil {
+		if updated, err := s.stripReader.GetByCallsign(ctx, session, callsign); err == nil {
 			nextOwners = updated.NextOwners
 		}
 	}
@@ -670,7 +670,7 @@ func (s *StripService) ForceAssumeStrip(ctx context.Context, session int32, call
 		}
 	}
 	if !slices.Equal(cleanedPrevious, previousOwners) {
-		if err := s.stripRepo.SetPreviousOwners(ctx, session, callsign, cleanedPrevious); err != nil {
+		if err := s.ownerStore.SetPreviousOwners(ctx, session, callsign, cleanedPrevious); err != nil {
 			return err
 		}
 		previousOwners = cleanedPrevious
@@ -710,7 +710,7 @@ func (s *StripService) CreateTagRequest(ctx context.Context, session int32, call
 		return errors.New("frontend hub not configured")
 	}
 
-	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		return err
 	}
@@ -755,7 +755,7 @@ func (s *StripService) AcceptTagRequest(ctx context.Context, session int32, call
 		return errors.New("frontend hub not configured")
 	}
 
-	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		return err
 	}
@@ -805,7 +805,7 @@ func (s *StripService) AcceptTagRequest(ctx context.Context, session int32, call
 		previousOwners = append(previousOwners, ownerPosition)
 	}
 
-	if err := s.stripRepo.SetNextAndPreviousOwners(ctx, session, callsign, nextOwners, previousOwners); err != nil {
+	if err := s.ownerStore.SetNextAndPreviousOwners(ctx, session, callsign, nextOwners, previousOwners); err != nil {
 		return err
 	}
 
@@ -821,7 +821,7 @@ func (s *StripService) AcceptTagRequest(ctx context.Context, session int32, call
 	if routeRecalculator := s.getRouteRecalculator(); routeRecalculator != nil {
 		_ = routeRecalculator.UpdateRouteForStrip(callsign, session, false)
 
-		if updated, err := s.stripRepo.GetByCallsign(ctx, session, callsign); err == nil {
+		if updated, err := s.stripReader.GetByCallsign(ctx, session, callsign); err == nil {
 			nextOwners = updated.NextOwners
 		}
 	}
@@ -834,7 +834,7 @@ func (s *StripService) AcceptTagRequest(ctx context.Context, session int32, call
 		}
 	}
 	if !slices.Equal(cleanedPrevious, previousOwners) {
-		if err := s.stripRepo.SetPreviousOwners(ctx, session, callsign, cleanedPrevious); err != nil {
+		if err := s.ownerStore.SetPreviousOwners(ctx, session, callsign, cleanedPrevious); err != nil {
 			return err
 		}
 		previousOwners = cleanedPrevious
@@ -870,7 +870,7 @@ func (s *StripService) CancelCoordinationTransfer(ctx context.Context, session i
 
 // FreeStrip releases ownership of a strip and notifies all frontend clients.
 func (s *StripService) FreeStrip(ctx context.Context, session int32, callsign string, position string) error {
-	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		return err
 	}
@@ -881,7 +881,7 @@ func (s *StripService) FreeStrip(ctx context.Context, session int32, callsign st
 
 	previousOwners := append(strip.PreviousOwners, position)
 
-	if err := s.stripRepo.SetPreviousOwners(ctx, session, callsign, previousOwners); err != nil {
+	if err := s.ownerStore.SetPreviousOwners(ctx, session, callsign, previousOwners); err != nil {
 		return err
 	}
 

--- a/backend/internal/services/strip_ctot_validation.go
+++ b/backend/internal/services/strip_ctot_validation.go
@@ -113,7 +113,7 @@ func (s *StripService) applyCtotValidation(ctx context.Context, session int32, s
 		if !isCtotValidation(current) {
 			return nil
 		}
-		if err := s.stripRepo.ClearValidationStatus(ctx, session, strip.Callsign); err != nil {
+		if err := s.validationStore.ClearValidationStatus(ctx, session, strip.Callsign); err != nil {
 			return err
 		}
 		shared.AddDBOperations(ctx, 1)
@@ -142,7 +142,7 @@ func (s *StripService) applyCtotValidation(ctx context.Context, session int32, s
 		return nil
 	}
 
-	if err := s.stripRepo.SetValidationStatus(ctx, session, strip.Callsign, desired); err != nil {
+	if err := s.validationStore.SetValidationStatus(ctx, session, strip.Callsign, desired); err != nil {
 		return err
 	}
 	shared.AddDBOperations(ctx, 1)

--- a/backend/internal/services/strip_duplicate_squawk_validation.go
+++ b/backend/internal/services/strip_duplicate_squawk_validation.go
@@ -153,7 +153,7 @@ func (s *StripService) applyDuplicateSquawkValidationState(ctx context.Context, 
 		if !isDuplicateSquawkValidation(current) {
 			return nil
 		}
-		if err := s.stripRepo.ClearValidationStatus(ctx, session, strip.Callsign); err != nil {
+		if err := s.validationStore.ClearValidationStatus(ctx, session, strip.Callsign); err != nil {
 			return err
 		}
 		shared.AddDBOperations(ctx, 1)
@@ -182,7 +182,7 @@ func (s *StripService) applyDuplicateSquawkValidationState(ctx context.Context, 
 		return nil
 	}
 
-	if err := s.stripRepo.SetValidationStatus(ctx, session, strip.Callsign, desired); err != nil {
+	if err := s.validationStore.SetValidationStatus(ctx, session, strip.Callsign, desired); err != nil {
 		return err
 	}
 	shared.AddDBOperations(ctx, 1)
@@ -453,7 +453,7 @@ func (s *StripService) reevaluateStoredSquawkValidation(ctx context.Context, ses
 }
 
 func (s *StripService) setOwnerAndReevaluateDuplicateSquawkValidation(ctx context.Context, session int32, callsign string, owner *string, version int32) (int64, error) {
-	count, err := s.stripRepo.SetOwner(ctx, session, callsign, owner, version)
+	count, err := s.ownerStore.SetOwner(ctx, session, callsign, owner, version)
 	if err != nil || count != 1 {
 		return count, err
 	}

--- a/backend/internal/services/strip_fields.go
+++ b/backend/internal/services/strip_fields.go
@@ -50,7 +50,7 @@ func (s *StripService) setStartReqState(ctx context.Context, session int32, call
 		return nil
 	}
 
-	affected, err := s.stripRepo.UpdateStartReq(ctx, session, callsign, startReq, nil)
+	affected, err := s.fieldStore.UpdateStartReq(ctx, session, callsign, startReq, nil)
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func (s *StripService) setStartReqState(ctx context.Context, session int32, call
 
 // UpdateAssignedSquawk updates the assigned squawk for a strip and notifies the frontend.
 func (s *StripService) UpdateAssignedSquawk(ctx context.Context, session int32, callsign string, squawk string) error {
-	count, err := s.stripRepo.UpdateAssignedSquawk(ctx, session, callsign, &squawk, nil)
+	count, err := s.fieldStore.UpdateAssignedSquawk(ctx, session, callsign, &squawk, nil)
 	if err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func (s *StripService) UpdateAssignedSquawk(ctx context.Context, session int32, 
 
 // UpdateSquawk updates the current squawk for a strip and notifies the frontend.
 func (s *StripService) UpdateSquawk(ctx context.Context, session int32, callsign string, squawk string) error {
-	count, err := s.stripRepo.UpdateSquawk(ctx, session, callsign, &squawk, nil)
+	count, err := s.fieldStore.UpdateSquawk(ctx, session, callsign, &squawk, nil)
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func (s *StripService) UpdateSquawk(ctx context.Context, session int32, callsign
 
 // UpdateRequestedAltitude updates the requested altitude for a strip and notifies the frontend.
 func (s *StripService) UpdateRequestedAltitude(ctx context.Context, session int32, callsign string, altitude int32) error {
-	count, err := s.stripRepo.UpdateRequestedAltitude(ctx, session, callsign, &altitude, nil)
+	count, err := s.fieldStore.UpdateRequestedAltitude(ctx, session, callsign, &altitude, nil)
 	if err != nil {
 		return err
 	}
@@ -129,7 +129,7 @@ func (s *StripService) UpdateRequestedAltitude(ctx context.Context, session int3
 
 // UpdateClearedAltitude updates the cleared altitude for a strip and notifies the frontend.
 func (s *StripService) UpdateClearedAltitude(ctx context.Context, session int32, callsign string, altitude int32) error {
-	count, err := s.stripRepo.UpdateClearedAltitude(ctx, session, callsign, &altitude, nil)
+	count, err := s.fieldStore.UpdateClearedAltitude(ctx, session, callsign, &altitude, nil)
 	if err != nil {
 		return err
 	}
@@ -143,7 +143,7 @@ func (s *StripService) UpdateClearedAltitude(ctx context.Context, session int32,
 
 // UpdateCommunicationType updates the communication type for a strip and notifies the frontend.
 func (s *StripService) UpdateCommunicationType(ctx context.Context, session int32, callsign string, commType string) error {
-	count, err := s.stripRepo.UpdateCommunicationType(ctx, session, callsign, &commType, nil)
+	count, err := s.fieldStore.UpdateCommunicationType(ctx, session, callsign, &commType, nil)
 	if err != nil {
 		return err
 	}
@@ -157,7 +157,7 @@ func (s *StripService) UpdateCommunicationType(ctx context.Context, session int3
 
 // UpdateHeading updates the heading for a strip and notifies the frontend.
 func (s *StripService) UpdateHeading(ctx context.Context, session int32, callsign string, heading int32) error {
-	count, err := s.stripRepo.UpdateHeading(ctx, session, callsign, &heading, nil)
+	count, err := s.fieldStore.UpdateHeading(ctx, session, callsign, &heading, nil)
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,7 @@ func (s *StripService) UpdateHeading(ctx context.Context, session int32, callsig
 // UpdateGroundState updates the ground state for a strip, recomputes the bay, and moves
 // the strip if the bay changed.
 func (s *StripService) UpdateGroundState(ctx context.Context, session int32, callsign string, groundState string, airport string) error {
-	existingStrip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+	existingStrip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			slog.DebugContext(ctx, "Strip being updated does not exist in database", slog.String("callsign", callsign), slog.String("event", "GroundState"))
@@ -202,7 +202,7 @@ func (s *StripService) UpdateGroundState(ctx context.Context, session int32, cal
 	}
 	bay := shared.GetDepartureBayFromGroundState(groundState, dbStrip, airport, s.isGndOnline(ctx, session))
 
-	_, err = s.stripRepo.UpdateGroundState(ctx, session, callsign, &groundState, bay, nil)
+	_, err = s.fieldStore.UpdateGroundState(ctx, session, callsign, &groundState, bay, nil)
 	if err != nil {
 		return err
 	}
@@ -225,7 +225,7 @@ func (s *StripService) UpdateGroundState(ctx context.Context, session int32, cal
 // UpdateClearedFlag updates the cleared flag for a strip, recomputes the bay,
 // triggers auto-assumption if cleared, and moves the strip if the bay changed.
 func (s *StripService) UpdateClearedFlag(ctx context.Context, session int32, callsign string, cleared bool) error {
-	existingStrip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+	existingStrip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			slog.DebugContext(ctx, "Strip being updated does not exist in database", slog.String("callsign", callsign), slog.String("event", "FlightStripOnline"))
@@ -246,7 +246,7 @@ func (s *StripService) UpdateClearedFlag(ctx context.Context, session int32, cal
 		bay = shared.BAY_HIDDEN
 	}
 
-	_, err = s.stripRepo.UpdateClearedFlag(ctx, session, callsign, cleared, bay, nil)
+	_, err = s.fieldStore.UpdateClearedFlag(ctx, session, callsign, cleared, bay, nil)
 	if err != nil {
 		return err
 	}
@@ -269,12 +269,12 @@ func (s *StripService) UpdateClearedFlag(ctx context.Context, session int32, cal
 
 // UpdateStand updates the stand for a strip, notifies the frontend, and triggers route recalculation.
 func (s *StripService) UpdateStand(ctx context.Context, session int32, callsign string, stand string) error {
-	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		return err
 	}
 
-	count, err := s.stripRepo.UpdateStand(ctx, session, callsign, &stand, nil)
+	count, err := s.fieldStore.UpdateStand(ctx, session, callsign, &stand, nil)
 	if err != nil {
 		return err
 	}
@@ -327,12 +327,12 @@ func (s *StripService) applyClearedFlagForMove(ctx context.Context, session int3
 }
 
 func (s *StripService) applyClearedFlagForMoveWithOptions(ctx context.Context, session int32, callsign string, isCleared bool, persistedBay string, clearOwnerForNotCleared bool, cid string, forceEuroscopeNotification bool, autoAssumeOnClear bool) error {
-	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		return err
 	}
 
-	count, err := s.stripRepo.UpdateClearedFlag(ctx, session, callsign, isCleared, persistedBay, nil)
+	count, err := s.fieldStore.UpdateClearedFlag(ctx, session, callsign, isCleared, persistedBay, nil)
 	if err != nil {
 		return err
 	}
@@ -369,7 +369,7 @@ func (s *StripService) UpdateGroundStateForMove(ctx context.Context, session int
 }
 
 func (s *StripService) updateGroundStateForMoveWithOptions(ctx context.Context, session int32, callsign string, targetBay string, cid string, airport string, persistedBay string, reevaluate bool) error {
-	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		return err
 	}
@@ -391,7 +391,7 @@ func (s *StripService) updateGroundStateForMoveWithOptions(ctx context.Context, 
 		state = &parked
 	}
 
-	count, err := s.stripRepo.UpdateGroundState(ctx, session, callsign, state, persistedBay, nil)
+	count, err := s.fieldStore.UpdateGroundState(ctx, session, callsign, state, persistedBay, nil)
 	if err != nil {
 		return err
 	}
@@ -406,7 +406,7 @@ func (s *StripService) updateGroundStateForMoveWithOptions(ctx context.Context, 
 	// Moving backward out of a runway-cleared bay must clear the runway status so the next runway
 	// action behaves like a fresh clearance instead of a confirmation.
 	if strip.RunwayCleared && shouldResetRunwayClearanceOnMove(strip.Bay, targetBay) {
-		if _, err := s.stripRepo.ResetRunwayClearance(ctx, session, callsign); err != nil {
+		if _, err := s.fieldStore.ResetRunwayClearance(ctx, session, callsign); err != nil {
 			return err
 		}
 		s.publisher.SendStripUpdate(session, callsign)
@@ -423,7 +423,7 @@ func (s *StripService) updateGroundStateForMoveWithOptions(ctx context.Context, 
 
 // UpdateReleasePoint updates the release point for a strip and broadcasts to all frontend clients.
 func (s *StripService) UpdateReleasePoint(ctx context.Context, session int32, callsign string, releasePoint string) error {
-	affected, err := s.stripRepo.UpdateReleasePoint(ctx, session, callsign, &releasePoint)
+	affected, err := s.fieldStore.UpdateReleasePoint(ctx, session, callsign, &releasePoint)
 	if err != nil {
 		return err
 	}
@@ -445,7 +445,7 @@ func (s *StripService) UpdateStartReq(ctx context.Context, session int32, callsi
 // Non-owners may overwrite an existing value (marks the cell yellow for both controllers).
 // Non-owners setting a value on a strip that has none are rejected.
 func (s *StripService) ApplyReleasePoint(ctx context.Context, session int32, callsign string, releasePoint string, clientPosition string) error {
-	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		return err
 	}
@@ -457,7 +457,7 @@ func (s *StripService) ApplyReleasePoint(ctx context.Context, session int32, cal
 		hasExisting := strip.ReleasePoint != nil && *strip.ReleasePoint != ""
 		if hasExisting && *strip.ReleasePoint != releasePoint {
 			// Non-owner overwriting existing value — allow, mark as unexpected change.
-			if err := s.stripRepo.AppendUnexpectedChangeField(ctx, session, callsign, "release_point"); err != nil {
+			if err := s.fieldStore.AppendUnexpectedChangeField(ctx, session, callsign, "release_point"); err != nil {
 				return err
 			}
 			unexpectedChange = true
@@ -480,7 +480,7 @@ func (s *StripService) ApplyReleasePoint(ctx context.Context, session int32, cal
 
 // UpdateMarked updates the marked flag for a strip and broadcasts to all frontend clients.
 func (s *StripService) UpdateMarked(ctx context.Context, session int32, callsign string, marked bool) error {
-	affected, err := s.stripRepo.UpdateMarked(ctx, session, callsign, marked, nil)
+	affected, err := s.fieldStore.UpdateMarked(ctx, session, callsign, marked, nil)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/services/strip_frontend_move.go
+++ b/backend/internal/services/strip_frontend_move.go
@@ -36,7 +36,7 @@ func (s *StripService) MoveFrontendStrip(ctx context.Context, session int32, cal
 		return errors.New("invalid bay value: " + targetBay)
 	}
 
-	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/services/strip_landing_clearance_validation.go
+++ b/backend/internal/services/strip_landing_clearance_validation.go
@@ -189,7 +189,7 @@ func (s *StripService) ReevaluateLandingClearanceValidationsForSession(ctx conte
 		if candidate != nil && strip.Callsign == candidate.Callsign {
 			continue
 		}
-		if err := s.stripRepo.ClearValidationStatus(ctx, session, strip.Callsign); err != nil {
+		if err := s.validationStore.ClearValidationStatus(ctx, session, strip.Callsign); err != nil {
 			return err
 		}
 		shared.AddDBOperations(ctx, 1)
@@ -199,7 +199,7 @@ func (s *StripService) ReevaluateLandingClearanceValidationsForSession(ctx conte
 
 	if candidate == nil || !landingClearanceValidationApplies(candidate, activeArrivalRunways) {
 		if candidate != nil && isLandingClearanceValidation(candidate.ValidationStatus) {
-			if err := s.stripRepo.ClearValidationStatus(ctx, session, candidate.Callsign); err != nil {
+			if err := s.validationStore.ClearValidationStatus(ctx, session, candidate.Callsign); err != nil {
 				return err
 			}
 			shared.AddDBOperations(ctx, 1)
@@ -222,7 +222,7 @@ func (s *StripService) ReevaluateLandingClearanceValidationsForSession(ctx conte
 		return nil
 	}
 
-	if err := s.stripRepo.SetValidationStatus(ctx, session, candidate.Callsign, desired); err != nil {
+	if err := s.validationStore.SetValidationStatus(ctx, session, candidate.Callsign, desired); err != nil {
 		return err
 	}
 	shared.AddDBOperations(ctx, 1)

--- a/backend/internal/services/strip_manual_fpl.go
+++ b/backend/internal/services/strip_manual_fpl.go
@@ -15,7 +15,7 @@ import (
 // the provided IFR flight-plan fields, marks it as manually created, moves it
 // to the correct uncleared bay, and notifies both the frontend and EuroScope.
 func (s *StripService) CreateManualFPL(ctx context.Context, session int32, req frontend.CreateManualFPLAction, cid string, airport string) error {
-	strip, err := s.stripRepo.GetByCallsign(ctx, session, req.Callsign)
+	strip, err := s.stripReader.GetByCallsign(ctx, session, req.Callsign)
 	if err != nil {
 		return fmt.Errorf("callsign %q not found in session: %w", req.Callsign, err)
 	}
@@ -44,7 +44,7 @@ func (s *StripService) CreateManualFPL(ctx context.Context, session int32, req f
 		}
 	}
 
-	affected, err := s.stripRepo.UpdateIFRManualFPLFields(ctx, session, req.Callsign, req.ADES, sid, ssr, eobt, aircraftType, requestedAltitude, route, stand, runway)
+	affected, err := s.manualFplStore.UpdateIFRManualFPLFields(ctx, session, req.Callsign, req.ADES, sid, ssr, eobt, aircraftType, requestedAltitude, route, stand, runway)
 	if err != nil {
 		return fmt.Errorf("UpdateIFRManualFPLFields: %w", err)
 	}
@@ -89,7 +89,7 @@ func (s *StripService) CreateManualFPL(ctx context.Context, session int32, req f
 // It validates that the callsign exists, updates VFR-specific fields, moves the
 // strip to the CONTROLZONE bay, and notifies both the frontend and EuroScope.
 func (s *StripService) CreateVFRFPL(ctx context.Context, session int32, req frontend.CreateVFRFPLAction, cid string) error {
-	strip, err := s.stripRepo.GetByCallsign(ctx, session, req.Callsign)
+	strip, err := s.stripReader.GetByCallsign(ctx, session, req.Callsign)
 	if err != nil {
 		return fmt.Errorf("callsign %q not found in session: %w", req.Callsign, err)
 	}
@@ -110,7 +110,7 @@ func (s *StripService) CreateVFRFPL(ctx context.Context, session int32, req fron
 		personsOnBoard = &pob
 	}
 
-	affected, err := s.stripRepo.UpdateVFRManualFPLFields(ctx, session, req.Callsign, aircraftType, personsOnBoard, ssr, fplType, language, remarks, shared.BAY_CONTROLZONE)
+	affected, err := s.manualFplStore.UpdateVFRManualFPLFields(ctx, session, req.Callsign, aircraftType, personsOnBoard, ssr, fplType, language, remarks, shared.BAY_CONTROLZONE)
 	if err != nil {
 		return fmt.Errorf("UpdateVFRManualFPLFields: %w", err)
 	}

--- a/backend/internal/services/strip_message_context.go
+++ b/backend/internal/services/strip_message_context.go
@@ -184,7 +184,7 @@ func (s *StripService) listCachedStrips(ctx context.Context, session int32) ([]*
 		}
 	}
 
-	strips, err := s.stripRepo.List(ctx, session)
+	strips, err := s.stripReader.List(ctx, session)
 	if err != nil {
 		return nil, false, err
 	}
@@ -228,7 +228,7 @@ func (s *StripService) getCachedStrip(ctx context.Context, session int32, callsi
 		}
 	}
 
-	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, false, nil
 	}

--- a/backend/internal/services/strip_missed_approach.go
+++ b/backend/internal/services/strip_missed_approach.go
@@ -21,7 +21,7 @@ func isMissedApproachReturn(fromPosition string, assumingPosition string) bool {
 //   - removes towerPosition from PreviousOwners (TWR should become next controller again)
 //   - recalculates NextOwners via UpdateRouteForStrip
 func (s *StripService) applyMissedApproachOwnerFix(ctx context.Context, session int32, callsign string, assumingPosition string, towerPosition string) {
-	updated, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+	updated, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		slog.WarnContext(ctx, "missed approach owner fix: failed to re-fetch strip", slog.String("callsign", callsign), slog.Any("error", err))
 		return
@@ -31,7 +31,7 @@ func (s *StripService) applyMissedApproachOwnerFix(ctx context.Context, session 
 		return p == towerPosition
 	})
 	if len(cleanedPrev) != len(updated.PreviousOwners) {
-		if setErr := s.stripRepo.SetPreviousOwners(ctx, session, callsign, cleanedPrev); setErr != nil {
+		if setErr := s.ownerStore.SetPreviousOwners(ctx, session, callsign, cleanedPrev); setErr != nil {
 			slog.WarnContext(ctx, "missed approach owner fix: failed to clear TWR from previous owners", slog.String("callsign", callsign), slog.Any("error", setErr))
 		} else {
 			s.publisher.SendOwnersUpdate(session, callsign, assumingPosition, updated.NextOwners, cleanedPrev, nil)
@@ -48,7 +48,7 @@ func (s *StripService) applyMissedApproachOwnerFix(ctx context.Context, session 
 // The strip is moved to AIRBORNE and a coordination transfer is initiated to the
 // approach controller configured for the active arrival runway.
 func (s *StripService) MissedApproach(ctx context.Context, session int32, callsign string, position string) error {
-	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/services/strip_no_stand_validation.go
+++ b/backend/internal/services/strip_no_stand_validation.go
@@ -81,7 +81,7 @@ func (s *StripService) applyNoStandValidation(ctx context.Context, session int32
 		if !isNoStandValidation(current) {
 			return nil
 		}
-		if err := s.stripRepo.ClearValidationStatus(ctx, session, strip.Callsign); err != nil {
+		if err := s.validationStore.ClearValidationStatus(ctx, session, strip.Callsign); err != nil {
 			return err
 		}
 		shared.AddDBOperations(ctx, 1)
@@ -110,7 +110,7 @@ func (s *StripService) applyNoStandValidation(ctx context.Context, session int32
 		return nil
 	}
 
-	if err := s.stripRepo.SetValidationStatus(ctx, session, strip.Callsign, desired); err != nil {
+	if err := s.validationStore.SetValidationStatus(ctx, session, strip.Callsign, desired); err != nil {
 		return err
 	}
 	shared.AddDBOperations(ctx, 1)

--- a/backend/internal/services/strip_options.go
+++ b/backend/internal/services/strip_options.go
@@ -75,3 +75,59 @@ func WithCdmService(cdmService shared.CdmService) StripServiceOption {
 		s.cdmService = cdmService
 	}
 }
+
+func WithStripLifecycleStore(store StripLifecycleStore) StripServiceOption {
+	return func(s *StripService) {
+		if store != nil {
+			s.lifecycleStore = store
+		}
+	}
+}
+
+func WithStripOrderingStore(store StripOrderingStore) StripServiceOption {
+	return func(s *StripService) {
+		if store != nil {
+			s.orderingStore = store
+		}
+	}
+}
+
+func WithStripFieldStore(store StripFieldStore) StripServiceOption {
+	return func(s *StripService) {
+		if store != nil {
+			s.fieldStore = store
+		}
+	}
+}
+
+func WithStripOwnerStore(store StripOwnerStore) StripServiceOption {
+	return func(s *StripService) {
+		if store != nil {
+			s.ownerStore = store
+		}
+	}
+}
+
+func WithStripCdmStore(store StripCdmStore) StripServiceOption {
+	return func(s *StripService) {
+		if store != nil {
+			s.cdmStore = store
+		}
+	}
+}
+
+func WithStripValidationStatusStore(store StripValidationStatusStore) StripServiceOption {
+	return func(s *StripService) {
+		if store != nil {
+			s.validationStore = store
+		}
+	}
+}
+
+func WithStripManualFplStore(store StripManualFplStore) StripServiceOption {
+	return func(s *StripService) {
+		if store != nil {
+			s.manualFplStore = store
+		}
+	}
+}

--- a/backend/internal/services/strip_ordering.go
+++ b/backend/internal/services/strip_ordering.go
@@ -64,7 +64,7 @@ func (s *StripService) needsRecalculation(prevOrder, nextOrder int32) bool {
 
 // updateStripSequence updates the sequence of a single strip in the database.
 func (s *StripService) updateStripSequence(ctx context.Context, session int32, callsign string, sequence int32, bay string, sendNotification bool) error {
-	_, err := s.stripRepo.UpdateBayAndSequence(ctx, session, callsign, bay, sequence)
+	_, err := s.orderingStore.UpdateBayAndSequence(ctx, session, callsign, bay, sequence)
 	if err != nil {
 		return fmt.Errorf("failed to update strip sequence: %w", err)
 	}
@@ -134,7 +134,7 @@ func (s *StripService) nextSequenceAtEndOfBay(ctx context.Context, session int32
 	if s.tacticalRepo != nil {
 		maxInBay, err = s.tacticalRepo.GetMaxSequenceInBayUnified(ctx, session, bay)
 	} else {
-		maxInBay, err = s.stripRepo.GetMaxSequenceInBay(ctx, session, bay)
+		maxInBay, err = s.orderingStore.GetMaxSequenceInBay(ctx, session, bay)
 	}
 	if err != nil {
 		return 0, fmt.Errorf("failed to get max sequence in bay: %w", err)
@@ -222,7 +222,7 @@ func (s *StripService) resolveRefSequence(ctx context.Context, session int32, ba
 		if ref.Callsign == nil {
 			return 0, fmt.Errorf("flight strip ref missing callsign")
 		}
-		return s.stripRepo.GetSequence(ctx, session, *ref.Callsign, bay)
+		return s.orderingStore.GetSequence(ctx, session, *ref.Callsign, bay)
 	case "tactical":
 		if ref.ID == nil {
 			return 0, fmt.Errorf("tactical strip ref missing id")
@@ -259,7 +259,7 @@ func (s *StripService) MoveStripBetween(ctx context.Context, session int32, call
 			next = &nextSeq
 		}
 	} else {
-		nextSeq, err := s.stripRepo.GetNextSequence(ctx, session, bay, prev)
+		nextSeq, err := s.orderingStore.GetNextSequence(ctx, session, bay, prev)
 		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			return fmt.Errorf("failed to get next sequence: %w", err)
 		} else if err == nil {
@@ -344,7 +344,7 @@ func (s *StripService) recalculateAllStripSequences(ctx context.Context, session
 	}
 
 	// Fetch sequences for both tables
-	flightSeqs, err := s.stripRepo.ListSequences(ctx, session, bay)
+	flightSeqs, err := s.orderingStore.ListSequences(ctx, session, bay)
 	if err != nil {
 		return fmt.Errorf("failed to list flight strip sequences: %w", err)
 	}
@@ -392,7 +392,7 @@ func (s *StripService) recalculateAllStripSequences(ctx context.Context, session
 	}
 
 	if len(newFlightCallsigns) > 0 {
-		if err := s.stripRepo.UpdateSequenceBulk(ctx, session, newFlightCallsigns, newFlightSeqs); err != nil {
+		if err := s.orderingStore.UpdateSequenceBulk(ctx, session, newFlightCallsigns, newFlightSeqs); err != nil {
 			return fmt.Errorf("failed to bulk update flight strip sequences during recalc: %w", err)
 		}
 		s.sendBulkSequenceUpdate(session, newFlightCallsigns, newFlightSeqs, bay)
@@ -402,12 +402,12 @@ func (s *StripService) recalculateAllStripSequences(ctx context.Context, session
 }
 
 func (s *StripService) recalculateFlightStripsOnly(ctx context.Context, session int32, bay string) error {
-	err := s.stripRepo.RecalculateSequences(ctx, session, bay, InitialOrderSpacing)
+	err := s.orderingStore.RecalculateSequences(ctx, session, bay, InitialOrderSpacing)
 	if err != nil {
 		return fmt.Errorf("failed to recalculate strip sequences: %w", err)
 	}
 
-	sequences, err := s.stripRepo.ListSequences(ctx, session, bay)
+	sequences, err := s.orderingStore.ListSequences(ctx, session, bay)
 	if err != nil {
 		return fmt.Errorf("failed to list strip sequences: %w", err)
 	}

--- a/backend/internal/services/strip_pdc_custom_validation.go
+++ b/backend/internal/services/strip_pdc_custom_validation.go
@@ -82,7 +82,7 @@ func (s *StripService) applyPdcCustomValidation(ctx context.Context, session int
 		if !isPdcCustomValidation(current) {
 			return nil
 		}
-		if err := s.stripRepo.ClearValidationStatus(ctx, session, strip.Callsign); err != nil {
+		if err := s.validationStore.ClearValidationStatus(ctx, session, strip.Callsign); err != nil {
 			return err
 		}
 		shared.AddDBOperations(ctx, 1)
@@ -111,7 +111,7 @@ func (s *StripService) applyPdcCustomValidation(ctx context.Context, session int
 		return nil
 	}
 
-	if err := s.stripRepo.SetValidationStatus(ctx, session, strip.Callsign, desired); err != nil {
+	if err := s.validationStore.SetValidationStatus(ctx, session, strip.Callsign, desired); err != nil {
 		return err
 	}
 	shared.AddDBOperations(ctx, 1)

--- a/backend/internal/services/strip_pdc_invalid_validation.go
+++ b/backend/internal/services/strip_pdc_invalid_validation.go
@@ -66,7 +66,7 @@ func (s *StripService) applyPdcInvalidValidation(ctx context.Context, session in
 		if !isPdcInvalidValidation(current) {
 			return nil
 		}
-		if err := s.stripRepo.ClearValidationStatus(ctx, session, strip.Callsign); err != nil {
+		if err := s.validationStore.ClearValidationStatus(ctx, session, strip.Callsign); err != nil {
 			return err
 		}
 		shared.AddDBOperations(ctx, 1)
@@ -95,7 +95,7 @@ func (s *StripService) applyPdcInvalidValidation(ctx context.Context, session in
 		return nil
 	}
 
-	if err := s.stripRepo.SetValidationStatus(ctx, session, strip.Callsign, desired); err != nil {
+	if err := s.validationStore.SetValidationStatus(ctx, session, strip.Callsign, desired); err != nil {
 		return err
 	}
 	shared.AddDBOperations(ctx, 1)

--- a/backend/internal/services/strip_runway.go
+++ b/backend/internal/services/strip_runway.go
@@ -31,7 +31,7 @@ func runwayClearanceTargetBay(currentBay string) string {
 // For departures from this airport in TAXI_LWR or DEPART bay, the ground state is set to 'DEPA'
 // and sent to EuroScope.
 func (s *StripService) RunwayClearance(ctx context.Context, session int32, callsign string, cid string, airport string) error {
-	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		return err
 	}
@@ -49,7 +49,7 @@ func (s *StripService) RunwayClearance(ctx context.Context, session int32, calls
 		targetSequence = &sequence
 	}
 
-	affected, err := s.stripRepo.UpdateRunwayClearance(ctx, session, callsign)
+	affected, err := s.fieldStore.UpdateRunwayClearance(ctx, session, callsign)
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (s *StripService) RunwayClearance(ctx context.Context, session int32, calls
 	isAtOrMovingToDepart := strip.Bay == shared.BAY_DEPART || strip.Bay == shared.BAY_TAXI_LWR
 	if isAtOrMovingToDepart && strip.Origin == airport {
 		state := euroscope.GroundStateDepart
-		if _, err := s.stripRepo.UpdateGroundState(ctx, session, callsign, &state, shared.BAY_DEPART, nil); err != nil {
+		if _, err := s.fieldStore.UpdateGroundState(ctx, session, callsign, &state, shared.BAY_DEPART, nil); err != nil {
 			return err
 		}
 		if s.esCommander != nil {
@@ -85,7 +85,7 @@ func (s *StripService) RunwayClearance(ctx context.Context, session int32, calls
 // RunwayConfirmation marks a cleared strip as runway-confirmed (green) and broadcasts the update.
 // A strip that is already confirmed stays confirmed; non-cleared strips are unaffected.
 func (s *StripService) RunwayConfirmation(ctx context.Context, session int32, callsign string) error {
-	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func (s *StripService) RunwayConfirmation(ctx context.Context, session int32, ca
 		return errors.New("strip is locked by an active validation")
 	}
 
-	affected, err := s.stripRepo.UpdateRunwayConfirmation(ctx, session, callsign)
+	affected, err := s.fieldStore.UpdateRunwayConfirmation(ctx, session, callsign)
 	if err != nil {
 		return err
 	}
@@ -107,7 +107,7 @@ func (s *StripService) RunwayConfirmation(ctx context.Context, session int32, ca
 // PropagateRunwayChange updates the runway on strips that had an auto-assigned runway
 // matching the old active runways.
 func (s *StripService) PropagateRunwayChange(ctx context.Context, session int32, airport string, oldRunways models.ActiveRunways, newRunways models.ActiveRunways) error {
-	strips, err := s.stripRepo.List(ctx, session)
+	strips, err := s.stripReader.List(ctx, session)
 	if err != nil {
 		return err
 	}
@@ -141,7 +141,7 @@ func (s *StripService) PropagateRunwayChange(ctx context.Context, session int32,
 			continue
 		}
 
-		if _, err := s.stripRepo.UpdateRunway(ctx, session, strip.Callsign, &newRunway, nil); err != nil {
+		if _, err := s.fieldStore.UpdateRunway(ctx, session, strip.Callsign, &newRunway, nil); err != nil {
 			slog.ErrorContext(ctx, "Failed to update auto-assigned runway on strip",
 				slog.String("callsign", strip.Callsign),
 				slog.String("old_runway", currentRunway),

--- a/backend/internal/services/strip_runway_type_validation.go
+++ b/backend/internal/services/strip_runway_type_validation.go
@@ -80,7 +80,7 @@ func (s *StripService) applyRunwayTypeValidation(ctx context.Context, session in
 		if !isRunwayTypeValidation(current) {
 			return nil
 		}
-		if err := s.stripRepo.ClearValidationStatus(ctx, session, strip.Callsign); err != nil {
+		if err := s.validationStore.ClearValidationStatus(ctx, session, strip.Callsign); err != nil {
 			return err
 		}
 		shared.AddDBOperations(ctx, 1)
@@ -109,7 +109,7 @@ func (s *StripService) applyRunwayTypeValidation(ctx context.Context, session in
 		return nil
 	}
 
-	if err := s.stripRepo.SetValidationStatus(ctx, session, strip.Callsign, desired); err != nil {
+	if err := s.validationStore.SetValidationStatus(ctx, session, strip.Callsign, desired); err != nil {
 		return err
 	}
 	shared.AddDBOperations(ctx, 1)

--- a/backend/internal/services/strip_sync.go
+++ b/backend/internal/services/strip_sync.go
@@ -157,7 +157,7 @@ func (s *StripService) syncEuroscopeStrip(ctx context.Context, session int32, ci
 		} else {
 			routeNeedsUpdate = true
 		}
-		if err = s.stripRepo.Create(ctx, newStrip); err != nil {
+		if err = s.lifecycleStore.Create(ctx, newStrip); err != nil {
 			return err
 		}
 		shared.AddDBOperations(ctx, 1)
@@ -473,7 +473,7 @@ func (s *StripService) syncEuroscopeStrip(ctx context.Context, session int32, ci
 		}
 
 		if primaryChange {
-			if _, err = s.stripRepo.Update(ctx, updateStrip); err != nil {
+			if _, err = s.lifecycleStore.Update(ctx, updateStrip); err != nil {
 				return err
 			}
 			shared.AddDBOperations(ctx, 1)

--- a/backend/internal/services/strip_taxiway_type_validation.go
+++ b/backend/internal/services/strip_taxiway_type_validation.go
@@ -136,7 +136,7 @@ func (s *StripService) applyTaxiwayTypeValidation(ctx context.Context, session i
 		if !isTaxiwayTypeValidation(current) {
 			return nil
 		}
-		if err := s.stripRepo.ClearValidationStatus(ctx, session, strip.Callsign); err != nil {
+		if err := s.validationStore.ClearValidationStatus(ctx, session, strip.Callsign); err != nil {
 			return err
 		}
 		shared.AddDBOperations(ctx, 1)
@@ -165,7 +165,7 @@ func (s *StripService) applyTaxiwayTypeValidation(ctx context.Context, session i
 		return nil
 	}
 
-	if err := s.stripRepo.SetValidationStatus(ctx, session, strip.Callsign, desired); err != nil {
+	if err := s.validationStore.SetValidationStatus(ctx, session, strip.Callsign, desired); err != nil {
 		return err
 	}
 	shared.AddDBOperations(ctx, 1)

--- a/backend/internal/services/strip_validation.go
+++ b/backend/internal/services/strip_validation.go
@@ -4,21 +4,54 @@ import (
 	internalModels "FlightStrips/internal/models"
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/google/uuid"
 )
 
+type validationStripReader interface {
+	GetByCallsign(ctx context.Context, session int32, callsign string) (*internalModels.Strip, error)
+}
+
+type validationStripNotifier interface {
+	SendStripUpdate(session int32, callsign string)
+}
+
+type StripValidationService struct {
+	stripReader     validationStripReader
+	validationStore StripValidationStatusStore
+	publisher       validationStripNotifier
+}
+
+func NewStripValidationService(stripReader validationStripReader, validationStore StripValidationStatusStore) *StripValidationService {
+	service := &StripValidationService{
+		stripReader:     missingStripValidationReader{},
+		validationStore: missingValidationStatusStore{},
+	}
+	if stripReader != nil {
+		service.stripReader = stripReader
+	}
+	if validationStore != nil {
+		service.validationStore = validationStore
+	}
+	return service
+}
+
+func (s *StripValidationService) SetFrontendHub(publisher validationStripNotifier) {
+	s.publisher = publisher
+}
+
 // SetValidationStatus sets a new validation status on a strip. A fresh activation key is
 // generated so that any outstanding acknowledgement from a previous trigger is ignored.
-func (s *StripService) SetValidationStatus(ctx context.Context, session int32, callsign string, status *internalModels.ValidationStatus) error {
+func (s *StripValidationService) SetValidationStatus(ctx context.Context, session int32, callsign string, status *internalModels.ValidationStatus) error {
 	if status == nil {
 		return errors.New("SetValidationStatus: status must not be nil; use ClearValidationStatus to remove")
 	}
 	status.ActivationKey = uuid.New().String()
-	if err := s.stripRepo.SetValidationStatus(ctx, session, callsign, status); err != nil {
+	if err := s.validationStore.SetValidationStatus(ctx, session, callsign, status); err != nil {
 		return err
 	}
-	s.queueOrSendStripUpdate(ctx, session, callsign, true)
+	s.sendStripUpdate(session, callsign)
 	return nil
 }
 
@@ -26,8 +59,8 @@ func (s *StripService) SetValidationStatus(ctx context.Context, session int32, c
 // matches and the requesting position is allowed to acknowledge it. Most validations remain
 // owner-scoped; PDC validations are visible and acknowledgeable for all online positions.
 // Uses a conditional DB update so concurrent triggers cannot be accidentally dismissed.
-func (s *StripService) AcknowledgeValidationStatus(ctx context.Context, session int32, callsign string, activationKey string, requestingPosition string) error {
-	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+func (s *StripValidationService) AcknowledgeValidationStatus(ctx context.Context, session int32, callsign string, activationKey string, requestingPosition string) error {
+	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		return err
 	}
@@ -39,7 +72,7 @@ func (s *StripService) AcknowledgeValidationStatus(ctx context.Context, session 
 		!isPdcCustomValidation(strip.ValidationStatus) {
 		return errors.New("acknowledge_validation_status: requesting position is not the owning position")
 	}
-	rows, err := s.stripRepo.AcknowledgeValidationStatus(ctx, session, callsign, activationKey)
+	rows, err := s.validationStore.AcknowledgeValidationStatus(ctx, session, callsign, activationKey)
 	if err != nil {
 		return err
 	}
@@ -47,24 +80,54 @@ func (s *StripService) AcknowledgeValidationStatus(ctx context.Context, session 
 		// Key mismatch or already acknowledged — not an error, just a no-op.
 		return nil
 	}
-	s.queueOrSendStripUpdate(ctx, session, callsign, true)
+	s.sendStripUpdate(session, callsign)
 	return nil
 }
 
 // ClearValidationStatus removes the validation status from a strip entirely.
-func (s *StripService) ClearValidationStatus(ctx context.Context, session int32, callsign string) error {
-	if err := s.stripRepo.ClearValidationStatus(ctx, session, callsign); err != nil {
+func (s *StripValidationService) ClearValidationStatus(ctx context.Context, session int32, callsign string) error {
+	if err := s.validationStore.ClearValidationStatus(ctx, session, callsign); err != nil {
 		return err
 	}
-	s.queueOrSendStripUpdate(ctx, session, callsign, true)
+	s.sendStripUpdate(session, callsign)
 	return nil
 }
 
 // IsValidationBlocking returns true when the strip has an active (unacknowledged) validation.
-func (s *StripService) IsValidationBlocking(ctx context.Context, session int32, callsign string) (bool, error) {
-	strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+func (s *StripValidationService) IsValidationBlocking(ctx context.Context, session int32, callsign string) (bool, error) {
+	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
 	if err != nil {
 		return false, err
 	}
 	return strip.IsValidationLocked(), nil
+}
+
+func (s *StripValidationService) sendStripUpdate(session int32, callsign string) {
+	if s.publisher != nil {
+		s.publisher.SendStripUpdate(session, callsign)
+	}
+}
+
+type missingStripValidationReader struct{}
+
+func (missingStripValidationReader) GetByCallsign(ctx context.Context, session int32, callsign string) (*internalModels.Strip, error) {
+	return nil, missingStripValidationDependency("strip reader")
+}
+
+type missingValidationStatusStore struct{}
+
+func (missingValidationStatusStore) SetValidationStatus(ctx context.Context, session int32, callsign string, status *internalModels.ValidationStatus) error {
+	return missingStripValidationDependency("validation status store")
+}
+
+func (missingValidationStatusStore) AcknowledgeValidationStatus(ctx context.Context, session int32, callsign string, activationKey string) (int64, error) {
+	return 0, missingStripValidationDependency("validation status store")
+}
+
+func (missingValidationStatusStore) ClearValidationStatus(ctx context.Context, session int32, callsign string) error {
+	return missingStripValidationDependency("validation status store")
+}
+
+func missingStripValidationDependency(name string) error {
+	return fmt.Errorf("strip validation service missing %s dependency", name)
 }

--- a/backend/internal/services/strip_validation_test.go
+++ b/backend/internal/services/strip_validation_test.go
@@ -11,12 +11,53 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type validationStoreFake struct {
+	getByCallsignFn               func(ctx context.Context, session int32, callsign string) (*models.Strip, error)
+	setValidationStatusFn         func(ctx context.Context, session int32, callsign string, status *models.ValidationStatus) error
+	acknowledgeValidationStatusFn func(ctx context.Context, session int32, callsign string, activationKey string) (int64, error)
+	clearValidationStatusFn       func(ctx context.Context, session int32, callsign string) error
+}
+
+func (f *validationStoreFake) GetByCallsign(ctx context.Context, session int32, callsign string) (*models.Strip, error) {
+	if f.getByCallsignFn == nil {
+		panic("unexpected call to validationStoreFake.GetByCallsign")
+	}
+	return f.getByCallsignFn(ctx, session, callsign)
+}
+
+func (f *validationStoreFake) SetValidationStatus(ctx context.Context, session int32, callsign string, status *models.ValidationStatus) error {
+	if f.setValidationStatusFn == nil {
+		panic("unexpected call to validationStoreFake.SetValidationStatus")
+	}
+	return f.setValidationStatusFn(ctx, session, callsign, status)
+}
+
+func (f *validationStoreFake) AcknowledgeValidationStatus(ctx context.Context, session int32, callsign string, activationKey string) (int64, error) {
+	if f.acknowledgeValidationStatusFn == nil {
+		panic("unexpected call to validationStoreFake.AcknowledgeValidationStatus")
+	}
+	return f.acknowledgeValidationStatusFn(ctx, session, callsign, activationKey)
+}
+
+func (f *validationStoreFake) ClearValidationStatus(ctx context.Context, session int32, callsign string) error {
+	if f.clearValidationStatusFn == nil {
+		panic("unexpected call to validationStoreFake.ClearValidationStatus")
+	}
+	return f.clearValidationStatusFn(ctx, session, callsign)
+}
+
+type readerOnlyStripFake struct{}
+
+func (readerOnlyStripFake) GetByCallsign(ctx context.Context, session int32, callsign string) (*models.Strip, error) {
+	return &models.Strip{Callsign: callsign}, nil
+}
+
 func TestAcknowledgeValidationStatus_AllowsPdcValidationForNonOwnerPosition(t *testing.T) {
 	t.Parallel()
 
 	var acknowledged bool
-	repo := &testutil.MockStripRepository{
-		GetByCallsignFn: func(_ context.Context, _ int32, callsign string) (*models.Strip, error) {
+	repo := &validationStoreFake{
+		getByCallsignFn: func(_ context.Context, _ int32, callsign string) (*models.Strip, error) {
 			assert.Equal(t, "SAS123", callsign)
 			return &models.Strip{
 				Callsign: "SAS123",
@@ -28,7 +69,7 @@ func TestAcknowledgeValidationStatus_AllowsPdcValidationForNonOwnerPosition(t *t
 				},
 			}, nil
 		},
-		AcknowledgeValidationStatusFn: func(_ context.Context, _ int32, callsign string, activationKey string) (int64, error) {
+		acknowledgeValidationStatusFn: func(_ context.Context, _ int32, callsign string, activationKey string) (int64, error) {
 			assert.Equal(t, "SAS123", callsign)
 			assert.Equal(t, "activation-key", activationKey)
 			acknowledged = true
@@ -36,7 +77,7 @@ func TestAcknowledgeValidationStatus_AllowsPdcValidationForNonOwnerPosition(t *t
 		},
 	}
 
-	svc := NewStripService(repo)
+	svc := NewStripValidationService(repo, repo)
 	svc.SetFrontendHub(&testutil.MockFrontendHub{})
 
 	require.NoError(t, svc.AcknowledgeValidationStatus(context.Background(), 1, "SAS123", "activation-key", "EKCH_GND"))
@@ -46,8 +87,8 @@ func TestAcknowledgeValidationStatus_AllowsPdcValidationForNonOwnerPosition(t *t
 func TestAcknowledgeValidationStatus_RejectsNonOwnerForNonPdcValidation(t *testing.T) {
 	t.Parallel()
 
-	repo := &testutil.MockStripRepository{
-		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
+	repo := &validationStoreFake{
+		getByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
 			return &models.Strip{
 				Callsign: "SAS123",
 				ValidationStatus: &models.ValidationStatus{
@@ -60,9 +101,31 @@ func TestAcknowledgeValidationStatus_RejectsNonOwnerForNonPdcValidation(t *testi
 		},
 	}
 
-	svc := NewStripService(repo)
+	svc := NewStripValidationService(repo, repo)
 
 	err := svc.AcknowledgeValidationStatus(context.Background(), 1, "SAS123", "activation-key", "EKCH_GND")
 	require.Error(t, err)
 	assert.EqualError(t, err, "acknowledge_validation_status: requesting position is not the owning position")
+}
+
+func TestStripValidationService_SetValidationStatusReturnsMissingStoreErrorWhenOnlyReaderInjected(t *testing.T) {
+	t.Parallel()
+
+	svc := NewStripValidationService(readerOnlyStripFake{}, nil)
+
+	err := svc.SetValidationStatus(context.Background(), 1, "SAS123", &models.ValidationStatus{})
+
+	require.Error(t, err)
+	assert.EqualError(t, err, "strip validation service missing validation status store dependency")
+}
+
+func TestNewStripValidationService_ReturnsMissingReaderErrorWhenReaderNotInjected(t *testing.T) {
+	t.Parallel()
+
+	svc := NewStripValidationService(nil, nil)
+
+	_, err := svc.IsValidationBlocking(context.Background(), 1, "SAS123")
+
+	require.Error(t, err)
+	assert.EqualError(t, err, "strip validation service missing strip reader dependency")
 }

--- a/backend/internal/services/strip_wrong_squawk_validation.go
+++ b/backend/internal/services/strip_wrong_squawk_validation.go
@@ -80,7 +80,7 @@ func (s *StripService) applyWrongSquawkValidation(ctx context.Context, session i
 		if !isWrongSquawkValidation(current) {
 			return nil
 		}
-		if err := s.stripRepo.ClearValidationStatus(ctx, session, strip.Callsign); err != nil {
+		if err := s.validationStore.ClearValidationStatus(ctx, session, strip.Callsign); err != nil {
 			return err
 		}
 		shared.AddDBOperations(ctx, 1)
@@ -108,7 +108,7 @@ func (s *StripService) applyWrongSquawkValidation(ctx context.Context, session i
 		return nil
 	}
 
-	if err := s.stripRepo.SetValidationStatus(ctx, session, strip.Callsign, desired); err != nil {
+	if err := s.validationStore.SetValidationStatus(ctx, session, strip.Callsign, desired); err != nil {
 		return err
 	}
 	shared.AddDBOperations(ctx, 1)

--- a/backend/internal/services/traffic_metrics.go
+++ b/backend/internal/services/traffic_metrics.go
@@ -27,8 +27,12 @@ var taxiingBays = map[string]bool{
 
 type TrafficMetricsService struct {
 	sessionRepo repository.SessionRepository
-	stripRepo   repository.StripRepository
+	stripRepo   TrafficMetricsStripStore
 	interval    time.Duration
+}
+
+type TrafficMetricsStripStore interface {
+	List(ctx context.Context, session int32) ([]*models.Strip, error)
 }
 
 type trafficSnapshot struct {
@@ -38,7 +42,7 @@ type trafficSnapshot struct {
 	dep15m  int64
 }
 
-func NewTrafficMetricsService(sessionRepo repository.SessionRepository, stripRepo repository.StripRepository) *TrafficMetricsService {
+func NewTrafficMetricsService(sessionRepo repository.SessionRepository, stripRepo TrafficMetricsStripStore) *TrafficMetricsService {
 	return &TrafficMetricsService{
 		sessionRepo: sessionRepo,
 		stripRepo:   stripRepo,

--- a/backend/internal/shared/services.go
+++ b/backend/internal/shared/services.go
@@ -1,7 +1,6 @@
 package shared
 
 import (
-	internalModels "FlightStrips/internal/models"
 	"FlightStrips/pkg/events/frontend"
 	"FlightStrips/pkg/models"
 	"context"
@@ -119,11 +118,6 @@ type StripService interface {
 	CreateManualFPL(ctx context.Context, session int32, req frontend.CreateManualFPLAction, cid string, airport string) error
 	CreateVFRFPL(ctx context.Context, session int32, req frontend.CreateVFRFPLAction, cid string) error
 
-	// Validation status
-	SetValidationStatus(ctx context.Context, session int32, callsign string, status *internalModels.ValidationStatus) error
-	AcknowledgeValidationStatus(ctx context.Context, session int32, callsign string, activationKey string, requestingPosition string) error
-	ClearValidationStatus(ctx context.Context, session int32, callsign string) error
-	IsValidationBlocking(ctx context.Context, session int32, callsign string) (bool, error)
 	ReevaluatePdcInvalidValidation(ctx context.Context, session int32, callsign string, publish bool, forceReactivate bool) error
 	ReevaluatePdcRequestValidations(ctx context.Context, session int32, callsign string, publish bool, forceReactivate bool) error
 }


### PR DESCRIPTION
## Summary
- add consumer-owned strip repository interfaces for PDC, CDM, ECFMP, frontend, and strip services
- split validation status lifecycle into a dedicated strip validation service
- add postgres compile-time interface checks and focused test fakes

## Tests
- go test ./...