### PR TITLE
fix(pdc): sync web clearance state with strips

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -163,6 +163,7 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 
 	if pdcService != nil {
 		stripService.SetPdcService(pdcService)
+		pdcService.SetStripService(stripService)
 		pdcService.SetFrontendHub(frontendHub)
 		pdcService.SetEuroscopeHub(euroscopeHub)
 		pdcService.SetTransceiverLookup(transceiverLookup)

--- a/backend/internal/euroscope/hub.go
+++ b/backend/internal/euroscope/hub.go
@@ -57,6 +57,7 @@ type Hub struct {
 
 	master          map[int32]*Client
 	masterCallsigns sync.Map // map[int32]string — concurrent-safe callsign of master per session
+	masterCids      sync.Map // map[int32]string — concurrent-safe CID of master per session
 
 	handlers shared.MessageHandlers[euroscope.EventType, *Client]
 
@@ -559,6 +560,7 @@ func (hub *Hub) setMasterClient(client *Client) {
 		}
 
 		hub.masterCallsigns.Store(client.session, client.callsign)
+		hub.masterCids.Store(client.session, client.GetCid())
 		metrics.MasterClientAssigned(context.Background(), client.sessionName, client.airport, client.callsign, client.version)
 		return
 	}
@@ -569,6 +571,7 @@ func (hub *Hub) setMasterClient(client *Client) {
 
 	hub.master[client.session] = client
 	hub.masterCallsigns.Store(client.session, client.callsign)
+	hub.masterCids.Store(client.session, client.GetCid())
 	metrics.MasterClientAssigned(context.Background(), client.sessionName, client.airport, client.callsign, client.version)
 }
 
@@ -579,10 +582,18 @@ func (hub *Hub) clearMasterClient(session int32) {
 
 	delete(hub.master, session)
 	hub.masterCallsigns.Delete(session)
+	hub.masterCids.Delete(session)
 }
 
 func (hub *Hub) GetMasterCallsign(session int32) string {
 	if v, ok := hub.masterCallsigns.Load(session); ok {
+		return v.(string)
+	}
+	return ""
+}
+
+func (hub *Hub) GetMasterCid(session int32) string {
+	if v, ok := hub.masterCids.Load(session); ok {
 		return v.(string)
 	}
 	return ""

--- a/backend/internal/pdc/integration_test.go
+++ b/backend/internal/pdc/integration_test.go
@@ -559,6 +559,7 @@ func TestHandleWilcoFlow(t *testing.T) {
 	mock.InOrder(
 		suite.mockStrip.On("ConfirmPdcClearance", mock.Anything, sessionID, callsign, shared.BAY_CLEARED, cid).Return(nil),
 		suite.mockStrip.On("AutoAssumeForClearedStripByCid", mock.Anything, sessionID, callsign, cid).Return(nil),
+		suite.mockFrontend.On("SendStripUpdate", sessionID, callsign).Return(),
 		suite.mockEuroscope.On("SendPdcStateChange", sessionID, callsign, "CONFIRMED", "").Return(),
 		suite.mockEuroscope.On("SendClearedFlag", sessionID, cid, callsign, true).Return(),
 		suite.mockFrontend.On("SendPdcStateChange", sessionID, callsign, "CONFIRMED", "").Return(),

--- a/backend/internal/pdc/mocks/hubs.go
+++ b/backend/internal/pdc/mocks/hubs.go
@@ -305,6 +305,11 @@ func (m *EuroscopeHub) GetMasterCallsign(session int32) string {
 	return ""
 }
 
+func (m *EuroscopeHub) GetMasterCid(session int32) string {
+	args := m.Called(session)
+	return args.String(0)
+}
+
 func (m *EuroscopeHub) GetClientLocalIP(session int32, cid string) string {
 	return ""
 }

--- a/backend/internal/pdc/service.go
+++ b/backend/internal/pdc/service.go
@@ -173,8 +173,18 @@ func (s *Service) notifyStateChangeEuroscope(sessionID int32, callsign string, s
 	}
 }
 
-func (s *Service) notifyClearedFlagEuroscope(sessionID int32, callsign string, cleared bool, cid string) {
+func (s *Service) notifyClearedFlagEuroscope(ctx context.Context, sessionID int32, callsign string, cleared bool, cid string) {
 	if s.euroscopeHub != nil {
+		if strings.TrimSpace(cid) == "" {
+			cid = s.resolveEuroscopeTargetCID(ctx, sessionID)
+		}
+		if strings.TrimSpace(cid) == "" {
+			slog.WarnContext(ctx, "PDC Service: Unable to resolve EuroScope target for cleared flag",
+				slog.Int("session", int(sessionID)),
+				slog.String("callsign", callsign),
+			)
+			return
+		}
 		s.euroscopeHub.SendClearedFlag(sessionID, cid, callsign, cleared)
 	}
 }
@@ -280,7 +290,15 @@ func (s *Service) getDepartureAtisCode(sessionID int32) string {
 }
 
 func (s *Service) resolveEuroscopeTargetCID(ctx context.Context, sessionID int32) string {
-	if s.euroscopeHub == nil || s.controllerRepo == nil {
+	if s.euroscopeHub == nil {
+		return ""
+	}
+
+	if masterCID := strings.TrimSpace(s.euroscopeHub.GetMasterCid(sessionID)); masterCID != "" {
+		return masterCID
+	}
+
+	if s.controllerRepo == nil {
 		return ""
 	}
 
@@ -406,11 +424,15 @@ func (s *Service) confirmPilotAcknowledgement(ctx context.Context, sessionID int
 		}
 	}
 
+	if s.frontendHub != nil {
+		s.frontendHub.SendStripUpdate(sessionID, strip.Callsign)
+	}
+
 	if sessionInfo, err := s.getSessionInfo(context.Background(), sessionID); err == nil {
 		metrics.PDCStateChange(context.Background(), sessionInfo.name, sessionInfo.airport, string(StateConfirmed))
 	}
 	s.notifyStateChangeEuroscope(sessionID, strip.Callsign, StateConfirmed, "")
-	s.notifyClearedFlagEuroscope(sessionID, strip.Callsign, true, clearanceCid)
+	s.notifyClearedFlagEuroscope(ctx, sessionID, strip.Callsign, true, clearanceCid)
 
 	s.notifyStateChangeFrontend(sessionID, strip.Callsign, StateConfirmed, "")
 

--- a/backend/internal/pdc/webapi_handler_test.go
+++ b/backend/internal/pdc/webapi_handler_test.go
@@ -163,6 +163,7 @@ func TestHandleAcknowledgeSuccessConfirmsClearance(t *testing.T) {
 
 	s := setupHandlerTest(t)
 	testdata.SeedTestStrip(t, s.queries, s.sessionID, "SAS123")
+	masterCID := "MASTER-CID"
 
 	s.mockStrip.On("MoveToBay", mock.Anything, s.sessionID, "SAS123", shared.BAY_CLEARED, true).Return(nil)
 	s.mockFrontend.On("SendPdcStateChange", s.sessionID, "SAS123", string(StateCleared), "").Return()
@@ -174,8 +175,10 @@ func TestHandleAcknowledgeSuccessConfirmsClearance(t *testing.T) {
 	mock.InOrder(
 		s.mockStrip.On("ConfirmPdcClearance", mock.Anything, s.sessionID, "SAS123", shared.BAY_CLEARED, "").Return(nil),
 		s.mockStrip.On("AutoAssumeForClearedStripByCid", mock.Anything, s.sessionID, "SAS123", "").Return(nil),
+		s.mockFrontend.On("SendStripUpdate", s.sessionID, "SAS123").Return(),
 		s.mockEuroscope.On("SendPdcStateChange", s.sessionID, "SAS123", string(StateConfirmed), "").Return(),
-		s.mockEuroscope.On("SendClearedFlag", s.sessionID, "", "SAS123", true).Return(),
+		s.mockEuroscope.On("GetMasterCid", s.sessionID).Return(masterCID),
+		s.mockEuroscope.On("SendClearedFlag", s.sessionID, masterCID, "SAS123", true).Return(),
 		s.mockFrontend.On("SendPdcStateChange", s.sessionID, "SAS123", string(StateConfirmed), "").Return(),
 	)
 

--- a/backend/internal/shared/euroscope.go
+++ b/backend/internal/shared/euroscope.go
@@ -10,6 +10,7 @@ type EuroscopeHub interface {
 	IsSessionSynced(sessionId int32) bool
 	IsObserverCid(cid string) bool
 	GetMasterCallsign(session int32) string
+	GetMasterCid(session int32) string
 	GetClientLocalIP(session int32, cid string) string
 	GetRunwayMismatchStatus(session int32, cid string) (bool, bool)
 	Broadcast(session int32, message euroscope.OutgoingMessage)

--- a/backend/internal/testutil/mock_euroscope_hub.go
+++ b/backend/internal/testutil/mock_euroscope_hub.go
@@ -126,6 +126,7 @@ type MockEuroscopeHub struct {
 	HasActiveClientForAirportFn func(airport string) bool
 	IsObserverCidFn             func(cid string) bool
 	GetMasterCallsignFn         func(session int32) string
+	GetMasterCidFn              func(session int32) string
 	GetClientLocalIPFn          func(session int32, cid string) string
 
 	ClearedFlags          []ClearedFlagCall
@@ -167,6 +168,13 @@ func (m *MockEuroscopeHub) IsSessionSynced(sessionId int32) bool {
 func (m *MockEuroscopeHub) GetMasterCallsign(session int32) string {
 	if m.GetMasterCallsignFn != nil {
 		return m.GetMasterCallsignFn(session)
+	}
+	return ""
+}
+
+func (m *MockEuroscopeHub) GetMasterCid(session int32) string {
+	if m.GetMasterCidFn != nil {
+		return m.GetMasterCidFn(session)
 	}
 	return ""
 }


### PR DESCRIPTION
## Summary
- wire the PDC service to strip lifecycle operations in production
- refresh the frontend strip after pilot acknowledgement
- send the EuroScope cleared flag only to the live master client

## Behavior
- issued PDC moves the strip from CLRDEL to STARTUP
- confirmed PDC remains in STARTUP
- timeout or UNABLE returns the strip to CLRDEL

## Testing
- go test ./internal/pdc ./internal/services ./internal/euroscope ./internal/frontend ./internal/app ./cmd/server -count=1