### PR TITLE
chore(strip): serialize CTOT clock tests

### DIFF
--- a/backend/internal/services/strip_ctot_validation_test.go
+++ b/backend/internal/services/strip_ctot_validation_test.go
@@ -168,8 +168,6 @@ func TestApplyCtotValidation_ReactivatesOnOwnerChange(t *testing.T) {
 }
 
 func TestReevaluateSquawkValidation_TransitionsFromWrongSquawkToCtot(t *testing.T) {
-	t.Parallel()
-
 	now := time.Date(2024, time.January, 1, 10, 0, 0, 0, time.UTC)
 	owner := "EKCH_A_TWR"
 	assignedSquawk := "4231"

--- a/backend/internal/services/strip_runway_type_validation_test.go
+++ b/backend/internal/services/strip_runway_type_validation_test.go
@@ -188,8 +188,6 @@ func TestApplyRunwayTypeValidation_ReactivatesOnOwnerChange(t *testing.T) {
 }
 
 func TestReevaluateDepartureValidation_TransitionsFromRunwayTypeToCtotAfterCorrection(t *testing.T) {
-	t.Parallel()
-
 	now := time.Date(2024, time.January, 1, 10, 0, 0, 0, time.UTC)
 	owner := "EKCH_A_TWR"
 	aircraftType := "A388"


### PR DESCRIPTION
## Summary

- serialize the two CTOT transition tests that replace the package-global validation clock
- prevent parallel cleanup from restoring wall-clock time during another test
- eliminate the flaky nil CTOT validation seen in GitHub Actions job 85970595370

## Verification

- `go test -race ./internal/services -run 'TestReevaluate(SquawkValidation_TransitionsFromWrongSquawkToCtot|DepartureValidation_TransitionsFromRunwayTypeToCtotAfterCorrection)$' -count=100`
- `go test ./internal/services -count=20`
- `go test ./...`