### PR TITLE
feat(cdm): add E/TOBT tag item

### DIFF
--- a/euroscope-plugin/src/plugin/Constants.h
+++ b/euroscope-plugin/src/plugin/Constants.h
@@ -27,6 +27,7 @@ constexpr int TAG_ITEM_CDM_PHASE = 106;
 constexpr int TAG_ITEM_CDM_TTG = 107;
 constexpr int TAG_ITEM_CDM_READY_STARTUP = 108;
 constexpr int TAG_ITEM_CDM_ASAT = 109;
+constexpr int TAG_ITEM_CDM_E_TOBT = 111;
 
 constexpr int TAG_FUNC_CDM_EDIT_TOBT = 2002;
 constexpr int TAG_FUNC_CDM_SET_TOBT = 2003;
@@ -55,6 +56,7 @@ constexpr int TAG_FUNC_CDM_TSAC_OPTIONS = 2025;
 constexpr int TAG_FUNC_CDM_TOGGLE_TSAC = 2026;
 constexpr int TAG_FUNC_CDM_EDIT_TSAC = 2027;
 constexpr int TAG_FUNC_CDM_SET_TSAC = 2028;
+constexpr int TAG_FUNC_CDM_E_TOBT_OPTIONS = 2032;
 
 constexpr int TAG_ITEM_CLEARANCE_STATUS    = 110;
 constexpr int TAG_FUNC_CLEARANCE_OPTIONS   = 2029;

--- a/euroscope-plugin/src/plugin/bootstrap/InitializePlugin.cpp
+++ b/euroscope-plugin/src/plugin/bootstrap/InitializePlugin.cpp
@@ -81,6 +81,10 @@ namespace FlightStrips {
             TAG_ITEM_CDM_EOBT
         );
         this->container->tagItemHandlers->RegisterHandler(
+            std::make_shared<TagItems::CdmStateHandler>(this->container->flightPlanService, TagItems::CdmStateHandler::Field::EobtTobt),
+            TAG_ITEM_CDM_E_TOBT
+        );
+        this->container->tagItemHandlers->RegisterHandler(
             std::make_shared<TagItems::CdmStateHandler>(this->container->flightPlanService, TagItems::CdmStateHandler::Field::Phase),
             TAG_ITEM_CDM_PHASE
         );

--- a/euroscope-plugin/src/plugin/plugin/FlightStripsPlugin.cpp
+++ b/euroscope-plugin/src/plugin/plugin/FlightStripsPlugin.cpp
@@ -177,6 +177,7 @@ namespace FlightStrips {
 
         RegisterTagItemType("DE-ICE", TAG_ITEM_DEICING_DESIGNATOR);
         RegisterTagItemType("EOBT", TAG_ITEM_CDM_EOBT);
+        RegisterTagItemType("E/TOBT", TAG_ITEM_CDM_E_TOBT);
         RegisterTagItemType("E", TAG_ITEM_CDM_PHASE);
         RegisterTagItemType("TOBT", TAG_ITEM_CDM_TOBT);
         RegisterTagItemType("REQ-TOBT", TAG_ITEM_CDM_REQ_TOBT);
@@ -195,6 +196,7 @@ namespace FlightStrips {
         RegisterTagItemType("ASAT", TAG_ITEM_CDM_ASAT);
 
         RegisterTagItemFunction("Edit EOBT", TAG_FUNC_CDM_EOBT_ACTION);
+        RegisterTagItemFunction("E/TOBT Options", TAG_FUNC_CDM_E_TOBT_OPTIONS);
         RegisterTagItemFunction("EOBT to TOBT", TAG_FUNC_CDM_EOBT_TO_TOBT);
         RegisterTagItemFunction("Edit TOBT", TAG_FUNC_CDM_EDIT_TOBT);
         RegisterTagItemFunction("Ready TOBT", TAG_FUNC_CDM_READY_TOBT);
@@ -662,6 +664,7 @@ namespace FlightStrips {
         const auto currentTsac = tracked == nullptr ? "" : tracked->cdm.tsac;
         const auto currentDeice = tracked == nullptr ? "" : tracked->cdm.deice_type;
         const auto currentFlowMessage = tracked == nullptr ? "" : tracked->cdm.ecfmp_id;
+        const auto isCdmFlight = tracked != nullptr && (!currentEobt.empty() || !currentTobt.empty());
 
         const auto addEobtActions = [&] {
             if (IsValidHhmm(currentEobt)) {
@@ -712,6 +715,14 @@ namespace FlightStrips {
             addTobtOptions();
         };
 
+        const auto openEobtTobtOptions = [&] {
+            if (isCdmFlight) {
+                openTobtOptions();
+            } else {
+                openEobtActions();
+            }
+        };
+
         const auto openCtotOptions = [&] {
             OpenPopupList(Area, "CTOT Options", 1);
             addCtotOptions();
@@ -759,6 +770,9 @@ namespace FlightStrips {
         switch (FunctionId) {
             case TAG_FUNC_CDM_EOBT_ACTION:
                 openEobtActions();
+                break;
+            case TAG_FUNC_CDM_E_TOBT_OPTIONS:
+                openEobtTobtOptions();
                 break;
             case TAG_FUNC_CDM_EOBT_TO_TOBT:
                 if (IsValidHhmm(currentEobt)) {

--- a/euroscope-plugin/src/plugin/tag_items/CdmStateHandler.cpp
+++ b/euroscope-plugin/src/plugin/tag_items/CdmStateHandler.cpp
@@ -43,6 +43,9 @@ namespace FlightStrips::TagItems {
                 if (IsFlightSuspended(cdm)) return {effectiveEobt, TAG_RED, true};
                 if (HasLargeEobtTobtMismatch(cdm)) return {effectiveEobt, TAG_ORANGE, true};
                 return {effectiveEobt, TAG_EOBT, true};
+            case Field::EobtTobt:
+                if (!cdm.tobt.empty()) return ResolvePresentation(cdm, Field::Tobt, fallbackEobt);
+                return ResolvePresentation(cdm, Field::Eobt, fallbackEobt);
             case Field::Phase: {
                 if (_stricmp(cdm.phase.c_str(), "I") == 0) return {"I", TAG_RED, true};
                 if (!cdm.tsat.empty()) return {"C", TAG_GREEN, true};

--- a/euroscope-plugin/src/plugin/tag_items/CdmStateHandler.h
+++ b/euroscope-plugin/src/plugin/tag_items/CdmStateHandler.h
@@ -8,6 +8,7 @@ namespace FlightStrips::TagItems {
     public:
         enum class Field {
             Eobt,
+            EobtTobt,
             Phase,
             Tobt,
             ReqTobt,

--- a/euroscope-plugin/test/plugin/tag_items/CdmStateHandlerTest.cpp
+++ b/euroscope-plugin/test/plugin/tag_items/CdmStateHandlerTest.cpp
@@ -359,6 +359,31 @@ TEST(CdmStateHandlerTest, ResolvePresentation_EobtFallbackEmptyReturnsNoValue) {
     EXPECT_FALSE(presentation.hasValue);
 }
 
+TEST(CdmStateHandlerTest, ResolvePresentation_EobtTobtUsesFlightplanEobtWithoutTobt) {
+    const auto presentation = CdmStateHandler::ResolvePresentation(
+        CdmState{},
+        CdmStateHandler::Field::EobtTobt,
+        "1430"
+    );
+
+    ASSERT_TRUE(presentation.hasValue);
+    EXPECT_EQ(presentation.value, "1430");
+    EXPECT_EQ(presentation.color, RGB(182, 182, 182));
+}
+
+TEST(CdmStateHandlerTest, ResolvePresentation_EobtTobtUsesTobtWhenAvailable) {
+    const auto tobt = CurrentUtcHHMM(-2);
+    const auto presentation = CdmStateHandler::ResolvePresentation(
+        CdmState{.eobt = "1430", .tobt = tobt},
+        CdmStateHandler::Field::EobtTobt,
+        "1430"
+    );
+
+    ASSERT_TRUE(presentation.hasValue);
+    EXPECT_EQ(presentation.value, tobt);
+    EXPECT_EQ(presentation.color, RGB(0, 192, 0));
+}
+
 TEST(CdmStateHandlerTest, ResolvePresentation_PhaseFallsBackToFlightplanEobt) {
     const auto futureEobt = CurrentUtcHHMM(10);
     const auto presentation = CdmStateHandler::ResolvePresentation(


### PR DESCRIPTION
## Summary
- Add the EuroScope E/TOBT tag item.
- Show TOBT for CDM-backed flights and fall back to EOBT otherwise.
- Add the matching options action and presentation tests.

## Verification
- Compiled the changed plugin sources and CdmStateHandlerTest.cpp with CMake/Ninja and clang-cl.
- Full FlightStripsCoreTests linking remains unavailable in this environment because the EuroScope import library cannot resolve against the available compiler/link target.