### PR TITLE
fix(cdm): prioritize confirmed TOBT flights

### DIFF
--- a/backend/config/ekch.yaml
+++ b/backend/config/ekch.yaml
@@ -18,6 +18,7 @@ cdm:
   rateUri: ekch/rate.txt
   sidIntervalUri: ekch/sidInterval.txt
   taxizonesUri: ekch/taxizones.txt
+  defaultTaxiTime: 12
   deice:
     light: 3
     medium: 5

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -374,7 +374,7 @@ func configureCDM(
 		cdm.CdmConfigDefaults{
 			Rate:        cdmCfg.Rate,
 			RateLvo:     cdmCfg.RateLvo,
-			TaxiMinutes: cdm.DefaultCDMTaxiMinutes,
+			TaxiMinutes: cdmCfg.DefaultTaxiTime,
 		},
 		nil,
 	)

--- a/backend/internal/cdm/sequence.go
+++ b/backend/internal/cdm/sequence.go
@@ -297,6 +297,13 @@ func compareSequencingCandidates(left, right sequencingCandidate, anchor time.Ti
 		return 1
 	}
 
+	if left.input.TobtAuthoritative != right.input.TobtAuthoritative {
+		if left.input.TobtAuthoritative {
+			return -1
+		}
+		return 1
+	}
+
 	if preserveExistingSlots {
 		if cmp := compareClockForSort(left.slot.Ttot, right.slot.Ttot, anchor); cmp != 0 {
 			return cmp
@@ -523,7 +530,7 @@ func preservedSlotBlocksHigherPriorityCandidate(candidate sequencingCandidate, r
 	}
 
 	for _, pending := range recalculate {
-		if pending.started || !pending.hasCtot || pending.naturalTtot == "" {
+		if pending.started || pending.naturalTtot == "" || (!pending.hasCtot && !pending.input.TobtAuthoritative) {
 			continue
 		}
 		if compareSequencingCandidates(pending, candidate, now, false) >= 0 {

--- a/backend/internal/cdm/sequence_test.go
+++ b/backend/internal/cdm/sequence_test.go
@@ -219,6 +219,73 @@ func TestSequenceService_RecalculateAirport_SortsEqualBaseTimesByNaturalTtot(t *
 	assertPersistedCdmTimes(t, persisted, "SAS503", addMinutes(baseTobt, 2), addMinutes(baseTobt, 14))
 }
 
+func TestSequenceService_RecalculateAirport_PrioritizesConfirmedTobt(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	baseTobt := addMinutes(timeToClock(now), 40)
+
+	unconfirmed := &models.Strip{
+		Callsign: "SASUNCONF",
+		Origin:   "EKCH",
+		Runway:   testStringPtr("04L"),
+		CdmData:  (&models.CdmData{Tobt: testStringPtr(baseTobt)}).Normalize(),
+	}
+	confirmed := &models.Strip{
+		Callsign: "SASCONF",
+		Origin:   "EKCH",
+		Runway:   testStringPtr("04L"),
+		CdmData: (&models.CdmData{
+			Tobt:                  testStringPtr(baseTobt),
+			TobtManuallyConfirmed: true,
+		}).Normalize(),
+	}
+
+	persisted := map[string]*models.CdmData{}
+	stripRepo := &testutil.MockStripRepository{
+		ListByOriginFn: func(ctx context.Context, session int32, origin string) ([]*models.Strip, error) {
+			return []*models.Strip{unconfirmed, confirmed}, nil
+		},
+		SetCdmDataFn: func(ctx context.Context, session int32, callsign string, data *models.CdmData) (int64, error) {
+			persisted[callsign] = data.Clone()
+			return 1, nil
+		},
+	}
+	sessionRepo := &testutil.MockSessionRepository{
+		GetByIDFn: func(ctx context.Context, id int32) (*models.Session, error) {
+			return &models.Session{
+				ID:      id,
+				Airport: "EKCH",
+				ActiveRunways: pkgModels.ActiveRunways{
+					DepartureRunways: []string{"04L"},
+				},
+			}, nil
+		},
+	}
+	configStore := NewCdmConfigStore("", "", "", 0, CdmConfigDefaults{Rate: 40, TaxiMinutes: 10}, nil)
+	service := NewSequenceService(stripRepo, sessionRepo, configStore, &testutil.MockFrontendHub{}, &testutil.MockEuroscopeHub{})
+
+	if err := service.RecalculateAirport(context.Background(), 7, "EKCH"); err != nil {
+		t.Fatalf("RecalculateAirport returned error: %v", err)
+	}
+
+	confirmedTtot := addMinutes(baseTobt, 10)
+	confirmedData, ok := persisted["SASCONF"]
+	if !ok {
+		t.Fatal("expected confirmed TOBT flight to be persisted")
+	}
+	unconfirmedData, ok := persisted["SASUNCONF"]
+	if !ok {
+		t.Fatal("expected unconfirmed TOBT flight to be persisted")
+	}
+	if got := valueOrEmpty(confirmedData.Ttot); got != confirmedTtot {
+		t.Fatalf("expected confirmed TOBT flight to retain first slot %q, got %q", confirmedTtot, got)
+	}
+	if got := valueOrEmpty(unconfirmedData.Ttot); got <= confirmedTtot {
+		t.Fatalf("expected unconfirmed TOBT flight to follow confirmed flight, got %q", got)
+	}
+}
+
 func TestSequenceService_RecalculateAirport_SortsCrossBaseTimesByNaturalTtot(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/cdm/service_test.go
+++ b/backend/internal/cdm/service_test.go
@@ -1837,19 +1837,22 @@ func TestHandleReadyRequest_MasterSessionUsesNextFreeGapWithoutMovingExistingFli
 
 	stored := map[string]*models.CdmData{
 		"SAS123": (&models.CdmData{
-			Tobt: stringPtr(firstTsat),
-			Tsat: stringPtr(firstTsat),
-			Ttot: stringPtr(addMinutes(firstTsat, 10)),
+			Tobt:                  stringPtr(firstTsat),
+			Tsat:                  stringPtr(firstTsat),
+			Ttot:                  stringPtr(addMinutes(firstTsat, 10)),
+			TobtManuallyConfirmed: true,
 		}).Normalize(),
 		"SAS456": (&models.CdmData{
-			Tobt: stringPtr(secondTsat),
-			Tsat: stringPtr(secondTsat),
-			Ttot: stringPtr(addMinutes(secondTsat, 10)),
+			Tobt:                  stringPtr(secondTsat),
+			Tsat:                  stringPtr(secondTsat),
+			Ttot:                  stringPtr(addMinutes(secondTsat, 10)),
+			TobtManuallyConfirmed: true,
 		}).Normalize(),
 		"SAS400": (&models.CdmData{
-			Tobt: stringPtr(thirdTsat),
-			Tsat: stringPtr(thirdTsat),
-			Ttot: stringPtr(addMinutes(thirdTsat, 10)),
+			Tobt:                  stringPtr(thirdTsat),
+			Tsat:                  stringPtr(thirdTsat),
+			Ttot:                  stringPtr(addMinutes(thirdTsat, 10)),
+			TobtManuallyConfirmed: true,
 		}).Normalize(),
 		callsign: (&models.CdmData{
 			Tobt: stringPtr(addMinutes(firstTsat, 20)),
@@ -1914,7 +1917,7 @@ func TestHandleReadyRequest_MasterSessionUsesNextFreeGapWithoutMovingExistingFli
 	service.sessionMaster.Store(sessionID, true)
 
 	require.NoError(t, service.HandleReadyRequest(context.Background(), sessionID, callsign, "EKCH_DEL", "ATC"))
-	afterNow = time.Now().UTC().Format("1504")
+	afterNow = time.Now().UTC().Format("150405")
 
 	expectedTsats := []string{addMinutes(beforeNow, 6), addMinutes(afterNow, 6)}
 	expectedTtots := []string{addMinutes(beforeNow, 16), addMinutes(afterNow, 16)}

--- a/backend/internal/config/cdm_config_test.go
+++ b/backend/internal/config/cdm_config_test.go
@@ -37,6 +37,7 @@ cdm:
   rateUri: ekch/rate.txt
   sidIntervalUri: ekch/sidInterval.txt
   taxizonesUri: ekch/taxizones.txt
+  defaultTaxiTime: 12
   deice:
     light: 3
     medium: 5
@@ -68,6 +69,9 @@ cdm:
 	}
 	if cfg.TaxizonesUri != "ekch/taxizones.txt" {
 		t.Errorf("TaxizonesUri = %q, want %q", cfg.TaxizonesUri, "ekch/taxizones.txt")
+	}
+	if cfg.DefaultTaxiTime != 12 {
+		t.Errorf("DefaultTaxiTime = %d, want 12", cfg.DefaultTaxiTime)
 	}
 	if cfg.Deice.Light != 3 {
 		t.Errorf("Deice.Light = %d, want 3", cfg.Deice.Light)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -25,12 +25,13 @@ type CdmDeiceConfig struct {
 }
 
 type CdmConfig struct {
-	Rate           int            `yaml:"rate"`
-	RateLvo        int            `yaml:"rateLvo"`
-	RateUri        string         `yaml:"rateUri"`
-	SidIntervalUri string         `yaml:"sidIntervalUri"`
-	TaxizonesUri   string         `yaml:"taxizonesUri"`
-	Deice          CdmDeiceConfig `yaml:"deice"`
+	Rate            int            `yaml:"rate"`
+	RateLvo         int            `yaml:"rateLvo"`
+	RateUri         string         `yaml:"rateUri"`
+	SidIntervalUri  string         `yaml:"sidIntervalUri"`
+	TaxizonesUri    string         `yaml:"taxizonesUri"`
+	DefaultTaxiTime int            `yaml:"defaultTaxiTime"`
+	Deice           CdmDeiceConfig `yaml:"deice"`
 }
 
 type Config struct {
@@ -54,7 +55,6 @@ type Config struct {
 	RunwayInitialCFL       map[string]int              `yaml:"runway_initial_cfl"`
 	Cdm                    CdmConfig                   `yaml:"cdm"`
 	ClxValidation          ClxValidationConfig         `yaml:"clx_validation"`
-
 }
 
 // TestModeConfig holds test/replay mode configuration
@@ -95,7 +95,6 @@ var standRoutes []Route
 var missedApproachHandover map[string]string
 var transitionAltitude int
 var runwayInitialCFL map[string]int
-
 
 func loadAirportConfig(r io.Reader) error {
 	var cfg Config


### PR DESCRIPTION
## Summary

- Align the EKCH default taxi fallback with the reference CDM configuration by using 12 minutes.
- Prioritize confirmed-TOBT flights ahead of unconfirmed flights during CDM sequencing, including preserved-slot handling.
- Add configuration parsing and sequencing regression tests.
- Update the ready-request sequencing fixture to reflect confirmed-TOBT priority.

## Validation

- `go test ./...`
