### PR TITLE
chore(sat): add rollout boundary tests

### DIFF
--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -1,0 +1,38 @@
+package main
+
+import "testing"
+
+func TestEnvBool(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		fallback bool
+		expected bool
+	}{
+		{name: "unset defaults false", value: "", fallback: false, expected: false},
+		{name: "true", value: "true", fallback: false, expected: true},
+		{name: "false", value: "false", fallback: true, expected: false},
+		{name: "malformed uses false fallback", value: "enabled", fallback: false, expected: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("TEST_ENV_BOOL", test.value)
+			if got := envBool("TEST_ENV_BOOL", test.fallback); got != test.expected {
+				t.Fatalf("envBool() = %v, want %v", got, test.expected)
+			}
+		})
+	}
+}
+
+func TestStandAssignmentFlagDefaultsFalseRegardlessOfEnvironment(t *testing.T) {
+	t.Setenv("ENABLE_STAND_ASSIGNMENT", "")
+	if got := envBool("ENABLE_STAND_ASSIGNMENT", false); got {
+		t.Fatal("ENABLE_STAND_ASSIGNMENT should default to false when unset")
+	}
+
+	t.Setenv("ENVIRONMENT", "production")
+	if got := envBool("ENABLE_STAND_ASSIGNMENT", false); got {
+		t.Fatal("ENABLE_STAND_ASSIGNMENT should remain false in production unless explicitly enabled")
+	}
+}

--- a/backend/internal/app/app_test.go
+++ b/backend/internal/app/app_test.go
@@ -1,0 +1,83 @@
+package app
+
+import (
+	"FlightStrips/internal/services"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildKeepsUnrelatedApplicationAvailableWhenStandAssignmentIsUnavailable(t *testing.T) {
+	poolConfig, err := pgxpool.ParseConfig("postgres://user:password@127.0.0.1:1/test")
+	require.NoError(t, err)
+	dbPool, err := pgxpool.NewWithConfig(context.Background(), poolConfig)
+	require.NoError(t, err)
+	t.Cleanup(dbPool.Close)
+
+	application, err := Build(context.Background(), Config{
+		Environment:           "test",
+		EnableStandAssignment: true,
+		EnableCDMConfigStore:  false,
+		EnablePDC:             false,
+		EnableECFMP:           false,
+		EnableECFMPAPI:        false,
+		EnablePilotAPI:        false,
+		EnableALB:             false,
+		EnableMetar:           false,
+		EnableVATSIM:          false,
+		EnableTraffic:         false,
+		EnableDBSeed:          false,
+	}, Dependencies{
+		DBPool:                dbPool,
+		AuthenticationService: services.NewTestAuthenticationService(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, application)
+	require.False(t, application.StandAssignmentReadiness().Ready)
+	require.True(t, application.StandAssignmentReadiness().Enabled)
+
+	response := httptest.NewRecorder()
+	application.Handler().ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	require.Equal(t, http.StatusOK, response.Code)
+
+	workersContext, cancelWorkers := context.WithCancel(context.Background())
+	application.StartWorkers(workersContext)
+	cancelWorkers()
+
+	// CDM is the only normal worker enabled by this fixture. SAT must not add
+	// a worker or timer when its configuration is unavailable.
+	require.Len(t, application.workers, 1)
+}
+
+func TestBuildDisablesStandAssignmentByDefault(t *testing.T) {
+	poolConfig, err := pgxpool.ParseConfig("postgres://user:password@127.0.0.1:1/test")
+	require.NoError(t, err)
+	dbPool, err := pgxpool.NewWithConfig(context.Background(), poolConfig)
+	require.NoError(t, err)
+	t.Cleanup(dbPool.Close)
+
+	application, err := Build(context.Background(), Config{
+		Environment:          "production",
+		EnableCDMConfigStore: false,
+		EnablePDC:            false,
+		EnableECFMP:          false,
+		EnableECFMPAPI:       false,
+		EnablePilotAPI:       false,
+		EnableALB:            false,
+		EnableMetar:          false,
+		EnableVATSIM:         false,
+		EnableTraffic:        false,
+		EnableDBSeed:         false,
+	}, Dependencies{
+		DBPool:                dbPool,
+		AuthenticationService: services.NewTestAuthenticationService(),
+	})
+	require.NoError(t, err)
+	require.False(t, application.StandAssignmentReadiness().Enabled)
+	require.False(t, application.StandAssignmentReadiness().Ready)
+	require.Len(t, application.workers, 1)
+}

--- a/backend/internal/config/stand_assignment_test.go
+++ b/backend/internal/config/stand_assignment_test.go
@@ -37,11 +37,38 @@ func TestInitializeStandAssignmentLoadsAircraftReferenceWhenEnabled(t *testing.T
 }
 
 func TestInitializeStandAssignmentDisabledDoesNotLoadAircraftReference(t *testing.T) {
-	InitializeStandAssignment(true)
+	dir := t.TempDir()
+	originalConfigDir := standAssignmentConfigDir
+	standAssignmentConfigDir = func() string { return dir }
+	t.Cleanup(func() {
+		standAssignmentConfigDir = originalConfigDir
+		InitializeStandAssignment(false)
+	})
+
+	// Neither SAT file exists in this directory. Disabled mode must not try to
+	// open either file, and must leave no stale registries from an earlier run.
 	state := InitializeStandAssignment(false)
 	assert.False(t, state.Enabled)
 	assert.False(t, state.Ready)
 	assert.Nil(t, GetAircraftReference())
+	assert.Nil(t, GetStandCapabilities())
+}
+
+func TestInitializeStandAssignmentReportsMissingConfigurationWithoutBlocking(t *testing.T) {
+	dir := t.TempDir()
+	originalConfigDir := standAssignmentConfigDir
+	standAssignmentConfigDir = func() string { return dir }
+	t.Cleanup(func() {
+		standAssignmentConfigDir = originalConfigDir
+		InitializeStandAssignment(false)
+	})
+
+	state := InitializeStandAssignment(true)
+	assert.True(t, state.Enabled)
+	assert.False(t, state.Ready)
+	assert.Contains(t, state.Reason, "load aircraft reference data")
+	assert.Nil(t, GetAircraftReference())
+	assert.Nil(t, GetStandCapabilities())
 }
 
 func TestInitializeStandAssignmentReportsInvalidAircraftReference(t *testing.T) {


### PR DESCRIPTION
## What changed

- Add environment parsing coverage for ENABLE_STAND_ASSIGNMENT.
- Verify disabled SAT mode ignores missing SAT configuration.
- Verify enabled-but-unavailable SAT leaves health routes and unrelated workers available.
- Verify application construction defaults SAT to disabled.

## Why

The SAT rollout boundary is already implemented; these tests cover the task 00 acceptance criteria so later SAT work remains safe to merge while the feature flag is off.

## Validation

- go test ./... from backend