### PR TITLE
feat(stand): resolve flight compatibility facts

### DIFF
--- a/backend/internal/config/stand_assignment.go
+++ b/backend/internal/config/stand_assignment.go
@@ -3,7 +3,9 @@ package config
 import (
 	"FlightStrips/internal/sat"
 	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 )
 
 // StandAssignmentReadiness describes whether SAT was requested and whether its
@@ -17,10 +19,20 @@ type StandAssignmentReadiness struct {
 var (
 	standAssignmentReadiness StandAssignmentReadiness
 	aircraftReference        *sat.AircraftRegistry
+	aircraftEngineReference  *sat.AircraftEngineRegistry
+	airportCountries         *sat.AirportCountryRegistry
 	standCapabilities        *sat.StandCapabilityRegistry
 	airlineAssignment        *sat.AirlineAssignmentConfig
 	standAssignmentConfigDir = GetConfigDir
+	standAssignmentICAOFile  = defaultStandAssignmentICAOFile
 )
+
+func defaultStandAssignmentICAOFile() string {
+	if path := strings.TrimSpace(os.Getenv("GRPLUGIN_ICAO_AIRCRAFT_JSON")); path != "" {
+		return path
+	}
+	return filepath.Join(GetConfigDir(), "data", "ICAO_Aircraft.json")
+}
 
 // InitializeStandAssignment loads SAT-only configuration when explicitly
 // enabled. A failed load leaves the rest of FlightStrips usable and records the
@@ -29,6 +41,8 @@ func InitializeStandAssignment(enabled bool) StandAssignmentReadiness {
 	if !enabled {
 		standAssignmentReadiness = StandAssignmentReadiness{}
 		aircraftReference = nil
+		aircraftEngineReference = nil
+		airportCountries = nil
 		standCapabilities = nil
 		airlineAssignment = nil
 		return standAssignmentReadiness
@@ -42,6 +56,21 @@ func InitializeStandAssignment(enabled bool) StandAssignmentReadiness {
 			Reason:  fmt.Sprintf("load aircraft reference data: %v", err),
 		}
 		aircraftReference = nil
+		aircraftEngineReference = nil
+		airportCountries = nil
+		standCapabilities = nil
+		return standAssignmentReadiness
+	}
+
+	engineReference, err := sat.LoadAircraftEngineReferenceFile(standAssignmentICAOFile(), registry)
+	if err != nil {
+		standAssignmentReadiness = StandAssignmentReadiness{
+			Enabled: true,
+			Reason:  fmt.Sprintf("load aircraft engine reference data: %v", err),
+		}
+		aircraftReference = nil
+		aircraftEngineReference = nil
+		airportCountries = nil
 		standCapabilities = nil
 		airlineAssignment = nil
 		return standAssignmentReadiness
@@ -54,6 +83,8 @@ func InitializeStandAssignment(enabled bool) StandAssignmentReadiness {
 			Reason:  fmt.Sprintf("load stand capabilities: %v", err),
 		}
 		aircraftReference = nil
+		aircraftEngineReference = nil
+		airportCountries = nil
 		standCapabilities = nil
 		airlineAssignment = nil
 		return standAssignmentReadiness
@@ -72,6 +103,8 @@ func InitializeStandAssignment(enabled bool) StandAssignmentReadiness {
 	}
 
 	aircraftReference = registry
+	aircraftEngineReference = engineReference
+	airportCountries = sat.NewAirportCountryRegistry()
 	standCapabilities = capabilities
 	airlineAssignment = assignments
 	standAssignmentReadiness = StandAssignmentReadiness{Enabled: true, Ready: true}
@@ -87,6 +120,18 @@ func GetStandAssignmentReadiness() StandAssignmentReadiness {
 // while SAT is disabled or unavailable.
 func GetAircraftReference() *sat.AircraftRegistry {
 	return aircraftReference
+}
+
+// GetAircraftEngineReference returns the validated SAT engine mapping, or nil
+// while SAT is disabled or unavailable.
+func GetAircraftEngineReference() *sat.AircraftEngineRegistry {
+	return aircraftEngineReference
+}
+
+// GetAirportCountries returns the validated SAT airport/country mapping, or
+// nil while SAT is disabled or unavailable.
+func GetAirportCountries() *sat.AirportCountryRegistry {
+	return airportCountries
 }
 
 // GetStandCapabilities returns the read-only SAT stand capability registry, or

--- a/backend/internal/config/stand_assignment_test.go
+++ b/backend/internal/config/stand_assignment_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"FlightStrips/internal/sat"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,20 +10,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestDefaultStandAssignmentICAOFileUsesConfigDirectory(t *testing.T) {
+	t.Setenv("GRPLUGIN_ICAO_AIRCRAFT_JSON", "")
+	assert.Equal(t, filepath.Join("config", "data", "ICAO_Aircraft.json"), defaultStandAssignmentICAOFile())
+}
+
 func TestInitializeStandAssignmentLoadsAircraftReferenceWhenEnabled(t *testing.T) {
 	dir := t.TempDir()
 	ekchDir := filepath.Join(dir, "ekch")
 	require.NoError(t, os.Mkdir(ekchDir, 0o755))
-	aircraftData, err := os.ReadFile(filepath.Join("..", "..", "config", "ekch", "GRpluginAircraftInfo.txt"))
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(filepath.Join(ekchDir, "GRpluginAircraftInfo.txt"), aircraftData, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(ekchDir, "GRpluginAircraftInfo.txt"), []byte("A20N\t35.8\t37.57\t11.76\t79000\tA\t32N\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(ekchDir, "ICAO_Aircraft.json"), []byte(`[{"ICAO":"A20N","Description":"L2J","WTC":"M","IATA":"32N"}]`), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(ekchDir, "GRpluginStands.txt"), []byte("STAND:EKCH:A1:N055.37.42.710:E012.38.33.450:30\n"), 0o644))
 	copyCommittedAirlineAssignment(t, ekchDir)
 
 	originalConfigDir := standAssignmentConfigDir
+	originalICAOFile := standAssignmentICAOFile
 	standAssignmentConfigDir = func() string { return dir }
+	standAssignmentICAOFile = func() string { return filepath.Join(dir, "ekch", "ICAO_Aircraft.json") }
 	t.Cleanup(func() {
 		standAssignmentConfigDir = originalConfigDir
+		standAssignmentICAOFile = originalICAOFile
 		InitializeStandAssignment(false)
 	})
 
@@ -34,6 +42,10 @@ func TestInitializeStandAssignmentLoadsAircraftReferenceWhenEnabled(t *testing.T
 	facts, ok := GetAircraftReference().Lookup("32N")
 	require.True(t, ok)
 	assert.Equal(t, "A20N", facts.Type)
+	engine, ok := GetAircraftEngineReference().Lookup("32N")
+	assert.True(t, ok)
+	assert.Equal(t, sat.EngineJet, engine)
+	assert.Equal(t, sat.BorderStatusSchengen, GetAirportCountries().BorderStatus("EKCH"))
 	assert.NotNil(t, GetStandCapabilities())
 }
 
@@ -97,13 +109,17 @@ func TestInitializeStandAssignmentIgnoresUnknownBlockTargets(t *testing.T) {
 	ekchDir := filepath.Join(dir, "ekch")
 	require.NoError(t, os.Mkdir(ekchDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(ekchDir, "GRpluginAircraftInfo.txt"), []byte("A20N\t35.8\t37.57\t11.76\t79000\tA\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(ekchDir, "ICAO_Aircraft.json"), []byte(`[{"ICAO":"A20N","Description":"L2J","WTC":"M"}]`), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(ekchDir, "GRpluginStands.txt"), []byte("STAND:EKCH:A1:N055.37.42.710:E012.38.33.450:30\nBLOCKS:A99\n"), 0o644))
 	copyCommittedAirlineAssignment(t, ekchDir)
 
 	originalConfigDir := standAssignmentConfigDir
+	originalICAOFile := standAssignmentICAOFile
 	standAssignmentConfigDir = func() string { return dir }
+	standAssignmentICAOFile = func() string { return filepath.Join(dir, "ekch", "ICAO_Aircraft.json") }
 	t.Cleanup(func() {
 		standAssignmentConfigDir = originalConfigDir
+		standAssignmentICAOFile = originalICAOFile
 		InitializeStandAssignment(false)
 	})
 
@@ -120,16 +136,20 @@ func TestInitializeStandAssignmentReportsInvalidAirlineAssignment(t *testing.T) 
 	dir := t.TempDir()
 	ekchDir := filepath.Join(dir, "ekch")
 	require.NoError(t, os.Mkdir(ekchDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(ekchDir, "GRpluginAircraftInfo.txt"), []byte("A20N\t35.8\t37.57\t11.76\t79000\tA\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(ekchDir, "GRpluginAircraftInfo.txt"), []byte("A20N\t35.8\t37.57\t11.76\t79000\tA\t32N\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(ekchDir, "ICAO_Aircraft.json"), []byte(`[{"ICAO":"A20N","Description":"L2J","WTC":"M","IATA":"32N"}]`), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(ekchDir, "GRpluginStands.txt"), []byte("STAND:EKCH:A1:N055.37.42.710:E012.38.33.450:30\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(ekchDir, "airline_assignment.json"), []byte(`{
   "rules": [], "stand_groups": {}, "fallback_rules": {}
 }`), 0o644))
 
 	originalConfigDir := standAssignmentConfigDir
+	originalICAOFile := standAssignmentICAOFile
 	standAssignmentConfigDir = func() string { return dir }
+	standAssignmentICAOFile = func() string { return filepath.Join(dir, "ekch", "ICAO_Aircraft.json") }
 	t.Cleanup(func() {
 		standAssignmentConfigDir = originalConfigDir
+		standAssignmentICAOFile = originalICAOFile
 		InitializeStandAssignment(false)
 	})
 

--- a/backend/internal/sat/aircraft_engine_reference.go
+++ b/backend/internal/sat/aircraft_engine_reference.go
@@ -1,0 +1,215 @@
+package sat
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// EngineType is the EuroScope/GRPlugin engine code used by stand capability
+// rules. The zero value is never a resolved engine type.
+type EngineType string
+
+const (
+	EngineUnknown   EngineType = "UNKNOWN"
+	EnginePiston    EngineType = "P"
+	EngineTurboprop EngineType = "T"
+	EngineJet       EngineType = "J"
+	EngineElectric  EngineType = "E"
+)
+
+func parseEngineType(value string) (EngineType, bool) {
+	switch strings.ToUpper(strings.TrimSpace(value)) {
+	case string(EnginePiston):
+		return EnginePiston, true
+	case string(EngineTurboprop):
+		return EngineTurboprop, true
+	case string(EngineJet):
+		return EngineJet, true
+	case string(EngineElectric):
+		return EngineElectric, true
+	default:
+		return EngineUnknown, false
+	}
+}
+
+// ParseEngineType validates a live EuroScope engine value.
+func ParseEngineType(value string) (EngineType, bool) {
+	return parseEngineType(value)
+}
+
+// AircraftEngineFacts contains engine and WTC facts from the installed ICAO
+// aircraft database.
+type AircraftEngineFacts struct {
+	EngineType EngineType
+	WTC        string
+}
+
+// AircraftEngineRegistry is a read-only view of the installed ICAO aircraft
+// database. It contains no copied database rows or generated mapping data.
+type AircraftEngineRegistry struct {
+	byType   map[string]AircraftEngineFacts
+	aircraft *AircraftRegistry
+}
+
+type icaoAircraftRecord struct {
+	ICAO        string `json:"ICAO"`
+	Description string `json:"Description"`
+	WTC         string `json:"WTC"`
+	IATA        string `json:"IATA"`
+	IATACargo   string `json:"IATA_cargo"`
+}
+
+// Lookup resolves an ICAO type or an ICAO JSON record's IATA alias.
+func (r *AircraftEngineRegistry) Lookup(aircraftType string) (EngineType, bool) {
+	facts, ok := r.lookup(aircraftType)
+	if !ok || facts.EngineType == EngineUnknown {
+		return EngineUnknown, false
+	}
+	return facts.EngineType, true
+}
+
+// LookupWTC resolves the WTC published by the installed aircraft database.
+func (r *AircraftEngineRegistry) LookupWTC(aircraftType string) (string, bool) {
+	facts, ok := r.lookup(aircraftType)
+	if !ok || facts.WTC == "UNKNOWN" {
+		return "", false
+	}
+	return facts.WTC, true
+}
+
+func (r *AircraftEngineRegistry) lookup(aircraftType string) (AircraftEngineFacts, bool) {
+	if r == nil {
+		return AircraftEngineFacts{}, false
+	}
+	key := normalizeAircraftToken(aircraftType)
+	if facts, ok := r.byType[key]; ok {
+		return facts, true
+	}
+	if r.aircraft != nil {
+		if reference, ok := r.aircraft.Lookup(key); ok {
+			facts, ok := r.byType[reference.Type]
+			return facts, ok
+		}
+	}
+	return AircraftEngineFacts{}, false
+}
+
+// LoadAircraftEngineReference parses the installed ICAO_Aircraft.json data.
+func LoadAircraftEngineReference(source io.Reader, aircraft *AircraftRegistry) (*AircraftEngineRegistry, error) {
+	if source == nil {
+		return nil, errors.New("ICAO aircraft source is nil")
+	}
+
+	data, err := io.ReadAll(source)
+	if err != nil {
+		return nil, fmt.Errorf("read ICAO aircraft JSON: %w", err)
+	}
+	data = bytes.TrimPrefix(data, []byte{0xEF, 0xBB, 0xBF})
+	var records []icaoAircraftRecord
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	if err := decoder.Decode(&records); err != nil {
+		return nil, fmt.Errorf("decode ICAO aircraft JSON: %w", err)
+	}
+	var extra json.RawMessage
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return nil, errors.New("ICAO aircraft JSON contains multiple top-level values")
+		}
+		return nil, fmt.Errorf("read ICAO aircraft JSON tail: %w", err)
+	}
+
+	registry := &AircraftEngineRegistry{byType: make(map[string]AircraftEngineFacts, len(records)), aircraft: aircraft}
+	canonicalFacts := make(map[string]AircraftEngineFacts, len(records))
+	type aliasEntry struct {
+		alias string
+		facts AircraftEngineFacts
+	}
+	var aliases []aliasEntry
+	var problems []error
+	for index, record := range records {
+		recordNumber := index + 1
+		aircraftType := normalizeAircraftToken(record.ICAO)
+		if aircraftType == "" {
+			problems = append(problems, fmt.Errorf("record %d: ICAO type is required", recordNumber))
+			continue
+		}
+		engine, valid := parseDescriptionEngine(record.Description)
+		if !valid {
+			problems = append(problems, fmt.Errorf("record %d (%s): invalid engine code in Description %q", recordNumber, aircraftType, record.Description))
+			continue
+		}
+		wtc := "UNKNOWN"
+		if strings.TrimSpace(record.WTC) != "" {
+			wtc = strings.ToUpper(strings.TrimSpace(record.WTC))
+			if !validWTC(wtc) {
+				problems = append(problems, fmt.Errorf("record %d (%s): invalid WTC %q", recordNumber, aircraftType, record.WTC))
+				continue
+			}
+		}
+		if _, duplicate := canonicalFacts[aircraftType]; duplicate {
+			problems = append(problems, fmt.Errorf("record %d: duplicate ICAO type %q", recordNumber, aircraftType))
+			continue
+		}
+		facts := AircraftEngineFacts{EngineType: engine, WTC: wtc}
+		canonicalFacts[aircraftType] = facts
+		for _, alias := range []string{record.IATA, record.IATACargo} {
+			alias = normalizeAircraftToken(alias)
+			if alias == "" || alias == aircraftType {
+				continue
+			}
+			aliases = append(aliases, aliasEntry{alias: alias, facts: facts})
+		}
+	}
+	if len(problems) > 0 {
+		return nil, fmt.Errorf("invalid ICAO aircraft data: %w", errors.Join(problems...))
+	}
+	for aircraftType, facts := range canonicalFacts {
+		registry.byType[aircraftType] = facts
+	}
+	for _, entry := range aliases {
+		if _, canonical := registry.byType[entry.alias]; canonical {
+			continue
+		}
+		if _, exists := registry.byType[entry.alias]; !exists {
+			registry.byType[entry.alias] = entry.facts
+		}
+	}
+	return registry, nil
+}
+
+func parseDescriptionEngine(description string) (EngineType, bool) {
+	description = strings.TrimSpace(description)
+	if description == "" || strings.HasSuffix(description, "-") || strings.HasSuffix(description, "R") {
+		return EngineUnknown, true
+	}
+	return parseEngineType(description[len(description)-1:])
+}
+
+func validWTC(value string) bool {
+	switch value {
+	case "L", "M", "H", "J":
+		return true
+	default:
+		return false
+	}
+}
+
+// LoadAircraftEngineReferenceFile opens the installed ICAO aircraft database.
+func LoadAircraftEngineReferenceFile(path string, aircraft *AircraftRegistry) (*AircraftEngineRegistry, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open ICAO aircraft file %q: %w", path, err)
+	}
+	defer f.Close()
+
+	registry, err := LoadAircraftEngineReference(f, aircraft)
+	if err != nil {
+		return nil, fmt.Errorf("load ICAO aircraft file %q: %w", path, err)
+	}
+	return registry, nil
+}

--- a/backend/internal/sat/aircraft_reference.go
+++ b/backend/internal/sat/aircraft_reference.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -53,6 +54,22 @@ type Aircraft struct {
 type AircraftRegistry struct {
 	byType   map[string]Aircraft
 	warnings []string
+}
+
+// Types returns all canonical aircraft types in deterministic order.
+func (r *AircraftRegistry) Types() []string {
+	if r == nil {
+		return nil
+	}
+
+	types := make([]string, 0, len(r.byType))
+	for aircraftType, facts := range r.byType {
+		if aircraftType == facts.Type {
+			types = append(types, aircraftType)
+		}
+	}
+	slices.Sort(types)
+	return types
 }
 
 // Lookup resolves an ICAO type or source alias, case-insensitively. The returned

--- a/backend/internal/sat/airline_assignment.go
+++ b/backend/internal/sat/airline_assignment.go
@@ -18,6 +18,10 @@ type BorderStatus string
 const (
 	BorderStatusSchengen    BorderStatus = "SCHENGEN"
 	BorderStatusNonSchengen BorderStatus = "NON_SCHENGEN"
+	// BorderStatusUnknown is produced by airport border classification when no
+	// repository-owned mapping matches the airport code. It is not a valid
+	// airline assignment condition value.
+	BorderStatusUnknown BorderStatus = "UNKNOWN"
 )
 
 // AssignmentDirection identifies the flight leg to which a rule applies.

--- a/backend/internal/sat/border_reference.go
+++ b/backend/internal/sat/border_reference.go
@@ -1,0 +1,75 @@
+package sat
+
+import "strings"
+
+// FlightDirection determines which route endpoint supplies border status.
+type FlightDirection string
+
+const (
+	Arrival   FlightDirection = "ARRIVAL"
+	Departure FlightDirection = "DEPARTURE"
+)
+
+// AirportCountryRegistry is a read-only airport/prefix-to-border-status map.
+// Prefixes cover the global feed, while exact airport codes can override a
+// prefix when an airport needs special handling.
+type AirportCountryRegistry struct {
+	byCode   map[string]BorderStatus
+	prefixes map[string]BorderStatus
+}
+
+var defaultAirportBorderStatuses = map[string]BorderStatus{
+	"BI": BorderStatusSchengen, "EB": BorderStatusSchengen, "ED": BorderStatusSchengen,
+	"EE": BorderStatusSchengen, "EF": BorderStatusSchengen, "EH": BorderStatusSchengen,
+	"EK": BorderStatusSchengen, "EL": BorderStatusSchengen, "EN": BorderStatusSchengen, "EP": BorderStatusSchengen,
+	"ES": BorderStatusSchengen, "ET": BorderStatusSchengen, "EV": BorderStatusSchengen,
+	"EY": BorderStatusSchengen, "GC": BorderStatusSchengen, "LB": BorderStatusSchengen,
+	"LD": BorderStatusSchengen, "LE": BorderStatusSchengen, "LF": BorderStatusSchengen,
+	"LG": BorderStatusSchengen, "LH": BorderStatusSchengen, "LI": BorderStatusSchengen,
+	"LJ": BorderStatusSchengen, "LK": BorderStatusSchengen, "LM": BorderStatusSchengen,
+	"LO": BorderStatusSchengen, "LP": BorderStatusSchengen, "LR": BorderStatusSchengen,
+	"LS": BorderStatusSchengen, "LZ": BorderStatusSchengen,
+
+	"C": BorderStatusNonSchengen, "EG": BorderStatusNonSchengen, "EI": BorderStatusNonSchengen,
+	"K": BorderStatusNonSchengen, "LT": BorderStatusNonSchengen, "LU": BorderStatusNonSchengen,
+	"LW": BorderStatusNonSchengen, "RJ": BorderStatusNonSchengen, "RK": BorderStatusNonSchengen,
+	"U": BorderStatusNonSchengen, "V": BorderStatusNonSchengen, "Y": BorderStatusNonSchengen,
+	"ZB": BorderStatusNonSchengen, "ZG": BorderStatusNonSchengen, "ZK": BorderStatusNonSchengen,
+	"ZL": BorderStatusNonSchengen, "ZM": BorderStatusNonSchengen, "ZP": BorderStatusNonSchengen,
+	"ZS": BorderStatusNonSchengen, "ZU": BorderStatusNonSchengen, "ZW": BorderStatusNonSchengen,
+	"ZY": BorderStatusNonSchengen,
+}
+
+// NewAirportCountryRegistry returns the repository-owned border mapping.
+func NewAirportCountryRegistry() *AirportCountryRegistry {
+	prefixes := make(map[string]BorderStatus, len(defaultAirportBorderStatuses))
+	for prefix, status := range defaultAirportBorderStatuses {
+		prefixes[prefix] = status
+	}
+	return &AirportCountryRegistry{
+		byCode:   make(map[string]BorderStatus),
+		prefixes: prefixes,
+	}
+}
+
+func (r *AirportCountryRegistry) statusForAirport(airport string) BorderStatus {
+	if r == nil {
+		return BorderStatusUnknown
+	}
+	code := strings.ToUpper(strings.TrimSpace(airport))
+	if status, ok := r.byCode[code]; ok {
+		return status
+	}
+	for length := len(code) - 1; length >= 1; length-- {
+		if status, ok := r.prefixes[code[:length]]; ok {
+			return status
+		}
+	}
+	return BorderStatusUnknown
+}
+
+// BorderStatus returns the status of an airport, or BorderStatusUnknown when
+// its airport code has no repository-owned mapping.
+func (r *AirportCountryRegistry) BorderStatus(airport string) BorderStatus {
+	return r.statusForAirport(airport)
+}

--- a/backend/internal/sat/border_reference_test.go
+++ b/backend/internal/sat/border_reference_test.go
@@ -1,0 +1,18 @@
+package sat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAirportCountryRegistryClassifiesExactAndPrefixCodes(t *testing.T) {
+	registry := NewAirportCountryRegistry()
+
+	assert.Equal(t, BorderStatusSchengen, registry.BorderStatus("EKCH"))
+	assert.Equal(t, BorderStatusSchengen, registry.BorderStatus("ELLX"))
+	assert.Equal(t, BorderStatusNonSchengen, registry.BorderStatus("kjfk"))
+	assert.Equal(t, BorderStatusNonSchengen, registry.BorderStatus("ZBAA"))
+	assert.Equal(t, BorderStatusUnknown, registry.BorderStatus("XXXX"))
+	assert.Equal(t, BorderStatusUnknown, registry.BorderStatus("ZZZZ"))
+}

--- a/backend/internal/sat/flight_compatibility.go
+++ b/backend/internal/sat/flight_compatibility.go
@@ -1,0 +1,130 @@
+package sat
+
+import (
+	"slices"
+	"strings"
+)
+
+// FlightFact identifies a fact that could not be resolved.
+type FlightFact string
+
+const (
+	FlightFactAircraftType FlightFact = "AIRCRAFT_TYPE"
+	FlightFactEngineType   FlightFact = "ENGINE_TYPE"
+	FlightFactWTC          FlightFact = "WTC"
+	FlightFactBorder       FlightFact = "BORDER"
+)
+
+// FlightCompatibilityInput contains only flight facts. It deliberately does
+// not include stand or airline preference data.
+type FlightCompatibilityInput struct {
+	Direction      FlightDirection
+	Origin         string
+	Destination    string
+	AircraftType   string
+	LiveEngineType string
+	WTC            string
+}
+
+// FlightCompatibilityFacts is the immutable, normalized value consumed by
+// later compatibility and airline eligibility code. Unknown values are
+// represented explicitly by the UNKNOWN constants and listed in UnknownFacts.
+type FlightCompatibilityFacts struct {
+	Direction      FlightDirection
+	Origin         string
+	Destination    string
+	BorderEndpoint string
+	Aircraft       Aircraft
+	AircraftKnown  bool
+	EngineType     EngineType
+	WTC            string
+	BorderStatus   BorderStatus
+	unknownFacts   []FlightFact
+}
+
+// ResolveFlightCompatibilityFacts normalizes all input facts without
+// mutating the input or the registries. A valid live EuroScope engine value
+// takes precedence over the repo mapping; an empty live value uses the map.
+func ResolveFlightCompatibilityFacts(input FlightCompatibilityInput, aircraft *AircraftRegistry, engines *AircraftEngineRegistry, borders *AirportCountryRegistry) FlightCompatibilityFacts {
+	facts := FlightCompatibilityFacts{
+		Direction:    input.Direction,
+		Origin:       strings.ToUpper(strings.TrimSpace(input.Origin)),
+		Destination:  strings.ToUpper(strings.TrimSpace(input.Destination)),
+		EngineType:   EngineUnknown,
+		WTC:          "UNKNOWN",
+		BorderStatus: BorderStatusUnknown,
+	}
+	unknown := make([]FlightFact, 0, 4)
+
+	if aircraft != nil {
+		if resolved, ok := aircraft.Lookup(input.AircraftType); ok {
+			facts.Aircraft = resolved
+			facts.AircraftKnown = true
+		} else {
+			unknown = append(unknown, FlightFactAircraftType)
+		}
+	} else {
+		unknown = append(unknown, FlightFactAircraftType)
+	}
+
+	if live := strings.TrimSpace(input.LiveEngineType); live != "" {
+		if engine, ok := ParseEngineType(live); ok {
+			facts.EngineType = engine
+		} else {
+			unknown = append(unknown, FlightFactEngineType)
+		}
+	} else if engines != nil {
+		if engine, ok := engines.Lookup(input.AircraftType); ok {
+			facts.EngineType = engine
+		} else {
+			unknown = append(unknown, FlightFactEngineType)
+		}
+	} else {
+		unknown = append(unknown, FlightFactEngineType)
+	}
+
+	if wtc := strings.ToUpper(strings.TrimSpace(input.WTC)); wtc != "" {
+		if validWTC(wtc) {
+			facts.WTC = wtc
+		} else {
+			unknown = append(unknown, FlightFactWTC)
+		}
+	} else if engines != nil {
+		if wtc, ok := engines.LookupWTC(input.AircraftType); ok {
+			facts.WTC = wtc
+		} else {
+			unknown = append(unknown, FlightFactWTC)
+		}
+	} else {
+		unknown = append(unknown, FlightFactWTC)
+	}
+
+	borderEndpoint := ""
+	switch input.Direction {
+	case Arrival:
+		borderEndpoint = facts.Origin
+	case Departure:
+		borderEndpoint = facts.Destination
+	}
+	facts.BorderEndpoint = borderEndpoint
+	if borderEndpoint != "" && borders != nil {
+		facts.BorderStatus = borders.BorderStatus(borderEndpoint)
+	}
+	if facts.BorderStatus == BorderStatusUnknown {
+		unknown = append(unknown, FlightFactBorder)
+	}
+
+	facts.unknownFacts = unknown
+	return facts
+}
+
+// UnknownFactKinds returns a copy of the unresolved fact kinds.
+func (f FlightCompatibilityFacts) UnknownFactKinds() []FlightFact {
+	return slices.Clone(f.unknownFacts)
+}
+
+// Complete reports whether all facts required for automatic compatibility are
+// known. Unknown facts never pass an explicit stand restriction.
+func (f FlightCompatibilityFacts) Complete() bool {
+	return len(f.unknownFacts) == 0
+}

--- a/backend/internal/sat/flight_compatibility_test.go
+++ b/backend/internal/sat/flight_compatibility_test.go
@@ -1,0 +1,129 @@
+package sat
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testICAOAircraftJSON = `[
+{"ICAO":"A20N","Description":"L2J","WTC":"M","IATA":"32N"},
+{"ICAO":"C172","Description":"L1P","WTC":"L"}
+]`
+
+func testAircraftRegistry(t *testing.T) *AircraftRegistry {
+	t.Helper()
+	registry, err := LoadAircraftReference(strings.NewReader("A20N\t35.8\t37.57\t11.76\t79000\tA\t32N\nC172\t11.2\t8.3\t2.7\t1100\tP\n"))
+	require.NoError(t, err)
+	return registry
+}
+
+func TestLoadAircraftEngineReferenceReadsICAOJSONAndAliases(t *testing.T) {
+	aircraft := testAircraftRegistry(t)
+	registry, err := LoadAircraftEngineReference(strings.NewReader(testICAOAircraftJSON), aircraft)
+	require.NoError(t, err)
+
+	engine, ok := registry.Lookup("32n")
+	require.True(t, ok)
+	assert.Equal(t, EngineJet, engine)
+	wtc, ok := registry.LookupWTC("C172")
+	require.True(t, ok)
+	assert.Equal(t, "L", wtc)
+}
+
+func TestLoadAircraftEngineReferenceValidatesICAOJSON(t *testing.T) {
+	aircraft := testAircraftRegistry(t)
+	for _, test := range []struct {
+		name string
+		data string
+		want string
+	}{
+		{name: "invalid engine", data: `[{"ICAO":"A20N","Description":"L2Q","WTC":"M"}]`, want: "invalid engine code"},
+		{name: "invalid WTC", data: `[{"ICAO":"A20N","Description":"L2J","WTC":"X"}]`, want: "invalid WTC"},
+		{name: "malformed JSON", data: `[{"ICAO":"A20N"`, want: "decode ICAO aircraft JSON"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := LoadAircraftEngineReference(strings.NewReader(test.data), aircraft)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.want)
+		})
+	}
+}
+
+func TestLoadAircraftEngineReferenceFile(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "ICAO_Aircraft.json")
+	require.NoError(t, os.WriteFile(file, []byte(testICAOAircraftJSON), 0o600))
+	registry, err := LoadAircraftEngineReferenceFile(file, testAircraftRegistry(t))
+	require.NoError(t, err)
+	engine, ok := registry.Lookup("32N")
+	assert.True(t, ok)
+	assert.Equal(t, EngineJet, engine)
+}
+
+func TestResolveFlightCompatibilityFactsPrefersLiveEngineAndUsesCorrectBorderEndpoint(t *testing.T) {
+	aircraft := testAircraftRegistry(t)
+	engines, err := LoadAircraftEngineReference(strings.NewReader(testICAOAircraftJSON), aircraft)
+	require.NoError(t, err)
+	borders := NewAirportCountryRegistry()
+
+	arrival := ResolveFlightCompatibilityFacts(FlightCompatibilityInput{
+		Direction:      Arrival,
+		Origin:         "KJFK",
+		Destination:    "EKCH",
+		AircraftType:   "32N",
+		LiveEngineType: "T",
+		WTC:            "m",
+	}, aircraft, engines, borders)
+	assert.True(t, arrival.Complete())
+	assert.Equal(t, EngineTurboprop, arrival.EngineType)
+	assert.Equal(t, BorderStatusNonSchengen, arrival.BorderStatus)
+	assert.Equal(t, "KJFK", arrival.BorderEndpoint)
+	assert.Equal(t, "M", arrival.WTC)
+
+	departure := ResolveFlightCompatibilityFacts(FlightCompatibilityInput{
+		Direction:    Departure,
+		Origin:       "KJFK",
+		Destination:  "EKCH",
+		AircraftType: "C172",
+	}, aircraft, engines, borders)
+	assert.True(t, departure.Complete())
+	assert.Equal(t, BorderStatusSchengen, departure.BorderStatus)
+	assert.Equal(t, "EKCH", departure.BorderEndpoint)
+}
+
+func TestResolveFlightCompatibilityFactsReportsUnknownFacts(t *testing.T) {
+	aircraft := testAircraftRegistry(t)
+	engines, err := LoadAircraftEngineReference(strings.NewReader(testICAOAircraftJSON), aircraft)
+	require.NoError(t, err)
+	borders := NewAirportCountryRegistry()
+
+	facts := ResolveFlightCompatibilityFacts(FlightCompatibilityInput{
+		Direction:      Arrival,
+		Origin:         "XXXX",
+		Destination:    "EKCH",
+		AircraftType:   "UNKNOWN",
+		LiveEngineType: "invalid",
+		WTC:            "X",
+	}, aircraft, engines, borders)
+
+	assert.False(t, facts.Complete())
+	assert.Equal(t, EngineUnknown, facts.EngineType)
+	assert.Equal(t, "UNKNOWN", facts.WTC)
+	assert.Equal(t, BorderStatusUnknown, facts.BorderStatus)
+	assert.ElementsMatch(t, []FlightFact{FlightFactAircraftType, FlightFactEngineType, FlightFactWTC, FlightFactBorder}, facts.UnknownFactKinds())
+}
+
+func TestFlightCompatibilityFactsUnknownFactKindsReturnsCopy(t *testing.T) {
+	aircraft := testAircraftRegistry(t)
+	engines, err := LoadAircraftEngineReference(strings.NewReader(testICAOAircraftJSON), aircraft)
+	require.NoError(t, err)
+
+	facts := ResolveFlightCompatibilityFacts(FlightCompatibilityInput{AircraftType: "UNKNOWN"}, aircraft, engines, NewAirportCountryRegistry())
+	unknown := facts.UnknownFactKinds()
+	unknown[0] = "MUTATED"
+	assert.Equal(t, FlightFactAircraftType, facts.UnknownFactKinds()[0])
+}


### PR DESCRIPTION
## Summary

- Parse the externally mounted `ICAO_Aircraft.json` database for engine and WTC facts without committing the licensed source or a derived mapping.
- Resolve live EuroScope engine overrides, aircraft aliases, explicit unknown facts, and arrival/departure border endpoints.
- Add the repository-owned airport border map, including Luxembourg and safe unknown-airport handling.
- Wire the SAT facts registries into configuration readiness and add focused coverage.

## Validation

- `go test ./...`
