### PR TITLE
feat(stand): evaluate physical compatibility

### DIFF
--- a/backend/internal/sat/stand_capability.go
+++ b/backend/internal/sat/stand_capability.go
@@ -45,6 +45,7 @@ type StandCapability struct {
 	Length   float64
 	Width    float64
 	Height   float64
+	MTOW     float64
 	Code     string
 
 	AircraftTypes    []string
@@ -326,8 +327,10 @@ func applyStandDirective(capability *StandCapability, key, value string, line in
 		return setDimension(&capability.Width, "WIDTH", value, line)
 	case "HEIGHT":
 		return setDimension(&capability.Height, "HEIGHT", value, line)
+	case "MTOW":
+		return setDimension(&capability.MTOW, "MTOW", value, line)
 	case "CODE":
-		capability.Code = value
+		capability.Code = normalizeToken(value)
 	case "ATYP":
 		capability.AircraftTypes = unionTokens(capability.AircraftTypes, parseTokenList(value))
 	case "NOTATYP":

--- a/backend/internal/sat/stand_capability_test.go
+++ b/backend/internal/sat/stand_capability_test.go
@@ -23,6 +23,7 @@ WINGSPAN:44
 LENGTH:40
 WIDTH:30
 HEIGHT:12
+MTOW:90000
 CODE:ABC
 ATYP:B77*, A20N
 NOTATYP:CRJ*
@@ -65,6 +66,7 @@ STAND:EKCH:A3:N055.37.43.000:E012.38.34.000:20
 	assert.Equal(t, 40.0, schengen.Length)
 	assert.Equal(t, 30.0, schengen.Width)
 	assert.Equal(t, 12.0, schengen.Height)
+	assert.Equal(t, 90000.0, schengen.MTOW)
 	assert.Equal(t, "ABC", schengen.Code)
 	assert.Equal(t, []string{"B77*", "A20N"}, schengen.AircraftTypes)
 	assert.Equal(t, []string{"CRJ*"}, schengen.NotAircraftTypes)

--- a/backend/internal/sat/stand_compatibility.go
+++ b/backend/internal/sat/stand_compatibility.go
@@ -1,0 +1,249 @@
+package sat
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// StandCompatibilityCapability identifies the stand capability that rejected
+// a flight. BLOCKS is deliberately absent: occupancy is evaluated by the
+// transactional allocator, not by this physical-fit pass.
+type StandCompatibilityCapability string
+
+const (
+	StandCapabilityManual       StandCompatibilityCapability = "MANUAL"
+	StandCapabilityBorder       StandCompatibilityCapability = "BORDER"
+	StandCapabilityAircraftType StandCompatibilityCapability = "AIRCRAFT_TYPE"
+	StandCapabilityWTC          StandCompatibilityCapability = "WTC"
+	StandCapabilityEngineType   StandCompatibilityCapability = "ENGINE_TYPE"
+	StandCapabilityWingspan     StandCompatibilityCapability = "WINGSPAN"
+	StandCapabilityLength       StandCompatibilityCapability = "LENGTH"
+	StandCapabilityHeight       StandCompatibilityCapability = "HEIGHT"
+	StandCapabilityMTOW         StandCompatibilityCapability = "MTOW"
+	StandCapabilityCode         StandCompatibilityCapability = "CODE"
+)
+
+// StandCompatibilityRejection records one failed capability on one complete
+// stand variant. Expected is the directive value and Actual is the normalized
+// flight fact; this makes diagnostics useful without parsing text messages.
+type StandCompatibilityRejection struct {
+	Airport     string
+	Stand       string
+	VariantLine int
+	Capability  StandCompatibilityCapability
+	Expected    string
+	Actual      string
+}
+
+// StandCompatibilityMatch is a physical stand and the complete variant that
+// passed all physical and border checks. Blocks belongs to that variant and is
+// returned for the allocator to consider later; it is never a fit rejection.
+type StandCompatibilityMatch struct {
+	Stand   Stand
+	Variant StandCapability
+	Blocks  []string
+}
+
+// StandCompatibilityEvaluation separates qualifying stands from structured
+// rejections. A physical stand appears at most once in Matches, even when more
+// than one of its variants would fit.
+type StandCompatibilityEvaluation struct {
+	Matches    []StandCompatibilityMatch
+	Rejections []StandCompatibilityRejection
+}
+
+// EvaluateStandCompatibility evaluates complete variants for automatic stand
+// assignment. MANUAL variants are retained in the registry but excluded here;
+// use EvaluateManualStandCompatibility for an explicit controller selection.
+func EvaluateStandCompatibility(stands []Stand, facts FlightCompatibilityFacts) StandCompatibilityEvaluation {
+	return evaluateStandCompatibility(stands, facts, false)
+}
+
+// EvaluateManualStandCompatibility evaluates complete variants for an
+// explicit manual stand selection. It includes MANUAL variants but still
+// applies every physical and border restriction.
+func EvaluateManualStandCompatibility(stands []Stand, facts FlightCompatibilityFacts) StandCompatibilityEvaluation {
+	return evaluateStandCompatibility(stands, facts, true)
+}
+
+// EvaluateCompatibility evaluates all stands at an airport for automatic
+// assignment.
+func (r *StandCapabilityRegistry) EvaluateCompatibility(airport string, facts FlightCompatibilityFacts) StandCompatibilityEvaluation {
+	if r == nil {
+		return StandCompatibilityEvaluation{}
+	}
+	return EvaluateStandCompatibility(r.Stands(airport), facts)
+}
+
+// EvaluateManualCompatibility evaluates all stands at an airport for explicit
+// manual selection, including MANUAL variants.
+func (r *StandCapabilityRegistry) EvaluateManualCompatibility(airport string, facts FlightCompatibilityFacts) StandCompatibilityEvaluation {
+	if r == nil {
+		return StandCompatibilityEvaluation{}
+	}
+	return EvaluateManualStandCompatibility(r.Stands(airport), facts)
+}
+
+func evaluateStandCompatibility(stands []Stand, facts FlightCompatibilityFacts, includeManual bool) StandCompatibilityEvaluation {
+	result := StandCompatibilityEvaluation{}
+	for _, stand := range stands {
+		for _, variant := range stand.Variants {
+			rejections := evaluateStandVariant(stand.Airport, stand.Name, variant, facts, includeManual)
+			if len(rejections) != 0 {
+				result.Rejections = append(result.Rejections, rejections...)
+				continue
+			}
+			result.Matches = append(result.Matches, StandCompatibilityMatch{
+				Stand:   cloneStand(stand),
+				Variant: cloneStandCapability(variant),
+				Blocks:  slices.Clone(variant.Blocks),
+			})
+			break
+		}
+	}
+	return result
+}
+
+func evaluateStandVariant(airport, stand string, variant StandCapability, facts FlightCompatibilityFacts, includeManual bool) []StandCompatibilityRejection {
+	rejections := make([]StandCompatibilityRejection, 0)
+	reject := func(capability StandCompatibilityCapability, expected, actual string) {
+		rejections = append(rejections, StandCompatibilityRejection{
+			Airport:     airport,
+			Stand:       stand,
+			VariantLine: variant.Line,
+			Capability:  capability,
+			Expected:    expected,
+			Actual:      actual,
+		})
+	}
+
+	if variant.Manual && !includeManual {
+		reject(StandCapabilityManual, "manual selection", "automatic assignment")
+	}
+	if variant.BorderClass != StandBorderAny && !borderClassMatches(variant.BorderClass, facts.BorderStatus) {
+		reject(StandCapabilityBorder, string(variant.BorderClass), string(facts.BorderStatus))
+	}
+
+	if len(variant.AircraftTypes) > 0 && (!facts.AircraftKnown || !matchesAnyGRPattern(variant.AircraftTypes, facts.Aircraft.Type)) {
+		reject(StandCapabilityAircraftType, strings.Join(variant.AircraftTypes, ","), aircraftTypeActual(facts))
+	}
+	if len(variant.NotAircraftTypes) > 0 && (!facts.AircraftKnown || matchesAnyGRPattern(variant.NotAircraftTypes, facts.Aircraft.Type)) {
+		reject(StandCapabilityAircraftType, "NOT "+strings.Join(variant.NotAircraftTypes, ","), aircraftTypeActual(facts))
+	}
+
+	if len(variant.WTC) > 0 && !matchesCapabilityTokens(variant.WTC, facts.WTC) {
+		reject(StandCapabilityWTC, strings.Join(variant.WTC, ","), facts.WTC)
+	}
+	if len(variant.NotWTC) > 0 && (!knownWTC(facts.WTC) || matchesCapabilityTokens(variant.NotWTC, facts.WTC)) {
+		reject(StandCapabilityWTC, "NOT "+strings.Join(variant.NotWTC, ","), facts.WTC)
+	}
+	if len(variant.EngineTypes) > 0 && !matchesCapabilityTokens(variant.EngineTypes, string(facts.EngineType)) {
+		reject(StandCapabilityEngineType, strings.Join(variant.EngineTypes, ","), string(facts.EngineType))
+	}
+	if len(variant.NotEngineTypes) > 0 && (facts.EngineType == EngineUnknown || matchesCapabilityTokens(variant.NotEngineTypes, string(facts.EngineType))) {
+		reject(StandCapabilityEngineType, "NOT "+strings.Join(variant.NotEngineTypes, ","), string(facts.EngineType))
+	}
+
+	if variant.Wingspan > 0 && (!facts.AircraftKnown || facts.Aircraft.WingspanMetres > variant.Wingspan) {
+		reject(StandCapabilityWingspan, formatLimit(variant.Wingspan), aircraftDimensionActual(facts, func(a Aircraft) float64 { return a.WingspanMetres }))
+	}
+	if variant.Length > 0 && (!facts.AircraftKnown || facts.Aircraft.LengthMetres > variant.Length) {
+		reject(StandCapabilityLength, formatLimit(variant.Length), aircraftDimensionActual(facts, func(a Aircraft) float64 { return a.LengthMetres }))
+	}
+	if variant.Height > 0 && (!facts.AircraftKnown || facts.Aircraft.HeightMetres > variant.Height) {
+		reject(StandCapabilityHeight, formatLimit(variant.Height), aircraftDimensionActual(facts, func(a Aircraft) float64 { return a.HeightMetres }))
+	}
+	if variant.MTOW > 0 && (!facts.AircraftKnown || facts.Aircraft.MTOWKilograms > variant.MTOW) {
+		reject(StandCapabilityMTOW, formatLimit(variant.MTOW), aircraftDimensionActual(facts, func(a Aircraft) float64 { return a.MTOWKilograms }))
+	}
+	if variant.Code != "" && (!facts.AircraftKnown || !strings.Contains(variant.Code, string(facts.Aircraft.UseCode))) {
+		reject(StandCapabilityCode, variant.Code, aircraftUseActual(facts))
+	}
+	return rejections
+}
+
+func borderClassMatches(class StandBorderClass, status BorderStatus) bool {
+	return (class == StandBorderSchengen && status == BorderStatusSchengen) ||
+		(class == StandBorderNonSchengen && status == BorderStatusNonSchengen)
+}
+
+func matchesCapabilityTokens(tokens []string, value string) bool {
+	if value == "" || value == "UNKNOWN" {
+		return false
+	}
+	for _, token := range tokens {
+		if strings.Contains(token, value) {
+			return true
+		}
+	}
+	return false
+}
+
+func knownWTC(value string) bool {
+	return validWTC(value)
+}
+
+func matchesAnyGRPattern(patterns []string, value string) bool {
+	for _, pattern := range patterns {
+		if grWildcardMatch(pattern, value) {
+			return true
+		}
+	}
+	return false
+}
+
+// grWildcardMatch implements GRPlugin's case-insensitive glob-style matching:
+// '*' matches any sequence and '?' matches one character. Stand configuration
+// is normalized during load, but normalizing here keeps direct callers safe.
+func grWildcardMatch(pattern, value string) bool {
+	pattern = normalizeToken(pattern)
+	value = normalizeToken(value)
+	patternIndex, valueIndex, starIndex, resumeValue := 0, 0, -1, 0
+	for valueIndex < len(value) {
+		switch {
+		case patternIndex < len(pattern) && (pattern[patternIndex] == '?' || pattern[patternIndex] == value[valueIndex]):
+			patternIndex++
+			valueIndex++
+		case patternIndex < len(pattern) && pattern[patternIndex] == '*':
+			starIndex = patternIndex
+			patternIndex++
+			resumeValue = valueIndex
+		case starIndex >= 0:
+			patternIndex = starIndex + 1
+			resumeValue++
+			valueIndex = resumeValue
+		default:
+			return false
+		}
+	}
+	for patternIndex < len(pattern) && pattern[patternIndex] == '*' {
+		patternIndex++
+	}
+	return patternIndex == len(pattern)
+}
+
+func aircraftTypeActual(facts FlightCompatibilityFacts) string {
+	if !facts.AircraftKnown {
+		return "UNKNOWN"
+	}
+	return facts.Aircraft.Type
+}
+
+func aircraftUseActual(facts FlightCompatibilityFacts) string {
+	if !facts.AircraftKnown {
+		return "UNKNOWN"
+	}
+	return string(facts.Aircraft.UseCode)
+}
+
+func aircraftDimensionActual(facts FlightCompatibilityFacts, value func(Aircraft) float64) string {
+	if !facts.AircraftKnown {
+		return "UNKNOWN"
+	}
+	return formatLimit(value(facts.Aircraft))
+}
+
+func formatLimit(value float64) string {
+	return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.3f", value), "0"), ".")
+}

--- a/backend/internal/sat/stand_compatibility_test.go
+++ b/backend/internal/sat/stand_compatibility_test.go
@@ -1,0 +1,191 @@
+package sat
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvaluateStandCompatibilityMatchesCompleteVariantWithoutMixingDuplicates(t *testing.T) {
+	registry := compatibilityRegistry(t, `
+STAND:EKCH:A1:N055.37.42.710:E012.38.33.450:30
+SCHENGEN
+WTC:H
+ENGINETYPE:J
+WINGSPAN:40
+BLOCKS:A2
+STAND:EKCH:A1:N055.37.42.710:E012.38.33.450:30
+NON-SCHENGEN
+WTC:M
+ENGINETYPE:T
+WINGSPAN:30
+BLOCKS:A3
+STAND:EKCH:A2:N055.37.42.000:E012.38.33.000:30
+MANUAL
+STAND:EKCH:A3:N055.37.43.000:E012.38.34.000:30
+MANUAL
+`)
+
+	result := registry.EvaluateCompatibility("EKCH", compatibilityFacts())
+	assert.Empty(t, result.Matches, "no one variant contains the required border, WTC, engine, and wingspan facts")
+	assert.Contains(t, rejectionCapabilities(result, "A1"), StandCapabilityBorder)
+	assert.Contains(t, rejectionCapabilities(result, "A1"), StandCapabilityWTC)
+	assert.Contains(t, rejectionCapabilities(result, "A1"), StandCapabilityEngineType)
+	assert.Contains(t, rejectionCapabilities(result, "A1"), StandCapabilityWingspan)
+}
+
+func TestEvaluateStandCompatibilityCapabilityMatrix(t *testing.T) {
+	base := compatibilityFacts()
+	for _, test := range []struct {
+		name       string
+		directive  string
+		facts      FlightCompatibilityFacts
+		capability StandCompatibilityCapability
+	}{
+		{"schengen rejects non-schengen", "SCHENGEN", withBorder(base, BorderStatusNonSchengen), StandCapabilityBorder},
+		{"non-schengen rejects schengen", "NON-SCHENGEN", withBorder(base, BorderStatusSchengen), StandCapabilityBorder},
+		{"WTC allow", "WTC:H", base, StandCapabilityWTC},
+		{"WTC deny", "NOTWTC:M", base, StandCapabilityWTC},
+		{"engine allow", "ENGINETYPE:T", base, StandCapabilityEngineType},
+		{"engine deny", "NOTENGINETYPE:J", base, StandCapabilityEngineType},
+		{"wingspan", "WINGSPAN:35", base, StandCapabilityWingspan},
+		{"length", "LENGTH:35", base, StandCapabilityLength},
+		{"height", "HEIGHT:10", base, StandCapabilityHeight},
+		{"MTOW", "MTOW:70000", base, StandCapabilityMTOW},
+		{"code", "CODE:B", base, StandCapabilityCode},
+		{"aircraft allow GR wildcard", "ATYP:B7*", base, StandCapabilityAircraftType},
+		{"aircraft deny GR wildcard", "NOTATYP:A?0N", base, StandCapabilityAircraftType},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			registry := compatibilityRegistry(t, standRecord("A1", test.directive))
+			result := registry.EvaluateCompatibility("EKCH", test.facts)
+			assert.Empty(t, result.Matches)
+			assert.Contains(t, rejectionCapabilities(result, "A1"), test.capability)
+		})
+	}
+}
+
+func TestEvaluateStandCompatibilitySupportsGRWildcardPatterns(t *testing.T) {
+	registry := compatibilityRegistry(t, standRecord("A1", "ATYP:A*0?"))
+	result := registry.EvaluateCompatibility("EKCH", compatibilityFacts())
+	require.Len(t, result.Matches, 1)
+	assert.Empty(t, result.Rejections)
+}
+
+func TestEvaluateStandCompatibilityIgnoresGRPreferenceDirectives(t *testing.T) {
+	registry := compatibilityRegistry(t, `
+STAND:EKCH:A1:N055.37.42.710:E012.38.33.450:30
+WTC:M
+PRIORITY:-99
+USE:ARR
+CALLSIGN:ZZZ
+NOTCALLSIGN:A20
+ROUTE:NEVER
+`)
+
+	result := registry.EvaluateCompatibility("EKCH", compatibilityFacts())
+	require.Len(t, result.Matches, 1)
+	assert.Equal(t, "A1", result.Matches[0].Stand.Name)
+	assert.Empty(t, result.Rejections)
+}
+
+func TestEvaluateStandCompatibilityRejectsUnknownFactsOnlyWhenRestricted(t *testing.T) {
+	unknown := FlightCompatibilityFacts{
+		EngineType:   EngineUnknown,
+		WTC:          "UNKNOWN",
+		BorderStatus: BorderStatusUnknown,
+	}
+
+	unrestricted := compatibilityRegistry(t, standRecord("A1", ""))
+	assert.Len(t, unrestricted.EvaluateCompatibility("EKCH", unknown).Matches, 1)
+
+	for _, directive := range []string{
+		"SCHENGEN", "WTC:M", "NOTWTC:H", "ENGINETYPE:J", "NOTENGINETYPE:T",
+		"ATYP:A20N", "NOTATYP:B738", "WINGSPAN:40", "LENGTH:40", "HEIGHT:20", "MTOW:90000", "CODE:A",
+	} {
+		registry := compatibilityRegistry(t, standRecord("A1", directive))
+		result := registry.EvaluateCompatibility("EKCH", unknown)
+		assert.Emptyf(t, result.Matches, "directive %s must not be bypassed by unknown facts", directive)
+		assert.NotEmpty(t, result.Rejections)
+	}
+}
+
+func TestEvaluateStandCompatibilityExcludesManualVariantsButManualSelectionRetainsThem(t *testing.T) {
+	registry := compatibilityRegistry(t, standRecord("M1", "MANUAL"))
+	facts := compatibilityFacts()
+
+	automatic := registry.EvaluateCompatibility("EKCH", facts)
+	assert.Empty(t, automatic.Matches)
+	assert.Equal(t, []StandCompatibilityCapability{StandCapabilityManual}, rejectionCapabilities(automatic, "M1"))
+
+	manual := registry.EvaluateManualCompatibility("EKCH", facts)
+	require.Len(t, manual.Matches, 1)
+	assert.True(t, manual.Matches[0].Variant.Manual)
+}
+
+func TestEvaluateStandCompatibilityReturnsVariantBlocksWithoutUsingThemForFit(t *testing.T) {
+	registry := compatibilityRegistry(t, `
+STAND:EKCH:A1:N055.37.42.710:E012.38.33.450:30
+BLOCKS:A2
+STAND:EKCH:A1:N055.37.42.710:E012.38.33.450:30
+WTC:H
+BLOCKS:A3
+STAND:EKCH:A2:N055.37.42.000:E012.38.33.000:30
+MANUAL
+STAND:EKCH:A3:N055.37.43.000:E012.38.34.000:30
+MANUAL
+`)
+
+	result := registry.EvaluateCompatibility("EKCH", compatibilityFacts())
+	require.Len(t, result.Matches, 1)
+	assert.Equal(t, []string{"A2"}, result.Matches[0].Blocks)
+	assert.NotContains(t, rejectionCapabilities(result, "A1"), StandCapabilityManual)
+}
+
+func compatibilityRegistry(t *testing.T, data string) *StandCapabilityRegistry {
+	t.Helper()
+	registry, err := LoadStandCapabilities(strings.NewReader(data))
+	require.NoError(t, err)
+	return registry
+}
+
+func compatibilityFacts() FlightCompatibilityFacts {
+	return FlightCompatibilityFacts{
+		Aircraft: Aircraft{
+			Type:           "A20N",
+			WingspanMetres: 35.8,
+			LengthMetres:   37.57,
+			HeightMetres:   11.76,
+			MTOWKilograms:  79000,
+			UseCode:        AircraftUseCodeA,
+		},
+		AircraftKnown: true,
+		EngineType:    EngineJet,
+		WTC:           "M",
+		BorderStatus:  BorderStatusSchengen,
+	}
+}
+
+func withBorder(facts FlightCompatibilityFacts, status BorderStatus) FlightCompatibilityFacts {
+	facts.BorderStatus = status
+	return facts
+}
+
+func standRecord(name, directive string) string {
+	if directive != "" {
+		directive += "\n"
+	}
+	return "STAND:EKCH:" + name + ":N055.37.42.710:E012.38.33.450:30\n" + directive
+}
+
+func rejectionCapabilities(result StandCompatibilityEvaluation, stand string) []StandCompatibilityCapability {
+	resultCapabilities := make([]StandCompatibilityCapability, 0)
+	for _, rejection := range result.Rejections {
+		if rejection.Stand == stand {
+			resultCapabilities = append(resultCapabilities, rejection.Capability)
+		}
+	}
+	return resultCapabilities
+}


### PR DESCRIPTION
## What changed

Adds the SAT stand-compatibility evaluator that evaluates each complete GRPlugin stand variant before any airline preference or allocation logic.

- Enforces border status, aircraft type patterns, WTC, engine type, dimensions, MTOW, and aircraft-use code limits.
- Returns compatible physical stands with their matched variant and variant-specific blocking relationships.
- Returns structured capability-level rejection reasons and keeps MANUAL variants available for explicit manual evaluation.
- Extends stand capability parsing with MTOW support.

## Why

Physical fit and operational border constraints must be established before weighted airline selection and transactional occupancy handling. Keeping variants whole prevents directives from separate duplicate stand records being combined accidentally.

## Validation

- `go test ./internal/sat -count=1`
- `go vet ./internal/sat`
- `go test ./...` (all Docker-backed suites passed)

The only remaining full-suite failure is the pre-existing `internal/cdm` test `TestSequenceService_RecalculateAirport_TreatsMidnightAsBaseTime`, which reports an empty TSAT for the midnight case and is unrelated to this PR.
