### PR TITLE
feat(vatsim): expand feed cache snapshots

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -87,7 +87,7 @@ func main() {
 		EnableDBSeed:             true,
 	}, app.Dependencies{
 		VATSIMStatusURL:      getEnv("VATSIM_STATUS_URL", ""),
-		VATSIMPollInterval:   envDuration("VATSIM_POLL_INTERVAL", 30*time.Second),
+		VATSIMPollInterval:   envDuration("VATSIM_POLL_INTERVAL", 15*time.Second),
 		TransceiversURL:      getEnv("VATSIM_TRANSCEIVERS_URL", ""),
 		TransceiversInterval: envDuration("VATSIM_TRANSCEIVER_POLL_INTERVAL", 30*time.Second),
 	})

--- a/backend/internal/vatsim/cache.go
+++ b/backend/internal/vatsim/cache.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -12,13 +13,101 @@ import (
 
 const (
 	defaultStatusURL       = "https://status.vatsim.net/status.json"
-	defaultRefreshInterval = 30 * time.Second
+	defaultRefreshInterval = 15 * time.Second
 	defaultHTTPTimeout     = 10 * time.Second
 )
 
-type Pilot struct {
-	CID      string
-	Callsign string
+// FlightState identifies whether VATSIM reported the flight as connected or
+// merely prefiled in the current network-data snapshot.
+type FlightState string
+
+const (
+	FlightStateOnline  FlightState = "online"
+	FlightStatePrefile FlightState = "prefile"
+)
+
+// FlightPlan contains the parts of a VATSIM flight plan used by downstream
+// consumers. EOBT and EnrouteDuration retain the feed's HHMM representation.
+type FlightPlan struct {
+	FlightRules     string
+	Aircraft        string
+	AircraftFAA     string
+	AircraftShort   string
+	Origin          string
+	Destination     string
+	Alternate       string
+	EOBT            string
+	EnrouteDuration string
+	Remarks         string
+	Route           string
+	AssignedSquawk  string
+	Revision        int64
+}
+
+// Flight is one immutable, normalized VATSIM pilot or prefile record.
+type Flight struct {
+	CID         string
+	Callsign    string
+	State       FlightState
+	Latitude    float64
+	Longitude   float64
+	Altitude    int
+	Groundspeed int
+	LogonTime   time.Time
+	LastUpdated time.Time
+	FlightPlan  FlightPlan
+}
+
+// Online reports whether the flight is currently connected to VATSIM.
+func (f Flight) Online() bool {
+	return f.State == FlightStateOnline
+}
+
+// Prefile reports whether the flight is an offline VATSIM prefile.
+func (f Flight) Prefile() bool {
+	return f.State == FlightStatePrefile
+}
+
+// Snapshot is a read-only view of a single VATSIM feed generation. The lookup
+// methods return values, so callers cannot mutate cache state.
+type Snapshot struct {
+	Timestamp        time.Time
+	Age              time.Duration
+	LastRefreshError error
+
+	flightsByCallsign map[string]Flight
+	flightsByCID      map[string]Flight
+}
+
+// FlightByCallsign retrieves either an online pilot or prefile by normalized
+// callsign.
+func (s Snapshot) FlightByCallsign(callsign string) (Flight, bool) {
+	flight, ok := s.flightsByCallsign[normalizeCallsign(callsign)]
+	return flight, ok
+}
+
+// FlightByCID retrieves either an online pilot or prefile by VATSIM CID.
+func (s Snapshot) FlightByCID(cid string) (Flight, bool) {
+	flight, ok := s.flightsByCID[strings.TrimSpace(cid)]
+	return flight, ok
+}
+
+// Flights returns the snapshot records sorted by callsign.
+func (s Snapshot) Flights() []Flight {
+	flights := make([]Flight, 0, len(s.flightsByCallsign))
+	for _, flight := range s.flightsByCallsign {
+		flights = append(flights, flight)
+	}
+	slices.SortFunc(flights, func(left, right Flight) int {
+		return strings.Compare(left.Callsign, right.Callsign)
+	})
+	return flights
+}
+
+type cacheSnapshot struct {
+	timestamp         time.Time
+	flightsByCallsign map[string]Flight
+	flightsByCID      map[string]Flight
 }
 
 type Cache struct {
@@ -27,10 +116,9 @@ type Cache struct {
 	refreshInterval time.Duration
 
 	mu               sync.RWMutex
-	pilotsByCallsign map[string]Pilot
-	pilotsByCID      map[string]Pilot
+	snapshot         cacheSnapshot
 	dataURL          string
-	lastUpdated      time.Time
+	lastRefreshError error
 }
 
 type statusResponse struct {
@@ -40,10 +128,39 @@ type statusResponse struct {
 }
 
 type networkDataResponse struct {
-	Pilots []struct {
-		CID      int    `json:"cid"`
-		Callsign string `json:"callsign"`
-	} `json:"pilots"`
+	General struct {
+		UpdateTimestamp time.Time `json:"update_timestamp"`
+	} `json:"general"`
+	Pilots   []networkFlight `json:"pilots"`
+	Prefiles []networkFlight `json:"prefiles"`
+}
+
+type networkFlight struct {
+	CID         int64       `json:"cid"`
+	Callsign    string      `json:"callsign"`
+	Latitude    float64     `json:"latitude"`
+	Longitude   float64     `json:"longitude"`
+	Altitude    int         `json:"altitude"`
+	Groundspeed int         `json:"groundspeed"`
+	LogonTime   time.Time   `json:"logon_time"`
+	LastUpdated time.Time   `json:"last_updated"`
+	FlightPlan  *flightPlan `json:"flight_plan"`
+}
+
+type flightPlan struct {
+	FlightRules         string `json:"flight_rules"`
+	Aircraft            string `json:"aircraft"`
+	AircraftFAA         string `json:"aircraft_faa"`
+	AircraftShort       string `json:"aircraft_short"`
+	Departure           string `json:"departure"`
+	Arrival             string `json:"arrival"`
+	Alternate           string `json:"alternate"`
+	DepartureTime       string `json:"deptime"`
+	EnrouteTime         string `json:"enroute_time"`
+	Remarks             string `json:"remarks"`
+	Route               string `json:"route"`
+	RevisionID          int64  `json:"revision_id"`
+	AssignedTransponder string `json:"assigned_transponder"`
 }
 
 func NewCache(statusURL string, refreshInterval time.Duration, client *http.Client) *Cache {
@@ -58,11 +175,13 @@ func NewCache(statusURL string, refreshInterval time.Duration, client *http.Clie
 	}
 
 	return &Cache{
-		client:           client,
-		statusURL:        statusURL,
-		refreshInterval:  refreshInterval,
-		pilotsByCallsign: make(map[string]Pilot),
-		pilotsByCID:      make(map[string]Pilot),
+		client:          client,
+		statusURL:       statusURL,
+		refreshInterval: refreshInterval,
+		snapshot: cacheSnapshot{
+			flightsByCallsign: make(map[string]Flight),
+			flightsByCID:      make(map[string]Flight),
+		},
 	}
 }
 
@@ -82,6 +201,26 @@ func (c *Cache) Start(ctx context.Context) {
 	}
 }
 
+// Snapshot returns the current data and refresh health without initiating I/O.
+func (c *Cache) Snapshot() Snapshot {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	snapshot := Snapshot{
+		Timestamp:         c.snapshot.timestamp,
+		LastRefreshError:  c.lastRefreshError,
+		flightsByCallsign: c.snapshot.flightsByCallsign,
+		flightsByCID:      c.snapshot.flightsByCID,
+	}
+	if !snapshot.Timestamp.IsZero() {
+		snapshot.Age = time.Since(snapshot.Timestamp)
+		if snapshot.Age < 0 {
+			snapshot.Age = 0
+		}
+	}
+	return snapshot
+}
+
 func (c *Cache) VerifyPilotOwnsCallsign(ctx context.Context, cid string, callsign string) (bool, error) {
 	normalizedCID := strings.TrimSpace(cid)
 	normalizedCallsign := normalizeCallsign(callsign)
@@ -89,19 +228,19 @@ func (c *Cache) VerifyPilotOwnsCallsign(ctx context.Context, cid string, callsig
 		return false, nil
 	}
 
-	if pilot, ok := c.getPilot(normalizedCallsign); ok {
-		return pilot.CID == normalizedCID, nil
+	if pilot, ok := c.Snapshot().FlightByCallsign(normalizedCallsign); ok {
+		return pilot.CID == normalizedCID && pilot.Online(), nil
 	}
 
 	if err := c.refresh(ctx); err != nil {
 		return false, err
 	}
 
-	pilot, ok := c.getPilot(normalizedCallsign)
+	pilot, ok := c.Snapshot().FlightByCallsign(normalizedCallsign)
 	if !ok {
 		return false, nil
 	}
-	return pilot.CID == normalizedCID, nil
+	return pilot.CID == normalizedCID && pilot.Online(), nil
 }
 
 func (c *Cache) GetCallsignByCID(ctx context.Context, cid string) (string, bool, error) {
@@ -110,7 +249,7 @@ func (c *Cache) GetCallsignByCID(ctx context.Context, cid string) (string, bool,
 		return "", false, nil
 	}
 
-	if pilot, ok := c.getPilotByCID(normalizedCID); ok {
+	if pilot, ok := c.getOnlinePilotByCID(normalizedCID); ok {
 		return pilot.Callsign, true, nil
 	}
 
@@ -118,7 +257,7 @@ func (c *Cache) GetCallsignByCID(ctx context.Context, cid string) (string, bool,
 		return "", false, err
 	}
 
-	pilot, ok := c.getPilotByCID(normalizedCID)
+	pilot, ok := c.getOnlinePilotByCID(normalizedCID)
 	if !ok {
 		return "", false, nil
 	}
@@ -126,55 +265,148 @@ func (c *Cache) GetCallsignByCID(ctx context.Context, cid string) (string, bool,
 }
 
 func (c *Cache) refresh(ctx context.Context) error {
+	snapshot, dataURL, err := c.fetch(ctx)
+	if err != nil {
+		c.recordRefreshError(err)
+		return err
+	}
+
+	c.mu.Lock()
+	snapshot = preserveNewerFlightPlans(c.snapshot, snapshot)
+	c.snapshot = snapshot
+	c.dataURL = dataURL
+	c.lastRefreshError = nil
+	c.mu.Unlock()
+
+	return nil
+}
+
+func (c *Cache) fetch(ctx context.Context) (cacheSnapshot, string, error) {
 	dataURL, err := c.resolveDataURL(ctx)
 	if err != nil {
-		return err
+		return cacheSnapshot{}, "", err
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, dataURL, nil)
 	if err != nil {
-		return fmt.Errorf("create vatsim data request: %w", err)
+		return cacheSnapshot{}, "", fmt.Errorf("create vatsim data request: %w", err)
 	}
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("fetch vatsim network data: %w", err)
+		return cacheSnapshot{}, "", fmt.Errorf("fetch vatsim network data: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("fetch vatsim network data: unexpected status %d", resp.StatusCode)
+		return cacheSnapshot{}, "", fmt.Errorf("fetch vatsim network data: unexpected status %d", resp.StatusCode)
 	}
 
 	var payload networkDataResponse
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return fmt.Errorf("decode vatsim network data: %w", err)
+		return cacheSnapshot{}, "", fmt.Errorf("decode vatsim network data: %w", err)
 	}
 
-	pilots := make(map[string]Pilot, len(payload.Pilots))
-	pilotsByCID := make(map[string]Pilot, len(payload.Pilots))
+	now := time.Now().UTC()
+	snapshot := newCacheSnapshot(payload.General.UpdateTimestamp, now)
 	for _, pilot := range payload.Pilots {
-		callsign := normalizeCallsign(pilot.Callsign)
-		if callsign == "" {
+		snapshot.add(toFlight(pilot, FlightStateOnline))
+	}
+	for _, prefile := range payload.Prefiles {
+		snapshot.add(toFlight(prefile, FlightStatePrefile))
+	}
+	return snapshot, dataURL, nil
+}
+
+func newCacheSnapshot(timestamp time.Time, receivedAt time.Time) cacheSnapshot {
+	if timestamp.IsZero() {
+		timestamp = receivedAt
+	}
+	return cacheSnapshot{
+		timestamp:         timestamp.UTC(),
+		flightsByCallsign: make(map[string]Flight),
+		flightsByCID:      make(map[string]Flight),
+	}
+}
+
+func (s *cacheSnapshot) add(flight Flight) {
+	if flight.CID == "" || flight.Callsign == "" {
+		return
+	}
+
+	if current, ok := s.flightsByCallsign[flight.Callsign]; ok && !preferFlight(flight, current) {
+		return
+	}
+	s.flightsByCallsign[flight.Callsign] = flight
+}
+
+func preserveNewerFlightPlans(current, next cacheSnapshot) cacheSnapshot {
+	for callsign, nextFlight := range next.flightsByCallsign {
+		currentFlight, ok := current.flightsByCallsign[callsign]
+		if !ok || currentFlight.CID != nextFlight.CID || currentFlight.FlightPlan.Revision <= nextFlight.FlightPlan.Revision {
 			continue
 		}
-
-		entry := Pilot{
-			CID:      fmt.Sprintf("%d", pilot.CID),
-			Callsign: callsign,
-		}
-		pilots[callsign] = entry
-		pilotsByCID[entry.CID] = entry
+		nextFlight.FlightPlan = currentFlight.FlightPlan
+		next.flightsByCallsign[callsign] = nextFlight
 	}
 
-	c.mu.Lock()
-	c.pilotsByCallsign = pilots
-	c.pilotsByCID = pilotsByCID
-	c.dataURL = dataURL
-	c.lastUpdated = time.Now().UTC()
-	c.mu.Unlock()
+	for callsign, flight := range next.flightsByCallsign {
+		if current, ok := next.flightsByCID[flight.CID]; ok && !preferFlight(flight, current) {
+			delete(next.flightsByCallsign, callsign)
+			continue
+		}
+		next.flightsByCID[flight.CID] = flight
+	}
+	return next
+}
 
-	return nil
+func preferFlight(candidate, current Flight) bool {
+	if candidate.Online() != current.Online() {
+		return candidate.Online()
+	}
+	if candidate.FlightPlan.Revision != current.FlightPlan.Revision {
+		return candidate.FlightPlan.Revision > current.FlightPlan.Revision
+	}
+	return candidate.LastUpdated.After(current.LastUpdated)
+}
+
+func toFlight(entry networkFlight, state FlightState) Flight {
+	flight := Flight{
+		CID:         fmt.Sprintf("%d", entry.CID),
+		Callsign:    normalizeCallsign(entry.Callsign),
+		State:       state,
+		Latitude:    entry.Latitude,
+		Longitude:   entry.Longitude,
+		Altitude:    entry.Altitude,
+		Groundspeed: entry.Groundspeed,
+		LogonTime:   entry.LogonTime,
+		LastUpdated: entry.LastUpdated,
+	}
+	if entry.FlightPlan == nil {
+		return flight
+	}
+	flight.FlightPlan = FlightPlan{
+		FlightRules:     entry.FlightPlan.FlightRules,
+		Aircraft:        entry.FlightPlan.Aircraft,
+		AircraftFAA:     entry.FlightPlan.AircraftFAA,
+		AircraftShort:   entry.FlightPlan.AircraftShort,
+		Origin:          entry.FlightPlan.Departure,
+		Destination:     entry.FlightPlan.Arrival,
+		Alternate:       entry.FlightPlan.Alternate,
+		EOBT:            entry.FlightPlan.DepartureTime,
+		EnrouteDuration: entry.FlightPlan.EnrouteTime,
+		Remarks:         entry.FlightPlan.Remarks,
+		Route:           entry.FlightPlan.Route,
+		AssignedSquawk:  entry.FlightPlan.AssignedTransponder,
+		Revision:        entry.FlightPlan.RevisionID,
+	}
+	return flight
+}
+
+func (c *Cache) recordRefreshError(err error) {
+	c.mu.Lock()
+	c.lastRefreshError = err
+	c.mu.Unlock()
 }
 
 func (c *Cache) resolveDataURL(ctx context.Context) (string, error) {
@@ -205,20 +437,9 @@ func (c *Cache) resolveDataURL(ctx context.Context) (string, error) {
 	return payload.Data.V3[0], nil
 }
 
-func (c *Cache) getPilot(callsign string) (Pilot, bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	pilot, ok := c.pilotsByCallsign[callsign]
-	return pilot, ok
-}
-
-func (c *Cache) getPilotByCID(cid string) (Pilot, bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	pilot, ok := c.pilotsByCID[cid]
-	return pilot, ok
+func (c *Cache) getOnlinePilotByCID(cid string) (Flight, bool) {
+	pilot, ok := c.Snapshot().FlightByCID(cid)
+	return pilot, ok && pilot.Online()
 }
 
 func normalizeCallsign(callsign string) string {

--- a/backend/internal/vatsim/cache_test.go
+++ b/backend/internal/vatsim/cache_test.go
@@ -2,64 +2,211 @@ package vatsim
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCacheVerifyPilotOwnsCallsign(t *testing.T) {
-	dataServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"pilots":[{"cid":1234567,"callsign":"dal123"}]}`))
-	}))
-	defer dataServer.Close()
+	t.Parallel()
 
-	statusServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":{"v3":["` + dataServer.URL + `"]}}`))
-	}))
-	defer statusServer.Close()
-
-	cache := NewCache(statusServer.URL, time.Second, dataServer.Client())
+	cache, _ := newTestCache(t, `{"pilots":[{"cid":1234567,"callsign":"dal123"}]}`)
 
 	ok, err := cache.VerifyPilotOwnsCallsign(context.Background(), "1234567", "DAL123")
-	if err != nil {
-		t.Fatalf("VerifyPilotOwnsCallsign returned error: %v", err)
-	}
-	if !ok {
-		t.Fatal("expected callsign ownership verification to succeed")
-	}
+	require.NoError(t, err)
+	assert.True(t, ok)
 
 	ok, err = cache.VerifyPilotOwnsCallsign(context.Background(), "7654321", "DAL123")
-	if err != nil {
-		t.Fatalf("VerifyPilotOwnsCallsign returned error: %v", err)
-	}
-	if ok {
-		t.Fatal("expected callsign ownership verification to fail for wrong CID")
-	}
+	require.NoError(t, err)
+	assert.False(t, ok)
 }
 
 func TestCacheVerifyPilotOwnsCallsignReturnsFalseForUnknownPilot(t *testing.T) {
+	t.Parallel()
+
+	cache, _ := newTestCache(t, `{"pilots":[]}`)
+
+	ok, err := cache.VerifyPilotOwnsCallsign(context.Background(), "1234567", "DAL123")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestCacheSnapshotDecodesPilotsAndPrefiles(t *testing.T) {
+	t.Parallel()
+
+	cache, _ := newTestCache(t, `{
+  "general":{"update_timestamp":"2020-07-12T10:00:00Z"},
+  "pilots":[{
+    "cid":1234567,"callsign":"dal123","latitude":55.618,"longitude":12.656,"altitude":34000,"groundspeed":456,
+    "logon_time":"2026-07-12T08:00:00Z","last_updated":"2026-07-12T09:59:50Z",
+    "flight_plan":{"flight_rules":"I","aircraft":"A320/M-SDE2E3FGHIJ1RWXYZ/LB1","aircraft_faa":"A320/L","aircraft_short":"A320","departure":"EKCH","arrival":"EGLL","alternate":"EGKK","deptime":"0815","enroute_time":"0145","remarks":"PBN/B2","route":"DCT LAM","revision_id":4,"assigned_transponder":"1234"}
+  }],
+  "prefiles":[{
+    "cid":7654321,"callsign":" sas456 ","last_updated":"2026-07-12T09:58:00Z",
+    "flight_plan":{"flight_rules":"V","aircraft":"C172/L-S","aircraft_faa":"C172/L","aircraft_short":"C172","departure":"EKRK","arrival":"EKCH","alternate":"","deptime":"1015","enroute_time":"0045","remarks":"TRAINING","route":"DCT","revision_id":2,"assigned_transponder":"7000"}
+  }]
+}`)
+
+	require.NoError(t, cache.refresh(context.Background()))
+	snapshot := cache.Snapshot()
+
+	assert.Equal(t, time.Date(2020, 7, 12, 10, 0, 0, 0, time.UTC), snapshot.Timestamp)
+	assert.Greater(t, snapshot.Age, time.Duration(0))
+	assert.NoError(t, snapshot.LastRefreshError)
+
+	pilot, ok := snapshot.FlightByCallsign(" DAL123 ")
+	require.True(t, ok)
+	assert.True(t, pilot.Online())
+	assert.False(t, pilot.Prefile())
+	assert.Equal(t, "1234567", pilot.CID)
+	assert.Equal(t, 55.618, pilot.Latitude)
+	assert.Equal(t, 12.656, pilot.Longitude)
+	assert.Equal(t, 34000, pilot.Altitude)
+	assert.Equal(t, 456, pilot.Groundspeed)
+	assert.Equal(t, time.Date(2026, 7, 12, 8, 0, 0, 0, time.UTC), pilot.LogonTime)
+	assert.Equal(t, time.Date(2026, 7, 12, 9, 59, 50, 0, time.UTC), pilot.LastUpdated)
+	assert.Equal(t, FlightPlan{
+		FlightRules: "I", Aircraft: "A320/M-SDE2E3FGHIJ1RWXYZ/LB1", AircraftFAA: "A320/L", AircraftShort: "A320",
+		Origin: "EKCH", Destination: "EGLL", Alternate: "EGKK", EOBT: "0815", EnrouteDuration: "0145",
+		Remarks: "PBN/B2", Route: "DCT LAM", AssignedSquawk: "1234", Revision: 4,
+	}, pilot.FlightPlan)
+
+	prefile, ok := snapshot.FlightByCID("7654321")
+	require.True(t, ok)
+	assert.Equal(t, "SAS456", prefile.Callsign)
+	assert.True(t, prefile.Prefile())
+	assert.False(t, prefile.Online())
+	assert.True(t, prefile.LogonTime.IsZero())
+	assert.Equal(t, "EKRK", prefile.FlightPlan.Origin)
+	assert.Equal(t, "EKCH", prefile.FlightPlan.Destination)
+	assert.Equal(t, "7000", prefile.FlightPlan.AssignedSquawk)
+}
+
+func TestCacheSnapshotRetainsFlightsWithoutFlightPlans(t *testing.T) {
+	t.Parallel()
+
+	cache, _ := newTestCache(t, `{"pilots":[{"cid":1234567,"callsign":"DAL123"}],"prefiles":[{"cid":7654321,"callsign":"SAS456"}]}`)
+	require.NoError(t, cache.refresh(context.Background()))
+
+	snapshot := cache.Snapshot()
+	pilot, ok := snapshot.FlightByCallsign("DAL123")
+	require.True(t, ok)
+	assert.Equal(t, FlightPlan{}, pilot.FlightPlan)
+	prefile, ok := snapshot.FlightByCallsign("SAS456")
+	require.True(t, ok)
+	assert.Equal(t, FlightPlan{}, prefile.FlightPlan)
+}
+
+func TestCacheSnapshotPrefersOnlinePilotForDuplicateCallsign(t *testing.T) {
+	t.Parallel()
+
+	cache, _ := newTestCache(t, `{
+  "pilots":[{"cid":1234567,"callsign":"DAL123","altitude":15000,"flight_plan":{"route":"ONLINE","revision_id":1}}],
+  "prefiles":[{"cid":7654321,"callsign":" dal123 ","flight_plan":{"route":"PREFILE","revision_id":9}}]
+}`)
+	require.NoError(t, cache.refresh(context.Background()))
+
+	flights := cache.Snapshot().Flights()
+	require.Len(t, flights, 1)
+	assert.Equal(t, "1234567", flights[0].CID)
+	assert.True(t, flights[0].Online())
+	assert.Equal(t, "ONLINE", flights[0].FlightPlan.Route)
+}
+
+func TestCacheSnapshotDoesNotMoveFlightPlanRevisionBackward(t *testing.T) {
+	t.Parallel()
+
+	cache, payload := newTestCache(t, `{"pilots":[{"cid":1234567,"callsign":"DAL123","altitude":30000,"flight_plan":{"route":"NEW","revision_id":5}}]}`)
+	require.NoError(t, cache.refresh(context.Background()))
+
+	payload.Store(`{"pilots":[{"cid":1234567,"callsign":"DAL123","altitude":31000,"flight_plan":{"route":"STALE","revision_id":4}}]}`)
+	require.NoError(t, cache.refresh(context.Background()))
+
+	flight, ok := cache.Snapshot().FlightByCallsign("DAL123")
+	require.True(t, ok)
+	assert.Equal(t, 31000, flight.Altitude, "fresh position data should still be retained")
+	assert.Equal(t, int64(5), flight.FlightPlan.Revision)
+	assert.Equal(t, "NEW", flight.FlightPlan.Route)
+}
+
+func TestCacheSnapshotKeepsLastGoodDataAfterFailedRefreshAndRecovers(t *testing.T) {
+	t.Parallel()
+
+	cache, payload := newTestCache(t, `{"general":{"update_timestamp":"2026-07-12T10:00:00Z"},"pilots":[{"cid":1234567,"callsign":"DAL123","flight_plan":{"revision_id":1}}]}`)
+	require.NoError(t, cache.refresh(context.Background()))
+	beforeFailure := cache.Snapshot()
+
+	payload.Store("FAIL")
+	err := cache.refresh(context.Background())
+	require.Error(t, err)
+	afterFailure := cache.Snapshot()
+	assert.Equal(t, beforeFailure.Timestamp, afterFailure.Timestamp)
+	_, ok := afterFailure.FlightByCallsign("DAL123")
+	assert.True(t, ok)
+	assert.Error(t, afterFailure.LastRefreshError)
+
+	payload.Store(`{"general":{"update_timestamp":"2026-07-12T10:00:15Z"},"pilots":[{"cid":1234567,"callsign":"DAL123","flight_plan":{"revision_id":2}}]}`)
+	require.NoError(t, cache.refresh(context.Background()))
+	afterRecovery := cache.Snapshot()
+	assert.Equal(t, time.Date(2026, 7, 12, 10, 0, 15, 0, time.UTC), afterRecovery.Timestamp)
+	assert.NoError(t, afterRecovery.LastRefreshError)
+	flight, ok := afterRecovery.FlightByCallsign("DAL123")
+	require.True(t, ok)
+	assert.Equal(t, int64(2), flight.FlightPlan.Revision)
+}
+
+func TestCacheSnapshotConcurrentReadersDuringReplacement(t *testing.T) {
+	cache, payload := newTestCache(t, `{"pilots":[{"cid":1234567,"callsign":"DAL123","flight_plan":{"revision_id":1}}]}`)
+	require.NoError(t, cache.refresh(context.Background()))
+
+	var readers sync.WaitGroup
+	for range 8 {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for range 200 {
+				snapshot := cache.Snapshot()
+				_, _ = snapshot.FlightByCallsign("DAL123")
+				_, _ = snapshot.FlightByCID("1234567")
+				_ = snapshot.Flights()
+			}
+		}()
+	}
+
+	for revision := 2; revision < 202; revision++ {
+		payload.Store(fmt.Sprintf(`{"pilots":[{"cid":1234567,"callsign":"DAL123","altitude":%d,"flight_plan":{"revision_id":%d}}]}`, revision, revision))
+		require.NoError(t, cache.refresh(context.Background()))
+	}
+	readers.Wait()
+}
+
+func newTestCache(t *testing.T, initialPayload string) (*Cache, *atomic.Value) {
+	t.Helper()
+
+	var payload atomic.Value
+	payload.Store(initialPayload)
 	dataServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if payload.Load().(string) == "FAIL" {
+			http.Error(w, "temporarily unavailable", http.StatusServiceUnavailable)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"pilots":[]}`))
+		_, _ = w.Write([]byte(payload.Load().(string)))
 	}))
-	defer dataServer.Close()
+	t.Cleanup(dataServer.Close)
 
 	statusServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"v3":["` + dataServer.URL + `"]}}`))
 	}))
-	defer statusServer.Close()
+	t.Cleanup(statusServer.Close)
 
-	cache := NewCache(statusServer.URL, time.Second, dataServer.Client())
-
-	ok, err := cache.VerifyPilotOwnsCallsign(context.Background(), "1234567", "DAL123")
-	if err != nil {
-		t.Fatalf("VerifyPilotOwnsCallsign returned error: %v", err)
-	}
-	if ok {
-		t.Fatal("expected callsign ownership verification to fail for unknown pilot")
-	}
+	return NewCache(statusServer.URL, time.Second, dataServer.Client()), &payload
 }


### PR DESCRIPTION
## Summary
- Expand the VATSIM V3 cache to expose immutable pilot and prefile snapshots indexed by callsign and CID.
- Retain flight-plan, position, timing, state, revision, snapshot-age, and refresh-error data while preserving live ownership verification behavior.
- Poll at the VATSIM 15-second feed generation interval and cover decoding, stale-revision, refresh recovery, and concurrent-reader behavior.

## Validation
- `go test ./internal/vatsim`
- `go test -race ./internal/vatsim`
- `go test ./internal/app ./internal/pilot`
- `go test ./...` (all packages except pre-existing `internal/cdm` failure: `TestSequenceService_RecalculateAirport_TreatsMidnightAsBaseTime` returns an empty TSAT; the CDM package is unchanged from `origin/main`.)