### PR TITLE
fix(cdm): stabilize midnight sequence recalculation test

### DIFF
--- a/backend/internal/cdm/sequence.go
+++ b/backend/internal/cdm/sequence.go
@@ -38,6 +38,7 @@ type SequenceService struct {
 	frontendHub    shared.FrontendHub
 	euroscopeHub   shared.EuroscopeHub
 	afterPersist   func(ctx context.Context, session int32, callsign string)
+	now            func() time.Time
 }
 
 func NewSequenceService(stripRepo CdmSequenceStripStore, sessionRepo repository.SessionRepository, configProvider ConfigProvider, frontendHub shared.FrontendHub, euroscopeHub shared.EuroscopeHub) *SequenceService {
@@ -47,6 +48,7 @@ func NewSequenceService(stripRepo CdmSequenceStripStore, sessionRepo repository.
 		configProvider: configProvider,
 		frontendHub:    frontendHub,
 		euroscopeHub:   euroscopeHub,
+		now:            time.Now,
 	}
 }
 
@@ -105,7 +107,7 @@ func (s *SequenceService) recalculateAirport(ctx context.Context, session int32,
 		}
 	}
 	config = config.SnapshotWithRunways(sessionData.ActiveRunways.ArrivalRunways, sessionData.ActiveRunways.DepartureRunways)
-	now := time.Now().UTC()
+	now := s.now().UTC()
 	nowHHMMSS := timeToClock(now)
 
 	candidates := make([]sequencingCandidate, 0, len(strips))

--- a/backend/internal/cdm/sequence_test.go
+++ b/backend/internal/cdm/sequence_test.go
@@ -759,6 +759,9 @@ func TestSequenceService_RecalculateAirport_TreatsMidnightAsBaseTime(t *testing.
 	}
 
 	service := NewSequenceService(stripRepo, sessionRepo, NewCdmConfigStore("", "", "", 0, CdmConfigDefaults{}, nil), &testutil.MockFrontendHub{}, &testutil.MockEuroscopeHub{})
+	service.now = func() time.Time {
+		return time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	}
 
 	if err := service.RecalculateAirport(context.Background(), 7, "EKCH"); err != nil {
 		t.Fatalf("RecalculateAirport returned error: %v", err)


### PR DESCRIPTION
## Summary

- Inject the clock used by airport sequence recalculation.
- Pin the midnight-base regression test to exactly midnight.

## Root cause

The test used a `0000` TOBT while recalculation read the real wall clock. Outside the midnight window, stale-TOBT handling cleared the calculated times before the assertion.

## Impact

The regression test now verifies midnight handling deterministically; production continues to use `time.Now`.

## Validation

- `go test ./internal/cdm -count=1`
