### PR TITLE
feat(vatsim): reconcile flights into sessions

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -110,6 +110,10 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	sectorRepo := postgres.NewSectorOwnerRepository(dbpool)
 	coordRepo := postgres.NewCoordinationRepository(dbpool)
 	tacticalStripRepo := postgres.NewTacticalStripRepository(dbpool)
+	var standAssignmentRepo repository.StandAssignmentRepository
+	if standAssignmentReadiness.Ready {
+		standAssignmentRepo = postgres.NewStandAssignmentRepository(dbpool)
+	}
 
 	stripService := services.NewStripService(
 		stripRepo,
@@ -128,7 +132,7 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 
 	pdcService := buildPDCService(cfg, deps.PDCClient, sessionRepo, stripRepo, sectorRepo, controllerRepo)
 	requireLiveCIDVerification := isLiveEnvironment(cfg.Environment)
-	vatsimCache := buildVATSIMCache(cfg, deps, requireLiveCIDVerification)
+	vatsimCache := buildVATSIMCache(cfg, deps, requireLiveCIDVerification, standAssignmentReadiness.Ready)
 
 	var fsServer *server.Server
 	var transceiverCache *vatsim.TransceiverCache
@@ -151,6 +155,11 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 
 	frontendHub := frontend.NewHub(stripService, authService)
 	euroscopeHub := euroscope.NewHub(stripService, controllerService, authService)
+	var vatsimReconciler *vatsim.Reconciler
+	if standAssignmentReadiness.Ready && vatsimCache != nil && standAssignmentRepo != nil {
+		vatsimReconciler = vatsim.NewReconciler(vatsimCache, sessionRepo, stripRepo, standAssignmentRepo, frontendHub, deps.VATSIMPollInterval)
+		euroscopeHub.SetAircraftDisconnectRetainer(vatsimReconciler.RetainsStrip)
+	}
 	albHub := alb.NewHub()
 	ecfmpService := ecfmp.NewService(ecfmp.NewClient(ecfmp.WithBaseURL(cfg.ECFMPBaseURL)), stripRepo, sessionRepo, frontendHub, euroscopeHub)
 
@@ -219,6 +228,9 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	}
 	if cfg.EnableVATSIM && vatsimCache != nil {
 		app.addWorker(vatsimCache.Start)
+	}
+	if vatsimReconciler != nil {
+		app.addWorker(vatsimReconciler.Start)
 	}
 	if transceiverCache != nil {
 		app.addWorker(transceiverCache.Start)
@@ -360,13 +372,13 @@ func buildPDCService(
 	return service
 }
 
-func buildVATSIMCache(cfg Config, deps Dependencies, requireLiveCIDVerification bool) *vatsim.Cache {
-	if !cfg.EnableVATSIM || !requireLiveCIDVerification {
+func buildVATSIMCache(cfg Config, deps Dependencies, requireLiveCIDVerification bool, enableReconciliation bool) *vatsim.Cache {
+	if !cfg.EnableVATSIM || (!requireLiveCIDVerification && !enableReconciliation) {
 		return nil
 	}
 
 	cache := vatsim.NewCache(deps.VATSIMStatusURL, deps.VATSIMPollInterval, nil)
-	slog.Info("VATSIM cache enabled for live web PDC ownership verification")
+	slog.Info("VATSIM cache enabled", slog.Bool("livePdcVerification", requireLiveCIDVerification), slog.Bool("standAssignmentReconciliation", enableReconciliation))
 	return cache
 }
 

--- a/backend/internal/database/models.go
+++ b/backend/internal/database/models.go
@@ -156,6 +156,10 @@ type Strip struct {
 	ValidationStatus         []byte
 	StartReq                 bool
 	SpokenCallsign           *string
+	VatsimCid                *string
+	VatsimRevision           *int64
+	VatsimSeenAt             pgtype.Timestamptz
+	EuroscopeSeenAt          pgtype.Timestamptz
 }
 
 type TacticalStrip struct {

--- a/backend/internal/database/strips.sql.go
+++ b/backend/internal/database/strips.sql.go
@@ -7,6 +7,8 @@ package database
 
 import (
 	"context"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 const appendControllerModifiedField = `-- name: AppendControllerModifiedField :exec
@@ -40,6 +42,22 @@ type AppendUnexpectedChangeFieldParams struct {
 
 func (q *Queries) AppendUnexpectedChangeField(ctx context.Context, arg AppendUnexpectedChangeFieldParams) error {
 	_, err := q.db.Exec(ctx, appendUnexpectedChangeField, arg.Session, arg.Callsign, arg.ArrayAppend)
+	return err
+}
+
+const clearStripEuroscopeSeen = `-- name: ClearStripEuroscopeSeen :exec
+UPDATE strips
+SET euroscope_seen_at = NULL
+WHERE callsign = $1 AND session = $2
+`
+
+type ClearStripEuroscopeSeenParams struct {
+	Callsign string
+	Session  int32
+}
+
+func (q *Queries) ClearStripEuroscopeSeen(ctx context.Context, arg ClearStripEuroscopeSeenParams) error {
+	_, err := q.db.Exec(ctx, clearStripEuroscopeSeen, arg.Callsign, arg.Session)
 	return err
 }
 
@@ -295,7 +313,7 @@ func (q *Queries) GetSequence(ctx context.Context, arg GetSequenceParams) (int32
 }
 
 const getStrip = `-- name: GetStrip :one
-SELECT id, version, callsign, session, origin, destination, alternative, route, remarks, assigned_squawk, squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities, communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay, position_latitude, position_longitude, position_altitude, next_owners, previous_owners, release_point, marked, registration, tracking_controller, runway_cleared, unexpected_change_fields, controller_modified_fields, engine_type, is_manual, persons_on_board, fpl_type, language, has_fp, cdm_data, runway_confirmed, pdc_data, validation_status, start_req, spoken_callsign
+SELECT id, version, callsign, session, origin, destination, alternative, route, remarks, assigned_squawk, squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities, communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay, position_latitude, position_longitude, position_altitude, next_owners, previous_owners, release_point, marked, registration, tracking_controller, runway_cleared, unexpected_change_fields, controller_modified_fields, engine_type, is_manual, persons_on_board, fpl_type, language, has_fp, cdm_data, runway_confirmed, pdc_data, validation_status, start_req, spoken_callsign, vatsim_cid, vatsim_revision, vatsim_seen_at, euroscope_seen_at
 FROM strips
 WHERE callsign = $1 AND session = $2
 `
@@ -359,6 +377,10 @@ func (q *Queries) GetStrip(ctx context.Context, arg GetStripParams) (Strip, erro
 		&i.ValidationStatus,
 		&i.StartReq,
 		&i.SpokenCallsign,
+		&i.VatsimCid,
+		&i.VatsimRevision,
+		&i.VatsimSeenAt,
+		&i.EuroscopeSeenAt,
 	)
 	return i, err
 }
@@ -368,7 +390,8 @@ INSERT INTO strips (version, callsign, session, origin, destination, alternative
                      squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities,
                      communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay,
                      position_latitude, position_longitude, position_altitude, cdm_data, next_owners, previous_owners,
-                     registration, tracking_controller, engine_type, spoken_callsign, has_fp, start_req)
+                     registration, tracking_controller, engine_type, spoken_callsign, has_fp, start_req,
+                     vatsim_cid, vatsim_revision, vatsim_seen_at, euroscope_seen_at)
 VALUES (
     1,
     $1,
@@ -406,7 +429,11 @@ VALUES (
     $33,
     $34,
     $35,
-    $36
+    $36,
+    $37,
+    $38,
+    $39,
+    $40
 )
 `
 
@@ -447,6 +474,10 @@ type InsertStripParams struct {
 	SpokenCallsign     *string
 	HasFp              bool
 	StartReq           bool
+	VatsimCid          *string
+	VatsimRevision     *int64
+	VatsimSeenAt       pgtype.Timestamptz
+	EuroscopeSeenAt    pgtype.Timestamptz
 }
 
 func (q *Queries) InsertStrip(ctx context.Context, arg InsertStripParams) error {
@@ -487,6 +518,10 @@ func (q *Queries) InsertStrip(ctx context.Context, arg InsertStripParams) error 
 		arg.SpokenCallsign,
 		arg.HasFp,
 		arg.StartReq,
+		arg.VatsimCid,
+		arg.VatsimRevision,
+		arg.VatsimSeenAt,
+		arg.EuroscopeSeenAt,
 	)
 	return err
 }
@@ -529,7 +564,7 @@ func (q *Queries) ListStripSequences(ctx context.Context, arg ListStripSequences
 }
 
 const listStrips = `-- name: ListStrips :many
-SELECT id, version, callsign, session, origin, destination, alternative, route, remarks, assigned_squawk, squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities, communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay, position_latitude, position_longitude, position_altitude, next_owners, previous_owners, release_point, marked, registration, tracking_controller, runway_cleared, unexpected_change_fields, controller_modified_fields, engine_type, is_manual, persons_on_board, fpl_type, language, has_fp, cdm_data, runway_confirmed, pdc_data, validation_status, start_req, spoken_callsign
+SELECT id, version, callsign, session, origin, destination, alternative, route, remarks, assigned_squawk, squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities, communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay, position_latitude, position_longitude, position_altitude, next_owners, previous_owners, release_point, marked, registration, tracking_controller, runway_cleared, unexpected_change_fields, controller_modified_fields, engine_type, is_manual, persons_on_board, fpl_type, language, has_fp, cdm_data, runway_confirmed, pdc_data, validation_status, start_req, spoken_callsign, vatsim_cid, vatsim_revision, vatsim_seen_at, euroscope_seen_at
 FROM strips
 WHERE session = $1
 ORDER BY callsign
@@ -595,6 +630,10 @@ func (q *Queries) ListStrips(ctx context.Context, session int32) ([]Strip, error
 			&i.ValidationStatus,
 			&i.StartReq,
 			&i.SpokenCallsign,
+			&i.VatsimCid,
+			&i.VatsimRevision,
+			&i.VatsimSeenAt,
+			&i.EuroscopeSeenAt,
 		); err != nil {
 			return nil, err
 		}
@@ -607,7 +646,7 @@ func (q *Queries) ListStrips(ctx context.Context, session int32) ([]Strip, error
 }
 
 const listStripsByOrigin = `-- name: ListStripsByOrigin :many
-SELECT id, version, callsign, session, origin, destination, alternative, route, remarks, assigned_squawk, squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities, communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay, position_latitude, position_longitude, position_altitude, next_owners, previous_owners, release_point, marked, registration, tracking_controller, runway_cleared, unexpected_change_fields, controller_modified_fields, engine_type, is_manual, persons_on_board, fpl_type, language, has_fp, cdm_data, runway_confirmed, pdc_data, validation_status, start_req, spoken_callsign
+SELECT id, version, callsign, session, origin, destination, alternative, route, remarks, assigned_squawk, squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities, communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay, position_latitude, position_longitude, position_altitude, next_owners, previous_owners, release_point, marked, registration, tracking_controller, runway_cleared, unexpected_change_fields, controller_modified_fields, engine_type, is_manual, persons_on_board, fpl_type, language, has_fp, cdm_data, runway_confirmed, pdc_data, validation_status, start_req, spoken_callsign, vatsim_cid, vatsim_revision, vatsim_seen_at, euroscope_seen_at
 FROM strips
 WHERE origin = $1 AND session = $2
 ORDER BY callsign
@@ -678,6 +717,10 @@ func (q *Queries) ListStripsByOrigin(ctx context.Context, arg ListStripsByOrigin
 			&i.ValidationStatus,
 			&i.StartReq,
 			&i.SpokenCallsign,
+			&i.VatsimCid,
+			&i.VatsimRevision,
+			&i.VatsimSeenAt,
+			&i.EuroscopeSeenAt,
 		); err != nil {
 			return nil, err
 		}
@@ -687,6 +730,22 @@ func (q *Queries) ListStripsByOrigin(ctx context.Context, arg ListStripsByOrigin
 		return nil, err
 	}
 	return items, nil
+}
+
+const markStripEuroscopeSeen = `-- name: MarkStripEuroscopeSeen :exec
+UPDATE strips
+SET euroscope_seen_at = NOW()
+WHERE callsign = $1 AND session = $2
+`
+
+type MarkStripEuroscopeSeenParams struct {
+	Callsign string
+	Session  int32
+}
+
+func (q *Queries) MarkStripEuroscopeSeen(ctx context.Context, arg MarkStripEuroscopeSeenParams) error {
+	_, err := q.db.Exec(ctx, markStripEuroscopeSeen, arg.Callsign, arg.Session)
+	return err
 }
 
 const recalculateStripSequences = `-- name: RecalculateStripSequences :exec
@@ -998,8 +1057,12 @@ SET version = version + 1,
     has_fp = $43,
     pdc_data = $44,
     validation_status = $45,
-    start_req = $46
-WHERE callsign = $47 AND session = $48
+    start_req = $46,
+    vatsim_cid = $47,
+    vatsim_revision = $48,
+    vatsim_seen_at = $49,
+    euroscope_seen_at = $50
+WHERE callsign = $51 AND session = $52
 `
 
 type UpdateStripParams struct {
@@ -1049,6 +1112,10 @@ type UpdateStripParams struct {
 	PdcData                  []byte
 	ValidationStatus         []byte
 	StartReq                 bool
+	VatsimCid                *string
+	VatsimRevision           *int64
+	VatsimSeenAt             pgtype.Timestamptz
+	EuroscopeSeenAt          pgtype.Timestamptz
 	Callsign                 string
 	Session                  int32
 }
@@ -1101,6 +1168,10 @@ func (q *Queries) UpdateStrip(ctx context.Context, arg UpdateStripParams) (int64
 		arg.PdcData,
 		arg.ValidationStatus,
 		arg.StartReq,
+		arg.VatsimCid,
+		arg.VatsimRevision,
+		arg.VatsimSeenAt,
+		arg.EuroscopeSeenAt,
 		arg.Callsign,
 		arg.Session,
 	)
@@ -1586,6 +1657,70 @@ func (q *Queries) UpdateStripStartReqByID(ctx context.Context, arg UpdateStripSt
 		arg.Callsign,
 		arg.Session,
 		arg.Version,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateStripVatsimSource = `-- name: UpdateStripVatsimSource :execrows
+UPDATE strips
+SET
+    version = version + 1,
+    vatsim_cid = $1,
+    vatsim_revision = $2,
+    vatsim_seen_at = $3,
+    origin = CASE WHEN NOT ('origin' = ANY(controller_modified_fields)) AND (euroscope_seen_at IS NULL OR euroscope_seen_at <= $3) THEN $4 ELSE origin END,
+    destination = CASE WHEN NOT ('destination' = ANY(controller_modified_fields)) AND (euroscope_seen_at IS NULL OR euroscope_seen_at <= $3) THEN $5 ELSE destination END,
+    alternative = CASE WHEN NOT ('alternative' = ANY(controller_modified_fields)) AND (euroscope_seen_at IS NULL OR euroscope_seen_at <= $3) THEN $6 ELSE alternative END,
+    route = CASE WHEN NOT ('route' = ANY(controller_modified_fields)) AND (euroscope_seen_at IS NULL OR euroscope_seen_at <= $3) THEN $7 ELSE route END,
+    remarks = CASE WHEN NOT ('remarks' = ANY(controller_modified_fields)) AND (euroscope_seen_at IS NULL OR euroscope_seen_at <= $3) THEN $8 ELSE remarks END,
+    assigned_squawk = CASE WHEN NOT ('assigned_squawk' = ANY(controller_modified_fields)) AND (euroscope_seen_at IS NULL OR euroscope_seen_at <= $3) THEN $9 ELSE assigned_squawk END,
+    aircraft_type = CASE WHEN NOT ('aircraft_type' = ANY(controller_modified_fields)) AND (euroscope_seen_at IS NULL OR euroscope_seen_at <= $3) THEN $10 ELSE aircraft_type END,
+    position_latitude = CASE WHEN $11::boolean AND NOT ('position_latitude' = ANY(controller_modified_fields)) AND (euroscope_seen_at IS NULL OR euroscope_seen_at <= $3) THEN $12 ELSE position_latitude END,
+    position_longitude = CASE WHEN $11::boolean AND NOT ('position_longitude' = ANY(controller_modified_fields)) AND (euroscope_seen_at IS NULL OR euroscope_seen_at <= $3) THEN $13 ELSE position_longitude END,
+    position_altitude = CASE WHEN $11::boolean AND NOT ('position_altitude' = ANY(controller_modified_fields)) AND (euroscope_seen_at IS NULL OR euroscope_seen_at <= $3) THEN $14 ELSE position_altitude END
+WHERE callsign = $15 AND session = $16
+`
+
+type UpdateStripVatsimSourceParams struct {
+	VatsimCid         *string
+	VatsimRevision    *int64
+	VatsimSeenAt      pgtype.Timestamptz
+	Origin            string
+	Destination       string
+	Alternative       *string
+	Route             *string
+	Remarks           *string
+	AssignedSquawk    *string
+	AircraftType      *string
+	Online            bool
+	PositionLatitude  *float64
+	PositionLongitude *float64
+	PositionAltitude  *int32
+	Callsign          string
+	Session           int32
+}
+
+func (q *Queries) UpdateStripVatsimSource(ctx context.Context, arg UpdateStripVatsimSourceParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateStripVatsimSource,
+		arg.VatsimCid,
+		arg.VatsimRevision,
+		arg.VatsimSeenAt,
+		arg.Origin,
+		arg.Destination,
+		arg.Alternative,
+		arg.Route,
+		arg.Remarks,
+		arg.AssignedSquawk,
+		arg.AircraftType,
+		arg.Online,
+		arg.PositionLatitude,
+		arg.PositionLongitude,
+		arg.PositionAltitude,
+		arg.Callsign,
+		arg.Session,
 	)
 	if err != nil {
 		return 0, err

--- a/backend/internal/euroscope/handlers.go
+++ b/backend/internal/euroscope/handlers.go
@@ -311,7 +311,11 @@ func handlePositionUpdate(ctx context.Context, client *Client, message Message) 
 		return err
 	}
 	client.hub.cancelAircraftDisconnect(client.session, event.Callsign)
-	return client.hub.stripService.UpdateAircraftPosition(ctx, client.session, event.Callsign, event.Lat, event.Lon, int32(event.Altitude), client.airport)
+	if err := client.hub.stripService.UpdateAircraftPosition(ctx, client.session, event.Callsign, event.Lat, event.Lon, int32(event.Altitude), client.airport); err != nil {
+		return err
+	}
+	client.hub.markEuroscopeSeen(ctx, client.session, event.Callsign)
+	return nil
 }
 
 func handleTrackingControllerChanged(ctx context.Context, client *Client, message Message) error {

--- a/backend/internal/euroscope/handlers_disconnect_test.go
+++ b/backend/internal/euroscope/handlers_disconnect_test.go
@@ -111,3 +111,16 @@ func TestHandlePositionUpdate_CancelsPendingAircraftDisconnect(t *testing.T) {
 	assert.Equal(t, int32(1), stripService.positionCalls.Load(), "position update should still be processed")
 	assert.Equal(t, int32(0), stripService.deleteCalls.Load(), "cancelled disconnect timer must not delete the strip")
 }
+
+func TestAircraftDisconnectTimerRetainsStripOwnedByAnotherSource(t *testing.T) {
+	stripService := &aircraftAliveStripService{}
+	hub := newAircraftDisconnectTestHub(stripService)
+	hub.SetAircraftDisconnectRetainer(func(_ context.Context, session int32, callsign string) bool {
+		return session == 42 && callsign == "SAS808"
+	})
+
+	hub.scheduleAircraftDisconnect(42, "SAS808", 10*time.Millisecond)
+	time.Sleep(30 * time.Millisecond)
+
+	assert.Equal(t, int32(0), stripService.deleteCalls.Load(), "VATSIM or an active SAT assignment must retain the strip")
+}

--- a/backend/internal/euroscope/hub.go
+++ b/backend/internal/euroscope/hub.go
@@ -69,8 +69,9 @@ type Hub struct {
 	offlineTimers map[string]*offlineTimerEntry // key: "<sessionID>:<positionName>"
 
 	// Aircraft disconnect timer support — delays strip removal to survive master transitions
-	aircraftDisconnectMu     sync.Mutex
-	aircraftDisconnectTimers map[string]*aircraftDisconnectEntry // key: "<sessionID>:<callsign>"
+	aircraftDisconnectMu       sync.Mutex
+	aircraftDisconnectTimers   map[string]*aircraftDisconnectEntry // key: "<sessionID>:<callsign>"
+	aircraftDisconnectRetainer func(context.Context, int32, string) bool
 
 	// Session update debouncer — batches UpdateSectors/UpdateLayouts/UpdateRoutes calls
 	// so concurrent offline timers produce a single recalculation per session.
@@ -88,6 +89,26 @@ type Hub struct {
 	runwayStates  map[string]*clientRunwayState
 
 	squawkThrottle *squawkThrottle
+}
+
+// SetAircraftDisconnectRetainer installs an optional source-of-truth check
+// used by the delayed EuroScope disconnect cleanup.
+func (hub *Hub) SetAircraftDisconnectRetainer(retainer func(context.Context, int32, string) bool) {
+	hub.aircraftDisconnectMu.Lock()
+	hub.aircraftDisconnectRetainer = retainer
+	hub.aircraftDisconnectMu.Unlock()
+}
+
+func (hub *Hub) markEuroscopeSeen(ctx context.Context, session int32, callsign string) {
+	if hub.server == nil || hub.server.GetStripRepository() == nil {
+		return
+	}
+	if err := hub.server.GetStripRepository().MarkEuroscopeSeen(ctx, session, callsign); err != nil {
+		slog.WarnContext(ctx, "Failed to record EuroScope strip presence",
+			slog.String("callsign", callsign),
+			slog.Int("session", int(session)),
+			slog.Any("error", err))
+	}
 }
 
 func NewHub(stripService shared.StripService, controllerService shared.ControllerService, authenticationService shared.AuthenticationService) *Hub {

--- a/backend/internal/euroscope/hub_aircraft_disconnect.go
+++ b/backend/internal/euroscope/hub_aircraft_disconnect.go
@@ -40,7 +40,15 @@ func (hub *Hub) scheduleAircraftDisconnect(session int32, callsign string, delay
 
 		hub.aircraftDisconnectMu.Lock()
 		delete(hub.aircraftDisconnectTimers, key)
+		retainer := hub.aircraftDisconnectRetainer
 		hub.aircraftDisconnectMu.Unlock()
+		if retainer != nil && retainer(context.Background(), session, callsign) {
+			hub.clearEuroscopeSeen(session, callsign)
+			slog.Debug("Aircraft disconnect retained by another source",
+				slog.String("callsign", callsign),
+				slog.Int("session", int(session)))
+			return
+		}
 
 		slog.Debug("Aircraft disconnected, removing strip",
 			slog.String("callsign", callsign),
@@ -51,6 +59,18 @@ func (hub *Hub) scheduleAircraftDisconnect(session int32, callsign string, delay
 				slog.Any("error", err))
 		}
 	}()
+}
+
+func (hub *Hub) clearEuroscopeSeen(session int32, callsign string) {
+	if hub.server == nil || hub.server.GetStripRepository() == nil {
+		return
+	}
+	if err := hub.server.GetStripRepository().ClearEuroscopeSeen(context.Background(), session, callsign); err != nil {
+		slog.Warn("Failed to clear EuroScope strip presence after disconnect",
+			slog.String("callsign", callsign),
+			slog.Int("session", int(session)),
+			slog.Any("error", err))
+	}
 }
 
 // cancelAircraftDisconnect cancels a pending aircraft disconnect timer.

--- a/backend/internal/models/strip.go
+++ b/backend/internal/models/strip.go
@@ -7,6 +7,25 @@ type NextDisplay struct {
 	Frequency string
 }
 
+// VatsimStripSource contains the fields that the VATSIM reconciler is allowed
+// to persist. It intentionally excludes all controller-owned operational state.
+type VatsimStripSource struct {
+	CID            string
+	Revision       int64
+	SeenAt         time.Time
+	Origin         string
+	Destination    string
+	Alternate      string
+	Route          string
+	Remarks        string
+	AssignedSquawk string
+	AircraftType   string
+	Online         bool
+	Latitude       float64
+	Longitude      float64
+	Altitude       int32
+}
+
 type Strip struct {
 	ID                       int32
 	Version                  int32
@@ -64,6 +83,10 @@ type Strip struct {
 	Language                 *string
 	HasFP                    bool
 	ValidationStatus         *ValidationStatus
+	VatsimCID                *string
+	VatsimRevision           *int64
+	VatsimSeenAt             *time.Time
+	EuroscopeSeenAt          *time.Time
 }
 
 // IsValidationLocked returns true when the strip has an active validation issue

--- a/backend/internal/repository/postgres/strip.go
+++ b/backend/internal/repository/postgres/strip.go
@@ -149,6 +149,10 @@ func stripToModel(db database.Strip) (*models.Strip, error) {
 		Language:                 db.Language,
 		HasFP:                    db.HasFp,
 		ValidationStatus:         validationStatus,
+		VatsimCID:                db.VatsimCid,
+		VatsimRevision:           db.VatsimRevision,
+		VatsimSeenAt:             PgTimestamptzToTime(db.VatsimSeenAt),
+		EuroscopeSeenAt:          PgTimestamptzToTime(db.EuroscopeSeenAt),
 	}, nil
 }
 
@@ -213,6 +217,10 @@ func (r *stripRepository) Create(ctx context.Context, strip *models.Strip) error
 		SpokenCallsign:     strip.SpokenCallsign,
 		HasFp:              strip.HasFP,
 		StartReq:           strip.StartReq,
+		VatsimCid:          strip.VatsimCID,
+		VatsimRevision:     strip.VatsimRevision,
+		VatsimSeenAt:       TimeToPgTimestamptz(strip.VatsimSeenAt),
+		EuroscopeSeenAt:    TimeToPgTimestamptz(strip.EuroscopeSeenAt),
 	})
 }
 
@@ -364,6 +372,10 @@ func (r *stripRepository) Update(ctx context.Context, strip *models.Strip) (int6
 		PdcData:                  pdcData,
 		ValidationStatus:         validationStatus,
 		StartReq:                 strip.StartReq,
+		VatsimCid:                strip.VatsimCID,
+		VatsimRevision:           strip.VatsimRevision,
+		VatsimSeenAt:             TimeToPgTimestamptz(strip.VatsimSeenAt),
+		EuroscopeSeenAt:          TimeToPgTimestamptz(strip.EuroscopeSeenAt),
 	})
 }
 
@@ -859,6 +871,58 @@ func (r *stripRepository) AppendControllerModifiedField(ctx context.Context, ses
 		Session:     session,
 		Callsign:    callsign,
 		ArrayAppend: fieldName,
+	})
+}
+
+func (r *stripRepository) MarkEuroscopeSeen(ctx context.Context, session int32, callsign string) error {
+	return r.queries.MarkStripEuroscopeSeen(ctx, database.MarkStripEuroscopeSeenParams{
+		Callsign: callsign,
+		Session:  session,
+	})
+}
+
+func (r *stripRepository) ClearEuroscopeSeen(ctx context.Context, session int32, callsign string) error {
+	return r.queries.ClearStripEuroscopeSeen(ctx, database.ClearStripEuroscopeSeenParams{
+		Callsign: callsign,
+		Session:  session,
+	})
+}
+
+func (r *stripRepository) UpdateVatsimSource(ctx context.Context, session int32, callsign string, source models.VatsimStripSource) (int64, error) {
+	cid := source.CID
+	revision := source.Revision
+	alternate := source.Alternate
+	route := source.Route
+	remarks := source.Remarks
+	assignedSquawk := source.AssignedSquawk
+	aircraftType := source.AircraftType
+
+	var latitude *float64
+	var longitude *float64
+	var altitude *int32
+	if source.Online {
+		latitude = &source.Latitude
+		longitude = &source.Longitude
+		altitude = &source.Altitude
+	}
+
+	return r.queries.UpdateStripVatsimSource(ctx, database.UpdateStripVatsimSourceParams{
+		VatsimCid:         &cid,
+		VatsimRevision:    &revision,
+		VatsimSeenAt:      TimeToPgTimestamptz(&source.SeenAt),
+		Origin:            source.Origin,
+		Destination:       source.Destination,
+		Alternative:       &alternate,
+		Route:             &route,
+		Remarks:           &remarks,
+		AssignedSquawk:    &assignedSquawk,
+		AircraftType:      &aircraftType,
+		Online:            source.Online,
+		PositionLatitude:  latitude,
+		PositionLongitude: longitude,
+		PositionAltitude:  altitude,
+		Callsign:          callsign,
+		Session:           session,
 	})
 }
 

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -75,6 +75,9 @@ type StripRepository interface {
 
 	// Controller-modified field tracking
 	AppendControllerModifiedField(ctx context.Context, session int32, callsign string, fieldName string) error
+	MarkEuroscopeSeen(ctx context.Context, session int32, callsign string) error
+	ClearEuroscopeSeen(ctx context.Context, session int32, callsign string) error
+	UpdateVatsimSource(ctx context.Context, session int32, callsign string, source models.VatsimStripSource) (int64, error)
 
 	// Manual FPL creation
 	UpdateIFRManualFPLFields(ctx context.Context, session int32, callsign string, destination string, sid *string, assignedSquawk *string, eobt *string, aircraftType *string, requestedAltitude *int32, route *string, stand *string, runway *string) (int64, error)

--- a/backend/internal/services/strip_sync.go
+++ b/backend/internal/services/strip_sync.go
@@ -28,7 +28,15 @@ func (s *StripService) SyncStrip(ctx context.Context, session int32, cid string,
 	if !ok {
 		return fmt.Errorf("SyncStrip: unexpected strip type %T", strip)
 	}
-	return s.syncEuroscopeStrip(ctx, session, cid, esStrip, airport)
+	if err := s.syncEuroscopeStrip(ctx, session, cid, esStrip, airport); err != nil {
+		return err
+	}
+	if sourceStore, ok := s.lifecycleStore.(interface {
+		MarkEuroscopeSeen(context.Context, int32, string) error
+	}); ok {
+		return sourceStore.MarkEuroscopeSeen(ctx, session, esStrip.Callsign)
+	}
+	return nil
 }
 
 type syncRouteComputer interface {
@@ -323,6 +331,10 @@ func (s *StripService) syncEuroscopeStrip(ctx context.Context, session int32, ci
 		personsOnBoard := existingStrip.PersonsOnBoard
 		fplType := existingStrip.FplType
 		language := existingStrip.Language
+		vatsimCID := existingStrip.VatsimCID
+		vatsimRevision := existingStrip.VatsimRevision
+		vatsimSeenAt := existingStrip.VatsimSeenAt
+		euroscopeSeenAt := existingStrip.EuroscopeSeenAt
 
 		if restartLifecycle {
 			cdmData = internalModels.NewLegacyCdmData(&strip.Eobt, nil, nil, nil, nil, nil, &strip.Eobt, nil)
@@ -417,6 +429,10 @@ func (s *StripService) syncEuroscopeStrip(ctx context.Context, session int32, ci
 			PersonsOnBoard:           personsOnBoard,
 			FplType:                  fplType,
 			Language:                 language,
+			VatsimCID:                vatsimCID,
+			VatsimRevision:           vatsimRevision,
+			VatsimSeenAt:             vatsimSeenAt,
+			EuroscopeSeenAt:          euroscopeSeenAt,
 		}
 		validationStrip = updateStrip
 		registrationNeedsUpdate := restartLifecycle

--- a/backend/internal/testutil/mock_strip_repository.go
+++ b/backend/internal/testutil/mock_strip_repository.go
@@ -56,6 +56,9 @@ type MockStripRepository struct {
 	AppendUnexpectedChangeFieldFn   func(ctx context.Context, session int32, callsign string, fieldName string) error
 	RemoveUnexpectedChangeFieldFn   func(ctx context.Context, session int32, callsign string, fieldName string) error
 	AppendControllerModifiedFieldFn func(ctx context.Context, session int32, callsign string, fieldName string) error
+	MarkEuroscopeSeenFn             func(ctx context.Context, session int32, callsign string) error
+	ClearEuroscopeSeenFn            func(ctx context.Context, session int32, callsign string) error
+	UpdateVatsimSourceFn            func(ctx context.Context, session int32, callsign string, source models.VatsimStripSource) (int64, error)
 	SetPdcDataFn                    func(ctx context.Context, session int32, callsign string, data *models.PdcData) error
 	SetPdcRequestedFn               func(ctx context.Context, session int32, callsign string, pdcState string, pdcRequestedAt *time.Time, pdcRequestRemarks *string) error
 	SetPdcMessageSentFn             func(ctx context.Context, session int32, callsign string, pdcState string, pdcMessageSequence *int32, pdcMessageSent *time.Time) error
@@ -94,6 +97,27 @@ func (m *MockStripRepository) Update(ctx context.Context, strip *models.Strip) (
 		panic("unexpected call to MockStripRepository.Update")
 	}
 	return m.UpdateFn(ctx, strip)
+}
+
+func (m *MockStripRepository) MarkEuroscopeSeen(ctx context.Context, session int32, callsign string) error {
+	if m.MarkEuroscopeSeenFn != nil {
+		return m.MarkEuroscopeSeenFn(ctx, session, callsign)
+	}
+	return nil
+}
+
+func (m *MockStripRepository) ClearEuroscopeSeen(ctx context.Context, session int32, callsign string) error {
+	if m.ClearEuroscopeSeenFn != nil {
+		return m.ClearEuroscopeSeenFn(ctx, session, callsign)
+	}
+	return nil
+}
+
+func (m *MockStripRepository) UpdateVatsimSource(ctx context.Context, session int32, callsign string, source models.VatsimStripSource) (int64, error) {
+	if m.UpdateVatsimSourceFn == nil {
+		panic("unexpected call to MockStripRepository.UpdateVatsimSource")
+	}
+	return m.UpdateVatsimSourceFn(ctx, session, callsign, source)
 }
 
 func (m *MockStripRepository) Delete(ctx context.Context, session int32, callsign string) error {

--- a/backend/internal/vatsim/reconciliation.go
+++ b/backend/internal/vatsim/reconciliation.go
@@ -1,0 +1,292 @@
+package vatsim
+
+import (
+	"FlightStrips/internal/models"
+	"context"
+	"strings"
+	"time"
+)
+
+const reconciliationSequenceSpacing int32 = 1000
+
+const (
+	plannedDepartureBay = "NOT_CLEARED"
+	hiddenArrivalBay    = "ARR_HIDDEN"
+)
+
+type reconciliationSessionStore interface {
+	List(context.Context) ([]*models.Session, error)
+}
+
+type reconciliationStripStore interface {
+	List(context.Context, int32) ([]*models.Strip, error)
+	Create(context.Context, *models.Strip) error
+	UpdateVatsimSource(context.Context, int32, string, models.VatsimStripSource) (int64, error)
+	Delete(context.Context, int32, string) error
+}
+
+type reconciliationAssignmentStore interface {
+	GetAssignment(context.Context, int32, string) (*models.StandAssignment, error)
+}
+
+type reconciliationNotifier interface {
+	SendStripUpdate(session int32, callsign string)
+}
+
+// Reconciler materializes relevant VATSIM records into each FlightStrips
+// session. It deliberately owns only feed fields; operational state remains
+// controller/EuroScope owned.
+type Reconciler struct {
+	cache       *Cache
+	sessions    reconciliationSessionStore
+	strips      reconciliationStripStore
+	assignments reconciliationAssignmentStore
+	notifier    reconciliationNotifier
+	interval    time.Duration
+}
+
+func NewReconciler(cache *Cache, sessions reconciliationSessionStore, strips reconciliationStripStore, assignments reconciliationAssignmentStore, notifier reconciliationNotifier, interval time.Duration) *Reconciler {
+	if interval <= 0 {
+		interval = defaultRefreshInterval
+	}
+	return &Reconciler{cache: cache, sessions: sessions, strips: strips, assignments: assignments, notifier: notifier, interval: interval}
+}
+
+func (r *Reconciler) Start(ctx context.Context) {
+	if r == nil || r.cache == nil || r.sessions == nil || r.strips == nil {
+		return
+	}
+	_ = r.Reconcile(ctx)
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			_ = r.Reconcile(ctx)
+		}
+	}
+}
+
+// Reconcile performs one source snapshot reconciliation. Sessions are listed
+// directly instead of deriving them from EuroScope clients, so it also works
+// before a tower or EuroScope master connects.
+func (r *Reconciler) Reconcile(ctx context.Context) error {
+	if r == nil || r.cache == nil || r.sessions == nil || r.strips == nil {
+		return nil
+	}
+	snapshot := r.cache.Snapshot()
+	if snapshot.Timestamp.IsZero() {
+		return nil
+	}
+	sessions, err := r.sessions.List(ctx)
+	if err != nil {
+		return err
+	}
+	for _, session := range sessions {
+		if session == nil || strings.TrimSpace(session.Airport) == "" {
+			continue
+		}
+		if err := r.reconcileSession(ctx, snapshot, session); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Reconciler) reconcileSession(ctx context.Context, snapshot Snapshot, session *models.Session) error {
+	strips, err := r.strips.List(ctx, session.ID)
+	if err != nil {
+		return err
+	}
+	existing := make(map[string]*models.Strip, len(strips))
+	for _, strip := range strips {
+		if strip != nil {
+			existing[normalizeCallsign(strip.Callsign)] = strip
+		}
+	}
+
+	relevant := make(map[string]Flight)
+	airport := strings.ToUpper(strings.TrimSpace(session.Airport))
+	for _, flight := range snapshot.Flights() {
+		if flight.Callsign == "" || (strings.ToUpper(strings.TrimSpace(flight.FlightPlan.Origin)) != airport && strings.ToUpper(strings.TrimSpace(flight.FlightPlan.Destination)) != airport) {
+			continue
+		}
+		relevant[flight.Callsign] = flight
+		strip := existing[flight.Callsign]
+		if strip == nil {
+			strip = r.newStrip(session, flight, snapshot.Timestamp, nextSequence(strips, flight, airport))
+			if err := r.strips.Create(ctx, strip); err != nil {
+				return err
+			}
+			existing[flight.Callsign] = strip
+			strips = append(strips, strip)
+			r.notify(session.ID, strip.Callsign)
+			continue
+		}
+		if r.applyFlight(strip, flight, snapshot.Timestamp) {
+			if _, err := r.strips.UpdateVatsimSource(ctx, session.ID, strip.Callsign, vatsimSource(flight, snapshot.Timestamp)); err != nil {
+				return err
+			}
+			r.notify(session.ID, strip.Callsign)
+		}
+	}
+
+	for callsign, strip := range existing {
+		if strip.VatsimCID == nil || relevant[callsign].Callsign != "" || strip.EuroscopeSeenAt != nil || r.isAssigned(ctx, session.ID, strip.Callsign) {
+			continue
+		}
+		if err := r.strips.Delete(ctx, session.ID, strip.Callsign); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func vatsimSource(flight Flight, snapshotTime time.Time) models.VatsimStripSource {
+	seenAt := flight.LastUpdated
+	if seenAt.IsZero() {
+		seenAt = snapshotTime
+	}
+	return models.VatsimStripSource{
+		CID: flight.CID, Revision: flight.FlightPlan.Revision, SeenAt: seenAt.UTC(),
+		Origin: flight.FlightPlan.Origin, Destination: flight.FlightPlan.Destination,
+		Alternate: flight.FlightPlan.Alternate, Route: flight.FlightPlan.Route,
+		Remarks: flight.FlightPlan.Remarks, AssignedSquawk: flight.FlightPlan.AssignedSquawk,
+		AircraftType: flight.FlightPlan.AircraftShort, Online: flight.Online(),
+		Latitude: flight.Latitude, Longitude: flight.Longitude, Altitude: int32(flight.Altitude),
+	}
+}
+
+func (r *Reconciler) newStrip(session *models.Session, flight Flight, seenAt time.Time, sequence int32) *models.Strip {
+	bay := hiddenArrivalBay
+	if strings.EqualFold(strings.TrimSpace(flight.FlightPlan.Origin), strings.TrimSpace(session.Airport)) {
+		bay = plannedDepartureBay
+	}
+	strip := &models.Strip{Callsign: flight.Callsign, Session: session.ID, Bay: bay, Sequence: &sequence, HasFP: true}
+	r.applyFlight(strip, flight, seenAt)
+	return strip
+}
+
+func (r *Reconciler) applyFlight(strip *models.Strip, flight Flight, snapshotTime time.Time) bool {
+	seenAt := flight.LastUpdated
+	if seenAt.IsZero() {
+		seenAt = snapshotTime
+	}
+	seenAt = seenAt.UTC()
+	changed := false
+	if strip.VatsimCID == nil || *strip.VatsimCID != flight.CID {
+		strip.VatsimCID = ptr(flight.CID)
+		changed = true
+	}
+	if strip.VatsimRevision == nil || *strip.VatsimRevision != flight.FlightPlan.Revision {
+		strip.VatsimRevision = int64ptr(flight.FlightPlan.Revision)
+		changed = true
+	}
+	if strip.VatsimSeenAt == nil || strip.VatsimSeenAt.Before(seenAt) {
+		strip.VatsimSeenAt = timeptr(seenAt)
+		changed = true
+	}
+	if strip.EuroscopeSeenAt != nil && strip.EuroscopeSeenAt.After(seenAt) {
+		return changed
+	}
+
+	changed = setSourceString(strip, "origin", &strip.Origin, flight.FlightPlan.Origin) || changed
+	changed = setSourceString(strip, "destination", &strip.Destination, flight.FlightPlan.Destination) || changed
+	changed = setSourcePointer(strip, "alternative", &strip.Alternative, flight.FlightPlan.Alternate) || changed
+	changed = setSourcePointer(strip, "route", &strip.Route, flight.FlightPlan.Route) || changed
+	changed = setSourcePointer(strip, "remarks", &strip.Remarks, flight.FlightPlan.Remarks) || changed
+	changed = setSourcePointer(strip, "assigned_squawk", &strip.AssignedSquawk, flight.FlightPlan.AssignedSquawk) || changed
+	changed = setSourcePointer(strip, "aircraft_type", &strip.AircraftType, flight.FlightPlan.AircraftShort) || changed
+	if flight.Online() {
+		changed = setSourceFloat(strip, "position_latitude", &strip.PositionLatitude, flight.Latitude) || changed
+		changed = setSourceFloat(strip, "position_longitude", &strip.PositionLongitude, flight.Longitude) || changed
+		changed = setSourceInt(strip, "position_altitude", &strip.PositionAltitude, int32(flight.Altitude)) || changed
+	}
+	return changed
+}
+
+// RetainsStrip reports whether VATSIM or SAT is still responsible for keeping
+// a strip alive after EuroScope disconnects it.
+func (r *Reconciler) RetainsStrip(ctx context.Context, session int32, callsign string) bool {
+	if r != nil && r.cache != nil {
+		if _, ok := r.cache.Snapshot().FlightByCallsign(callsign); ok {
+			return true
+		}
+	}
+	return r != nil && r.isAssigned(ctx, session, callsign)
+}
+
+func (r *Reconciler) isAssigned(ctx context.Context, session int32, callsign string) bool {
+	if r.assignments == nil {
+		return false
+	}
+	assignment, err := r.assignments.GetAssignment(ctx, session, callsign)
+	return err == nil && assignment != nil
+}
+
+func (r *Reconciler) notify(session int32, callsign string) {
+	if r.notifier != nil {
+		r.notifier.SendStripUpdate(session, callsign)
+	}
+}
+
+func nextSequence(strips []*models.Strip, flight Flight, airport string) int32 {
+	bay := hiddenArrivalBay
+	if strings.EqualFold(strings.TrimSpace(flight.FlightPlan.Origin), airport) {
+		bay = plannedDepartureBay
+	}
+	max := int32(0)
+	for _, strip := range strips {
+		if strip != nil && strip.Bay == bay && strip.Sequence != nil && *strip.Sequence > max {
+			max = *strip.Sequence
+		}
+	}
+	return max + reconciliationSequenceSpacing
+}
+
+func controllerModified(strip *models.Strip, field string) bool {
+	for _, modified := range strip.ControllerModifiedFields {
+		if strings.EqualFold(strings.TrimSpace(modified), field) {
+			return true
+		}
+	}
+	return false
+}
+
+func setSourceString(strip *models.Strip, field string, destination *string, value string) bool {
+	if controllerModified(strip, field) || *destination == value {
+		return false
+	}
+	*destination = value
+	return true
+}
+
+func setSourcePointer(strip *models.Strip, field string, destination **string, value string) bool {
+	if controllerModified(strip, field) || (*destination != nil && **destination == value) {
+		return false
+	}
+	*destination = ptr(value)
+	return true
+}
+
+func setSourceFloat(strip *models.Strip, field string, destination **float64, value float64) bool {
+	if controllerModified(strip, field) || (*destination != nil && **destination == value) {
+		return false
+	}
+	*destination = &value
+	return true
+}
+
+func setSourceInt(strip *models.Strip, field string, destination **int32, value int32) bool {
+	if controllerModified(strip, field) || (*destination != nil && **destination == value) {
+		return false
+	}
+	*destination = &value
+	return true
+}
+
+func ptr(value string) *string           { return &value }
+func int64ptr(value int64) *int64        { return &value }
+func timeptr(value time.Time) *time.Time { return &value }

--- a/backend/internal/vatsim/reconciliation_test.go
+++ b/backend/internal/vatsim/reconciliation_test.go
@@ -1,0 +1,171 @@
+package vatsim
+
+import (
+	"FlightStrips/internal/models"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type reconciliationTestStrips struct {
+	bySession map[int32][]*models.Strip
+	created   []*models.Strip
+	updated   []*models.Strip
+	deleted   []string
+}
+
+func (s *reconciliationTestStrips) List(_ context.Context, session int32) ([]*models.Strip, error) {
+	return s.bySession[session], nil
+}
+
+func (s *reconciliationTestStrips) Create(_ context.Context, strip *models.Strip) error {
+	s.created = append(s.created, strip)
+	s.bySession[strip.Session] = append(s.bySession[strip.Session], strip)
+	return nil
+}
+
+func (s *reconciliationTestStrips) Update(_ context.Context, strip *models.Strip) (int64, error) {
+	s.updated = append(s.updated, strip)
+	return 1, nil
+}
+
+func (s *reconciliationTestStrips) UpdateVatsimSource(_ context.Context, session int32, callsign string, source models.VatsimStripSource) (int64, error) {
+	for _, strip := range s.bySession[session] {
+		if strip.Callsign != callsign {
+			continue
+		}
+		strip.VatsimCID = ptr(source.CID)
+		strip.VatsimRevision = int64ptr(source.Revision)
+		strip.VatsimSeenAt = timeptr(source.SeenAt)
+		if strip.EuroscopeSeenAt == nil || !strip.EuroscopeSeenAt.After(source.SeenAt) {
+			if !controllerModified(strip, "route") {
+				strip.Route = ptr(source.Route)
+			}
+		}
+		s.updated = append(s.updated, strip)
+		return 1, nil
+	}
+	return 0, nil
+}
+
+func (s *reconciliationTestStrips) Delete(_ context.Context, session int32, callsign string) error {
+	s.deleted = append(s.deleted, callsign)
+	return nil
+}
+
+type reconciliationTestSessions struct{ items []*models.Session }
+
+func (s reconciliationTestSessions) List(context.Context) ([]*models.Session, error) {
+	return s.items, nil
+}
+
+type reconciliationTestAssignments struct{ active map[string]bool }
+
+func (s reconciliationTestAssignments) GetAssignment(_ context.Context, session int32, callsign string) (*models.StandAssignment, error) {
+	if s.active[assignmentKey(session, callsign)] {
+		return &models.StandAssignment{SessionID: session, Callsign: callsign}, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func assignmentKey(session int32, callsign string) string {
+	return string(rune(session)) + ":" + callsign
+}
+
+type reconciliationTestNotifier struct{ callsigns []string }
+
+func (n *reconciliationTestNotifier) SendStripUpdate(_ int32, callsign string) {
+	n.callsigns = append(n.callsigns, callsign)
+}
+
+func newReconciliationTestCache(now time.Time, flights ...Flight) *Cache {
+	cache := NewCache("", time.Second, nil)
+	snapshot := newCacheSnapshot(now, now)
+	for _, flight := range flights {
+		snapshot.add(flight)
+	}
+	cache.snapshot = snapshot
+	return cache
+}
+
+func TestReconcileCreatesPrefileDepartureAndHiddenArrivals(t *testing.T) {
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	cache := newReconciliationTestCache(now,
+		Flight{CID: "1", Callsign: "SAS101", State: FlightStatePrefile, LastUpdated: now, FlightPlan: FlightPlan{Origin: "EKCH", Destination: "EGLL", Revision: 4}},
+		Flight{CID: "2", Callsign: "SAS202", State: FlightStatePrefile, LastUpdated: now, FlightPlan: FlightPlan{Origin: "EGLL", Destination: "EKCH", Revision: 5}},
+		Flight{CID: "3", Callsign: "SAS303", State: FlightStateOnline, Latitude: 51.5, Longitude: -0.4, Altitude: 32000, LastUpdated: now, FlightPlan: FlightPlan{Origin: "EGLL", Destination: "EKCH", Revision: 6}},
+	)
+	strips := &reconciliationTestStrips{bySession: map[int32][]*models.Strip{}}
+	notifier := &reconciliationTestNotifier{}
+	reconciler := NewReconciler(cache, reconciliationTestSessions{items: []*models.Session{{ID: 7, Airport: "EKCH"}}}, strips, reconciliationTestAssignments{}, notifier, time.Second)
+
+	require.NoError(t, reconciler.Reconcile(context.Background()))
+	require.Len(t, strips.created, 3)
+	byCallsign := map[string]*models.Strip{}
+	for _, strip := range strips.created {
+		byCallsign[strip.Callsign] = strip
+	}
+	assert.Equal(t, plannedDepartureBay, byCallsign["SAS101"].Bay)
+	assert.Equal(t, hiddenArrivalBay, byCallsign["SAS202"].Bay)
+	assert.Equal(t, hiddenArrivalBay, byCallsign["SAS303"].Bay)
+	assert.Nil(t, byCallsign["SAS202"].PositionLatitude)
+	assert.Equal(t, 51.5, *byCallsign["SAS303"].PositionLatitude)
+	assert.Equal(t, "3", *byCallsign["SAS303"].VatsimCID)
+	assert.Equal(t, int64(6), *byCallsign["SAS303"].VatsimRevision)
+	assert.Len(t, notifier.callsigns, 3)
+}
+
+func TestReconcileKeepsEuroscopeFieldsAndProtectsControllerEdits(t *testing.T) {
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	euroscopeSeen := now.Add(time.Minute)
+	controllerRoute := "CONTROLLER ROUTE"
+	existing := &models.Strip{
+		Callsign: "SAS404", Session: 7, Origin: "EKCH", Destination: "EDDF", Route: &controllerRoute,
+		Stand: ptr("A12"), Bay: plannedDepartureBay, EuroscopeSeenAt: &euroscopeSeen,
+		ControllerModifiedFields: []string{"route", "stand"},
+	}
+	cache := newReconciliationTestCache(now, Flight{CID: "4", Callsign: "SAS404", State: FlightStateOnline, LastUpdated: now, FlightPlan: FlightPlan{Origin: "EKCH", Destination: "EDDF", Route: "VATSIM ROUTE", Revision: 7}})
+	strips := &reconciliationTestStrips{bySession: map[int32][]*models.Strip{7: {existing}}}
+	reconciler := NewReconciler(cache, reconciliationTestSessions{items: []*models.Session{{ID: 7, Airport: "EKCH"}}}, strips, reconciliationTestAssignments{}, nil, time.Second)
+
+	require.NoError(t, reconciler.Reconcile(context.Background()))
+	assert.Empty(t, strips.created, "the matching callsign must not create a duplicate strip")
+	assert.Equal(t, controllerRoute, *existing.Route)
+	assert.Equal(t, "A12", *existing.Stand)
+	assert.Equal(t, "4", *existing.VatsimCID, "provenance is retained even when EuroScope wins fields")
+}
+
+func TestReconcileUsesNewerVatsimFieldsWhenEuroScopeDataIsOlder(t *testing.T) {
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	euroscopeSeen := now.Add(-time.Minute)
+	oldRoute := "OLD ROUTE"
+	existing := &models.Strip{Callsign: "SAS707", Session: 7, Origin: "EKCH", Destination: "EDDF", Route: &oldRoute, Bay: plannedDepartureBay, EuroscopeSeenAt: &euroscopeSeen}
+	cache := newReconciliationTestCache(now, Flight{CID: "7", Callsign: "SAS707", State: FlightStateOnline, LastUpdated: now, FlightPlan: FlightPlan{Origin: "EKCH", Destination: "EDDF", Route: "NEW ROUTE", Revision: 8}})
+	strips := &reconciliationTestStrips{bySession: map[int32][]*models.Strip{7: {existing}}}
+	reconciler := NewReconciler(cache, reconciliationTestSessions{items: []*models.Session{{ID: 7, Airport: "EKCH"}}}, strips, reconciliationTestAssignments{}, nil, time.Second)
+
+	require.NoError(t, reconciler.Reconcile(context.Background()))
+	require.Len(t, strips.updated, 1)
+	assert.Equal(t, "NEW ROUTE", *existing.Route)
+}
+
+func TestReconcileCleanupAndDisconnectRetentionRespectOtherOwners(t *testing.T) {
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	vatsimCID := "5"
+	stale := &models.Strip{Callsign: "SAS505", Session: 7, VatsimCID: &vatsimCID}
+	assignedCID := "6"
+	assigned := &models.Strip{Callsign: "SAS606", Session: 7, VatsimCID: &assignedCID}
+	cache := newReconciliationTestCache(now)
+	strips := &reconciliationTestStrips{bySession: map[int32][]*models.Strip{7: {stale, assigned}}}
+	assignments := reconciliationTestAssignments{active: map[string]bool{assignmentKey(7, "SAS606"): true}}
+	reconciler := NewReconciler(cache, reconciliationTestSessions{items: []*models.Session{{ID: 7, Airport: "EKCH"}}}, strips, assignments, nil, time.Second)
+
+	require.NoError(t, reconciler.Reconcile(context.Background()))
+	assert.Equal(t, []string{"SAS505"}, strips.deleted)
+	assert.True(t, reconciler.RetainsStrip(context.Background(), 7, "SAS606"))
+	assert.False(t, reconciler.RetainsStrip(context.Background(), 7, "SAS505"))
+}

--- a/backend/migrations/0030-add-vatsim-strip-provenance.sql
+++ b/backend/migrations/0030-add-vatsim-strip-provenance.sql
@@ -1,0 +1,9 @@
+ALTER TABLE strips
+    ADD COLUMN IF NOT EXISTS vatsim_cid VARCHAR,
+    ADD COLUMN IF NOT EXISTS vatsim_revision BIGINT,
+    ADD COLUMN IF NOT EXISTS vatsim_seen_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS euroscope_seen_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_strips_vatsim_source
+    ON strips (session, vatsim_seen_at)
+    WHERE vatsim_seen_at IS NOT NULL;

--- a/backend/queries/strips.sql
+++ b/backend/queries/strips.sql
@@ -3,7 +3,8 @@ INSERT INTO strips (version, callsign, session, origin, destination, alternative
                      squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities,
                      communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay,
                      position_latitude, position_longitude, position_altitude, cdm_data, next_owners, previous_owners,
-                     registration, tracking_controller, engine_type, spoken_callsign, has_fp, start_req)
+                     registration, tracking_controller, engine_type, spoken_callsign, has_fp, start_req,
+                     vatsim_cid, vatsim_revision, vatsim_seen_at, euroscope_seen_at)
 VALUES (
     1,
     sqlc.arg(callsign),
@@ -41,7 +42,11 @@ VALUES (
     sqlc.arg(engine_type),
     sqlc.arg(spoken_callsign),
     sqlc.arg(has_fp),
-    sqlc.arg(start_req)
+    sqlc.arg(start_req),
+    sqlc.arg(vatsim_cid),
+    sqlc.arg(vatsim_revision),
+    sqlc.arg(vatsim_seen_at),
+    sqlc.arg(euroscope_seen_at)
 );
 
 -- name: UpdateStrip :execrows
@@ -92,8 +97,42 @@ SET version = version + 1,
     has_fp = sqlc.arg(has_fp),
     pdc_data = sqlc.arg(pdc_data),
     validation_status = sqlc.arg(validation_status),
-    start_req = sqlc.arg(start_req)
+    start_req = sqlc.arg(start_req),
+    vatsim_cid = sqlc.arg(vatsim_cid),
+    vatsim_revision = sqlc.arg(vatsim_revision),
+    vatsim_seen_at = sqlc.arg(vatsim_seen_at),
+    euroscope_seen_at = sqlc.arg(euroscope_seen_at)
 WHERE callsign = sqlc.arg(callsign) AND session = sqlc.arg(session);
+
+-- name: MarkStripEuroscopeSeen :exec
+UPDATE strips
+SET euroscope_seen_at = NOW()
+WHERE callsign = $1 AND session = $2;
+
+-- name: ClearStripEuroscopeSeen :exec
+UPDATE strips
+SET euroscope_seen_at = NULL
+WHERE callsign = $1 AND session = $2;
+
+-- name: UpdateStripVatsimSource :execrows
+UPDATE strips
+SET
+    version = version + 1,
+    vatsim_cid = sqlc.arg(vatsim_cid),
+    vatsim_revision = sqlc.arg(vatsim_revision),
+    vatsim_seen_at = sqlc.arg(vatsim_seen_at),
+    origin = CASE WHEN NOT ('origin' = ANY(controller_modified_fields)) AND (euroscope_seen_at IS NULL OR euroscope_seen_at <= sqlc.arg(vatsim_seen_at)) THEN sqlc.arg(origin) ELSE origin END,
+    destination = CASE WHEN NOT ('destination' = ANY(controller_modified_fields)) AND (euroscope_seen_at IS NULL OR euroscope_seen_at <= sqlc.arg(vatsim_seen_at)) THEN sqlc.arg(destination) ELSE destination END,
+    alternative = CASE WHEN NOT ('alternative' = ANY(controller_modified_fields)) AND (euroscope_seen_at IS NULL OR euroscope_seen_at <= sqlc.arg(vatsim_seen_at)) THEN sqlc.arg(alternative) ELSE alternative END,
+    route = CASE WHEN NOT ('route' = ANY(controller_modified_fields)) AND (euroscope_seen_at IS NULL OR euroscope_seen_at <= sqlc.arg(vatsim_seen_at)) THEN sqlc.arg(route) ELSE route END,
+    remarks = CASE WHEN NOT ('remarks' = ANY(controller_modified_fields)) AND (euroscope_seen_at IS NULL OR euroscope_seen_at <= sqlc.arg(vatsim_seen_at)) THEN sqlc.arg(remarks) ELSE remarks END,
+    assigned_squawk = CASE WHEN NOT ('assigned_squawk' = ANY(controller_modified_fields)) AND (euroscope_seen_at IS NULL OR euroscope_seen_at <= sqlc.arg(vatsim_seen_at)) THEN sqlc.arg(assigned_squawk) ELSE assigned_squawk END,
+    aircraft_type = CASE WHEN NOT ('aircraft_type' = ANY(controller_modified_fields)) AND (euroscope_seen_at IS NULL OR euroscope_seen_at <= sqlc.arg(vatsim_seen_at)) THEN sqlc.arg(aircraft_type) ELSE aircraft_type END,
+    position_latitude = CASE WHEN sqlc.arg(online)::boolean AND NOT ('position_latitude' = ANY(controller_modified_fields)) AND (euroscope_seen_at IS NULL OR euroscope_seen_at <= sqlc.arg(vatsim_seen_at)) THEN sqlc.arg(position_latitude) ELSE position_latitude END,
+    position_longitude = CASE WHEN sqlc.arg(online)::boolean AND NOT ('position_longitude' = ANY(controller_modified_fields)) AND (euroscope_seen_at IS NULL OR euroscope_seen_at <= sqlc.arg(vatsim_seen_at)) THEN sqlc.arg(position_longitude) ELSE position_longitude END,
+    position_altitude = CASE WHEN sqlc.arg(online)::boolean AND NOT ('position_altitude' = ANY(controller_modified_fields)) AND (euroscope_seen_at IS NULL OR euroscope_seen_at <= sqlc.arg(vatsim_seen_at)) THEN sqlc.arg(position_altitude) ELSE position_altitude END
+WHERE callsign = sqlc.arg(callsign) AND session = sqlc.arg(session);
+
 
 -- name: GetStrip :one
 SELECT *


### PR DESCRIPTION
## Summary
- reconcile relevant VATSIM prefiles and online flights into active sessions
- preserve controller-owned strip state while retaining VATSIM and EuroScope provenance
- keep strips alive across EuroScope disconnects while VATSIM or SAT still owns them

## Why
VATSIM data must maintain prefile and out-of-range strips without requiring an active EuroScope master, while respecting controller changes and safely cleaning up when every source is gone.

## Validation
- `go test ./...`