### PR TITLE
feat(stand): allocate stands transactionally

### DIFF
--- a/backend/internal/database/models.go
+++ b/backend/internal/database/models.go
@@ -87,6 +87,7 @@ type StandAssignment struct {
 	Version        int32
 	CreatedAt      pgtype.Timestamptz
 	UpdatedAt      pgtype.Timestamptz
+	ConflictReason *string
 }
 
 type StandBlock struct {

--- a/backend/internal/database/stand_assignments.sql.go
+++ b/backend/internal/database/stand_assignments.sql.go
@@ -14,17 +14,17 @@ import (
 const createStandAssignment = `-- name: CreateStandAssignment :one
 INSERT INTO stand_assignments (
     session_id, callsign, stand, direction, stage, source, rule_id, tier,
-    matched_variant, eta, eta_source,
+    matched_variant, conflict_reason, eta, eta_source,
     assigned_at, expires_at, manual, acknowledged, acknowledged_at,
     acknowledged_by, vatsim_cid, vatsim_revision
 )
 VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8,
-    $9, $10, $11,
-    $12, $13, $14, $15, $16,
-    $17, $18, $19
+    $9, $10, $11, $12,
+    $13, $14, $15, $16, $17,
+    $18, $19, $20
 )
-RETURNING id, session_id, callsign, stand, direction, stage, source, rule_id, tier, matched_variant, eta, eta_source, assigned_at, expires_at, manual, acknowledged, acknowledged_at, acknowledged_by, vatsim_cid, vatsim_revision, version, created_at, updated_at
+RETURNING id, session_id, callsign, stand, direction, stage, source, rule_id, tier, matched_variant, eta, eta_source, assigned_at, expires_at, manual, acknowledged, acknowledged_at, acknowledged_by, vatsim_cid, vatsim_revision, version, created_at, updated_at, conflict_reason
 `
 
 type CreateStandAssignmentParams struct {
@@ -37,6 +37,7 @@ type CreateStandAssignmentParams struct {
 	RuleID         *string
 	Tier           *int32
 	MatchedVariant *string
+	ConflictReason *string
 	Eta            pgtype.Timestamptz
 	EtaSource      *string
 	AssignedAt     pgtype.Timestamptz
@@ -60,6 +61,7 @@ func (q *Queries) CreateStandAssignment(ctx context.Context, arg CreateStandAssi
 		arg.RuleID,
 		arg.Tier,
 		arg.MatchedVariant,
+		arg.ConflictReason,
 		arg.Eta,
 		arg.EtaSource,
 		arg.AssignedAt,
@@ -96,6 +98,7 @@ func (q *Queries) CreateStandAssignment(ctx context.Context, arg CreateStandAssi
 		&i.Version,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.ConflictReason,
 	)
 	return i, err
 }
@@ -105,7 +108,8 @@ INSERT INTO stand_blocks (
     session_id, stand, block_type, source, reason, callsign, created_by,
     expires_at, manual
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9
+FROM (SELECT id FROM sessions WHERE id = $1 FOR UPDATE) AS locked_session
 RETURNING id, session_id, stand, block_type, source, reason, callsign, created_by, expires_at, manual, version, created_at, updated_at
 `
 
@@ -191,7 +195,7 @@ func (q *Queries) DeleteStandBlock(ctx context.Context, arg DeleteStandBlockPara
 }
 
 const getStandAssignment = `-- name: GetStandAssignment :one
-SELECT id, session_id, callsign, stand, direction, stage, source, rule_id, tier, matched_variant, eta, eta_source, assigned_at, expires_at, manual, acknowledged, acknowledged_at, acknowledged_by, vatsim_cid, vatsim_revision, version, created_at, updated_at
+SELECT id, session_id, callsign, stand, direction, stage, source, rule_id, tier, matched_variant, eta, eta_source, assigned_at, expires_at, manual, acknowledged, acknowledged_at, acknowledged_by, vatsim_cid, vatsim_revision, version, created_at, updated_at, conflict_reason
 FROM stand_assignments
 WHERE session_id = $1 AND callsign = $2
 `
@@ -228,6 +232,7 @@ func (q *Queries) GetStandAssignment(ctx context.Context, arg GetStandAssignment
 		&i.Version,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.ConflictReason,
 	)
 	return i, err
 }
@@ -265,7 +270,7 @@ func (q *Queries) GetStandBlock(ctx context.Context, arg GetStandBlockParams) (S
 }
 
 const listStandAssignments = `-- name: ListStandAssignments :many
-SELECT id, session_id, callsign, stand, direction, stage, source, rule_id, tier, matched_variant, eta, eta_source, assigned_at, expires_at, manual, acknowledged, acknowledged_at, acknowledged_by, vatsim_cid, vatsim_revision, version, created_at, updated_at
+SELECT id, session_id, callsign, stand, direction, stage, source, rule_id, tier, matched_variant, eta, eta_source, assigned_at, expires_at, manual, acknowledged, acknowledged_at, acknowledged_by, vatsim_cid, vatsim_revision, version, created_at, updated_at, conflict_reason
 FROM stand_assignments
 WHERE session_id = $1
 ORDER BY callsign
@@ -304,6 +309,7 @@ func (q *Queries) ListStandAssignments(ctx context.Context, sessionID int32) ([]
 			&i.Version,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.ConflictReason,
 		); err != nil {
 			return nil, err
 		}
@@ -402,6 +408,109 @@ func (q *Queries) ListStandBlocksByStand(ctx context.Context, arg ListStandBlock
 	return items, nil
 }
 
+const lockActiveManualStandBlocks = `-- name: LockActiveManualStandBlocks :many
+SELECT id, session_id, stand, block_type, source, reason, callsign, created_by, expires_at, manual, version, created_at, updated_at
+FROM stand_blocks
+WHERE session_id = $1
+  AND manual = TRUE
+  AND (expires_at IS NULL OR expires_at > NOW())
+ORDER BY stand, id
+FOR UPDATE
+`
+
+func (q *Queries) LockActiveManualStandBlocks(ctx context.Context, sessionID int32) ([]StandBlock, error) {
+	rows, err := q.db.Query(ctx, lockActiveManualStandBlocks, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []StandBlock
+	for rows.Next() {
+		var i StandBlock
+		if err := rows.Scan(
+			&i.ID,
+			&i.SessionID,
+			&i.Stand,
+			&i.BlockType,
+			&i.Source,
+			&i.Reason,
+			&i.Callsign,
+			&i.CreatedBy,
+			&i.ExpiresAt,
+			&i.Manual,
+			&i.Version,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const lockStandAssignments = `-- name: LockStandAssignments :many
+SELECT id, session_id, callsign, stand, direction, stage, source, rule_id, tier, matched_variant, eta, eta_source, assigned_at, expires_at, manual, acknowledged, acknowledged_at, acknowledged_by, vatsim_cid, vatsim_revision, version, created_at, updated_at, conflict_reason
+FROM stand_assignments
+WHERE session_id = $1
+  AND (callsign = $2 OR expires_at IS NULL OR expires_at > NOW())
+ORDER BY callsign
+FOR UPDATE
+`
+
+type LockStandAssignmentsParams struct {
+	SessionID int32
+	Callsign  string
+}
+
+func (q *Queries) LockStandAssignments(ctx context.Context, arg LockStandAssignmentsParams) ([]StandAssignment, error) {
+	rows, err := q.db.Query(ctx, lockStandAssignments, arg.SessionID, arg.Callsign)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []StandAssignment
+	for rows.Next() {
+		var i StandAssignment
+		if err := rows.Scan(
+			&i.ID,
+			&i.SessionID,
+			&i.Callsign,
+			&i.Stand,
+			&i.Direction,
+			&i.Stage,
+			&i.Source,
+			&i.RuleID,
+			&i.Tier,
+			&i.MatchedVariant,
+			&i.Eta,
+			&i.EtaSource,
+			&i.AssignedAt,
+			&i.ExpiresAt,
+			&i.Manual,
+			&i.Acknowledged,
+			&i.AcknowledgedAt,
+			&i.AcknowledgedBy,
+			&i.VatsimCid,
+			&i.VatsimRevision,
+			&i.Version,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.ConflictReason,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const updateStandAssignment = `-- name: UpdateStandAssignment :execrows
 UPDATE stand_assignments
 SET stand = $3,
@@ -411,19 +520,20 @@ SET stand = $3,
     rule_id = $7,
     tier = $8,
     matched_variant = $9,
-    eta = $10,
-    eta_source = $11,
-    assigned_at = $12,
-    expires_at = $13,
-    manual = $14,
-    acknowledged = $15,
-    acknowledged_at = $16,
-    acknowledged_by = $17,
-    vatsim_cid = $18,
-    vatsim_revision = $19,
+    conflict_reason = $10,
+    eta = $11,
+    eta_source = $12,
+    assigned_at = $13,
+    expires_at = $14,
+    manual = $15,
+    acknowledged = $16,
+    acknowledged_at = $17,
+    acknowledged_by = $18,
+    vatsim_cid = $19,
+    vatsim_revision = $20,
     version = version + 1,
     updated_at = NOW()
-WHERE id = $1 AND session_id = $2 AND version = $20
+WHERE id = $1 AND session_id = $2 AND version = $21
 `
 
 type UpdateStandAssignmentParams struct {
@@ -436,6 +546,7 @@ type UpdateStandAssignmentParams struct {
 	RuleID         *string
 	Tier           *int32
 	MatchedVariant *string
+	ConflictReason *string
 	Eta            pgtype.Timestamptz
 	EtaSource      *string
 	AssignedAt     pgtype.Timestamptz
@@ -460,6 +571,7 @@ func (q *Queries) UpdateStandAssignment(ctx context.Context, arg UpdateStandAssi
 		arg.RuleID,
 		arg.Tier,
 		arg.MatchedVariant,
+		arg.ConflictReason,
 		arg.Eta,
 		arg.EtaSource,
 		arg.AssignedAt,

--- a/backend/internal/database/strips.sql.go
+++ b/backend/internal/database/strips.sql.go
@@ -732,6 +732,80 @@ func (q *Queries) ListStripsByOrigin(ctx context.Context, arg ListStripsByOrigin
 	return items, nil
 }
 
+const lockStrip = `-- name: LockStrip :one
+SELECT id, version, callsign, session, origin, destination, alternative, route, remarks, assigned_squawk, squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities, communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay, position_latitude, position_longitude, position_altitude, next_owners, previous_owners, release_point, marked, registration, tracking_controller, runway_cleared, unexpected_change_fields, controller_modified_fields, engine_type, is_manual, persons_on_board, fpl_type, language, has_fp, cdm_data, runway_confirmed, pdc_data, validation_status, start_req, spoken_callsign, vatsim_cid, vatsim_revision, vatsim_seen_at, euroscope_seen_at
+FROM strips
+WHERE callsign = $1 AND session = $2
+FOR UPDATE
+`
+
+type LockStripParams struct {
+	Callsign string
+	Session  int32
+}
+
+func (q *Queries) LockStrip(ctx context.Context, arg LockStripParams) (Strip, error) {
+	row := q.db.QueryRow(ctx, lockStrip, arg.Callsign, arg.Session)
+	var i Strip
+	err := row.Scan(
+		&i.ID,
+		&i.Version,
+		&i.Callsign,
+		&i.Session,
+		&i.Origin,
+		&i.Destination,
+		&i.Alternative,
+		&i.Route,
+		&i.Remarks,
+		&i.AssignedSquawk,
+		&i.Squawk,
+		&i.Sid,
+		&i.ClearedAltitude,
+		&i.Heading,
+		&i.AircraftType,
+		&i.Runway,
+		&i.RequestedAltitude,
+		&i.Capabilities,
+		&i.CommunicationType,
+		&i.AircraftCategory,
+		&i.Stand,
+		&i.Sequence,
+		&i.State,
+		&i.Cleared,
+		&i.Owner,
+		&i.Bay,
+		&i.PositionLatitude,
+		&i.PositionLongitude,
+		&i.PositionAltitude,
+		&i.NextOwners,
+		&i.PreviousOwners,
+		&i.ReleasePoint,
+		&i.Marked,
+		&i.Registration,
+		&i.TrackingController,
+		&i.RunwayCleared,
+		&i.UnexpectedChangeFields,
+		&i.ControllerModifiedFields,
+		&i.EngineType,
+		&i.IsManual,
+		&i.PersonsOnBoard,
+		&i.FplType,
+		&i.Language,
+		&i.HasFp,
+		&i.CdmData,
+		&i.RunwayConfirmed,
+		&i.PdcData,
+		&i.ValidationStatus,
+		&i.StartReq,
+		&i.SpokenCallsign,
+		&i.VatsimCid,
+		&i.VatsimRevision,
+		&i.VatsimSeenAt,
+		&i.EuroscopeSeenAt,
+	)
+	return i, err
+}
+
 const markStripEuroscopeSeen = `-- name: MarkStripEuroscopeSeen :exec
 UPDATE strips
 SET euroscope_seen_at = NOW()

--- a/backend/internal/models/stand_assignment.go
+++ b/backend/internal/models/stand_assignment.go
@@ -16,6 +16,9 @@ type StandAssignment struct {
 	RuleID         *string
 	Tier           *int32
 	MatchedVariant *string
+	// ConflictReason is set only for an explicit manual override. It preserves
+	// why a controller knowingly allocated an incompatible or unavailable stand.
+	ConflictReason *string
 	ETA            *time.Time
 	ETASource      *string
 	AssignedAt     *time.Time

--- a/backend/internal/repository/postgres/stand_assignment.go
+++ b/backend/internal/repository/postgres/stand_assignment.go
@@ -34,6 +34,7 @@ func standAssignmentToModel(db database.StandAssignment) *models.StandAssignment
 		RuleID:         db.RuleID,
 		Tier:           db.Tier,
 		MatchedVariant: db.MatchedVariant,
+		ConflictReason: db.ConflictReason,
 		ETA:            PgTimestamptzToTime(db.Eta),
 		ETASource:      db.EtaSource,
 		AssignedAt:     PgTimestamptzToTime(db.AssignedAt),
@@ -86,6 +87,7 @@ func standAssignmentParams(assignment *models.StandAssignment) database.CreateSt
 		RuleID:         assignment.RuleID,
 		Tier:           assignment.Tier,
 		MatchedVariant: assignment.MatchedVariant,
+		ConflictReason: assignment.ConflictReason,
 		Eta:            TimeToPgTimestamptz(assignment.ETA),
 		EtaSource:      assignment.ETASource,
 		AssignedAt:     TimeToPgTimestamptz(assignment.AssignedAt),
@@ -142,6 +144,21 @@ func (r *standAssignmentRepository) ListAssignments(ctx context.Context, session
 	return result, nil
 }
 
+// LockAssignments locks session assignments for the duration of the caller's
+// transaction. It is used exclusively by the SAT allocator while calculating
+// availability and choosing an atomic replacement.
+func (r *standAssignmentRepository) LockAssignments(ctx context.Context, session int32, callsign string) ([]*models.StandAssignment, error) {
+	rows, err := r.queries.LockStandAssignments(ctx, database.LockStandAssignmentsParams{SessionID: session, Callsign: callsign})
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*models.StandAssignment, len(rows))
+	for i, row := range rows {
+		result[i] = standAssignmentToModel(row)
+	}
+	return result, nil
+}
+
 func (r *standAssignmentRepository) UpdateAssignment(ctx context.Context, assignment *models.StandAssignment) (int64, error) {
 	return r.queries.UpdateStandAssignment(ctx, database.UpdateStandAssignmentParams{
 		ID:             assignment.ID,
@@ -153,6 +170,7 @@ func (r *standAssignmentRepository) UpdateAssignment(ctx context.Context, assign
 		RuleID:         assignment.RuleID,
 		Tier:           assignment.Tier,
 		MatchedVariant: assignment.MatchedVariant,
+		ConflictReason: assignment.ConflictReason,
 		Eta:            TimeToPgTimestamptz(assignment.ETA),
 		EtaSource:      assignment.ETASource,
 		AssignedAt:     TimeToPgTimestamptz(assignment.AssignedAt),
@@ -190,6 +208,16 @@ func (r *standAssignmentRepository) GetBlock(ctx context.Context, session int32,
 
 func (r *standAssignmentRepository) ListBlocks(ctx context.Context, session int32) ([]*models.StandBlock, error) {
 	rows, err := r.queries.ListStandBlocks(ctx, session)
+	if err != nil {
+		return nil, err
+	}
+	return standBlocksToModels(rows), nil
+}
+
+// LockActiveManualBlocks locks only blocks that can currently affect an
+// allocation. Expired blocks are deliberately excluded from availability.
+func (r *standAssignmentRepository) LockActiveManualBlocks(ctx context.Context, session int32) ([]*models.StandBlock, error) {
+	rows, err := r.queries.LockActiveManualStandBlocks(ctx, session)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/repository/postgres/stand_assignment_repository_test.go
+++ b/backend/internal/repository/postgres/stand_assignment_repository_test.go
@@ -139,6 +139,31 @@ func TestStandAssignmentRepositoryWithTx(t *testing.T) {
 	require.Equal(t, "ECHO14", got.Stand)
 }
 
+func TestCreateStandBlockWaitsForSessionAllocationGuard(t *testing.T) {
+	pool, queries := testdata.SetupTestDB(t)
+	sessionID := testdata.SeedTestSessionNamedWithSectors(t, queries, "SAT-BLOCK-GUARD", nil)
+	repo := NewStandAssignmentRepository(pool)
+	ctx := context.Background()
+
+	tx, err := pool.Begin(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback(ctx)
+	_, err = tx.Exec(ctx, "SELECT id FROM sessions WHERE id = $1 FOR UPDATE", sessionID)
+	require.NoError(t, err)
+
+	timedOut, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+	err = repo.CreateBlock(timedOut, &models.StandBlock{
+		SessionID: sessionID,
+		Stand:     "ECHO12",
+		BlockType: "CLOSURE",
+		Source:    "CONTROLLER",
+		Manual:    true,
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
 func stringPtrForTest(value string) *string {
 	return &value
 }

--- a/backend/internal/repository/postgres/strip.go
+++ b/backend/internal/repository/postgres/strip.go
@@ -3,11 +3,13 @@ package postgres
 import (
 	"FlightStrips/internal/database"
 	"FlightStrips/internal/models"
+	"FlightStrips/internal/repository"
 	"context"
 	"encoding/json"
 	"errors"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -20,6 +22,11 @@ func NewStripRepository(db *pgxpool.Pool) *stripRepository {
 	return &stripRepository{
 		queries: database.New(db),
 	}
+}
+
+// WithTx returns a strip repository bound to tx.
+func (r *stripRepository) WithTx(tx pgx.Tx) repository.StripRepository {
+	return &stripRepository{queries: r.queries.WithTx(tx)}
 }
 
 func marshalCdmData(data *models.CdmData) ([]byte, error) {
@@ -230,6 +237,16 @@ func (r *stripRepository) GetByCallsign(ctx context.Context, session int32, call
 		Session:  session,
 		Callsign: callsign,
 	})
+	if err != nil {
+		return nil, err
+	}
+	return stripToModel(dbStrip)
+}
+
+// LockByCallsign retrieves a strip and holds a row lock until the caller's
+// transaction commits. SAT uses this before deciding strips.stand is current.
+func (r *stripRepository) LockByCallsign(ctx context.Context, session int32, callsign string) (*models.Strip, error) {
+	dbStrip, err := r.queries.LockStrip(ctx, database.LockStripParams{Callsign: callsign, Session: session})
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -14,6 +14,7 @@ type StripRepository interface {
 	// Basic CRUD operations
 	Create(ctx context.Context, strip *models.Strip) error
 	GetByCallsign(ctx context.Context, session int32, callsign string) (*models.Strip, error)
+	LockByCallsign(ctx context.Context, session int32, callsign string) (*models.Strip, error)
 	List(ctx context.Context, session int32) ([]*models.Strip, error)
 	Update(ctx context.Context, strip *models.Strip) (int64, error)
 	Delete(ctx context.Context, session int32, callsign string) error
@@ -94,6 +95,10 @@ type StripRepository interface {
 	SetValidationStatus(ctx context.Context, session int32, callsign string, status *models.ValidationStatus) error
 	AcknowledgeValidationStatus(ctx context.Context, session int32, callsign string, activationKey string) (int64, error)
 	ClearValidationStatus(ctx context.Context, session int32, callsign string) error
+
+	// WithTx returns a repository bound to the supplied transaction for
+	// operations that must update a strip atomically with SAT state.
+	WithTx(tx pgx.Tx) StripRepository
 }
 
 // ControllerRepository defines the interface for controller data access
@@ -180,12 +185,14 @@ type StandAssignmentRepository interface {
 	CreateAssignment(ctx context.Context, assignment *models.StandAssignment) error
 	GetAssignment(ctx context.Context, session int32, callsign string) (*models.StandAssignment, error)
 	ListAssignments(ctx context.Context, session int32) ([]*models.StandAssignment, error)
+	LockAssignments(ctx context.Context, session int32, callsign string) ([]*models.StandAssignment, error)
 	UpdateAssignment(ctx context.Context, assignment *models.StandAssignment) (int64, error)
 	DeleteAssignment(ctx context.Context, session int32, id int64, version int32) (int64, error)
 
 	CreateBlock(ctx context.Context, block *models.StandBlock) error
 	GetBlock(ctx context.Context, session int32, id int64) (*models.StandBlock, error)
 	ListBlocks(ctx context.Context, session int32) ([]*models.StandBlock, error)
+	LockActiveManualBlocks(ctx context.Context, session int32) ([]*models.StandBlock, error)
 	ListBlocksByStand(ctx context.Context, session int32, stand string) ([]*models.StandBlock, error)
 	UpdateBlock(ctx context.Context, block *models.StandBlock) (int64, error)
 	DeleteBlock(ctx context.Context, session int32, id int64, version int32) (int64, error)

--- a/backend/internal/services/stand_allocation.go
+++ b/backend/internal/services/stand_allocation.go
@@ -1,0 +1,463 @@
+package services
+
+import (
+	"FlightStrips/internal/models"
+	"FlightStrips/internal/repository"
+	"FlightStrips/internal/sat"
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// StandAllocationCommand is the caller's explicit allocation intent. The
+// later lifecycle and handler tasks decide when to issue each command; this
+// service owns the transaction that applies it.
+type StandAllocationCommand string
+
+const (
+	AutomaticStandAllocation   StandAllocationCommand = "AUTOMATIC_ALLOCATION"
+	AutomaticStandReallocation StandAllocationCommand = "AUTOMATIC_REALLOCATION"
+	CompatibleManualStand      StandAllocationCommand = "MANUAL_ASSIGNMENT"
+	IncompatibleManualOverride StandAllocationCommand = "MANUAL_OVERRIDE"
+)
+
+var (
+	ErrNoAvailableStand             = errors.New("no compatible stand is available")
+	ErrIncompatibleManualAssignment = errors.New("manual stand is not compatible or available")
+	ErrAllocationRetriesExhausted   = errors.New("stand allocation retries exhausted")
+	ErrUnknownManualOverrideStand   = errors.New("manual override stand is not configured")
+	errAllocationVersionConflict    = errors.New("stand assignment version conflict")
+)
+
+// StandAllocationRequest contains facts already resolved by the SAT data
+// layer. It intentionally excludes lifecycle and controller authorization
+// policy, which belong to later tasks.
+type StandAllocationRequest struct {
+	SessionID       int32
+	Callsign        string
+	Airport         string
+	Direction       sat.AssignmentDirection
+	Stage           string
+	FlightFacts     sat.FlightCompatibilityFacts
+	AssignmentFacts sat.AssignmentFlightFacts
+	ETA             *time.Time
+	ETASource       *string
+	ExpiresAt       *time.Time
+	VatsimCID       *int64
+	VatsimRevision  *int64
+
+	Stand          string
+	ConflictReason string
+}
+
+// StandAllocationResult is complete only after the transaction commits. The
+// eventual event/validation layer can use its decision data without rerunning
+// compatibility or selection.
+type StandAllocationResult struct {
+	Command             StandAllocationCommand
+	Assignment          models.StandAssignment
+	Selection           *sat.StandSelection
+	MatchedVariant      *sat.StandCompatibilityMatch
+	Compatibility       sat.StandCompatibilityEvaluation
+	ConflictReason      string
+	Attempts            int
+	AvailableCandidates []string
+}
+
+type StandAllocationPublisher func(context.Context, StandAllocationResult) error
+
+// StandAllocationService is the sole owner of the allocation transaction. It
+// builds on the SAT persistence repositories rather than bypassing their
+// versioning and transaction-bound access.
+type StandAllocationService struct {
+	pool        *pgxpool.Pool
+	strips      repository.StripRepository
+	assignments repository.StandAssignmentRepository
+	stands      *sat.StandCapabilityRegistry
+	policy      *sat.AirlineAssignmentConfig
+	random      func() float64
+	publish     StandAllocationPublisher
+	attempts    int
+}
+
+type StandAllocationOption func(*StandAllocationService)
+
+func WithStandAllocationRandom(random func() float64) StandAllocationOption {
+	return func(service *StandAllocationService) { service.random = random }
+}
+
+func WithStandAllocationPublisher(publisher StandAllocationPublisher) StandAllocationOption {
+	return func(service *StandAllocationService) { service.publish = publisher }
+}
+
+// WithStandAllocationAttempts bounds retries for serialization, uniqueness,
+// and optimistic-version conflicts. The default is three attempts.
+func WithStandAllocationAttempts(attempts int) StandAllocationOption {
+	return func(service *StandAllocationService) {
+		if attempts > 0 {
+			service.attempts = attempts
+		}
+	}
+}
+
+func NewStandAllocationService(pool *pgxpool.Pool, strips repository.StripRepository, assignments repository.StandAssignmentRepository, stands *sat.StandCapabilityRegistry, policy *sat.AirlineAssignmentConfig, options ...StandAllocationOption) (*StandAllocationService, error) {
+	if pool == nil || strips == nil || assignments == nil || stands == nil || policy == nil {
+		return nil, errors.New("stand allocation requires database, repositories, capabilities, and policy")
+	}
+	service := &StandAllocationService{
+		pool: pool, strips: strips, assignments: assignments, stands: stands,
+		policy: policy, random: rand.Float64, attempts: 3,
+	}
+	for _, option := range options {
+		if option != nil {
+			option(service)
+		}
+	}
+	if service.random == nil {
+		return nil, errors.New("stand allocation random source is nil")
+	}
+	return service, nil
+}
+
+func (s *StandAllocationService) Allocate(ctx context.Context, request StandAllocationRequest) (*StandAllocationResult, error) {
+	return s.allocate(ctx, AutomaticStandAllocation, request)
+}
+
+func (s *StandAllocationService) Reallocate(ctx context.Context, request StandAllocationRequest) (*StandAllocationResult, error) {
+	return s.allocate(ctx, AutomaticStandReallocation, request)
+}
+
+func (s *StandAllocationService) AssignManually(ctx context.Context, request StandAllocationRequest) (*StandAllocationResult, error) {
+	return s.allocate(ctx, CompatibleManualStand, request)
+}
+
+func (s *StandAllocationService) OverrideManually(ctx context.Context, request StandAllocationRequest) (*StandAllocationResult, error) {
+	return s.allocate(ctx, IncompatibleManualOverride, request)
+}
+
+func (s *StandAllocationService) allocate(ctx context.Context, command StandAllocationCommand, request StandAllocationRequest) (*StandAllocationResult, error) {
+	if err := validateStandAllocationRequest(command, &request); err != nil {
+		return nil, err
+	}
+	tried := map[string]struct{}{}
+	for attempt := 1; attempt <= s.attempts; attempt++ {
+		result, selected, err := s.allocateOnce(ctx, command, request, tried, attempt)
+		if err == nil {
+			if s.publish != nil {
+				if err := s.publish(ctx, *result); err != nil {
+					return result, fmt.Errorf("publish committed stand allocation: %w", err)
+				}
+			}
+			return result, nil
+		}
+		if selected != "" {
+			tried[selected] = struct{}{}
+		}
+		if !retryableStandAllocationError(err) {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("%w after %d attempts", ErrAllocationRetriesExhausted, s.attempts)
+}
+
+func validateStandAllocationRequest(command StandAllocationCommand, request *StandAllocationRequest) error {
+	request.Callsign = strings.ToUpper(strings.TrimSpace(request.Callsign))
+	request.Airport = strings.ToUpper(strings.TrimSpace(request.Airport))
+	request.Stand = standName(request.Stand)
+	if request.SessionID <= 0 || request.Callsign == "" || request.Airport == "" {
+		return errors.New("stand allocation requires session, callsign, and airport")
+	}
+	if request.Direction != sat.AssignmentDirectionArrival && request.Direction != sat.AssignmentDirectionDeparture {
+		return fmt.Errorf("invalid stand allocation direction %q", request.Direction)
+	}
+	if request.Stage == "" {
+		request.Stage = "ASSIGNED"
+	}
+	if command == CompatibleManualStand || command == IncompatibleManualOverride {
+		if request.Stand == "" {
+			return errors.New("manual stand allocation requires a stand")
+		}
+	}
+	if command == IncompatibleManualOverride && strings.TrimSpace(request.ConflictReason) == "" {
+		return errors.New("manual override requires a conflict reason")
+	}
+	request.AssignmentFacts.Callsign = request.Callsign
+	request.AssignmentFacts.Direction = request.Direction
+	return nil
+}
+
+func (s *StandAllocationService) allocateOnce(ctx context.Context, command StandAllocationCommand, request StandAllocationRequest, tried map[string]struct{}, attempt int) (*StandAllocationResult, string, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return nil, "", err
+	}
+	defer tx.Rollback(ctx)
+	if _, err := tx.Exec(ctx, "SELECT id FROM sessions WHERE id = $1 FOR UPDATE", request.SessionID); err != nil {
+		return nil, "", err
+	}
+
+	txStrips := s.strips.WithTx(tx)
+	txAssignments := s.assignments.WithTx(tx)
+	strip, err := txStrips.LockByCallsign(ctx, request.SessionID, request.Callsign)
+	if err != nil {
+		return nil, "", fmt.Errorf("load allocation strip: %w", err)
+	}
+	assignments, err := txAssignments.LockAssignments(ctx, request.SessionID, request.Callsign)
+	if err != nil {
+		return nil, "", err
+	}
+	blocks, err := txAssignments.LockActiveManualBlocks(ctx, request.SessionID)
+	if err != nil {
+		return nil, "", err
+	}
+
+	evaluation := s.stands.EvaluateCompatibility(request.Airport, request.FlightFacts)
+	if command == CompatibleManualStand || command == IncompatibleManualOverride {
+		evaluation = s.stands.EvaluateManualCompatibility(request.Airport, request.FlightFacts)
+	}
+	selected, selection, match, available, conflict, err := s.selectStand(command, request, evaluation, assignments, blocks, tried)
+	if err != nil {
+		return nil, selected, err
+	}
+	request.Stand = selected
+	assignment, err := persistStandAllocation(ctx, txAssignments, command, request, assignments, selection, match, conflict)
+	if err != nil {
+		return nil, selected, err
+	}
+	if strip.Stand == nil || *strip.Stand != selected {
+		updated, err := txStrips.UpdateStand(ctx, request.SessionID, request.Callsign, &selected, nil)
+		if err != nil {
+			return nil, selected, err
+		}
+		if updated != 1 {
+			return nil, selected, errAllocationVersionConflict
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, selected, err
+	}
+	return &StandAllocationResult{
+		Command: command, Assignment: *assignment, Selection: selection, MatchedVariant: match,
+		Compatibility: evaluation, ConflictReason: conflict, Attempts: attempt, AvailableCandidates: available,
+	}, selected, nil
+}
+
+func (s *StandAllocationService) selectStand(command StandAllocationCommand, request StandAllocationRequest, evaluation sat.StandCompatibilityEvaluation, assignments []*models.StandAssignment, blocks []*models.StandBlock, tried map[string]struct{}) (string, *sat.StandSelection, *sat.StandCompatibilityMatch, []string, string, error) {
+	matches := make(map[string]sat.StandCompatibilityMatch, len(evaluation.Matches))
+	for _, match := range evaluation.Matches {
+		matches[standName(match.Stand.Name)] = match
+	}
+	availability := s.availability(request, assignments, blocks, matches)
+	if command == IncompatibleManualOverride {
+		stand, known := s.stands.Lookup(request.Airport, request.Stand)
+		if !known {
+			return "", nil, nil, nil, "", fmt.Errorf("%w: %s", ErrUnknownManualOverrideStand, request.Stand)
+		}
+		match, compatible := matches[request.Stand]
+		reasons := append([]string{request.ConflictReason}, availability[request.Stand]...)
+		if !compatible {
+			reasons = append(reasons, compatibilityReason(request.Stand, evaluation.Rejections))
+			if len(stand.Variants) > 0 {
+				match = sat.StandCompatibilityMatch{Stand: stand, Variant: stand.Variants[0], Blocks: slices.Clone(stand.Variants[0].Blocks)}
+			}
+		}
+		return request.Stand, nil, &match, nil, joinAllocationReasons(reasons), nil
+	}
+	if command == CompatibleManualStand {
+		match, compatible := matches[request.Stand]
+		if !compatible || len(availability[request.Stand]) > 0 {
+			return request.Stand, nil, nil, nil, "", fmt.Errorf("%w: %s", ErrIncompatibleManualAssignment, request.Stand)
+		}
+		return request.Stand, nil, &match, []string{request.Stand}, "", nil
+	}
+
+	available := make([]string, 0, len(matches))
+	for stand := range matches {
+		if len(availability[stand]) == 0 {
+			if _, retrying := tried[stand]; !retrying {
+				available = append(available, stand)
+			}
+		}
+	}
+	slices.Sort(available)
+	selection, err := s.policy.SelectStand(request.AssignmentFacts, available, s.random)
+	if err != nil {
+		return "", nil, nil, available, "", err
+	}
+	if selection == nil {
+		return "", nil, nil, available, "", ErrNoAvailableStand
+	}
+	match := matches[selection.Stand]
+	return selection.Stand, selection, &match, available, "", nil
+}
+
+func (s *StandAllocationService) availability(request StandAllocationRequest, assignments []*models.StandAssignment, blocks []*models.StandBlock, matches map[string]sat.StandCompatibilityMatch) map[string][]string {
+	now := time.Now()
+	result := map[string][]string{}
+	for candidate, match := range matches {
+		for _, assignment := range assignments {
+			if assignment == nil || strings.EqualFold(assignment.Callsign, request.Callsign) || expired(assignment.ExpiresAt, now) {
+				continue
+			}
+			if candidate == standName(assignment.Stand) {
+				result[candidate] = append(result[candidate], "reserved by "+assignment.Callsign)
+				continue
+			}
+			if blocksEachOther(match.Blocks, s.assignedBlocks(request.Airport, assignment), candidate, assignment.Stand) {
+				result[candidate] = append(result[candidate], "blocked by allocated neighbor "+assignment.Stand)
+			}
+		}
+		for _, block := range blocks {
+			if block != nil && candidate == standName(block.Stand) {
+				reason := "manually blocked"
+				if block.Reason != nil && strings.TrimSpace(*block.Reason) != "" {
+					reason += ": " + strings.TrimSpace(*block.Reason)
+				}
+				result[candidate] = append(result[candidate], reason)
+			}
+		}
+	}
+	return result
+}
+
+func (s *StandAllocationService) assignedBlocks(airport string, assignment *models.StandAssignment) []string {
+	stand, found := s.stands.Lookup(airport, assignment.Stand)
+	if !found {
+		return nil
+	}
+	if assignment.MatchedVariant != nil {
+		for _, variant := range stand.Variants {
+			if allocationVariantKey(airport, stand.Name, variant.Line) == *assignment.MatchedVariant {
+				return slices.Clone(variant.Blocks)
+			}
+		}
+	}
+	return slices.Clone(stand.Blocks)
+}
+
+func persistStandAllocation(ctx context.Context, store repository.StandAssignmentRepository, command StandAllocationCommand, request StandAllocationRequest, current []*models.StandAssignment, selection *sat.StandSelection, match *sat.StandCompatibilityMatch, conflict string) (*models.StandAssignment, error) {
+	var existing *models.StandAssignment
+	for _, assignment := range current {
+		if assignment != nil && strings.EqualFold(assignment.Callsign, request.Callsign) {
+			existing = assignment
+			break
+		}
+	}
+	next := &models.StandAssignment{SessionID: request.SessionID, Callsign: request.Callsign}
+	if existing != nil {
+		*next = *existing
+	}
+	now := time.Now().UTC()
+	next.Stand, next.Direction, next.Stage = request.Stand, string(request.Direction), request.Stage
+	next.Source, next.Manual = allocationSource(command)
+	next.RuleID, next.Tier, next.MatchedVariant = allocationSelectionMetadata(request, selection, match)
+	next.ConflictReason = nil
+	if conflict != "" {
+		next.ConflictReason = &conflict
+	}
+	next.ETA, next.ETASource, next.AssignedAt, next.ExpiresAt = request.ETA, request.ETASource, &now, request.ExpiresAt
+	next.Acknowledged, next.AcknowledgedAt, next.AcknowledgedBy = false, nil, nil
+	next.VatsimCID, next.VatsimRevision = request.VatsimCID, request.VatsimRevision
+	if existing == nil {
+		if err := store.CreateAssignment(ctx, next); err != nil {
+			return nil, err
+		}
+		return next, nil
+	}
+	updated, err := store.UpdateAssignment(ctx, next)
+	if err != nil {
+		return nil, err
+	}
+	if updated != 1 {
+		return nil, errAllocationVersionConflict
+	}
+	next.Version++
+	return next, nil
+}
+
+func allocationSelectionMetadata(request StandAllocationRequest, selection *sat.StandSelection, match *sat.StandCompatibilityMatch) (*string, *int32, *string) {
+	var ruleID, variant *string
+	var tier *int32
+	if selection != nil {
+		ruleID = stringPointer(selection.RuleID)
+		value := int32(selection.Tier)
+		tier = &value
+	}
+	if match != nil && match.Variant.Line > 0 {
+		value := allocationVariantKey(request.Airport, request.Stand, match.Variant.Line)
+		variant = &value
+	}
+	return ruleID, tier, variant
+}
+
+func allocationSource(command StandAllocationCommand) (string, bool) {
+	switch command {
+	case CompatibleManualStand:
+		return "MANUAL", true
+	case IncompatibleManualOverride:
+		return "MANUAL_OVERRIDE", true
+	default:
+		return "AUTOMATIC", false
+	}
+}
+
+func expired(at *time.Time, now time.Time) bool { return at != nil && !at.After(now) }
+
+func blocksEachOther(candidateBlocks, assignedBlocks []string, candidate, assigned string) bool {
+	return containsStand(candidateBlocks, assigned) || containsStand(assignedBlocks, candidate)
+}
+
+func containsStand(blocks []string, wanted string) bool {
+	for _, stand := range blocks {
+		if standName(stand) == standName(wanted) {
+			return true
+		}
+	}
+	return false
+}
+
+func compatibilityReason(stand string, rejections []sat.StandCompatibilityRejection) string {
+	for _, rejection := range rejections {
+		if standName(rejection.Stand) == standName(stand) {
+			return fmt.Sprintf("incompatible %s: expected %s, got %s", rejection.Capability, rejection.Expected, rejection.Actual)
+		}
+	}
+	return "no compatible stand variant"
+}
+
+func joinAllocationReasons(reasons []string) string {
+	seen := map[string]struct{}{}
+	var result []string
+	for _, reason := range reasons {
+		reason = strings.TrimSpace(reason)
+		if reason != "" {
+			if _, exists := seen[reason]; !exists {
+				seen[reason] = struct{}{}
+				result = append(result, reason)
+			}
+		}
+	}
+	return strings.Join(result, "; ")
+}
+
+func standName(value string) string      { return strings.ToUpper(strings.TrimSpace(value)) }
+func stringPointer(value string) *string { return &value }
+func allocationVariantKey(airport, stand string, line int) string {
+	return fmt.Sprintf("%s:%s:%d", standName(airport), standName(stand), line)
+}
+
+func retryableStandAllocationError(err error) bool {
+	if errors.Is(err, errAllocationVersionConflict) {
+		return true
+	}
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && (pgErr.Code == "40001" || pgErr.Code == "40P01" || pgErr.Code == "23505")
+}

--- a/backend/internal/services/stand_allocation_test.go
+++ b/backend/internal/services/stand_allocation_test.go
@@ -1,0 +1,214 @@
+package services
+
+import (
+	"FlightStrips/internal/database"
+	"FlightStrips/internal/models"
+	"FlightStrips/internal/pdc/testdata"
+	"FlightStrips/internal/repository"
+	"FlightStrips/internal/repository/postgres"
+	"FlightStrips/internal/sat"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var standAllocationSessionSequence atomic.Int64
+
+func TestStandAllocationServiceTransactions(t *testing.T) {
+	pool, queries := testdata.SetupTestDB(t)
+	ctx := context.Background()
+
+	t.Run("updates strip and assignment before publishing", func(t *testing.T) {
+		service, session, _ := standAllocationFixture(t, pool, queries, "", "")
+		testdata.SeedTestStrip(t, queries, session, "SAS101")
+		published := make(chan StandAllocationResult, 1)
+		service.publish = func(_ context.Context, result StandAllocationResult) error { published <- result; return nil }
+
+		result, err := service.Allocate(ctx, standAllocationRequest(session, "SAS101"))
+		require.NoError(t, err)
+		assert.Equal(t, "A1", result.Assignment.Stand)
+		strip, err := queries.GetStrip(ctx, database.GetStripParams{Session: session, Callsign: "SAS101"})
+		require.NoError(t, err)
+		require.NotNil(t, strip.Stand)
+		assert.Equal(t, "A1", *strip.Stand)
+		select {
+		case event := <-published:
+			assert.Equal(t, result.Assignment.ID, event.Assignment.ID)
+		default:
+			t.Fatal("allocation was not published after commit")
+		}
+	})
+
+	t.Run("rejects direct occupancy and one-way or two-way blocks", func(t *testing.T) {
+		for _, directives := range []struct{ a1, a2 string }{
+			{a1: "BLOCKS:A2"},
+			{a1: "BLOCKS:A2", a2: "BLOCKS:A1"},
+		} {
+			service, session, _ := standAllocationFixture(t, pool, queries, directives.a1, directives.a2)
+			testdata.SeedTestStrip(t, queries, session, "SAS201")
+			testdata.SeedTestStrip(t, queries, session, "SAS202")
+			_, err := service.Allocate(ctx, standAllocationRequest(session, "SAS201"))
+			require.NoError(t, err)
+			_, err = service.AssignManually(ctx, withStand(standAllocationRequest(session, "SAS202"), "A1"))
+			require.ErrorIs(t, err, ErrIncompatibleManualAssignment)
+			_, err = service.AssignManually(ctx, withStand(standAllocationRequest(session, "SAS202"), "A2"))
+			require.ErrorIs(t, err, ErrIncompatibleManualAssignment)
+		}
+	})
+
+	t.Run("locks active manual blocks", func(t *testing.T) {
+		service, session, assignments := standAllocationFixture(t, pool, queries, "", "")
+		testdata.SeedTestStrip(t, queries, session, "SAS301")
+		require.NoError(t, assignments.CreateBlock(ctx, &models.StandBlock{
+			SessionID: session, Stand: "A1", BlockType: "CLOSURE", Source: "CONTROLLER", Manual: true,
+		}))
+		_, err := service.AssignManually(ctx, withStand(standAllocationRequest(session, "SAS301"), "A1"))
+		require.ErrorIs(t, err, ErrIncompatibleManualAssignment)
+	})
+
+	t.Run("records an explicit incompatible override and leaves failures unpublished", func(t *testing.T) {
+		service, session, _ := standAllocationFixture(t, pool, queries, "", "")
+		testdata.SeedTestStrip(t, queries, session, "SAS401")
+		testdata.SeedTestStrip(t, queries, session, "SAS402")
+		_, err := service.Allocate(ctx, standAllocationRequest(session, "SAS401"))
+		require.NoError(t, err)
+		override := withStand(standAllocationRequest(session, "SAS402"), "A1")
+		override.ConflictReason = "controller approved overlap"
+		result, err := service.OverrideManually(ctx, override)
+		require.NoError(t, err)
+		assert.Equal(t, "MANUAL_OVERRIDE", result.Assignment.Source)
+		require.NotNil(t, result.Assignment.ConflictReason)
+		assert.Contains(t, *result.Assignment.ConflictReason, "reserved by SAS401")
+
+		failed, failedSession, _ := standAllocationFixture(t, pool, queries, "", "")
+		testdata.SeedTestStrip(t, queries, failedSession, "SAS403")
+		published := false
+		failed.publish = func(context.Context, StandAllocationResult) error { published = true; return nil }
+		_, err = failed.AssignManually(ctx, withStand(standAllocationRequest(failedSession, "SAS403"), "A9"))
+		require.ErrorIs(t, err, ErrIncompatibleManualAssignment)
+		assert.False(t, published)
+		_, err = queries.GetStandAssignment(ctx, database.GetStandAssignmentParams{SessionID: failedSession, Callsign: "SAS403"})
+		require.Error(t, err)
+		strip, err := queries.GetStrip(ctx, database.GetStripParams{Session: failedSession, Callsign: "SAS403"})
+		require.NoError(t, err)
+		assert.Nil(t, strip.Stand)
+	})
+
+	t.Run("retries with remaining candidates and stops at its configured bound", func(t *testing.T) {
+		service, session, assignments := standAllocationFixture(t, pool, queries, "", "")
+		testdata.SeedTestStrip(t, queries, session, "SAS501")
+		_, err := service.Allocate(ctx, standAllocationRequest(session, "SAS501"))
+		require.NoError(t, err)
+		recorder := &retryRecorder{}
+		service.assignments = retryConflictRepository{StandAssignmentRepository: assignments, recorder: recorder}
+		service.random = func() float64 { return .99 }
+		service.attempts = 2
+		_, err = service.Reallocate(ctx, standAllocationRequest(session, "SAS501"))
+		require.ErrorIs(t, err, ErrAllocationRetriesExhausted)
+		assert.Equal(t, []string{"A2", "A1"}, recorder.stands, "the retry excludes the conflicted selection")
+		assignment, err := assignments.GetAssignment(ctx, session, "SAS501")
+		require.NoError(t, err)
+		assert.Equal(t, "A1", assignment.Stand, "failed attempts roll back the assignment")
+	})
+
+	t.Run("concurrent calls cannot allocate blocked neighbors", func(t *testing.T) {
+		service, session, _ := standAllocationFixture(t, pool, queries, "BLOCKS:A2", "")
+		testdata.SeedTestStrip(t, queries, session, "SAS601")
+		testdata.SeedTestStrip(t, queries, session, "SAS602")
+		start, results := make(chan struct{}), make(chan error, 2)
+		var wait sync.WaitGroup
+		for _, callsign := range []string{"SAS601", "SAS602"} {
+			wait.Add(1)
+			go func(callsign string) {
+				defer wait.Done()
+				<-start
+				_, err := service.Allocate(ctx, standAllocationRequest(session, callsign))
+				results <- err
+			}(callsign)
+		}
+		close(start)
+		wait.Wait()
+		close(results)
+		var successes, unavailable int
+		for err := range results {
+			if err == nil {
+				successes++
+			} else if errors.Is(err, ErrNoAvailableStand) {
+				unavailable++
+			} else {
+				t.Fatalf("unexpected allocation error: %v", err)
+			}
+		}
+		assert.Equal(t, 1, successes)
+		assert.Equal(t, 1, unavailable)
+	})
+}
+
+func standAllocationFixture(t *testing.T, pool *pgxpool.Pool, queries *database.Queries, a1Directive, a2Directive string) (*StandAllocationService, int32, repository.StandAssignmentRepository) {
+	t.Helper()
+	registry, err := sat.LoadStandCapabilities(strings.NewReader(`
+STAND:EKCH:A1:N055.37.42.710:E012.38.33.450:30
+` + a1Directive + `
+STAND:EKCH:A2:N055.37.42.710:E012.38.33.451:30
+` + a2Directive + `
+`))
+	require.NoError(t, err)
+	policy, err := sat.LoadAirlineAssignment(strings.NewReader(`{
+  "rules": [{"id":"sas","callsigns":["SAS"],"stands":{"tier1":{"A1":100,"A2":100}}}],
+  "stand_groups": {}, "fallback_rules": {`+testFallbackJSON("A1")+`}
+}`), registry)
+	require.NoError(t, err)
+	assignments := postgres.NewStandAssignmentRepository(pool)
+	service, err := NewStandAllocationService(pool, postgres.NewStripRepository(pool), assignments, registry, policy, WithStandAllocationRandom(func() float64 { return 0 }))
+	require.NoError(t, err)
+	name := fmt.Sprintf("%s-%d", t.Name(), standAllocationSessionSequence.Add(1))
+	return service, testdata.SeedTestSessionNamedWithSectors(t, queries, name, nil), assignments
+}
+
+func standAllocationRequest(session int32, callsign string) StandAllocationRequest {
+	return StandAllocationRequest{
+		SessionID: session, Callsign: callsign, Airport: "EKCH", Direction: sat.AssignmentDirectionArrival,
+		FlightFacts: sat.FlightCompatibilityFacts{Direction: sat.Arrival},
+	}
+}
+
+func withStand(request StandAllocationRequest, stand string) StandAllocationRequest {
+	request.Stand = stand
+	return request
+}
+
+func testFallbackJSON(stand string) string {
+	names := []string{"airliner_default", "business_vip", "cargo", "military", "military_helicopter", "helicopter", "ga_private", "unknown"}
+	parts := make([]string, 0, len(names))
+	for _, name := range names {
+		parts = append(parts, `"`+name+`":{"stands":{"tier1":{"`+stand+`":100}}}`)
+	}
+	return strings.Join(parts, ",")
+}
+
+type retryRecorder struct {
+	stands []string
+}
+
+type retryConflictRepository struct {
+	repository.StandAssignmentRepository
+	recorder *retryRecorder
+}
+
+func (r retryConflictRepository) WithTx(tx pgx.Tx) repository.StandAssignmentRepository {
+	return retryConflictRepository{StandAssignmentRepository: r.StandAssignmentRepository.WithTx(tx), recorder: r.recorder}
+}
+
+func (r retryConflictRepository) UpdateAssignment(_ context.Context, assignment *models.StandAssignment) (int64, error) {
+	r.recorder.stands = append(r.recorder.stands, assignment.Stand)
+	return 0, nil
+}

--- a/backend/internal/testutil/mock_strip_repository.go
+++ b/backend/internal/testutil/mock_strip_repository.go
@@ -2,8 +2,11 @@ package testutil
 
 import (
 	"FlightStrips/internal/models"
+	"FlightStrips/internal/repository"
 	"context"
 	"time"
+
+	"github.com/jackc/pgx/v5"
 )
 
 // MockStripRepository is a configurable mock for repository.StripRepository.
@@ -11,6 +14,7 @@ import (
 type MockStripRepository struct {
 	CreateFn                        func(ctx context.Context, strip *models.Strip) error
 	GetByCallsignFn                 func(ctx context.Context, session int32, callsign string) (*models.Strip, error)
+	LockByCallsignFn                func(ctx context.Context, session int32, callsign string) (*models.Strip, error)
 	ListFn                          func(ctx context.Context, session int32) ([]*models.Strip, error)
 	UpdateFn                        func(ctx context.Context, strip *models.Strip) (int64, error)
 	DeleteFn                        func(ctx context.Context, session int32, callsign string) error
@@ -69,6 +73,17 @@ type MockStripRepository struct {
 	SetValidationStatusFn           func(ctx context.Context, session int32, callsign string, status *models.ValidationStatus) error
 	AcknowledgeValidationStatusFn   func(ctx context.Context, session int32, callsign string, activationKey string) (int64, error)
 	ClearValidationStatusFn         func(ctx context.Context, session int32, callsign string) error
+	WithTxFn                        func(tx pgx.Tx) repository.StripRepository
+}
+
+// WithTx returns a transaction-bound repository in production. The mock has
+// no database state, so callers can either inject a transaction-specific mock
+// or continue using this instance.
+func (m *MockStripRepository) WithTx(tx pgx.Tx) repository.StripRepository {
+	if m.WithTxFn != nil {
+		return m.WithTxFn(tx)
+	}
+	return m
 }
 
 func (m *MockStripRepository) Create(ctx context.Context, strip *models.Strip) error {
@@ -83,6 +98,13 @@ func (m *MockStripRepository) GetByCallsign(ctx context.Context, session int32, 
 		panic("unexpected call to MockStripRepository.GetByCallsign")
 	}
 	return m.GetByCallsignFn(ctx, session, callsign)
+}
+
+func (m *MockStripRepository) LockByCallsign(ctx context.Context, session int32, callsign string) (*models.Strip, error) {
+	if m.LockByCallsignFn == nil {
+		panic("unexpected call to MockStripRepository.LockByCallsign")
+	}
+	return m.LockByCallsignFn(ctx, session, callsign)
 }
 
 func (m *MockStripRepository) List(ctx context.Context, session int32) ([]*models.Strip, error) {

--- a/backend/migrations/0031-stand-assignment-conflict-reason.sql
+++ b/backend/migrations/0031-stand-assignment-conflict-reason.sql
@@ -1,0 +1,2 @@
+ALTER TABLE stand_assignments
+    ADD COLUMN IF NOT EXISTS conflict_reason VARCHAR;

--- a/backend/queries/stand_assignments.sql
+++ b/backend/queries/stand_assignments.sql
@@ -1,15 +1,15 @@
 -- name: CreateStandAssignment :one
 INSERT INTO stand_assignments (
     session_id, callsign, stand, direction, stage, source, rule_id, tier,
-    matched_variant, eta, eta_source,
+    matched_variant, conflict_reason, eta, eta_source,
     assigned_at, expires_at, manual, acknowledged, acknowledged_at,
     acknowledged_by, vatsim_cid, vatsim_revision
 )
 VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8,
-    $9, $10, $11,
-    $12, $13, $14, $15, $16,
-    $17, $18, $19
+    $9, $10, $11, $12,
+    $13, $14, $15, $16, $17,
+    $18, $19, $20
 )
 RETURNING *;
 
@@ -24,6 +24,14 @@ FROM stand_assignments
 WHERE session_id = $1
 ORDER BY callsign;
 
+-- name: LockStandAssignments :many
+SELECT *
+FROM stand_assignments
+WHERE session_id = $1
+  AND (callsign = $2 OR expires_at IS NULL OR expires_at > NOW())
+ORDER BY callsign
+FOR UPDATE;
+
 -- name: UpdateStandAssignment :execrows
 UPDATE stand_assignments
 SET stand = $3,
@@ -33,19 +41,20 @@ SET stand = $3,
     rule_id = $7,
     tier = $8,
     matched_variant = $9,
-    eta = $10,
-    eta_source = $11,
-    assigned_at = $12,
-    expires_at = $13,
-    manual = $14,
-    acknowledged = $15,
-    acknowledged_at = $16,
-    acknowledged_by = $17,
-    vatsim_cid = $18,
-    vatsim_revision = $19,
+    conflict_reason = $10,
+    eta = $11,
+    eta_source = $12,
+    assigned_at = $13,
+    expires_at = $14,
+    manual = $15,
+    acknowledged = $16,
+    acknowledged_at = $17,
+    acknowledged_by = $18,
+    vatsim_cid = $19,
+    vatsim_revision = $20,
     version = version + 1,
     updated_at = NOW()
-WHERE id = $1 AND session_id = $2 AND version = $20;
+WHERE id = $1 AND session_id = $2 AND version = $21;
 
 -- name: DeleteStandAssignment :execrows
 DELETE FROM stand_assignments
@@ -56,7 +65,8 @@ INSERT INTO stand_blocks (
     session_id, stand, block_type, source, reason, callsign, created_by,
     expires_at, manual
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9
+FROM (SELECT id FROM sessions WHERE id = $1 FOR UPDATE) AS locked_session
 RETURNING *;
 
 -- name: GetStandBlock :one
@@ -69,6 +79,15 @@ SELECT *
 FROM stand_blocks
 WHERE session_id = $1
 ORDER BY stand, id;
+
+-- name: LockActiveManualStandBlocks :many
+SELECT *
+FROM stand_blocks
+WHERE session_id = $1
+  AND manual = TRUE
+  AND (expires_at IS NULL OR expires_at > NOW())
+ORDER BY stand, id
+FOR UPDATE;
 
 -- name: ListStandBlocksByStand :many
 SELECT *

--- a/backend/queries/strips.sql
+++ b/backend/queries/strips.sql
@@ -139,6 +139,12 @@ SELECT *
 FROM strips
 WHERE callsign = $1 AND session = $2;
 
+-- name: LockStrip :one
+SELECT *
+FROM strips
+WHERE callsign = $1 AND session = $2
+FOR UPDATE;
+
 -- name: ListStrips :many
 SELECT *
 FROM strips


### PR DESCRIPTION
## Summary

Adds the transactional stand-allocation service and its repository locking primitives.

The allocator serializes session allocation and manual block creation, checks compatibility and bidirectional stand blocking inside the transaction, synchronizes `strips.stand` with the durable SAT assignment, and records explicit manual-override conflicts.

## Validation

- `go test ./...` (from `backend`)
