### PR TITLE
feat(stand): calculate arrival ETA

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -157,7 +157,8 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	euroscopeHub := euroscope.NewHub(stripService, controllerService, authService)
 	var vatsimReconciler *vatsim.Reconciler
 	if standAssignmentReadiness.Ready && vatsimCache != nil && standAssignmentRepo != nil {
-		vatsimReconciler = vatsim.NewReconciler(vatsimCache, sessionRepo, stripRepo, standAssignmentRepo, frontendHub, deps.VATSIMPollInterval)
+		latitude, longitude := appconfig.GetAirportCoordinates()
+		vatsimReconciler = vatsim.NewReconciler(vatsimCache, sessionRepo, stripRepo, standAssignmentRepo, frontendHub, deps.VATSIMPollInterval, vatsim.WithAirportCoordinates(latitude, longitude))
 		euroscopeHub.SetAircraftDisconnectRetainer(vatsimReconciler.RetainsStrip)
 	}
 	albHub := alb.NewHub()

--- a/backend/internal/database/models.go
+++ b/backend/internal/database/models.go
@@ -161,6 +161,7 @@ type Strip struct {
 	VatsimRevision           *int64
 	VatsimSeenAt             pgtype.Timestamptz
 	EuroscopeSeenAt          pgtype.Timestamptz
+	ArrivalEta               []byte
 }
 
 type TacticalStrip struct {

--- a/backend/internal/database/strips.sql.go
+++ b/backend/internal/database/strips.sql.go
@@ -313,7 +313,7 @@ func (q *Queries) GetSequence(ctx context.Context, arg GetSequenceParams) (int32
 }
 
 const getStrip = `-- name: GetStrip :one
-SELECT id, version, callsign, session, origin, destination, alternative, route, remarks, assigned_squawk, squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities, communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay, position_latitude, position_longitude, position_altitude, next_owners, previous_owners, release_point, marked, registration, tracking_controller, runway_cleared, unexpected_change_fields, controller_modified_fields, engine_type, is_manual, persons_on_board, fpl_type, language, has_fp, cdm_data, runway_confirmed, pdc_data, validation_status, start_req, spoken_callsign, vatsim_cid, vatsim_revision, vatsim_seen_at, euroscope_seen_at
+SELECT id, version, callsign, session, origin, destination, alternative, route, remarks, assigned_squawk, squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities, communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay, position_latitude, position_longitude, position_altitude, next_owners, previous_owners, release_point, marked, registration, tracking_controller, runway_cleared, unexpected_change_fields, controller_modified_fields, engine_type, is_manual, persons_on_board, fpl_type, language, has_fp, cdm_data, runway_confirmed, pdc_data, validation_status, start_req, spoken_callsign, vatsim_cid, vatsim_revision, vatsim_seen_at, euroscope_seen_at, arrival_eta
 FROM strips
 WHERE callsign = $1 AND session = $2
 `
@@ -381,6 +381,7 @@ func (q *Queries) GetStrip(ctx context.Context, arg GetStripParams) (Strip, erro
 		&i.VatsimRevision,
 		&i.VatsimSeenAt,
 		&i.EuroscopeSeenAt,
+		&i.ArrivalEta,
 	)
 	return i, err
 }
@@ -564,7 +565,7 @@ func (q *Queries) ListStripSequences(ctx context.Context, arg ListStripSequences
 }
 
 const listStrips = `-- name: ListStrips :many
-SELECT id, version, callsign, session, origin, destination, alternative, route, remarks, assigned_squawk, squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities, communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay, position_latitude, position_longitude, position_altitude, next_owners, previous_owners, release_point, marked, registration, tracking_controller, runway_cleared, unexpected_change_fields, controller_modified_fields, engine_type, is_manual, persons_on_board, fpl_type, language, has_fp, cdm_data, runway_confirmed, pdc_data, validation_status, start_req, spoken_callsign, vatsim_cid, vatsim_revision, vatsim_seen_at, euroscope_seen_at
+SELECT id, version, callsign, session, origin, destination, alternative, route, remarks, assigned_squawk, squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities, communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay, position_latitude, position_longitude, position_altitude, next_owners, previous_owners, release_point, marked, registration, tracking_controller, runway_cleared, unexpected_change_fields, controller_modified_fields, engine_type, is_manual, persons_on_board, fpl_type, language, has_fp, cdm_data, runway_confirmed, pdc_data, validation_status, start_req, spoken_callsign, vatsim_cid, vatsim_revision, vatsim_seen_at, euroscope_seen_at, arrival_eta
 FROM strips
 WHERE session = $1
 ORDER BY callsign
@@ -634,6 +635,7 @@ func (q *Queries) ListStrips(ctx context.Context, session int32) ([]Strip, error
 			&i.VatsimRevision,
 			&i.VatsimSeenAt,
 			&i.EuroscopeSeenAt,
+			&i.ArrivalEta,
 		); err != nil {
 			return nil, err
 		}
@@ -646,7 +648,7 @@ func (q *Queries) ListStrips(ctx context.Context, session int32) ([]Strip, error
 }
 
 const listStripsByOrigin = `-- name: ListStripsByOrigin :many
-SELECT id, version, callsign, session, origin, destination, alternative, route, remarks, assigned_squawk, squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities, communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay, position_latitude, position_longitude, position_altitude, next_owners, previous_owners, release_point, marked, registration, tracking_controller, runway_cleared, unexpected_change_fields, controller_modified_fields, engine_type, is_manual, persons_on_board, fpl_type, language, has_fp, cdm_data, runway_confirmed, pdc_data, validation_status, start_req, spoken_callsign, vatsim_cid, vatsim_revision, vatsim_seen_at, euroscope_seen_at
+SELECT id, version, callsign, session, origin, destination, alternative, route, remarks, assigned_squawk, squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities, communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay, position_latitude, position_longitude, position_altitude, next_owners, previous_owners, release_point, marked, registration, tracking_controller, runway_cleared, unexpected_change_fields, controller_modified_fields, engine_type, is_manual, persons_on_board, fpl_type, language, has_fp, cdm_data, runway_confirmed, pdc_data, validation_status, start_req, spoken_callsign, vatsim_cid, vatsim_revision, vatsim_seen_at, euroscope_seen_at, arrival_eta
 FROM strips
 WHERE origin = $1 AND session = $2
 ORDER BY callsign
@@ -721,6 +723,7 @@ func (q *Queries) ListStripsByOrigin(ctx context.Context, arg ListStripsByOrigin
 			&i.VatsimRevision,
 			&i.VatsimSeenAt,
 			&i.EuroscopeSeenAt,
+			&i.ArrivalEta,
 		); err != nil {
 			return nil, err
 		}
@@ -733,7 +736,7 @@ func (q *Queries) ListStripsByOrigin(ctx context.Context, arg ListStripsByOrigin
 }
 
 const lockStrip = `-- name: LockStrip :one
-SELECT id, version, callsign, session, origin, destination, alternative, route, remarks, assigned_squawk, squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities, communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay, position_latitude, position_longitude, position_altitude, next_owners, previous_owners, release_point, marked, registration, tracking_controller, runway_cleared, unexpected_change_fields, controller_modified_fields, engine_type, is_manual, persons_on_board, fpl_type, language, has_fp, cdm_data, runway_confirmed, pdc_data, validation_status, start_req, spoken_callsign, vatsim_cid, vatsim_revision, vatsim_seen_at, euroscope_seen_at
+SELECT id, version, callsign, session, origin, destination, alternative, route, remarks, assigned_squawk, squawk, sid, cleared_altitude, heading, aircraft_type, runway, requested_altitude, capabilities, communication_type, aircraft_category, stand, sequence, state, cleared, owner, bay, position_latitude, position_longitude, position_altitude, next_owners, previous_owners, release_point, marked, registration, tracking_controller, runway_cleared, unexpected_change_fields, controller_modified_fields, engine_type, is_manual, persons_on_board, fpl_type, language, has_fp, cdm_data, runway_confirmed, pdc_data, validation_status, start_req, spoken_callsign, vatsim_cid, vatsim_revision, vatsim_seen_at, euroscope_seen_at, arrival_eta
 FROM strips
 WHERE callsign = $1 AND session = $2
 FOR UPDATE
@@ -802,6 +805,7 @@ func (q *Queries) LockStrip(ctx context.Context, arg LockStripParams) (Strip, er
 		&i.VatsimRevision,
 		&i.VatsimSeenAt,
 		&i.EuroscopeSeenAt,
+		&i.ArrivalEta,
 	)
 	return i, err
 }
@@ -1284,6 +1288,28 @@ func (q *Queries) UpdateStripAircraftPositionByID(ctx context.Context, arg Updat
 		arg.Session,
 		arg.Version,
 	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateStripArrivalETA = `-- name: UpdateStripArrivalETA :execrows
+UPDATE strips
+SET
+    version = version + 1,
+    arrival_eta = $1
+WHERE callsign = $2 AND session = $3
+`
+
+type UpdateStripArrivalETAParams struct {
+	ArrivalEta []byte
+	Callsign   string
+	Session    int32
+}
+
+func (q *Queries) UpdateStripArrivalETA(ctx context.Context, arg UpdateStripArrivalETAParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateStripArrivalETA, arg.ArrivalEta, arg.Callsign, arg.Session)
 	if err != nil {
 		return 0, err
 	}

--- a/backend/internal/models/strip.go
+++ b/backend/internal/models/strip.go
@@ -26,6 +26,19 @@ type VatsimStripSource struct {
 	Altitude       int32
 }
 
+// ArrivalETA records the currently accepted arrival estimate and the inputs
+// that produced it. It belongs to the strip rather than a stand assignment:
+// arrivals receive an ETA before SAT is allowed to reserve a stand.
+type ArrivalETA struct {
+	Time            time.Time `json:"time"`
+	Source          string    `json:"source"`
+	CalculatedAt    time.Time `json:"calculated_at"`
+	EOBT            string    `json:"eobt,omitempty"`
+	EnrouteDuration string    `json:"enroute_duration,omitempty"`
+	DistanceNM      *float64  `json:"distance_nm,omitempty"`
+	Groundspeed     *int32    `json:"groundspeed,omitempty"`
+}
+
 type Strip struct {
 	ID                       int32
 	Version                  int32
@@ -87,6 +100,7 @@ type Strip struct {
 	VatsimRevision           *int64
 	VatsimSeenAt             *time.Time
 	EuroscopeSeenAt          *time.Time
+	ArrivalETA               *ArrivalETA
 }
 
 // IsValidationLocked returns true when the strip has an active validation issue

--- a/backend/internal/repository/postgres/strip.go
+++ b/backend/internal/repository/postgres/strip.go
@@ -99,6 +99,10 @@ func stripToModel(db database.Strip) (*models.Strip, error) {
 	if err != nil {
 		return nil, err
 	}
+	arrivalETA, err := unmarshalArrivalETA(db.ArrivalEta)
+	if err != nil {
+		return nil, err
+	}
 
 	return &models.Strip{
 		ID:                       db.ID,
@@ -160,7 +164,19 @@ func stripToModel(db database.Strip) (*models.Strip, error) {
 		VatsimRevision:           db.VatsimRevision,
 		VatsimSeenAt:             PgTimestamptzToTime(db.VatsimSeenAt),
 		EuroscopeSeenAt:          PgTimestamptzToTime(db.EuroscopeSeenAt),
+		ArrivalETA:               arrivalETA,
 	}, nil
+}
+
+func unmarshalArrivalETA(raw []byte) (*models.ArrivalETA, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var eta models.ArrivalETA
+	if err := json.Unmarshal(raw, &eta); err != nil {
+		return nil, err
+	}
+	return &eta, nil
 }
 
 // Create inserts a new strip
@@ -902,6 +918,20 @@ func (r *stripRepository) ClearEuroscopeSeen(ctx context.Context, session int32,
 	return r.queries.ClearStripEuroscopeSeen(ctx, database.ClearStripEuroscopeSeenParams{
 		Callsign: callsign,
 		Session:  session,
+	})
+}
+
+// UpdateArrivalETA persists the accepted SAT arrival estimate. Arrival bay
+// transitions are owned by the existing arrival lifecycle, not SAT.
+func (r *stripRepository) UpdateArrivalETA(ctx context.Context, session int32, callsign string, eta models.ArrivalETA) (int64, error) {
+	payload, err := json.Marshal(eta)
+	if err != nil {
+		return 0, err
+	}
+	return r.queries.UpdateStripArrivalETA(ctx, database.UpdateStripArrivalETAParams{
+		ArrivalEta: payload,
+		Callsign:   callsign,
+		Session:    session,
 	})
 }
 

--- a/backend/internal/repository/postgres/strip_test.go
+++ b/backend/internal/repository/postgres/strip_test.go
@@ -4,9 +4,8 @@ import (
 	"FlightStrips/internal/database"
 	"FlightStrips/internal/models"
 	"encoding/json"
-	"testing"
-
 	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 func TestStripToModel_MapsEmbeddedManualAndValidationFields(t *testing.T) {
@@ -49,4 +48,25 @@ func TestStripToModel_MapsEmbeddedManualAndValidationFields(t *testing.T) {
 	require.True(t, strip.HasFP)
 	require.NotNil(t, strip.ValidationStatus)
 	require.Equal(t, *validationStatus, *strip.ValidationStatus)
+}
+
+func TestStripToModel_MapsPersistedArrivalETAInputs(t *testing.T) {
+	eta := models.ArrivalETA{Source: "LIVE", EOBT: "0800", EnrouteDuration: "0245"}
+	distance := 34.5
+	groundspeed := int32(130)
+	eta.DistanceNM = &distance
+	eta.Groundspeed = &groundspeed
+	rawETA, err := json.Marshal(eta)
+	require.NoError(t, err)
+
+	strip, err := stripToModel(database.Strip{
+		Callsign:    "SAS123",
+		Session:     7,
+		Origin:      "EGLL",
+		Destination: "EKCH",
+		ArrivalEta:  rawETA,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, strip.ArrivalETA)
+	require.Equal(t, eta, *strip.ArrivalETA)
 }

--- a/backend/internal/vatsim/arrival_eta.go
+++ b/backend/internal/vatsim/arrival_eta.go
@@ -1,0 +1,173 @@
+package vatsim
+
+import (
+	"FlightStrips/internal/models"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	ETAFiled = "FILED"
+	ETALive  = "LIVE"
+
+	minimumLiveGroundspeed = 100
+	minimumLiveAltitude    = 1000
+	etaHysteresis          = 2 * time.Minute
+)
+
+// AirportCoordinates is the configured destination used for live ETA
+// calculations. A zero location intentionally disables live estimation and
+// lets the filed estimate remain authoritative.
+type AirportCoordinates struct {
+	Latitude  float64
+	Longitude float64
+}
+
+// ArrivalETAOption configures the ETA portion of a reconciler. Options keep
+// the existing VATSIM reconciliation constructor stable for callers that do
+// not need a live calculation or a controlled clock.
+type ArrivalETAOption func(*Reconciler)
+
+// WithAirportCoordinates enables live ETA calculation against the configured
+// airport location.
+func WithAirportCoordinates(latitude, longitude float64) ArrivalETAOption {
+	return func(r *Reconciler) {
+		r.airportCoordinates = AirportCoordinates{Latitude: latitude, Longitude: longitude}
+	}
+}
+
+// WithClock injects time for deterministic ETA and reveal-boundary tests.
+func WithClock(now func() time.Time) ArrivalETAOption {
+	return func(r *Reconciler) {
+		if now != nil {
+			r.now = now
+		}
+	}
+}
+
+// calculateArrivalETA returns the best usable estimate. Live estimates require
+// a connected flight, a clearly airborne altitude, a non-ground groundspeed,
+// and a configured airport. Otherwise the filed EOBT plus enroute duration is
+// used when available.
+func calculateArrivalETA(now time.Time, flight Flight, airport AirportCoordinates) (models.ArrivalETA, bool) {
+	if reliableLiveMovement(flight, airport) {
+		distance := greatCircleDistanceNM(flight.Latitude, flight.Longitude, airport.Latitude, airport.Longitude)
+		eta := now.UTC().Add(time.Duration(float64(distance) / float64(flight.Groundspeed) * float64(time.Hour))).Round(time.Minute)
+		groundspeed := int32(flight.Groundspeed)
+		return models.ArrivalETA{
+			Time:            eta,
+			Source:          ETALive,
+			CalculatedAt:    now.UTC(),
+			EOBT:            strings.TrimSpace(flight.FlightPlan.EOBT),
+			EnrouteDuration: strings.TrimSpace(flight.FlightPlan.EnrouteDuration),
+			DistanceNM:      &distance,
+			Groundspeed:     &groundspeed,
+		}, true
+	}
+
+	eta, err := filedArrivalETA(now, flight.FlightPlan.EOBT, flight.FlightPlan.EnrouteDuration)
+	if err != nil {
+		return models.ArrivalETA{}, false
+	}
+	return models.ArrivalETA{
+		Time:            eta,
+		Source:          ETAFiled,
+		CalculatedAt:    now.UTC(),
+		EOBT:            strings.TrimSpace(flight.FlightPlan.EOBT),
+		EnrouteDuration: strings.TrimSpace(flight.FlightPlan.EnrouteDuration),
+	}, true
+}
+
+func reliableLiveMovement(flight Flight, airport AirportCoordinates) bool {
+	return flight.Online() &&
+		flight.Altitude >= minimumLiveAltitude &&
+		flight.Groundspeed >= minimumLiveGroundspeed &&
+		validCoordinates(flight.Latitude, flight.Longitude) &&
+		validCoordinates(airport.Latitude, airport.Longitude)
+}
+
+func validCoordinates(latitude, longitude float64) bool {
+	return latitude >= -90 && latitude <= 90 && longitude >= -180 && longitude <= 180 && (latitude != 0 || longitude != 0)
+}
+
+// filedArrivalETA interprets VATSIM's time-only fields relative to the UTC
+// service day nearest to now. Choosing the nearest EOBT first correctly covers
+// flights around midnight before adding the planned enroute duration.
+func filedArrivalETA(now time.Time, eobt, enroute string) (time.Time, error) {
+	hour, minute, err := parseClock(eobt)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse EOBT: %w", err)
+	}
+	duration, err := parseDuration(enroute)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse enroute duration: %w", err)
+	}
+	now = now.UTC()
+	candidates := []time.Time{
+		time.Date(now.Year(), now.Month(), now.Day()-1, hour, minute, 0, 0, time.UTC),
+		time.Date(now.Year(), now.Month(), now.Day(), hour, minute, 0, 0, time.UTC),
+		time.Date(now.Year(), now.Month(), now.Day()+1, hour, minute, 0, 0, time.UTC),
+	}
+	base := candidates[0]
+	for _, candidate := range candidates[1:] {
+		if absoluteDuration(candidate.Sub(now)) < absoluteDuration(base.Sub(now)) {
+			base = candidate
+		}
+	}
+	return base.Add(duration), nil
+}
+
+func parseClock(value string) (int, int, error) {
+	value = strings.ReplaceAll(strings.TrimSpace(value), ":", "")
+	if len(value) != 4 {
+		return 0, 0, fmt.Errorf("expected HHMM, got %q", value)
+	}
+	hour, hourErr := strconv.Atoi(value[:2])
+	minute, minuteErr := strconv.Atoi(value[2:])
+	if hourErr != nil || minuteErr != nil || hour > 23 || minute > 59 {
+		return 0, 0, fmt.Errorf("invalid HHMM %q", value)
+	}
+	return hour, minute, nil
+}
+
+func parseDuration(value string) (time.Duration, error) {
+	hour, minute, err := parseClock(value)
+	if err != nil {
+		return 0, err
+	}
+	return time.Duration(hour)*time.Hour + time.Duration(minute)*time.Minute, nil
+}
+
+func absoluteDuration(value time.Duration) time.Duration {
+	if value < 0 {
+		return -value
+	}
+	return value
+}
+
+// greatCircleDistanceNM uses the haversine formula and returns nautical miles.
+func greatCircleDistanceNM(latitudeA, longitudeA, latitudeB, longitudeB float64) float64 {
+	const earthRadiusNM = 3440.065
+	latA := latitudeA * math.Pi / 180
+	latB := latitudeB * math.Pi / 180
+	deltaLat := (latitudeB - latitudeA) * math.Pi / 180
+	deltaLon := (longitudeB - longitudeA) * math.Pi / 180
+	a := math.Sin(deltaLat/2)*math.Sin(deltaLat/2) + math.Cos(latA)*math.Cos(latB)*math.Sin(deltaLon/2)*math.Sin(deltaLon/2)
+	return earthRadiusNM * 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+}
+
+func acceptedArrivalETA(previous *models.ArrivalETA, candidate models.ArrivalETA) (models.ArrivalETA, bool) {
+	if previous == nil || previous.Time.IsZero() {
+		return candidate, true
+	}
+	if previous.Source == candidate.Source && absoluteDuration(candidate.Time.Sub(previous.Time)) <= etaHysteresis {
+		return *previous, false
+	}
+	if absoluteDuration(candidate.Time.Sub(previous.Time)) <= etaHysteresis {
+		candidate.Time = previous.Time
+	}
+	return candidate, true
+}

--- a/backend/internal/vatsim/arrival_eta_test.go
+++ b/backend/internal/vatsim/arrival_eta_test.go
@@ -1,0 +1,106 @@
+package vatsim
+
+import (
+	"FlightStrips/internal/models"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFiledArrivalETANearestUTCServiceDayAndMidnightRollover(t *testing.T) {
+	now := time.Date(2026, 7, 12, 0, 10, 0, 0, time.UTC)
+	eta, err := filedArrivalETA(now, "2350", "0040")
+	require.NoError(t, err)
+	assert.Equal(t, time.Date(2026, 7, 12, 0, 30, 0, 0, time.UTC), eta)
+
+	now = time.Date(2026, 7, 11, 23, 50, 0, 0, time.UTC)
+	eta, err = filedArrivalETA(now, "0010", "0020")
+	require.NoError(t, err)
+	assert.Equal(t, time.Date(2026, 7, 12, 0, 30, 0, 0, time.UTC), eta)
+}
+
+func TestCalculateArrivalETAUsesLiveOnlyForReliableAirborneMovement(t *testing.T) {
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	flight := Flight{
+		State:       FlightStateOnline,
+		Latitude:    55,
+		Longitude:   12,
+		Altitude:    minimumLiveAltitude,
+		Groundspeed: minimumLiveGroundspeed,
+		FlightPlan:  FlightPlan{EOBT: "0800", EnrouteDuration: "0300"},
+	}
+	eta, ok := calculateArrivalETA(now, flight, AirportCoordinates{Latitude: 55, Longitude: 13})
+	require.True(t, ok)
+	assert.Equal(t, ETALive, eta.Source)
+	assert.InDelta(t, 34.45, *eta.DistanceNM, 0.1)
+	assert.Equal(t, int32(minimumLiveGroundspeed), *eta.Groundspeed)
+
+	flight.Groundspeed = minimumLiveGroundspeed - 1
+	eta, ok = calculateArrivalETA(now, flight, AirportCoordinates{Latitude: 55, Longitude: 13})
+	require.True(t, ok)
+	assert.Equal(t, ETAFiled, eta.Source)
+	assert.Equal(t, time.Date(2026, 7, 12, 11, 0, 0, 0, time.UTC), eta.Time)
+
+	flight.Groundspeed = minimumLiveGroundspeed
+	flight.Altitude = minimumLiveAltitude - 1
+	eta, ok = calculateArrivalETA(now, flight, AirportCoordinates{Latitude: 55, Longitude: 13})
+	require.True(t, ok)
+	assert.Equal(t, ETAFiled, eta.Source)
+}
+
+func TestGreatCircleDistanceNM(t *testing.T) {
+	assert.InDelta(t, 60.04, greatCircleDistanceNM(0, 0, 0, 1), 0.1)
+}
+
+func TestAcceptedArrivalETAHoldsNormalFeedJitter(t *testing.T) {
+	previousTime := time.Date(2026, 7, 12, 11, 0, 0, 0, time.UTC)
+	previous := &models.ArrivalETA{Time: previousTime, Source: ETALive}
+	candidate := models.ArrivalETA{Time: previousTime.Add(90 * time.Second), Source: ETALive}
+
+	accepted, changed := acceptedArrivalETA(previous, candidate)
+	assert.False(t, changed)
+	assert.Equal(t, previousTime, accepted.Time)
+
+	candidate.Time = previousTime.Add(3 * time.Minute)
+	accepted, changed = acceptedArrivalETA(previous, candidate)
+	assert.True(t, changed)
+	assert.Equal(t, candidate.Time, accepted.Time)
+}
+
+func TestUpdateArrivalETARetainsLastEstimateWhenFeedCannotRecalculate(t *testing.T) {
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	previous := &models.ArrivalETA{Time: now.Add(time.Hour), Source: ETAFiled, CalculatedAt: now}
+	strip := &models.Strip{Callsign: "SAS101", Session: 7, ArrivalETA: previous}
+	reconciler := &Reconciler{now: func() time.Time { return now }}
+
+	changed, err := reconciler.updateArrivalETA(context.Background(), 7, strip, Flight{
+		State:      FlightStatePrefile,
+		FlightPlan: FlightPlan{Destination: "EKCH"},
+	})
+	require.NoError(t, err)
+	assert.False(t, changed)
+	assert.Same(t, previous, strip.ArrivalETA)
+}
+
+func TestReconcileKeepsHiddenArrivalOutOfFinalAtETAminusFortyFiveMinutes(t *testing.T) {
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	flight := Flight{
+		CID: "1", Callsign: "SAS101", State: FlightStatePrefile, LastUpdated: now,
+		FlightPlan: FlightPlan{Origin: "EGLL", Destination: "EKCH", EOBT: "0800", EnrouteDuration: "0245", Revision: 1},
+	}
+	cache := newReconciliationTestCache(now, flight)
+	strips := &reconciliationTestStrips{bySession: map[int32][]*models.Strip{}}
+	reconciler := NewReconciler(cache, reconciliationTestSessions{items: []*models.Session{{ID: 7, Airport: "EKCH"}}}, strips, reconciliationTestAssignments{}, nil, time.Second, WithClock(func() time.Time { return now }))
+
+	require.NoError(t, reconciler.Reconcile(context.Background()))
+	require.Len(t, strips.created, 1)
+	strip := strips.created[0]
+	require.NotNil(t, strip.ArrivalETA)
+	assert.Equal(t, ETAFiled, strip.ArrivalETA.Source)
+	assert.Equal(t, now.Add(45*time.Minute), strip.ArrivalETA.Time)
+	assert.Equal(t, hiddenArrivalBay, strip.Bay, "SAT must not move arrivals into FINAL")
+	assert.Nil(t, strip.Stand, "ETA calculation must not allocate a stand")
+}

--- a/backend/internal/vatsim/reconciliation.go
+++ b/backend/internal/vatsim/reconciliation.go
@@ -22,6 +22,7 @@ type reconciliationStripStore interface {
 	List(context.Context, int32) ([]*models.Strip, error)
 	Create(context.Context, *models.Strip) error
 	UpdateVatsimSource(context.Context, int32, string, models.VatsimStripSource) (int64, error)
+	UpdateArrivalETA(context.Context, int32, string, models.ArrivalETA) (int64, error)
 	Delete(context.Context, int32, string) error
 }
 
@@ -37,19 +38,25 @@ type reconciliationNotifier interface {
 // session. It deliberately owns only feed fields; operational state remains
 // controller/EuroScope owned.
 type Reconciler struct {
-	cache       *Cache
-	sessions    reconciliationSessionStore
-	strips      reconciliationStripStore
-	assignments reconciliationAssignmentStore
-	notifier    reconciliationNotifier
-	interval    time.Duration
+	cache              *Cache
+	sessions           reconciliationSessionStore
+	strips             reconciliationStripStore
+	assignments        reconciliationAssignmentStore
+	notifier           reconciliationNotifier
+	interval           time.Duration
+	airportCoordinates AirportCoordinates
+	now                func() time.Time
 }
 
-func NewReconciler(cache *Cache, sessions reconciliationSessionStore, strips reconciliationStripStore, assignments reconciliationAssignmentStore, notifier reconciliationNotifier, interval time.Duration) *Reconciler {
+func NewReconciler(cache *Cache, sessions reconciliationSessionStore, strips reconciliationStripStore, assignments reconciliationAssignmentStore, notifier reconciliationNotifier, interval time.Duration, options ...ArrivalETAOption) *Reconciler {
 	if interval <= 0 {
 		interval = defaultRefreshInterval
 	}
-	return &Reconciler{cache: cache, sessions: sessions, strips: strips, assignments: assignments, notifier: notifier, interval: interval}
+	reconciler := &Reconciler{cache: cache, sessions: sessions, strips: strips, assignments: assignments, notifier: notifier, interval: interval, now: time.Now}
+	for _, option := range options {
+		option(reconciler)
+	}
+	return reconciler
 }
 
 func (r *Reconciler) Start(ctx context.Context) {
@@ -115,6 +122,7 @@ func (r *Reconciler) reconcileSession(ctx context.Context, snapshot Snapshot, se
 		}
 		relevant[flight.Callsign] = flight
 		strip := existing[flight.Callsign]
+		created := false
 		if strip == nil {
 			strip = r.newStrip(session, flight, snapshot.Timestamp, nextSequence(strips, flight, airport))
 			if err := r.strips.Create(ctx, strip); err != nil {
@@ -122,13 +130,23 @@ func (r *Reconciler) reconcileSession(ctx context.Context, snapshot Snapshot, se
 			}
 			existing[flight.Callsign] = strip
 			strips = append(strips, strip)
-			r.notify(session.ID, strip.Callsign)
-			continue
+			created = true
 		}
-		if r.applyFlight(strip, flight, snapshot.Timestamp) {
+		changed := created
+		if !created && r.applyFlight(strip, flight, snapshot.Timestamp) {
 			if _, err := r.strips.UpdateVatsimSource(ctx, session.ID, strip.Callsign, vatsimSource(flight, snapshot.Timestamp)); err != nil {
 				return err
 			}
+			changed = true
+		}
+		if strings.EqualFold(strings.TrimSpace(flight.FlightPlan.Destination), airport) {
+			etaChanged, err := r.updateArrivalETA(ctx, session.ID, strip, flight)
+			if err != nil {
+				return err
+			}
+			changed = etaChanged || changed
+		}
+		if changed {
 			r.notify(session.ID, strip.Callsign)
 		}
 	}
@@ -142,6 +160,28 @@ func (r *Reconciler) reconcileSession(ctx context.Context, snapshot Snapshot, se
 		}
 	}
 	return nil
+}
+
+func (r *Reconciler) updateArrivalETA(ctx context.Context, session int32, strip *models.Strip, flight Flight) (bool, error) {
+	now := time.Now()
+	if r.now != nil {
+		now = r.now()
+	}
+	candidate, ok := calculateArrivalETA(now, flight, r.airportCoordinates)
+	if !ok {
+		// VATSIM can temporarily omit timing or movement fields. Keep the last
+		// accepted estimate rather than replacing a useful stable ETA with none.
+		return false, nil
+	}
+	accepted, changed := acceptedArrivalETA(strip.ArrivalETA, candidate)
+	if !changed {
+		return false, nil
+	}
+	if _, err := r.strips.UpdateArrivalETA(ctx, session, strip.Callsign, accepted); err != nil {
+		return false, err
+	}
+	strip.ArrivalETA = &accepted
+	return true, nil
 }
 
 func vatsimSource(flight Flight, snapshotTime time.Time) models.VatsimStripSource {
@@ -237,6 +277,10 @@ func nextSequence(strips []*models.Strip, flight Flight, airport string) int32 {
 	if strings.EqualFold(strings.TrimSpace(flight.FlightPlan.Origin), airport) {
 		bay = plannedDepartureBay
 	}
+	return nextSequenceForBay(strips, bay)
+}
+
+func nextSequenceForBay(strips []*models.Strip, bay string) int32 {
 	max := int32(0)
 	for _, strip := range strips {
 		if strip != nil && strip.Bay == bay && strip.Sequence != nil && *strip.Sequence > max {

--- a/backend/internal/vatsim/reconciliation_test.go
+++ b/backend/internal/vatsim/reconciliation_test.go
@@ -52,6 +52,18 @@ func (s *reconciliationTestStrips) UpdateVatsimSource(_ context.Context, session
 	return 0, nil
 }
 
+func (s *reconciliationTestStrips) UpdateArrivalETA(_ context.Context, session int32, callsign string, eta models.ArrivalETA) (int64, error) {
+	for _, strip := range s.bySession[session] {
+		if strip.Callsign != callsign {
+			continue
+		}
+		strip.ArrivalETA = &eta
+		s.updated = append(s.updated, strip)
+		return 1, nil
+	}
+	return 0, nil
+}
+
 func (s *reconciliationTestStrips) Delete(_ context.Context, session int32, callsign string) error {
 	s.deleted = append(s.deleted, callsign)
 	return nil

--- a/backend/migrations/0032-add-arrival-eta.sql
+++ b/backend/migrations/0032-add-arrival-eta.sql
@@ -1,0 +1,2 @@
+ALTER TABLE strips
+    ADD COLUMN IF NOT EXISTS arrival_eta JSONB;

--- a/backend/queries/strips.sql
+++ b/backend/queries/strips.sql
@@ -114,6 +114,13 @@ UPDATE strips
 SET euroscope_seen_at = NULL
 WHERE callsign = $1 AND session = $2;
 
+-- name: UpdateStripArrivalETA :execrows
+UPDATE strips
+SET
+    version = version + 1,
+    arrival_eta = sqlc.arg(arrival_eta)
+WHERE callsign = sqlc.arg(callsign) AND session = sqlc.arg(session);
+
 -- name: UpdateStripVatsimSource :execrows
 UPDATE strips
 SET


### PR DESCRIPTION
## Summary

- calculate filed ETAs from VATSIM EOBT and enroute duration, with UTC midnight rollover
- refine estimates from reliable live movement using configured airport coordinates and hysteresis
- persist ETA source and diagnostic inputs on strips without moving arrivals between bays

## Validation

- `go test ./...`