### PR TITLE
feat(stand): implement departure reservation lifecycle

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -66,6 +66,10 @@ type Config struct {
 	EnableStandAssignment bool
 	EnableDBSeed          bool
 	CloseDBOnClose        bool
+
+	StandAssignmentHoldDuration   time.Duration
+	StandAssignmentBlockExtension time.Duration
+	StandAssignmentSweepInterval  time.Duration
 }
 
 type Dependencies struct {
@@ -111,8 +115,26 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	coordRepo := postgres.NewCoordinationRepository(dbpool)
 	tacticalStripRepo := postgres.NewTacticalStripRepository(dbpool)
 	var standAssignmentRepo repository.StandAssignmentRepository
+	var standAllocationService *services.StandAllocationService
+	var departureLifecycle *services.DepartureLifecycleService
 	if standAssignmentReadiness.Ready {
 		standAssignmentRepo = postgres.NewStandAssignmentRepository(dbpool)
+		stands := appconfig.GetStandCapabilities()
+		policy := appconfig.GetAirlineAssignment()
+		standAllocationService, err = services.NewStandAllocationService(dbpool, stripRepo, standAssignmentRepo, stands, policy)
+		if err != nil {
+			return nil, fmt.Errorf("initialize stand allocation service: %w", err)
+		}
+		departureLifecycle, err = services.NewDepartureLifecycleService(
+			standAllocationService, standAssignmentRepo, stripRepo, sessionRepo,
+			stands, appconfig.GetAircraftReference(), appconfig.GetAircraftEngineReference(), appconfig.GetAirportCountries(),
+			services.WithDepartureHoldDuration(cfg.StandAssignmentHoldDuration),
+			services.WithDepartureBlockExtension(cfg.StandAssignmentBlockExtension),
+			services.WithDepartureSweepInterval(cfg.StandAssignmentSweepInterval),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("initialize departure lifecycle service: %w", err)
+		}
 	}
 
 	stripService := services.NewStripService(
@@ -159,6 +181,9 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	if standAssignmentReadiness.Ready && vatsimCache != nil && standAssignmentRepo != nil {
 		latitude, longitude := appconfig.GetAirportCoordinates()
 		vatsimReconciler = vatsim.NewReconciler(vatsimCache, sessionRepo, stripRepo, standAssignmentRepo, frontendHub, deps.VATSIMPollInterval, vatsim.WithAirportCoordinates(latitude, longitude))
+		if departureLifecycle != nil {
+			vatsimReconciler.SetDepartureLifecycle(departureLifecycle)
+		}
 		euroscopeHub.SetAircraftDisconnectRetainer(vatsimReconciler.RetainsStrip)
 	}
 	albHub := alb.NewHub()
@@ -232,6 +257,9 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	}
 	if vatsimReconciler != nil {
 		app.addWorker(vatsimReconciler.Start)
+	}
+	if departureLifecycle != nil {
+		app.addWorker(departureLifecycle.StartSweep)
 	}
 	if transceiverCache != nil {
 		app.addWorker(transceiverCache.Start)
@@ -526,6 +554,15 @@ func (cfg Config) withDefaults() Config {
 	}
 	if cfg.ECFMPBaseURL == "" {
 		cfg.ECFMPBaseURL = ecfmp.DefaultBaseURL
+	}
+	if cfg.StandAssignmentHoldDuration <= 0 {
+		cfg.StandAssignmentHoldDuration = 15 * time.Minute
+	}
+	if cfg.StandAssignmentBlockExtension <= 0 {
+		cfg.StandAssignmentBlockExtension = 10 * time.Minute
+	}
+	if cfg.StandAssignmentSweepInterval <= 0 {
+		cfg.StandAssignmentSweepInterval = 30 * time.Second
 	}
 	return cfg
 }

--- a/backend/internal/services/departure_lifecycle.go
+++ b/backend/internal/services/departure_lifecycle.go
@@ -1,0 +1,493 @@
+package services
+
+import (
+	"FlightStrips/internal/models"
+	"FlightStrips/internal/repository"
+	"FlightStrips/internal/sat"
+	"FlightStrips/internal/vatsim"
+	"context"
+	"errors"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// Departure reservation stages persisted on StandAssignment.Stage. The
+// lifecycle owns these values; the allocation service only persists them.
+const (
+	StageReserved       = "RESERVED"
+	StageDepartureBlock = "DEPARTURE_BLOCK"
+)
+
+const (
+	defaultDepartureHoldDuration    = 15 * time.Minute
+	defaultDepartureBlockExtension  = 10 * time.Minute
+	defaultDepartureSweepInterval   = 30 * time.Second
+	departureClockRolloverThreshold = 12 * time.Hour
+)
+
+// DepartureLifecycleService owns the timing rules that turn a prefiled
+// departure into a reserved stand and then a departure block. It delegates the
+// atomic stand selection to StandAllocationService and reconstructs every
+// deadline from persisted timestamps, so a backend restart needs no in-memory
+// state to resume sweeps.
+type DepartureLifecycleService struct {
+	allocations    *StandAllocationService
+	assignments    repository.StandAssignmentRepository
+	strips         repository.StripRepository
+	sessions       lifecycleSessionLister
+	stands         *sat.StandCapabilityRegistry
+	aircraft       *sat.AircraftRegistry
+	engines        *sat.AircraftEngineRegistry
+	borders        *sat.AirportCountryRegistry
+	now            func() time.Time
+	hold           time.Duration
+	blockExtension time.Duration
+	sweepInterval  time.Duration
+}
+
+type lifecycleSessionLister interface {
+	List(context.Context) ([]*models.Session, error)
+}
+
+type DepartureLifecycleOption func(*DepartureLifecycleService)
+
+func WithDepartureLifecycleClock(now func() time.Time) DepartureLifecycleOption {
+	return func(s *DepartureLifecycleService) {
+		if now != nil {
+			s.now = now
+		}
+	}
+}
+
+func WithDepartureHoldDuration(duration time.Duration) DepartureLifecycleOption {
+	return func(s *DepartureLifecycleService) {
+		if duration > 0 {
+			s.hold = duration
+		}
+	}
+}
+
+func WithDepartureBlockExtension(duration time.Duration) DepartureLifecycleOption {
+	return func(s *DepartureLifecycleService) {
+		if duration > 0 {
+			s.blockExtension = duration
+		}
+	}
+}
+
+func WithDepartureSweepInterval(duration time.Duration) DepartureLifecycleOption {
+	return func(s *DepartureLifecycleService) {
+		if duration > 0 {
+			s.sweepInterval = duration
+		}
+	}
+}
+
+func NewDepartureLifecycleService(
+	allocations *StandAllocationService,
+	assignments repository.StandAssignmentRepository,
+	strips repository.StripRepository,
+	sessions lifecycleSessionLister,
+	stands *sat.StandCapabilityRegistry,
+	aircraft *sat.AircraftRegistry,
+	engines *sat.AircraftEngineRegistry,
+	borders *sat.AirportCountryRegistry,
+	options ...DepartureLifecycleOption,
+) (*DepartureLifecycleService, error) {
+	if allocations == nil || assignments == nil || strips == nil || stands == nil {
+		return nil, errors.New("departure lifecycle requires allocation service, repositories, and stand registry")
+	}
+	service := &DepartureLifecycleService{
+		allocations:    allocations,
+		assignments:    assignments,
+		strips:         strips,
+		sessions:       sessions,
+		stands:         stands,
+		aircraft:       aircraft,
+		engines:        engines,
+		borders:        borders,
+		now:            time.Now,
+		hold:           defaultDepartureHoldDuration,
+		blockExtension: defaultDepartureBlockExtension,
+		sweepInterval:  defaultDepartureSweepInterval,
+	}
+	for _, option := range options {
+		if option != nil {
+			option(service)
+		}
+	}
+	return service, nil
+}
+
+// ProcessDeparture is the reconciler entry point. It dispatches to the
+// reservation path while the aircraft is offline and to the block path once it
+// is online. Both paths are idempotent: repeated feed polls with no change in
+// revision or timing leave the persisted assignment untouched.
+func (s *DepartureLifecycleService) ProcessDeparture(ctx context.Context, session int32, strip *models.Strip, flight vatsim.DepartureFlightInfo) error {
+	if strip == nil || strings.TrimSpace(strip.Callsign) == "" {
+		return nil
+	}
+	if flight.Online {
+		if err := s.activateBlock(ctx, session, strip, flight); err != nil {
+			return err
+		}
+		return s.revalidateFacts(ctx, session, strip, flight)
+	}
+	return s.ensureReservation(ctx, session, strip, flight)
+}
+
+// ensureReservation allocates a 15-minute hold for a new offline prefile, and
+// renews or reallocates it when a later qualifying flight-plan revision arrives.
+func (s *DepartureLifecycleService) ensureReservation(ctx context.Context, session int32, strip *models.Strip, flight vatsim.DepartureFlightInfo) error {
+	existing, err := s.assignments.GetAssignment(ctx, session, strip.Callsign)
+	if err != nil && !isNotFound(err) {
+		return err
+	}
+	now := s.now()
+	if existing == nil {
+		expiry := now.Add(s.hold)
+		request := s.buildRequest(session, strip, flight, StageReserved, &expiry)
+		_, err := s.allocations.Allocate(ctx, request)
+		return err
+	}
+	if existing.Stage != StageReserved {
+		return nil
+	}
+	if existing.VatsimRevision != nil && *existing.VatsimRevision == flight.Revision {
+		return nil
+	}
+	expiry := now.Add(s.hold)
+	request := s.buildRequest(session, strip, flight, StageReserved, &expiry)
+	available, err := s.allocations.StandAvailable(ctx, request, existing.Stand)
+	if err != nil {
+		return err
+	}
+	if available {
+		return s.renewInPlace(ctx, strip, existing, flight, expiry, now)
+	}
+	_, err = s.allocations.Reallocate(ctx, request)
+	return err
+}
+
+// renewInPlace extends the current reservation's hold without changing its
+// stand. A version conflict from a concurrent allocation falls back to a full
+// reallocation so the aircraft keeps a valid stand.
+func (s *DepartureLifecycleService) renewInPlace(ctx context.Context, strip *models.Strip, existing *models.StandAssignment, flight vatsim.DepartureFlightInfo, expiry, now time.Time) error {
+	updated := *existing
+	updated.ExpiresAt = &expiry
+	updated.AssignedAt = &now
+	updated.Stage = StageReserved
+	revision := flight.Revision
+	updated.VatsimRevision = &revision
+	affected, err := s.assignments.UpdateAssignment(ctx, &updated)
+	if err != nil {
+		return err
+	}
+	if affected == 1 {
+		return nil
+	}
+	request := s.buildRequest(existing.SessionID, strip, flight, StageReserved, &expiry)
+	_, err = s.allocations.Reallocate(ctx, request)
+	return err
+}
+
+// activateBlock converts an active reservation into a departure block when the
+// aircraft comes online, and recomputes the TSAT/TOBT retention deadline on
+// every subsequent poll. Aircraft without a prior reservation receive a fresh
+// block so an online departure that skipped the prefile stage still gets a
+// stand.
+func (s *DepartureLifecycleService) activateBlock(ctx context.Context, session int32, strip *models.Strip, flight vatsim.DepartureFlightInfo) error {
+	existing, err := s.assignments.GetAssignment(ctx, session, strip.Callsign)
+	if err != nil && !isNotFound(err) {
+		return err
+	}
+	expiry := s.computeBlockExpiry(strip)
+	now := s.now()
+	if existing == nil {
+		request := s.buildRequest(session, strip, flight, StageDepartureBlock, expiry)
+		_, err := s.allocations.Allocate(ctx, request)
+		return err
+	}
+	if existing.Stage != StageReserved && existing.Stage != StageDepartureBlock {
+		return nil
+	}
+	if existing.Stage == StageDepartureBlock && sameExpiry(existing.ExpiresAt, expiry) {
+		return nil
+	}
+	updated := *existing
+	updated.Stage = StageDepartureBlock
+	updated.ExpiresAt = expiry
+	updated.AssignedAt = &now
+	revision := flight.Revision
+	updated.VatsimRevision = &revision
+	affected, err := s.assignments.UpdateAssignment(ctx, &updated)
+	if err != nil {
+		return err
+	}
+	if affected == 1 {
+		return nil
+	}
+	// A concurrent mutation beat us; reload and retry once to avoid losing the
+	// online transition.
+	reloaded, reloadErr := s.assignments.GetAssignment(ctx, session, strip.Callsign)
+	if reloadErr != nil || reloaded == nil {
+		return nil
+	}
+	reloaded.Stage = StageDepartureBlock
+	reloaded.ExpiresAt = expiry
+	reloaded.AssignedAt = &now
+	reloaded.VatsimRevision = &revision
+	_, err = s.assignments.UpdateAssignment(ctx, reloaded)
+	return err
+}
+
+// revalidateFacts re-runs compatibility against the strip's current aircraft and
+// engine facts. EuroScope often supplies a live engine type or corrected
+// aircraft type after the initial reservation; when the assigned stand no
+// longer fits, a reallocation produces the conflict and selects a replacement.
+func (s *DepartureLifecycleService) revalidateFacts(ctx context.Context, session int32, strip *models.Strip, flight vatsim.DepartureFlightInfo) error {
+	existing, err := s.assignments.GetAssignment(ctx, session, strip.Callsign)
+	if err != nil && !isNotFound(err) {
+		return err
+	}
+	if existing == nil {
+		return nil
+	}
+	facts, assignmentFacts := s.resolveFacts(strip, flight)
+	if !facts.Complete() {
+		return nil
+	}
+	evaluation := s.stands.EvaluateCompatibility(strings.ToUpper(strings.TrimSpace(strip.Origin)), facts)
+	if standCompatible(evaluation, existing.Stand) {
+		return nil
+	}
+	request := StandAllocationRequest{
+		SessionID:       session,
+		Callsign:        strip.Callsign,
+		Airport:         strings.ToUpper(strings.TrimSpace(strip.Origin)),
+		Direction:       sat.AssignmentDirectionDeparture,
+		Stage:           existing.Stage,
+		FlightFacts:     facts,
+		AssignmentFacts: assignmentFacts,
+		ExpiresAt:       existing.ExpiresAt,
+		VatsimCID:       existing.VatsimCID,
+		VatsimRevision:  existing.VatsimRevision,
+	}
+	_, err = s.allocations.Reallocate(ctx, request)
+	return err
+}
+
+// ReleaseExpired releases expired offline reservations and completed departure
+// blocks. A departure block is completed when its strip no longer exists (the
+// aircraft has departed). The sweep is idempotent and reconstructs every
+// deadline from persisted ExpiresAt timestamps, so it is safe to run after a
+// restart.
+func (s *DepartureLifecycleService) ReleaseExpired(ctx context.Context) error {
+	if s.sessions == nil {
+		return nil
+	}
+	sessions, err := s.sessions.List(ctx)
+	if err != nil {
+		return err
+	}
+	now := s.now()
+	for _, session := range sessions {
+		if session == nil {
+			continue
+		}
+		assignments, err := s.assignments.ListAssignments(ctx, session.ID)
+		if err != nil {
+			return err
+		}
+		for _, assignment := range assignments {
+			if assignment == nil {
+				continue
+			}
+			if err := s.releaseIfDue(ctx, session.ID, assignment, now); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (s *DepartureLifecycleService) releaseIfDue(ctx context.Context, session int32, assignment *models.StandAssignment, now time.Time) error {
+	strip, err := s.strips.GetByCallsign(ctx, session, assignment.Callsign)
+	if err != nil && !isNotFound(err) {
+		return err
+	}
+	if strip == nil {
+		_, err := s.assignments.DeleteAssignment(ctx, session, assignment.ID, assignment.Version)
+		return err
+	}
+	if assignment.ExpiresAt == nil || assignment.ExpiresAt.After(now) {
+		return nil
+	}
+	if _, err := s.strips.UpdateStand(ctx, session, assignment.Callsign, nil, nil); err != nil {
+		return err
+	}
+	_, err = s.assignments.DeleteAssignment(ctx, session, assignment.ID, assignment.Version)
+	return err
+}
+
+// StartSweep runs the expired-release loop until the context is cancelled. It is
+// registered as a worker by the application composition root.
+func (s *DepartureLifecycleService) StartSweep(ctx context.Context) {
+	ticker := time.NewTicker(s.sweepInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := s.ReleaseExpired(ctx); err != nil {
+				slog.Warn("Departure lifecycle sweep failed", slog.Any("error", err))
+			}
+		}
+	}
+}
+
+func (s *DepartureLifecycleService) buildRequest(session int32, strip *models.Strip, flight vatsim.DepartureFlightInfo, stage string, expiresAt *time.Time) StandAllocationRequest {
+	facts, assignmentFacts := s.resolveFacts(strip, flight)
+	revision := flight.Revision
+	return StandAllocationRequest{
+		SessionID:       session,
+		Callsign:        strip.Callsign,
+		Airport:         strings.ToUpper(strings.TrimSpace(strip.Origin)),
+		Direction:       sat.AssignmentDirectionDeparture,
+		Stage:           stage,
+		FlightFacts:     facts,
+		AssignmentFacts: assignmentFacts,
+		ExpiresAt:       expiresAt,
+		VatsimCID:       parseCID(flight.CID),
+		VatsimRevision:  &revision,
+	}
+}
+
+func (s *DepartureLifecycleService) resolveFacts(strip *models.Strip, flight vatsim.DepartureFlightInfo) (sat.FlightCompatibilityFacts, sat.AssignmentFlightFacts) {
+	aircraftType := flight.AircraftType
+	if strip != nil && strip.AircraftType != nil && strings.TrimSpace(*strip.AircraftType) != "" {
+		aircraftType = *strip.AircraftType
+	}
+	origin, destination := "", ""
+	if strip != nil {
+		origin = strip.Origin
+		destination = strip.Destination
+	}
+	input := sat.FlightCompatibilityInput{
+		Direction:      sat.Departure,
+		Origin:         origin,
+		Destination:    destination,
+		AircraftType:   aircraftType,
+		LiveEngineType: engineTypeValue(strip),
+	}
+	facts := sat.ResolveFlightCompatibilityFacts(input, s.aircraft, s.engines, s.borders)
+	assignmentFacts := sat.AssignmentFlightFacts{
+		Callsign:     strip.Callsign,
+		AircraftType: aircraftType,
+		AircraftUse:  facts.Aircraft.UseCode,
+		BorderStatus: facts.BorderStatus,
+		Direction:    sat.AssignmentDirectionDeparture,
+	}
+	return facts, assignmentFacts
+}
+
+func (s *DepartureLifecycleService) computeBlockExpiry(strip *models.Strip) *time.Time {
+	now := s.now()
+	if value := stripClockValue(strip.EffectiveTsat()); value != "" {
+		if t, ok := parseDepartureClockUTC(value, now); ok {
+			expiry := t.Add(s.blockExtension)
+			return &expiry
+		}
+	}
+	if value := stripClockValue(strip.EffectiveTobt()); value != "" {
+		if t, ok := parseDepartureClockUTC(value, now); ok {
+			expiry := t.Add(s.blockExtension)
+			return &expiry
+		}
+	}
+	return nil
+}
+
+func standCompatible(evaluation sat.StandCompatibilityEvaluation, stand string) bool {
+	target := standName(stand)
+	for _, match := range evaluation.Matches {
+		if standName(match.Stand.Name) == target {
+			return true
+		}
+	}
+	return false
+}
+
+func sameExpiry(left, right *time.Time) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return left.Equal(*right)
+}
+
+func engineTypeValue(strip *models.Strip) string {
+	if strip == nil {
+		return ""
+	}
+	return strings.TrimSpace(strip.EngineType)
+}
+
+func stripClockValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(*value)
+}
+
+func parseCID(cid string) *int64 {
+	cid = strings.TrimSpace(cid)
+	if cid == "" {
+		return nil
+	}
+	value, err := strconv.ParseInt(cid, 10, 64)
+	if err != nil {
+		return nil
+	}
+	return &value
+}
+
+// parseDepartureClockUTC parses a CDM HHMM or HHMMSS clock string into a UTC
+// timestamp on the current day, rolling to the next day when the value is more
+// than half a day in the past so TSAT/TOBT deadlines near midnight stay valid.
+func parseDepartureClockUTC(value string, now time.Time) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if len(value) != 4 && len(value) != 6 {
+		return time.Time{}, false
+	}
+	for _, c := range value {
+		if c < '0' || c > '9' {
+			return time.Time{}, false
+		}
+	}
+	hour := int(value[0]-'0')*10 + int(value[1]-'0')
+	minute := int(value[2]-'0')*10 + int(value[3]-'0')
+	second := 0
+	if len(value) == 6 {
+		second = int(value[4]-'0')*10 + int(value[5]-'0')
+	}
+	if hour > 23 || minute > 59 || second > 59 {
+		return time.Time{}, false
+	}
+	candidate := time.Date(now.UTC().Year(), now.UTC().Month(), now.UTC().Day(), hour, minute, second, 0, time.UTC)
+	if now.UTC().Sub(candidate) > departureClockRolloverThreshold {
+		candidate = candidate.Add(24 * time.Hour)
+	}
+	return candidate, true
+}
+
+// isNotFound reports whether the error is a missing-row lookup result. The
+// lifecycle treats a missing assignment as "no reservation yet" rather than a
+// hard failure.
+func isNotFound(err error) bool {
+	return err != nil && (errors.Is(err, pgx.ErrNoRows) || strings.Contains(err.Error(), "no rows"))
+}

--- a/backend/internal/services/departure_lifecycle.go
+++ b/backend/internal/services/departure_lifecycle.go
@@ -215,8 +215,13 @@ func (s *DepartureLifecycleService) activateBlock(ctx context.Context, session i
 	if existing.Stage != StageReserved && existing.Stage != StageDepartureBlock {
 		return nil
 	}
-	if existing.Stage == StageDepartureBlock && sameExpiry(existing.ExpiresAt, expiry) {
-		return nil
+	if existing.Stage == StageDepartureBlock {
+		if expiry == nil && existing.ExpiresAt != nil {
+			return nil
+		}
+		if sameExpiry(existing.ExpiresAt, expiry) {
+			return nil
+		}
 	}
 	updated := *existing
 	updated.Stage = StageDepartureBlock
@@ -231,10 +236,11 @@ func (s *DepartureLifecycleService) activateBlock(ctx context.Context, session i
 	if affected == 1 {
 		return nil
 	}
-	// A concurrent mutation beat us; reload and retry once to avoid losing the
-	// online transition.
 	reloaded, reloadErr := s.assignments.GetAssignment(ctx, session, strip.Callsign)
 	if reloadErr != nil || reloaded == nil {
+		return nil
+	}
+	if reloaded.Stage == StageDepartureBlock && expiry == nil && reloaded.ExpiresAt != nil {
 		return nil
 	}
 	reloaded.Stage = StageDepartureBlock
@@ -301,14 +307,19 @@ func (s *DepartureLifecycleService) ReleaseExpired(ctx context.Context) error {
 		}
 		assignments, err := s.assignments.ListAssignments(ctx, session.ID)
 		if err != nil {
-			return err
+			slog.Warn("departure sweep cannot list session assignments",
+				slog.Int("sessionID", int(session.ID)),
+				slog.Any("error", err))
+			continue
 		}
 		for _, assignment := range assignments {
 			if assignment == nil {
 				continue
 			}
 			if err := s.releaseIfDue(ctx, session.ID, assignment, now); err != nil {
-				return err
+				slog.Warn("departure sweep failed to release assignment",
+					slog.String("callsign", assignment.Callsign),
+					slog.Any("error", err))
 			}
 		}
 	}
@@ -489,5 +500,5 @@ func parseDepartureClockUTC(value string, now time.Time) (time.Time, bool) {
 // lifecycle treats a missing assignment as "no reservation yet" rather than a
 // hard failure.
 func isNotFound(err error) bool {
-	return err != nil && (errors.Is(err, pgx.ErrNoRows) || strings.Contains(err.Error(), "no rows"))
+	return errors.Is(err, pgx.ErrNoRows)
 }

--- a/backend/internal/services/departure_lifecycle_test.go
+++ b/backend/internal/services/departure_lifecycle_test.go
@@ -210,6 +210,33 @@ func TestDepartureLifecycle(t *testing.T) {
 		assert.Equal(t, StageDepartureBlock, reallocated.Stage)
 	})
 
+	t.Run("a temporary TSAT gap does not clear the existing block expiry", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := departureLifecycleFixture(t, pool, queries, "", "", nil)
+		testdata.SeedTestStrip(t, queries, session, "SAS920")
+		clock.set(time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC))
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS920"), offlineFlight("SAS920", 1)))
+		tsat := "1030"
+		_, err := strips.SetCdmData(ctx, session, "SAS920", &models.CdmData{Tsat: &tsat})
+		require.NoError(t, err)
+		clock.advance(2 * time.Minute)
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS920"), onlineFlight("SAS920", 1)))
+
+		block, err := assignments.GetAssignment(ctx, session, "SAS920")
+		require.NoError(t, err)
+		require.NotNil(t, block.ExpiresAt)
+		original := *block.ExpiresAt
+
+		_, err = strips.SetCdmData(ctx, session, "SAS920", &models.CdmData{})
+		require.NoError(t, err)
+		clock.advance(2 * time.Minute)
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS920"), onlineFlight("SAS920", 1)))
+
+		polled, err := assignments.GetAssignment(ctx, session, "SAS920")
+		require.NoError(t, err)
+		require.NotNil(t, polled.ExpiresAt)
+		assert.Equal(t, original.UTC(), polled.ExpiresAt.UTC(), "existing TSAT-based expiry is preserved during a CDM gap")
+	})
+
 	t.Run("restart reconstructs pending deadlines from persisted timestamps", func(t *testing.T) {
 		_, allocations, session, assignments, strips, clock := departureLifecycleFixture(t, pool, queries, "", "", nil)
 		testdata.SeedTestStrip(t, queries, session, "SAS110")

--- a/backend/internal/services/departure_lifecycle_test.go
+++ b/backend/internal/services/departure_lifecycle_test.go
@@ -1,0 +1,321 @@
+package services
+
+import (
+	"FlightStrips/internal/database"
+	"FlightStrips/internal/models"
+	"FlightStrips/internal/pdc/testdata"
+	"FlightStrips/internal/repository"
+	"FlightStrips/internal/repository/postgres"
+	"FlightStrips/internal/sat"
+	"FlightStrips/internal/vatsim"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeClock struct{ now time.Time }
+
+func (c *fakeClock) current() time.Time      { return c.now }
+func (c *fakeClock) set(value time.Time)     { c.now = value }
+func (c *fakeClock) advance(d time.Duration) { c.now = c.now.Add(d) }
+
+func TestDepartureLifecycle(t *testing.T) {
+	pool, queries := testdata.SetupTestDB(t)
+	ctx := context.Background()
+
+	t.Run("offline prefile allocates a 15-minute reservation", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := departureLifecycleFixture(t, pool, queries, "", "", nil)
+		testdata.SeedTestStrip(t, queries, session, "SAS101")
+		clock.set(time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC))
+
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS101"), offlineFlight("SAS101", 1)))
+
+		assignment, err := assignments.GetAssignment(ctx, session, "SAS101")
+		require.NoError(t, err)
+		assert.Equal(t, StageReserved, assignment.Stage)
+		assert.Equal(t, "A1", assignment.Stand)
+		require.NotNil(t, assignment.ExpiresAt)
+		assert.Equal(t, clock.current().Add(15*time.Minute).UTC(), assignment.ExpiresAt.UTC())
+		require.NotNil(t, assignment.VatsimRevision)
+		assert.Equal(t, int64(1), *assignment.VatsimRevision)
+	})
+
+	t.Run("repeated feed polls do not extend or reshuffle the reservation", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := departureLifecycleFixture(t, pool, queries, "", "", nil)
+		testdata.SeedTestStrip(t, queries, session, "SAS201")
+		clock.set(time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC))
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS201"), offlineFlight("SAS201", 1)))
+
+		original, err := assignments.GetAssignment(ctx, session, "SAS201")
+		require.NoError(t, err)
+
+		clock.advance(5 * time.Minute)
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS201"), offlineFlight("SAS201", 1)))
+
+		repeated, err := assignments.GetAssignment(ctx, session, "SAS201")
+		require.NoError(t, err)
+		assert.Equal(t, original.ExpiresAt.UTC(), repeated.ExpiresAt.UTC(), "expiry must not move on a repeated poll")
+		assert.Equal(t, original.Stand, repeated.Stand)
+		assert.Equal(t, original.Version, repeated.Version)
+	})
+
+	t.Run("a later revision renews the reservation in place", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := departureLifecycleFixture(t, pool, queries, "", "", nil)
+		testdata.SeedTestStrip(t, queries, session, "SAS301")
+		clock.set(time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC))
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS301"), offlineFlight("SAS301", 1)))
+
+		clock.advance(5 * time.Minute)
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS301"), offlineFlight("SAS301", 2)))
+
+		renewed, err := assignments.GetAssignment(ctx, session, "SAS301")
+		require.NoError(t, err)
+		assert.Equal(t, StageReserved, renewed.Stage)
+		assert.Equal(t, "A1", renewed.Stand, "renewal keeps the same stand when it remains free")
+		require.NotNil(t, renewed.ExpiresAt)
+		assert.Equal(t, clock.current().Add(15*time.Minute).UTC(), renewed.ExpiresAt.UTC())
+		require.NotNil(t, renewed.VatsimRevision)
+		assert.Equal(t, int64(2), *renewed.VatsimRevision)
+	})
+
+	t.Run("renewal reallocates when the stand becomes unavailable", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := departureLifecycleFixture(t, pool, queries, "", "", nil)
+		testdata.SeedTestStrip(t, queries, session, "SAS401")
+		clock.set(time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC))
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS401"), offlineFlight("SAS401", 1)))
+
+		require.NoError(t, assignments.CreateBlock(ctx, &models.StandBlock{
+			SessionID: session, Stand: "A1", BlockType: "CLOSURE", Source: "CONTROLLER", Manual: true,
+		}))
+
+		clock.advance(5 * time.Minute)
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS401"), offlineFlight("SAS401", 2)))
+
+		reallocated, err := assignments.GetAssignment(ctx, session, "SAS401")
+		require.NoError(t, err)
+		assert.Equal(t, StageReserved, reallocated.Stage)
+		assert.Equal(t, "A2", reallocated.Stand, "the unavailable stand is replaced by a fresh 15-minute hold on A2")
+		require.NotNil(t, reallocated.ExpiresAt)
+		assert.Equal(t, clock.current().Add(15*time.Minute).UTC(), reallocated.ExpiresAt.UTC())
+	})
+
+	t.Run("expired offline reservations are released idempotently", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := departureLifecycleFixture(t, pool, queries, "", "", nil)
+		testdata.SeedTestStrip(t, queries, session, "SAS501")
+		clock.set(time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC))
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS501"), offlineFlight("SAS501", 1)))
+		strip := loadStrip(t, strips, session, "SAS501")
+		require.NotNil(t, strip.Stand)
+
+		clock.advance(16 * time.Minute)
+		require.NoError(t, lifecycle.ReleaseExpired(ctx))
+
+		_, err := assignments.GetAssignment(ctx, session, "SAS501")
+		require.Error(t, err, "the reservation is removed once it expires")
+		updated := loadStrip(t, strips, session, "SAS501")
+		require.Nil(t, updated.Stand, "the operational stand is cleared")
+
+		require.NoError(t, lifecycle.ReleaseExpired(ctx), "a second sweep is a no-op")
+	})
+
+	t.Run("coming online converts the reservation to a departure block", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := departureLifecycleFixture(t, pool, queries, "", "", nil)
+		testdata.SeedTestStrip(t, queries, session, "SAS601")
+		clock.set(time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC))
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS601"), offlineFlight("SAS601", 1)))
+
+		tsat := "1030"
+		_, err := strips.SetCdmData(ctx, session, "SAS601", &models.CdmData{Tsat: &tsat})
+		require.NoError(t, err)
+
+		clock.advance(2 * time.Minute)
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS601"), onlineFlight("SAS601", 1)))
+
+		block, err := assignments.GetAssignment(ctx, session, "SAS601")
+		require.NoError(t, err)
+		assert.Equal(t, StageDepartureBlock, block.Stage)
+		assert.Equal(t, "A1", block.Stand)
+		require.NotNil(t, block.ExpiresAt)
+		assert.Equal(t, time.Date(2026, 7, 12, 10, 40, 0, 0, time.UTC), block.ExpiresAt.UTC(), "block is retained through TSAT+10 minutes")
+	})
+
+	t.Run("TSAT controls block release when present", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := departureLifecycleFixture(t, pool, queries, "", "", nil)
+		testdata.SeedTestStrip(t, queries, session, "SAS701")
+		clock.set(time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC))
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS701"), offlineFlight("SAS701", 1)))
+		tsat := "1030"
+		_, err := strips.SetCdmData(ctx, session, "SAS701", &models.CdmData{Tsat: &tsat})
+		require.NoError(t, err)
+		clock.advance(2 * time.Minute)
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS701"), onlineFlight("SAS701", 1)))
+
+		clock.set(time.Date(2026, 7, 12, 10, 39, 0, 0, time.UTC))
+		require.NoError(t, lifecycle.ReleaseExpired(ctx))
+		if assignment, err := assignments.GetAssignment(ctx, session, "SAS701"); assert.NoError(t, err) {
+			assert.NotNil(t, assignment.ExpiresAt, "block is retained before TSAT+10")
+		}
+
+		clock.set(time.Date(2026, 7, 12, 10, 41, 0, 0, time.UTC))
+		require.NoError(t, lifecycle.ReleaseExpired(ctx))
+		_, err = assignments.GetAssignment(ctx, session, "SAS701")
+		require.Error(t, err, "block is released once TSAT+10 has passed")
+	})
+
+	t.Run("TOBT controls release when TSAT is absent", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := departureLifecycleFixture(t, pool, queries, "", "", nil)
+		testdata.SeedTestStrip(t, queries, session, "SAS801")
+		clock.set(time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC))
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS801"), offlineFlight("SAS801", 1)))
+		tobt := "1030"
+		_, err := strips.SetCdmData(ctx, session, "SAS801", &models.CdmData{Tobt: &tobt})
+		require.NoError(t, err)
+		clock.advance(2 * time.Minute)
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS801"), onlineFlight("SAS801", 1)))
+
+		block, err := assignments.GetAssignment(ctx, session, "SAS801")
+		require.NoError(t, err)
+		require.NotNil(t, block.ExpiresAt)
+		assert.Equal(t, time.Date(2026, 7, 12, 10, 40, 0, 0, time.UTC), block.ExpiresAt.UTC(), "TOBT+10 governs the block when TSAT is absent")
+
+		clock.set(time.Date(2026, 7, 12, 10, 41, 0, 0, time.UTC))
+		require.NoError(t, lifecycle.ReleaseExpired(ctx))
+		_, err = assignments.GetAssignment(ctx, session, "SAS801")
+		require.Error(t, err)
+	})
+
+	t.Run("revalidation reallocates when EuroScope facts invalidate the stand", func(t *testing.T) {
+		aircraft := mustLoadAircraftRegistry(t, "A320", "B737")
+		engines := mustLoadEngineRegistry(t, aircraft, []engineRecord{{ICAO: "A320", WTC: "M", Engine: "J"}, {ICAO: "B737", WTC: "M", Engine: "J"}})
+		lifecycle, _, session, assignments, strips, clock := departureLifecycleFixtureWithEngines(t, pool, queries, "ATYP:A320", "ATYP:B737", aircraft, engines)
+		testdata.SeedTestStrip(t, queries, session, "SAS901")
+		clock.set(time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC))
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS901"), offlineFlight("SAS901", 1)))
+
+		_, err := pool.Exec(ctx, "UPDATE strips SET engine_type = $3, aircraft_type = $4 WHERE session = $1 AND callsign = $2", session, "SAS901", "J", "B737")
+		require.NoError(t, err)
+
+		clock.advance(2 * time.Minute)
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS901"), onlineFlight("SAS901", 1)))
+
+		reallocated, err := assignments.GetAssignment(ctx, session, "SAS901")
+		require.NoError(t, err)
+		assert.Equal(t, "A2", reallocated.Stand, "an incompatible stand is replaced once better facts arrive")
+		assert.Equal(t, StageDepartureBlock, reallocated.Stage)
+	})
+
+	t.Run("restart reconstructs pending deadlines from persisted timestamps", func(t *testing.T) {
+		_, allocations, session, assignments, strips, clock := departureLifecycleFixture(t, pool, queries, "", "", nil)
+		testdata.SeedTestStrip(t, queries, session, "SAS110")
+		clock.set(time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC))
+		expiry := time.Date(2026, 7, 12, 10, 5, 0, 0, time.UTC)
+		require.NoError(t, assignments.CreateAssignment(ctx, &models.StandAssignment{
+			SessionID: session, Callsign: "SAS110", Stand: "A1", Direction: "DEPARTURE",
+			Stage: StageReserved, Source: "AUTOMATIC", AssignedAt: &expiry, ExpiresAt: &expiry,
+		}))
+
+		restarted, err := NewDepartureLifecycleService(
+			allocations, assignments, strips, postgres.NewSessionRepository(pool),
+			allocations.stands, nil, nil, nil,
+			WithDepartureLifecycleClock(func() time.Time { return time.Date(2026, 7, 12, 10, 6, 0, 0, time.UTC) }),
+		)
+		require.NoError(t, err)
+
+		require.NoError(t, restarted.ReleaseExpired(ctx))
+		_, err = assignments.GetAssignment(ctx, session, "SAS110")
+		require.Error(t, err, "the restarted sweep releases the assignment from its persisted expiry alone")
+		updated := loadStrip(t, strips, session, "SAS110")
+		require.Nil(t, updated.Stand, "the operational stand is cleared from persisted state")
+	})
+}
+
+func departureLifecycleFixture(t *testing.T, pool *pgxpool.Pool, queries *database.Queries, a1Directive, a2Directive string, aircraft *sat.AircraftRegistry) (*DepartureLifecycleService, *StandAllocationService, int32, repository.StandAssignmentRepository, repository.StripRepository, *fakeClock) {
+	t.Helper()
+	return departureLifecycleFixtureWithEngines(t, pool, queries, a1Directive, a2Directive, aircraft, nil)
+}
+
+func departureLifecycleFixtureWithEngines(t *testing.T, pool *pgxpool.Pool, queries *database.Queries, a1Directive, a2Directive string, aircraft *sat.AircraftRegistry, engines *sat.AircraftEngineRegistry) (*DepartureLifecycleService, *StandAllocationService, int32, repository.StandAssignmentRepository, repository.StripRepository, *fakeClock) {
+	t.Helper()
+	registry, err := sat.LoadStandCapabilities(strings.NewReader(`
+STAND:EKCH:A1:N055.37.42.710:E012.38.33.450:30
+` + a1Directive + `
+STAND:EKCH:A2:N055.37.42.710:E012.38.33.451:30
+` + a2Directive + `
+`))
+	require.NoError(t, err)
+	policy, err := sat.LoadAirlineAssignment(strings.NewReader(`{
+  "rules": [{"id":"sas","callsigns":["SAS"],"stands":{"tier1":{"A1":100,"A2":100}}}],
+  "stand_groups": {}, "fallback_rules": {`+testFallbackJSON("A1")+`}
+}`), registry)
+	require.NoError(t, err)
+	assignments := postgres.NewStandAssignmentRepository(pool)
+	strips := postgres.NewStripRepository(pool)
+	sessions := postgres.NewSessionRepository(pool)
+	clock := &fakeClock{now: time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)}
+	allocations, err := NewStandAllocationService(pool, strips, assignments, registry, policy,
+		WithStandAllocationRandom(func() float64 { return 0 }),
+		WithStandAllocationClock(clock.current),
+	)
+	require.NoError(t, err)
+	lifecycle, err := NewDepartureLifecycleService(allocations, assignments, strips, sessions, registry, aircraft, engines, sat.NewAirportCountryRegistry(),
+		WithDepartureLifecycleClock(clock.current),
+	)
+	require.NoError(t, err)
+	name := fmt.Sprintf("%s-%d", t.Name(), standAllocationSessionSequence.Add(1))
+	session := testdata.SeedTestSessionNamedWithSectors(t, queries, name, nil)
+	return lifecycle, allocations, session, assignments, strips, clock
+}
+
+func loadStrip(t *testing.T, strips repository.StripRepository, session int32, callsign string) *models.Strip {
+	t.Helper()
+	strip, err := strips.GetByCallsign(context.Background(), session, callsign)
+	require.NoError(t, err)
+	return strip
+}
+
+func offlineFlight(callsign string, revision int64) vatsim.DepartureFlightInfo {
+	return vatsim.DepartureFlightInfo{
+		Callsign: callsign, CID: "1001", Online: false, Revision: revision,
+		Origin: "EKCH", Destination: "ESSA", AircraftType: "A320",
+	}
+}
+
+func onlineFlight(callsign string, revision int64) vatsim.DepartureFlightInfo {
+	info := offlineFlight(callsign, revision)
+	info.Online = true
+	return info
+}
+
+type engineRecord struct {
+	ICAO   string
+	WTC    string
+	Engine string
+}
+
+func mustLoadAircraftRegistry(t *testing.T, types ...string) *sat.AircraftRegistry {
+	t.Helper()
+	var rows []string
+	for _, aircraftType := range types {
+		rows = append(rows, aircraftType+"\t35.8\t37.6\t11.8\t78000\tA")
+	}
+	registry, err := sat.LoadAircraftReference(strings.NewReader(strings.Join(rows, "\n")))
+	require.NoError(t, err)
+	return registry
+}
+
+func mustLoadEngineRegistry(t *testing.T, aircraft *sat.AircraftRegistry, records []engineRecord) *sat.AircraftEngineRegistry {
+	t.Helper()
+	var parts []string
+	for _, record := range records {
+		parts = append(parts, fmt.Sprintf(`{"ICAO":%q,"Description":"%s %s","WTC":%q}`, record.ICAO, record.ICAO, record.Engine, record.WTC))
+	}
+	engines, err := sat.LoadAircraftEngineReference(strings.NewReader("["+strings.Join(parts, ",")+"]"), aircraft)
+	require.NoError(t, err)
+	return engines
+}

--- a/backend/internal/services/stand_allocation.go
+++ b/backend/internal/services/stand_allocation.go
@@ -86,6 +86,7 @@ type StandAllocationService struct {
 	random      func() float64
 	publish     StandAllocationPublisher
 	attempts    int
+	now         func() time.Time
 }
 
 type StandAllocationOption func(*StandAllocationService)
@@ -108,13 +109,23 @@ func WithStandAllocationAttempts(attempts int) StandAllocationOption {
 	}
 }
 
+// WithStandAllocationClock injects the clock used for assignment timestamps.
+// It lets lifecycle and tests drive expiry from a deterministic time source.
+func WithStandAllocationClock(now func() time.Time) StandAllocationOption {
+	return func(service *StandAllocationService) {
+		if now != nil {
+			service.now = now
+		}
+	}
+}
+
 func NewStandAllocationService(pool *pgxpool.Pool, strips repository.StripRepository, assignments repository.StandAssignmentRepository, stands *sat.StandCapabilityRegistry, policy *sat.AirlineAssignmentConfig, options ...StandAllocationOption) (*StandAllocationService, error) {
 	if pool == nil || strips == nil || assignments == nil || stands == nil || policy == nil {
 		return nil, errors.New("stand allocation requires database, repositories, capabilities, and policy")
 	}
 	service := &StandAllocationService{
 		pool: pool, strips: strips, assignments: assignments, stands: stands,
-		policy: policy, random: rand.Float64, attempts: 3,
+		policy: policy, random: rand.Float64, attempts: 3, now: time.Now,
 	}
 	for _, option := range options {
 		if option != nil {
@@ -228,7 +239,7 @@ func (s *StandAllocationService) allocateOnce(ctx context.Context, command Stand
 		return nil, selected, err
 	}
 	request.Stand = selected
-	assignment, err := persistStandAllocation(ctx, txAssignments, command, request, assignments, selection, match, conflict)
+	assignment, err := s.persistStandAllocation(ctx, txAssignments, command, request, assignments, selection, match, conflict)
 	if err != nil {
 		return nil, selected, err
 	}
@@ -248,6 +259,48 @@ func (s *StandAllocationService) allocateOnce(ctx context.Context, command Stand
 		Command: command, Assignment: *assignment, Selection: selection, MatchedVariant: match,
 		Compatibility: evaluation, ConflictReason: conflict, Attempts: attempt, AvailableCandidates: available,
 	}, selected, nil
+}
+
+// StandAvailable reports whether the named stand is currently compatible with
+// the request's flight facts and free of occupancy or manual blocks. It runs
+// the same locking read as an allocation so the lifecycle can decide whether to
+// renew an existing reservation in place or reallocate. The transaction is
+// read-only and rolls back without persisting any state.
+func (s *StandAllocationService) StandAvailable(ctx context.Context, request StandAllocationRequest, stand string) (bool, error) {
+	if err := validateStandAllocationRequest(AutomaticStandAllocation, &request); err != nil {
+		return false, err
+	}
+	target := standName(stand)
+	if target == "" {
+		return false, errors.New("stand availability requires a stand")
+	}
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback(ctx)
+	if _, err := tx.Exec(ctx, "SELECT id FROM sessions WHERE id = $1 FOR UPDATE", request.SessionID); err != nil {
+		return false, err
+	}
+	txAssignments := s.assignments.WithTx(tx)
+	assignments, err := txAssignments.LockAssignments(ctx, request.SessionID, request.Callsign)
+	if err != nil {
+		return false, err
+	}
+	blocks, err := txAssignments.LockActiveManualBlocks(ctx, request.SessionID)
+	if err != nil {
+		return false, err
+	}
+	evaluation := s.stands.EvaluateCompatibility(request.Airport, request.FlightFacts)
+	matches := make(map[string]sat.StandCompatibilityMatch, len(evaluation.Matches))
+	for _, match := range evaluation.Matches {
+		matches[standName(match.Stand.Name)] = match
+	}
+	if _, compatible := matches[target]; !compatible {
+		return false, nil
+	}
+	availability := s.availability(request, assignments, blocks, matches)
+	return len(availability[target]) == 0, nil
 }
 
 func (s *StandAllocationService) selectStand(command StandAllocationCommand, request StandAllocationRequest, evaluation sat.StandCompatibilityEvaluation, assignments []*models.StandAssignment, blocks []*models.StandBlock, tried map[string]struct{}) (string, *sat.StandSelection, *sat.StandCompatibilityMatch, []string, string, error) {
@@ -300,7 +353,7 @@ func (s *StandAllocationService) selectStand(command StandAllocationCommand, req
 }
 
 func (s *StandAllocationService) availability(request StandAllocationRequest, assignments []*models.StandAssignment, blocks []*models.StandBlock, matches map[string]sat.StandCompatibilityMatch) map[string][]string {
-	now := time.Now()
+	now := s.now()
 	result := map[string][]string{}
 	for candidate, match := range matches {
 		for _, assignment := range assignments {
@@ -343,7 +396,7 @@ func (s *StandAllocationService) assignedBlocks(airport string, assignment *mode
 	return slices.Clone(stand.Blocks)
 }
 
-func persistStandAllocation(ctx context.Context, store repository.StandAssignmentRepository, command StandAllocationCommand, request StandAllocationRequest, current []*models.StandAssignment, selection *sat.StandSelection, match *sat.StandCompatibilityMatch, conflict string) (*models.StandAssignment, error) {
+func (s *StandAllocationService) persistStandAllocation(ctx context.Context, store repository.StandAssignmentRepository, command StandAllocationCommand, request StandAllocationRequest, current []*models.StandAssignment, selection *sat.StandSelection, match *sat.StandCompatibilityMatch, conflict string) (*models.StandAssignment, error) {
 	var existing *models.StandAssignment
 	for _, assignment := range current {
 		if assignment != nil && strings.EqualFold(assignment.Callsign, request.Callsign) {
@@ -355,7 +408,7 @@ func persistStandAllocation(ctx context.Context, store repository.StandAssignmen
 	if existing != nil {
 		*next = *existing
 	}
-	now := time.Now().UTC()
+	now := s.now().UTC()
 	next.Stand, next.Direction, next.Stage = request.Stand, string(request.Direction), request.Stage
 	next.Source, next.Manual = allocationSource(command)
 	next.RuleID, next.Tier, next.MatchedVariant = allocationSelectionMetadata(request, selection, match)

--- a/backend/internal/vatsim/reconciliation.go
+++ b/backend/internal/vatsim/reconciliation.go
@@ -30,6 +30,26 @@ type reconciliationAssignmentStore interface {
 	GetAssignment(context.Context, int32, string) (*models.StandAssignment, error)
 }
 
+// DepartureFlightInfo is the minimal VATSIM view the departure lifecycle needs
+// to reserve, renew, or block a departure stand. It is deliberately decoupled
+// from the full Flight record so the lifecycle service can stay testable.
+type DepartureFlightInfo struct {
+	Callsign     string
+	CID          string
+	Online       bool
+	Revision     int64
+	Origin       string
+	Destination  string
+	AircraftType string
+}
+
+// DepartureLifecycle drives stand reservation and departure-block transitions
+// for a departure the reconciler has just applied. The reconciler owns feed
+// timing; the lifecycle owns allocation timing and persistence.
+type DepartureLifecycle interface {
+	ProcessDeparture(ctx context.Context, session int32, strip *models.Strip, flight DepartureFlightInfo) error
+}
+
 type reconciliationNotifier interface {
 	SendStripUpdate(session int32, callsign string)
 }
@@ -42,6 +62,7 @@ type Reconciler struct {
 	sessions           reconciliationSessionStore
 	strips             reconciliationStripStore
 	assignments        reconciliationAssignmentStore
+	lifecycle          DepartureLifecycle
 	notifier           reconciliationNotifier
 	interval           time.Duration
 	airportCoordinates AirportCoordinates
@@ -57,6 +78,15 @@ func NewReconciler(cache *Cache, sessions reconciliationSessionStore, strips rec
 		option(reconciler)
 	}
 	return reconciler
+}
+
+// SetDepartureLifecycle wires the stand reservation lifecycle. It is installed
+// after construction so the lifecycle can depend on the reconciler's stores
+// without a circular constructor dependency.
+func (r *Reconciler) SetDepartureLifecycle(lifecycle DepartureLifecycle) {
+	if r != nil {
+		r.lifecycle = lifecycle
+	}
 }
 
 func (r *Reconciler) Start(ctx context.Context) {
@@ -148,6 +178,11 @@ func (r *Reconciler) reconcileSession(ctx context.Context, snapshot Snapshot, se
 		}
 		if changed {
 			r.notify(session.ID, strip.Callsign)
+		}
+		if r.lifecycle != nil && strings.EqualFold(strings.TrimSpace(flight.FlightPlan.Origin), airport) {
+			if err := r.lifecycle.ProcessDeparture(ctx, session.ID, strip, departureFlightInfo(flight)); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -263,7 +298,29 @@ func (r *Reconciler) isAssigned(ctx context.Context, session int32, callsign str
 		return false
 	}
 	assignment, err := r.assignments.GetAssignment(ctx, session, callsign)
-	return err == nil && assignment != nil
+	if err != nil || assignment == nil {
+		return false
+	}
+	if assignment.ExpiresAt == nil {
+		return true
+	}
+	now := time.Now()
+	if r.now != nil {
+		now = r.now()
+	}
+	return assignment.ExpiresAt.After(now)
+}
+
+func departureFlightInfo(flight Flight) DepartureFlightInfo {
+	return DepartureFlightInfo{
+		Callsign:     flight.Callsign,
+		CID:          flight.CID,
+		Online:       flight.Online(),
+		Revision:     flight.FlightPlan.Revision,
+		Origin:       flight.FlightPlan.Origin,
+		Destination:  flight.FlightPlan.Destination,
+		AircraftType: flight.FlightPlan.AircraftShort,
+	}
 }
 
 func (r *Reconciler) notify(session int32, callsign string) {

--- a/backend/internal/vatsim/reconciliation_test.go
+++ b/backend/internal/vatsim/reconciliation_test.go
@@ -88,6 +88,19 @@ func assignmentKey(session int32, callsign string) string {
 	return string(rune(session)) + ":" + callsign
 }
 
+// expiryTestAssignments reports an assignment with a controllable expiry so the
+// reconciler's retainer can distinguish active reservations from expired ones.
+type expiryTestAssignments struct {
+	expiry map[string]*time.Time
+}
+
+func (s expiryTestAssignments) GetAssignment(_ context.Context, session int32, callsign string) (*models.StandAssignment, error) {
+	if expiry, ok := s.expiry[assignmentKey(session, callsign)]; ok {
+		return &models.StandAssignment{SessionID: session, Callsign: callsign, ExpiresAt: expiry}, nil
+	}
+	return nil, errors.New("not found")
+}
+
 type reconciliationTestNotifier struct{ callsigns []string }
 
 func (n *reconciliationTestNotifier) SendStripUpdate(_ int32, callsign string) {
@@ -180,4 +193,19 @@ func TestReconcileCleanupAndDisconnectRetentionRespectOtherOwners(t *testing.T) 
 	assert.Equal(t, []string{"SAS505"}, strips.deleted)
 	assert.True(t, reconciler.RetainsStrip(context.Background(), 7, "SAS606"))
 	assert.False(t, reconciler.RetainsStrip(context.Background(), 7, "SAS505"))
+}
+
+func TestRetainsStripHonorsReservationExpiry(t *testing.T) {
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	active := now.Add(15 * time.Minute)
+	expired := now.Add(-time.Minute)
+	assignments := expiryTestAssignments{expiry: map[string]*time.Time{
+		assignmentKey(7, "SAS1"): &active,
+		assignmentKey(7, "SAS2"): &expired,
+	}}
+	cache := newReconciliationTestCache(now)
+	reconciler := NewReconciler(cache, reconciliationTestSessions{items: []*models.Session{{ID: 7, Airport: "EKCH"}}}, &reconciliationTestStrips{bySession: map[int32][]*models.Strip{}}, assignments, nil, time.Second, WithClock(func() time.Time { return now }))
+
+	assert.True(t, reconciler.RetainsStrip(context.Background(), 7, "SAS1"), "an active reservation keeps the strip alive")
+	assert.False(t, reconciler.RetainsStrip(context.Background(), 7, "SAS2"), "an expired reservation no longer retains the strip")
 }


### PR DESCRIPTION
## Summary

Implements [task 12](../blob/main/stand-assignment/12-departure-lifecycle.md): assign prefiled departures and hold/release their stands according to the agreed timing rules.

## Changes

- **New DepartureLifecycleService** (ackend/internal/services/departure_lifecycle.go) owns the timing rules and is wired as the reconciler hook plus a periodic sweep worker:
  - Offline prefile → 15-minute RESERVED hold.
  - Repeated feed polls do not extend or reshuffle the reservation (no-op on unchanged revision).
  - Later flight-plan revision renews in place (same stand, extended expiry) when the stand remains compatible/free; otherwise reallocates with a fresh 15-minute hold.
  - Aircraft comes online at the assigned stand → converts the reservation to a DEPARTURE_BLOCK.
  - Block retained through **TSAT+10** when TSAT is present, otherwise **TOBT+10**.
  - Revalidates aircraft/engine facts once EuroScope supplies complete data; reallocates when the current stand no longer fits.
  - ReleaseExpired sweep releases expired offline reservations and completed departure blocks **idempotently**, reconstructing all deadlines from persisted ExpiresAt timestamps so a backend restart needs no in-memory state.
- **stand_allocation.go**: added injectable clock (WithStandAllocationClock) and a read-only StandAvailable helper (same locking read as allocation) so the lifecycle can decide renew-vs-reallocate atomically.
- **atsim/reconciliation.go**: added DepartureLifecycle interface + DepartureFlightInfo, wired ProcessDeparture after applying a departure flight, and made isAssigned (used by the EuroScope disconnect retainer) honor ExpiresAt so active reservations keep strips alive but expired ones no longer block cleanup.
- **pp/app.go**: constructs the allocation + lifecycle services when SAT is ready, wires the lifecycle into the reconciler, registers the sweep worker, and adds StandAssignmentHoldDuration/BlockExtension/SweepInterval config (defaults 15m / 10m / 30s).

## Acceptance criteria

- [x] An offline prefile gets one persisted assignment and 15-minute expiry.
- [x] Repeated feed polls do not extend or reshuffle the reservation by themselves.
- [x] TSAT controls release when present; otherwise TOBT controls it.
- [x] Restarting the backend reconstructs all pending deadlines from persisted timestamps.
- [x] Existing EuroScope disconnect cleanup does not prematurely remove an active reservation (expiry-aware retainer).

## Tests

DB-backed fake-clock tests in departure_lifecycle_test.go:
- initial hold
- repeated-poll no-op
- renewal in place
- renewal reallocates when stand unavailable
- expiry idempotency
- online → departure block conversion
- TSAT+10 release
- TOBT+10 release (TSAT absent)
- revalidation reallocation on EuroScope facts
- restart recovery from persisted timestamps

Plus TestRetainsStripHonorsReservationExpiry in econciliation_test.go covering disconnect-retention honoring expiry.

Full go test ./... passes.

## Out of scope

Per task 12: wrong-stand PM/five-minute behavior and EFB endpoints, and arrival displacement policy (task 13).