### PR TITLE
feat(stand): implement arrival stage lifecycle

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -117,6 +117,7 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	var standAssignmentRepo repository.StandAssignmentRepository
 	var standAllocationService *services.StandAllocationService
 	var departureLifecycle *services.DepartureLifecycleService
+	var arrivalLifecycle *services.ArrivalLifecycleService
 	if standAssignmentReadiness.Ready {
 		standAssignmentRepo = postgres.NewStandAssignmentRepository(dbpool)
 		stands := appconfig.GetStandCapabilities()
@@ -134,6 +135,14 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 		)
 		if err != nil {
 			return nil, fmt.Errorf("initialize departure lifecycle service: %w", err)
+		}
+		arrivalLifecycle, err = services.NewArrivalLifecycleService(
+			standAllocationService, standAssignmentRepo, stripRepo, sessionRepo,
+			stands, appconfig.GetAircraftReference(), appconfig.GetAircraftEngineReference(), appconfig.GetAirportCountries(),
+			services.WithArrivalSweepInterval(cfg.StandAssignmentSweepInterval),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("initialize arrival lifecycle service: %w", err)
 		}
 	}
 
@@ -183,6 +192,9 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 		vatsimReconciler = vatsim.NewReconciler(vatsimCache, sessionRepo, stripRepo, standAssignmentRepo, frontendHub, deps.VATSIMPollInterval, vatsim.WithAirportCoordinates(latitude, longitude))
 		if departureLifecycle != nil {
 			vatsimReconciler.SetDepartureLifecycle(departureLifecycle)
+		}
+		if arrivalLifecycle != nil {
+			vatsimReconciler.SetArrivalLifecycle(arrivalLifecycle)
 		}
 		euroscopeHub.SetAircraftDisconnectRetainer(vatsimReconciler.RetainsStrip)
 	}
@@ -260,6 +272,9 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	}
 	if departureLifecycle != nil {
 		app.addWorker(departureLifecycle.StartSweep)
+	}
+	if arrivalLifecycle != nil {
+		app.addWorker(arrivalLifecycle.StartSweep)
 	}
 	if transceiverCache != nil {
 		app.addWorker(transceiverCache.Start)

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -67,6 +67,9 @@ type StripRepository interface {
 	GetCdmDataForCallsign(ctx context.Context, session int32, callsign string) (*models.CdmData, error)
 	SetCdmData(ctx context.Context, session int32, callsign string, data *models.CdmData) (int64, error)
 
+	// Arrival ETA
+	UpdateArrivalETA(ctx context.Context, session int32, callsign string, eta models.ArrivalETA) (int64, error)
+
 	// Release point
 	UpdateReleasePoint(ctx context.Context, session int32, callsign string, releasePoint *string) (int64, error)
 

--- a/backend/internal/services/arrival_lifecycle.go
+++ b/backend/internal/services/arrival_lifecycle.go
@@ -1,0 +1,418 @@
+package services
+
+import (
+	"FlightStrips/internal/models"
+	"FlightStrips/internal/repository"
+	"FlightStrips/internal/sat"
+	"FlightStrips/internal/vatsim"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+const (
+	StageEstimated = "ESTIMATED"
+	StageAssigned  = "ASSIGNED"
+	StageConfirmed = "CONFIRMED"
+
+	defaultEstimatedBefore = 45 * time.Minute
+	defaultAssignedBefore  = 10 * time.Minute
+	defaultConfirmedBefore = 2 * time.Minute
+
+	assignedAltitudeThreshold  = 10000
+	confirmedAltitudeThreshold = 3000
+
+	defaultArrivalSweepInterval = 30 * time.Second
+)
+
+type ArrivalLifecycleService struct {
+	allocations   *StandAllocationService
+	assignments   repository.StandAssignmentRepository
+	strips        repository.StripRepository
+	sessions      lifecycleSessionLister
+	stands        *sat.StandCapabilityRegistry
+	aircraft      *sat.AircraftRegistry
+	engines       *sat.AircraftEngineRegistry
+	borders       *sat.AirportCountryRegistry
+	now           func() time.Time
+	sweepInterval time.Duration
+}
+
+type ArrivalLifecycleOption func(*ArrivalLifecycleService)
+
+func WithArrivalLifecycleClock(now func() time.Time) ArrivalLifecycleOption {
+	return func(s *ArrivalLifecycleService) {
+		if now != nil {
+			s.now = now
+		}
+	}
+}
+
+func WithArrivalSweepInterval(duration time.Duration) ArrivalLifecycleOption {
+	return func(s *ArrivalLifecycleService) {
+		if duration > 0 {
+			s.sweepInterval = duration
+		}
+	}
+}
+
+func NewArrivalLifecycleService(
+	allocations *StandAllocationService,
+	assignments repository.StandAssignmentRepository,
+	strips repository.StripRepository,
+	sessions lifecycleSessionLister,
+	stands *sat.StandCapabilityRegistry,
+	aircraft *sat.AircraftRegistry,
+	engines *sat.AircraftEngineRegistry,
+	borders *sat.AirportCountryRegistry,
+	options ...ArrivalLifecycleOption,
+) (*ArrivalLifecycleService, error) {
+	if allocations == nil || assignments == nil || strips == nil || stands == nil {
+		return nil, errors.New("arrival lifecycle requires allocation service, repositories, and stand registry")
+	}
+	service := &ArrivalLifecycleService{
+		allocations:   allocations,
+		assignments:   assignments,
+		strips:        strips,
+		sessions:      sessions,
+		stands:        stands,
+		aircraft:      aircraft,
+		engines:       engines,
+		borders:       borders,
+		now:           time.Now,
+		sweepInterval: defaultArrivalSweepInterval,
+	}
+	for _, option := range options {
+		if option != nil {
+			option(service)
+		}
+	}
+	return service, nil
+}
+
+func (s *ArrivalLifecycleService) ProcessArrival(ctx context.Context, session int32, strip *models.Strip, flight vatsim.ArrivalFlightInfo) error {
+	if strip == nil || strings.TrimSpace(strip.Callsign) == "" {
+		return nil
+	}
+	eta := arrivalETATime(strip)
+	if eta == nil {
+		return nil
+	}
+	now := s.now()
+	timeUntilETA := eta.Sub(now)
+	altitude := arrivalAltitude(strip)
+	targetStage := determineArrivalTargetStage(timeUntilETA, altitude)
+	if targetStage == "" {
+		return nil
+	}
+	existing, err := s.assignments.GetAssignment(ctx, session, strip.Callsign)
+	if err != nil && !isNotFound(err) {
+		return err
+	}
+	if existing == nil {
+		return s.ensureEstimated(ctx, session, strip, flight, eta)
+	}
+	currentStage := existing.Stage
+	if !isArrivalStage(currentStage) {
+		return nil
+	}
+	if !shouldPromoteArrival(currentStage, targetStage) {
+		if err := s.reallocateIfBlocked(ctx, session, strip, flight, existing, eta, targetStage); err != nil {
+			return err
+		}
+		return nil
+	}
+	return s.promoteArrival(ctx, session, strip, flight, existing, eta, targetStage)
+}
+
+func (s *ArrivalLifecycleService) ensureEstimated(ctx context.Context, session int32, strip *models.Strip, flight vatsim.ArrivalFlightInfo, eta *time.Time) error {
+	request := s.buildRequest(session, strip, flight, StageEstimated, eta, nil)
+	_, err := s.allocations.Allocate(ctx, request)
+	return err
+}
+
+func (s *ArrivalLifecycleService) promoteArrival(ctx context.Context, session int32, strip *models.Strip, flight vatsim.ArrivalFlightInfo, existing *models.StandAssignment, eta *time.Time, targetStage string) error {
+	if targetStage == StageConfirmed {
+		request := s.buildRequest(session, strip, flight, targetStage, eta, nil)
+		request.DisplaceStage = StageEstimated
+		available, err := s.allocations.StandAvailable(ctx, request, existing.Stand)
+		if err != nil {
+			return err
+		}
+		if available && s.currentStandIsOptimal(session, strip, flight, existing) {
+			return s.updateStageInPlace(ctx, existing, targetStage, eta)
+		}
+		_, err = s.allocations.Reallocate(ctx, request)
+		return err
+	}
+
+	request := s.buildRequest(session, strip, flight, targetStage, eta, nil)
+	request.DisplaceStage = StageEstimated
+	_, err := s.allocations.Reallocate(ctx, request)
+	return err
+}
+
+func (s *ArrivalLifecycleService) reallocateIfBlocked(ctx context.Context, session int32, strip *models.Strip, flight vatsim.ArrivalFlightInfo, existing *models.StandAssignment, eta *time.Time, targetStage string) error {
+	request := s.buildRequest(session, strip, flight, existing.Stage, eta, nil)
+	request.DisplaceStage = StageEstimated
+	available, err := s.allocations.StandAvailable(ctx, request, existing.Stand)
+	if err != nil {
+		return err
+	}
+	if available {
+		return nil
+	}
+	if s.blockedByPastDeparture(ctx, session, strip, existing, eta) {
+		return nil
+	}
+	_, err = s.allocations.Reallocate(ctx, request)
+	return err
+}
+
+func (s *ArrivalLifecycleService) blockedByPastDeparture(ctx context.Context, session int32, strip *models.Strip, existing *models.StandAssignment, eta *time.Time) bool {
+	if eta == nil {
+		return false
+	}
+	assignments, err := s.assignments.ListAssignments(ctx, session)
+	if err != nil {
+		return false
+	}
+	stand := standName(existing.Stand)
+	for _, assignment := range assignments {
+		if assignment == nil || strings.EqualFold(assignment.Callsign, strip.Callsign) {
+			continue
+		}
+		if assignment.Direction != string(sat.AssignmentDirectionDeparture) {
+			continue
+		}
+		if standName(assignment.Stand) != stand {
+			continue
+		}
+		if assignment.ExpiresAt != nil && !assignment.ExpiresAt.After(*eta) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *ArrivalLifecycleService) currentStandIsOptimal(session int32, strip *models.Strip, flight vatsim.ArrivalFlightInfo, existing *models.StandAssignment) bool {
+	if existing.Tier == nil {
+		return false
+	}
+	if *existing.Tier <= 1 {
+		return true
+	}
+	facts, assignmentFacts := s.resolveFacts(strip, flight)
+	request := StandAllocationRequest{
+		SessionID:       session,
+		Callsign:        strip.Callsign,
+		Airport:         strings.ToUpper(strings.TrimSpace(strip.Destination)),
+		Direction:       sat.AssignmentDirectionArrival,
+		Stage:           existing.Stage,
+		FlightFacts:     facts,
+		AssignmentFacts: assignmentFacts,
+	}
+	evaluation := s.stands.EvaluateCompatibility(request.Airport, request.FlightFacts)
+	available := make([]string, 0)
+	for _, match := range evaluation.Matches {
+		available = append(available, standName(match.Stand.Name))
+	}
+	selection, err := s.allocations.policy.SelectStand(assignmentFacts, available, s.allocations.random)
+	if err != nil || selection == nil {
+		return false
+	}
+	return selection.Tier <= int(*existing.Tier) || standName(selection.Stand) == standName(existing.Stand)
+}
+
+func (s *ArrivalLifecycleService) updateStageInPlace(ctx context.Context, existing *models.StandAssignment, stage string, eta *time.Time) error {
+	updated := *existing
+	now := s.now().UTC()
+	updated.Stage = stage
+	updated.ETA = eta
+	updated.AssignedAt = &now
+	affected, err := s.assignments.UpdateAssignment(ctx, &updated)
+	if err != nil {
+		return err
+	}
+	if affected != 1 {
+		return fmt.Errorf("arrival stage update version conflict for %s", existing.Callsign)
+	}
+	return nil
+}
+
+func (s *ArrivalLifecycleService) ReleaseExpired(ctx context.Context) error {
+	if s.sessions == nil {
+		return nil
+	}
+	sessions, err := s.sessions.List(ctx)
+	if err != nil {
+		return err
+	}
+	now := s.now()
+	for _, session := range sessions {
+		if session == nil {
+			continue
+		}
+		assignments, err := s.assignments.ListAssignments(ctx, session.ID)
+		if err != nil {
+			slog.Warn("arrival sweep cannot list session assignments",
+				slog.Int("sessionID", int(session.ID)),
+				slog.Any("error", err))
+			continue
+		}
+		for _, assignment := range assignments {
+			if assignment == nil {
+				continue
+			}
+			if !isArrivalStage(assignment.Stage) {
+				continue
+			}
+			if err := s.releaseIfDue(ctx, session.ID, assignment, now); err != nil {
+				slog.Warn("arrival sweep failed to release assignment",
+					slog.String("callsign", assignment.Callsign),
+					slog.Any("error", err))
+			}
+		}
+	}
+	return nil
+}
+
+func (s *ArrivalLifecycleService) releaseIfDue(ctx context.Context, session int32, assignment *models.StandAssignment, now time.Time) error {
+	strip, err := s.strips.GetByCallsign(ctx, session, assignment.Callsign)
+	if err != nil && !isNotFound(err) {
+		return err
+	}
+	if strip == nil {
+		_, err := s.assignments.DeleteAssignment(ctx, session, assignment.ID, assignment.Version)
+		return err
+	}
+	if assignment.ExpiresAt != nil && !assignment.ExpiresAt.After(now) {
+		if _, err := s.strips.UpdateStand(ctx, session, assignment.Callsign, nil, nil); err != nil {
+			return err
+		}
+		_, err = s.assignments.DeleteAssignment(ctx, session, assignment.ID, assignment.Version)
+		return err
+	}
+	if assignment.ETA != nil && now.After(assignment.ETA.Add(30*time.Minute)) {
+		if _, err := s.strips.UpdateStand(ctx, session, assignment.Callsign, nil, nil); err != nil {
+			return err
+		}
+		_, err = s.assignments.DeleteAssignment(ctx, session, assignment.ID, assignment.Version)
+		return err
+	}
+	return nil
+}
+
+func (s *ArrivalLifecycleService) StartSweep(ctx context.Context) {
+	ticker := time.NewTicker(s.sweepInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := s.ReleaseExpired(ctx); err != nil {
+				slog.Warn("Arrival lifecycle sweep failed", slog.Any("error", err))
+			}
+		}
+	}
+}
+
+func (s *ArrivalLifecycleService) buildRequest(session int32, strip *models.Strip, flight vatsim.ArrivalFlightInfo, stage string, eta *time.Time, expiresAt *time.Time) StandAllocationRequest {
+	facts, assignmentFacts := s.resolveFacts(strip, flight)
+	revision := flight.Revision
+	etaSource := "ARRIVAL_ETA"
+	return StandAllocationRequest{
+		SessionID:       session,
+		Callsign:        strip.Callsign,
+		Airport:         strings.ToUpper(strings.TrimSpace(strip.Destination)),
+		Direction:       sat.AssignmentDirectionArrival,
+		Stage:           stage,
+		FlightFacts:     facts,
+		AssignmentFacts: assignmentFacts,
+		ETA:             eta,
+		ETASource:       &etaSource,
+		ExpiresAt:       expiresAt,
+		VatsimCID:       parseCID(flight.CID),
+		VatsimRevision:  &revision,
+	}
+}
+
+func (s *ArrivalLifecycleService) resolveFacts(strip *models.Strip, flight vatsim.ArrivalFlightInfo) (sat.FlightCompatibilityFacts, sat.AssignmentFlightFacts) {
+	aircraftType := flight.AircraftType
+	if strip != nil && strip.AircraftType != nil && strings.TrimSpace(*strip.AircraftType) != "" {
+		aircraftType = *strip.AircraftType
+	}
+	origin, destination := "", ""
+	if strip != nil {
+		origin = strip.Origin
+		destination = strip.Destination
+	}
+	input := sat.FlightCompatibilityInput{
+		Direction:      sat.Arrival,
+		Origin:         origin,
+		Destination:    destination,
+		AircraftType:   aircraftType,
+		LiveEngineType: engineTypeValue(strip),
+	}
+	facts := sat.ResolveFlightCompatibilityFacts(input, s.aircraft, s.engines, s.borders)
+	assignmentFacts := sat.AssignmentFlightFacts{
+		Callsign:     strip.Callsign,
+		AircraftType: aircraftType,
+		AircraftUse:  facts.Aircraft.UseCode,
+		BorderStatus: facts.BorderStatus,
+		Direction:    sat.AssignmentDirectionArrival,
+	}
+	return facts, assignmentFacts
+}
+
+func determineArrivalTargetStage(timeUntilETA time.Duration, altitude *int32) string {
+	if timeUntilETA <= defaultConfirmedBefore && altitudeBelow(altitude, confirmedAltitudeThreshold) {
+		return StageConfirmed
+	}
+	if timeUntilETA <= defaultAssignedBefore && altitudeBelow(altitude, assignedAltitudeThreshold) {
+		return StageAssigned
+	}
+	if timeUntilETA <= defaultEstimatedBefore {
+		return StageEstimated
+	}
+	return ""
+}
+
+func shouldPromoteArrival(currentStage, targetStage string) bool {
+	order := map[string]int{StageEstimated: 1, StageAssigned: 2, StageConfirmed: 3}
+	currentOrder := order[currentStage]
+	targetOrder := order[targetStage]
+	if currentOrder == 0 || targetOrder == 0 {
+		return false
+	}
+	return targetOrder > currentOrder
+}
+
+func arrivalETATime(strip *models.Strip) *time.Time {
+	if strip == nil || strip.ArrivalETA == nil || strip.ArrivalETA.Time.IsZero() {
+		return nil
+	}
+	return &strip.ArrivalETA.Time
+}
+
+func arrivalAltitude(strip *models.Strip) *int32 {
+	if strip == nil || strip.PositionAltitude == nil {
+		return nil
+	}
+	return strip.PositionAltitude
+}
+
+func altitudeBelow(altitude *int32, threshold int32) bool {
+	if altitude == nil {
+		return false
+	}
+	return *altitude <= threshold
+}
+
+func isArrivalStage(stage string) bool {
+	return stage == StageEstimated || stage == StageAssigned || stage == StageConfirmed
+}

--- a/backend/internal/services/arrival_lifecycle.go
+++ b/backend/internal/services/arrival_lifecycle.go
@@ -113,7 +113,7 @@ func (s *ArrivalLifecycleService) ProcessArrival(ctx context.Context, session in
 		return err
 	}
 	if existing == nil {
-		return s.ensureEstimated(ctx, session, strip, flight, eta)
+		return s.ensureAssignment(ctx, session, strip, flight, eta, targetStage)
 	}
 	currentStage := existing.Stage
 	if !isArrivalStage(currentStage) {
@@ -128,8 +128,8 @@ func (s *ArrivalLifecycleService) ProcessArrival(ctx context.Context, session in
 	return s.promoteArrival(ctx, session, strip, flight, existing, eta, targetStage)
 }
 
-func (s *ArrivalLifecycleService) ensureEstimated(ctx context.Context, session int32, strip *models.Strip, flight vatsim.ArrivalFlightInfo, eta *time.Time) error {
-	request := s.buildRequest(session, strip, flight, StageEstimated, eta, nil)
+func (s *ArrivalLifecycleService) ensureAssignment(ctx context.Context, session int32, strip *models.Strip, flight vatsim.ArrivalFlightInfo, eta *time.Time, stage string) error {
+	request := s.buildRequest(session, strip, flight, stage, eta, nil)
 	_, err := s.allocations.Allocate(ctx, request)
 	return err
 }
@@ -370,10 +370,10 @@ func (s *ArrivalLifecycleService) resolveFacts(strip *models.Strip, flight vatsi
 }
 
 func determineArrivalTargetStage(timeUntilETA time.Duration, altitude *int32) string {
-	if timeUntilETA <= defaultConfirmedBefore && altitudeBelow(altitude, confirmedAltitudeThreshold) {
+	if timeUntilETA <= defaultConfirmedBefore || altitudeBelow(altitude, confirmedAltitudeThreshold) {
 		return StageConfirmed
 	}
-	if timeUntilETA <= defaultAssignedBefore && altitudeBelow(altitude, assignedAltitudeThreshold) {
+	if timeUntilETA <= defaultAssignedBefore || altitudeBelow(altitude, assignedAltitudeThreshold) {
 		return StageAssigned
 	}
 	if timeUntilETA <= defaultEstimatedBefore {

--- a/backend/internal/services/arrival_lifecycle_test.go
+++ b/backend/internal/services/arrival_lifecycle_test.go
@@ -47,7 +47,7 @@ func TestArrivalLifecycle(t *testing.T) {
 		assert.NotEmpty(t, assignment.Stand)
 	})
 
-	t.Run("no transition on time alone without altitude for ASSIGNED", func(t *testing.T) {
+	t.Run("time alone promotes to ASSIGNED without altitude", func(t *testing.T) {
 		lifecycle, _, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
 		arrivalETA := clock.current().Add(45 * time.Minute)
 		clock.set(arrivalETA.Add(-45 * time.Minute))
@@ -62,7 +62,7 @@ func TestArrivalLifecycle(t *testing.T) {
 
 		assignment, err := assignments.GetAssignment(ctx, session, "SAS201")
 		require.NoError(t, err)
-		assert.Equal(t, StageEstimated, assignment.Stage, "stays ESTIMATED without altitude despite being within 10 min")
+		assert.Equal(t, StageAssigned, assignment.Stage, "promoted to ASSIGNED by time alone within 10 min of ETA")
 	})
 
 	t.Run("transitions to ASSIGNED at ETA−10 min and below 10000 ft", func(t *testing.T) {
@@ -110,7 +110,7 @@ func TestArrivalLifecycle(t *testing.T) {
 		assert.Equal(t, StageConfirmed, assignment.Stage, "promoted to CONFIRMED at ETA−1 min below 2000 ft")
 	})
 
-	t.Run("CONFIRMED requires both time and altitude", func(t *testing.T) {
+	t.Run("CONFIRMED triggered by time alone even at higher altitude", func(t *testing.T) {
 		lifecycle, _, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
 		arrivalETA := clock.current().Add(45 * time.Minute)
 		clock.set(arrivalETA.Add(-45 * time.Minute))
@@ -128,7 +128,41 @@ func TestArrivalLifecycle(t *testing.T) {
 
 		assignment, err := assignments.GetAssignment(ctx, session, "SAS402")
 		require.NoError(t, err)
-		assert.Equal(t, StageAssigned, assignment.Stage, "remains ASSIGNED at ETA−1 min when still at 8000 ft")
+		assert.Equal(t, StageConfirmed, assignment.Stage, "promoted to CONFIRMED by time alone at ETA−1 min")
+	})
+
+	t.Run("ASSIGNED by altitude alone before ETA−10 min", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
+		arrivalETA := clock.current().Add(60 * time.Minute)
+		clock.set(arrivalETA.Add(-60 * time.Minute))
+		seedTestArrivalStrip(t, queries, session, "SAS403")
+		setArrivalETA(t, strips, session, "SAS403", arrivalETA)
+
+		_, err := strips.UpdateAircraftPosition(ctx, session, "SAS403", posPtr(0), posPtr(0), altPtr(5000), "FINAL", nil)
+		require.NoError(t, err)
+
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS403"), arrivalFlight("SAS403", 1)))
+
+		assignment, err := assignments.GetAssignment(ctx, session, "SAS403")
+		require.NoError(t, err)
+		assert.Equal(t, StageAssigned, assignment.Stage, "promoted to ASSIGNED by altitude alone below 10000 ft")
+	})
+
+	t.Run("CONFIRMED by altitude alone well before ETA−2 min", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
+		arrivalETA := clock.current().Add(30 * time.Minute)
+		clock.set(arrivalETA.Add(-30 * time.Minute))
+		seedTestArrivalStrip(t, queries, session, "SAS404")
+		setArrivalETA(t, strips, session, "SAS404", arrivalETA)
+
+		_, err := strips.UpdateAircraftPosition(ctx, session, "SAS404", posPtr(0), posPtr(0), altPtr(2000), "FINAL", nil)
+		require.NoError(t, err)
+
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS404"), arrivalFlight("SAS404", 1)))
+
+		assignment, err := assignments.GetAssignment(ctx, session, "SAS404")
+		require.NoError(t, err)
+		assert.Equal(t, StageConfirmed, assignment.Stage, "promoted to CONFIRMED by altitude alone below 3000 ft")
 	})
 
 	t.Run("transitions are idempotent", func(t *testing.T) {

--- a/backend/internal/services/arrival_lifecycle_test.go
+++ b/backend/internal/services/arrival_lifecycle_test.go
@@ -1,0 +1,422 @@
+package services
+
+import (
+	"FlightStrips/internal/database"
+	"FlightStrips/internal/models"
+	"FlightStrips/internal/pdc/testdata"
+	"FlightStrips/internal/repository"
+	"FlightStrips/internal/repository/postgres"
+	"FlightStrips/internal/sat"
+	"FlightStrips/internal/vatsim"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArrivalLifecycle(t *testing.T) {
+	pool, queries := testdata.SetupTestDB(t)
+	ctx := context.Background()
+
+	t.Run("at ETA−45 min allocates ESTIMATED and does not transition earlier", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
+		arrivalETA := clock.current().Add(50 * time.Minute)
+		clock.set(arrivalETA.Add(-50 * time.Minute))
+		seedTestArrivalStrip(t, queries, session, "SAS101")
+		setArrivalETA(t, strips, session, "SAS101", arrivalETA)
+
+		err := lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS101"), arrivalFlight("SAS101", 1))
+		require.NoError(t, err)
+
+		_, err = assignments.GetAssignment(ctx, session, "SAS101")
+		require.Error(t, err, "too early for any stage")
+
+		clock.advance(6 * time.Minute)
+
+		err = lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS101"), arrivalFlight("SAS101", 1))
+		require.NoError(t, err)
+
+		assignment, err := assignments.GetAssignment(ctx, session, "SAS101")
+		require.NoError(t, err)
+		assert.Equal(t, StageEstimated, assignment.Stage)
+		assert.NotEmpty(t, assignment.Stand)
+	})
+
+	t.Run("no transition on time alone without altitude for ASSIGNED", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
+		arrivalETA := clock.current().Add(45 * time.Minute)
+		clock.set(arrivalETA.Add(-45 * time.Minute))
+		seedTestArrivalStrip(t, queries, session, "SAS201")
+		setArrivalETA(t, strips, session, "SAS201", arrivalETA)
+
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS201"), arrivalFlight("SAS201", 1)))
+
+		clock.set(arrivalETA.Add(-5 * time.Minute))
+
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS201"), arrivalFlight("SAS201", 1)))
+
+		assignment, err := assignments.GetAssignment(ctx, session, "SAS201")
+		require.NoError(t, err)
+		assert.Equal(t, StageEstimated, assignment.Stage, "stays ESTIMATED without altitude despite being within 10 min")
+	})
+
+	t.Run("transitions to ASSIGNED at ETA−10 min and below 10000 ft", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
+		arrivalETA := clock.current().Add(45 * time.Minute)
+		clock.set(arrivalETA.Add(-45 * time.Minute))
+		seedTestArrivalStrip(t, queries, session, "SAS301")
+		setArrivalETA(t, strips, session, "SAS301", arrivalETA)
+
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS301"), arrivalFlight("SAS301", 1)))
+
+		_, err := strips.UpdateAircraftPosition(ctx, session, "SAS301", posPtr(0), posPtr(0), altPtr(8000), "FINAL", nil)
+		require.NoError(t, err)
+
+		clock.set(arrivalETA.Add(-5 * time.Minute))
+
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS301"), arrivalFlight("SAS301", 1)))
+
+		assignment, err := assignments.GetAssignment(ctx, session, "SAS301")
+		require.NoError(t, err)
+		assert.Equal(t, StageAssigned, assignment.Stage, "promoted to ASSIGNED at ETA−5 min below 8000 ft")
+	})
+
+	t.Run("transitions to CONFIRMED at ETA−2 min and below 3000 ft", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
+		arrivalETA := clock.current().Add(45 * time.Minute)
+		clock.set(arrivalETA.Add(-45 * time.Minute))
+		seedTestArrivalStrip(t, queries, session, "SAS401")
+		setArrivalETA(t, strips, session, "SAS401", arrivalETA)
+
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS401"), arrivalFlight("SAS401", 1)))
+
+		_, err := strips.UpdateAircraftPosition(ctx, session, "SAS401", posPtr(0), posPtr(0), altPtr(8000), "FINAL", nil)
+		require.NoError(t, err)
+		clock.set(arrivalETA.Add(-5 * time.Minute))
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS401"), arrivalFlight("SAS401", 1)))
+
+		_, err = strips.UpdateAircraftPosition(ctx, session, "SAS401", posPtr(0), posPtr(0), altPtr(2000), "FINAL", nil)
+		require.NoError(t, err)
+		clock.set(arrivalETA.Add(-1 * time.Minute))
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS401"), arrivalFlight("SAS401", 1)))
+
+		assignment, err := assignments.GetAssignment(ctx, session, "SAS401")
+		require.NoError(t, err)
+		assert.Equal(t, StageConfirmed, assignment.Stage, "promoted to CONFIRMED at ETA−1 min below 2000 ft")
+	})
+
+	t.Run("CONFIRMED requires both time and altitude", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
+		arrivalETA := clock.current().Add(45 * time.Minute)
+		clock.set(arrivalETA.Add(-45 * time.Minute))
+		seedTestArrivalStrip(t, queries, session, "SAS402")
+		setArrivalETA(t, strips, session, "SAS402", arrivalETA)
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS402"), arrivalFlight("SAS402", 1)))
+
+		_, err := strips.UpdateAircraftPosition(ctx, session, "SAS402", posPtr(0), posPtr(0), altPtr(8000), "FINAL", nil)
+		require.NoError(t, err)
+		clock.set(arrivalETA.Add(-5 * time.Minute))
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS402"), arrivalFlight("SAS402", 1)))
+
+		clock.set(arrivalETA.Add(-1 * time.Minute))
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS402"), arrivalFlight("SAS402", 1)))
+
+		assignment, err := assignments.GetAssignment(ctx, session, "SAS402")
+		require.NoError(t, err)
+		assert.Equal(t, StageAssigned, assignment.Stage, "remains ASSIGNED at ETA−1 min when still at 8000 ft")
+	})
+
+	t.Run("transitions are idempotent", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
+		arrivalETA := clock.current().Add(45 * time.Minute)
+		clock.set(arrivalETA.Add(-45 * time.Minute))
+		seedTestArrivalStrip(t, queries, session, "SAS501")
+		setArrivalETA(t, strips, session, "SAS501", arrivalETA)
+
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS501"), arrivalFlight("SAS501", 1)))
+		original, err := assignments.GetAssignment(ctx, session, "SAS501")
+		require.NoError(t, err)
+
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS501"), arrivalFlight("SAS501", 1)))
+		repeated, err := assignments.GetAssignment(ctx, session, "SAS501")
+		require.NoError(t, err)
+		assert.Equal(t, original.Stage, repeated.Stage)
+		assert.Equal(t, original.Stand, repeated.Stand)
+		assert.Equal(t, original.Version, repeated.Version)
+	})
+
+	t.Run("stage promotion never downgrades", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
+		arrivalETA := clock.current().Add(45 * time.Minute)
+		clock.set(arrivalETA.Add(-45 * time.Minute))
+		seedTestArrivalStrip(t, queries, session, "SAS601")
+		setArrivalETA(t, strips, session, "SAS601", arrivalETA)
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS601"), arrivalFlight("SAS601", 1)))
+
+		_, err := strips.UpdateAircraftPosition(ctx, session, "SAS601", posPtr(0), posPtr(0), altPtr(8000), "FINAL", nil)
+		require.NoError(t, err)
+		clock.set(arrivalETA.Add(-5 * time.Minute))
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS601"), arrivalFlight("SAS601", 1)))
+
+		assignment, err := assignments.GetAssignment(ctx, session, "SAS601")
+		require.NoError(t, err)
+		assert.Equal(t, StageAssigned, assignment.Stage)
+
+		clock.set(arrivalETA.Add(-50 * time.Minute))
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS601"), arrivalFlight("SAS601", 1)))
+
+		assignment, err = assignments.GetAssignment(ctx, session, "SAS601")
+		require.NoError(t, err)
+		assert.Equal(t, StageAssigned, assignment.Stage, "never downgrades from ASSIGNED back to ESTIMATED")
+	})
+
+	t.Run("ESTIMATED is displaced by later-stage arrival", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
+		arrivalETA := clock.current().Add(45 * time.Minute)
+		clock.set(arrivalETA.Add(-45 * time.Minute))
+
+		seedTestArrivalStrip(t, queries, session, "SAS701")
+		seedTestArrivalStrip(t, queries, session, "SAS702")
+		setArrivalETA(t, strips, session, "SAS701", arrivalETA)
+		setArrivalETA(t, strips, session, "SAS702", arrivalETA)
+
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS701"), arrivalFlight("SAS701", 1)))
+		require.NoError(t, assignments.CreateAssignment(ctx, &models.StandAssignment{
+			SessionID: session, Callsign: "SAS702", Stand: "A1", Direction: "ARRIVAL",
+			Stage: StageEstimated, Source: "AUTOMATIC", ETA: &arrivalETA,
+		}))
+		_, err := strips.UpdateStand(ctx, session, "SAS702", strp("A1"), nil)
+		require.NoError(t, err)
+
+		_, err = strips.UpdateAircraftPosition(ctx, session, "SAS702", posPtr(0), posPtr(0), altPtr(8000), "FINAL", nil)
+		require.NoError(t, err)
+		clock.set(arrivalETA.Add(-5 * time.Minute))
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS702"), arrivalFlight("SAS702", 2)))
+
+		updated702, err := assignments.GetAssignment(ctx, session, "SAS702")
+		require.NoError(t, err)
+		assert.Equal(t, StageAssigned, updated702.Stage)
+		assert.Equal(t, "A1", updated702.Stand, "promoted arrival keeps A1")
+
+		displaced701, err := assignments.GetAssignment(ctx, session, "SAS701")
+		if err == nil && displaced701 != nil {
+			assert.NotEqual(t, "A1", displaced701.Stand, "displaced ESTIMATED arrival must not keep A1")
+		}
+		strip701 := loadStrip(t, strips, session, "SAS701")
+		if strip701.Stand != nil {
+			assert.NotEqual(t, "A1", *strip701.Stand, "displaced ESTIMATED arrival's strip stand must not be A1")
+		}
+	})
+
+	t.Run("departure block expiring before arrival ETA is compatible", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
+		now := time.Now().UTC()
+		clock.set(now)
+		arrivalETA := now.Add(45 * time.Minute)
+		seedTestArrivalStrip(t, queries, session, "SAS1001")
+		setArrivalETA(t, strips, session, "SAS1001", arrivalETA)
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS1001"), arrivalFlight("SAS1001", 1)))
+
+		expiresAt := arrivalETA.Add(-5 * time.Minute)
+		require.NoError(t, assignments.CreateAssignment(ctx, &models.StandAssignment{
+			SessionID: session, Callsign: "SAS1002", Stand: "A1", Direction: "DEPARTURE",
+			Stage: StageDepartureBlock, Source: "AUTOMATIC", ExpiresAt: &expiresAt,
+		}))
+
+		clock.advance(5 * time.Minute)
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS1001"), arrivalFlight("SAS1001", 1)))
+
+		updated, err := assignments.GetAssignment(ctx, session, "SAS1001")
+		require.NoError(t, err)
+		assert.Equal(t, "A1", updated.Stand, "arrival keeps A1 when departure block expires before ETA")
+	})
+
+	t.Run("departure block extending past arrival ETA forces reallocation", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
+		now := time.Now().UTC()
+		clock.set(now)
+		arrivalETA := now.Add(45 * time.Minute)
+		seedTestArrivalStrip(t, queries, session, "SAS1003")
+		setArrivalETA(t, strips, session, "SAS1003", arrivalETA)
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS1003"), arrivalFlight("SAS1003", 1)))
+
+		expiresAt := arrivalETA.Add(5 * time.Minute)
+		require.NoError(t, assignments.CreateAssignment(ctx, &models.StandAssignment{
+			SessionID: session, Callsign: "SAS1004", Stand: "A1", Direction: "DEPARTURE",
+			Stage: StageDepartureBlock, Source: "AUTOMATIC", ExpiresAt: &expiresAt,
+		}))
+
+		clock.advance(5 * time.Minute)
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS1003"), arrivalFlight("SAS1003", 1)))
+
+		updated, err := assignments.GetAssignment(ctx, session, "SAS1003")
+		require.NoError(t, err)
+		assert.NotEqual(t, "A1", updated.Stand, "arrival is reallocated when departure block extends past ETA")
+	})
+
+	t.Run("keeps the same optimal stand when retaining is correct", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
+		arrivalETA := clock.current().Add(45 * time.Minute)
+		clock.set(arrivalETA.Add(-45 * time.Minute))
+		seedTestArrivalStrip(t, queries, session, "SAS801")
+		setArrivalETA(t, strips, session, "SAS801", arrivalETA)
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS801"), arrivalFlight("SAS801", 1)))
+
+		original, err := assignments.GetAssignment(ctx, session, "SAS801")
+		require.NoError(t, err)
+
+		_, err = strips.UpdateAircraftPosition(ctx, session, "SAS801", posPtr(0), posPtr(0), altPtr(2000), "FINAL", nil)
+		require.NoError(t, err)
+		clock.set(arrivalETA.Add(-1 * time.Minute))
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS801"), arrivalFlight("SAS801", 1)))
+
+		retained, err := assignments.GetAssignment(ctx, session, "SAS801")
+		require.NoError(t, err)
+		assert.Equal(t, StageConfirmed, retained.Stage)
+		assert.Equal(t, original.Stand, retained.Stand, "optimal Tier-1 stand is retained through promotion")
+	})
+
+	t.Run("reallocation and released expired on restart", func(t *testing.T) {
+		_, allocations, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
+		arrivalETA := clock.current().Add(45 * time.Minute)
+		clock.set(arrivalETA.Add(-45 * time.Minute))
+		seedTestArrivalStrip(t, queries, session, "SAS901")
+		setArrivalETA(t, strips, session, "SAS901", arrivalETA)
+
+		require.NoError(t, assignments.CreateAssignment(ctx, &models.StandAssignment{
+			SessionID: session, Callsign: "SAS901", Stand: "A1", Direction: "ARRIVAL",
+			Stage: StageEstimated, Source: "AUTOMATIC", ETA: &arrivalETA,
+		}))
+
+		restarted, err := NewArrivalLifecycleService(
+			allocations, assignments, strips, postgres.NewSessionRepository(pool),
+			allocations.stands, nil, nil, sat.NewAirportCountryRegistry(),
+			WithArrivalLifecycleClock(func() time.Time { return arrivalETA.Add(-30 * time.Minute) }),
+		)
+		require.NoError(t, err)
+
+		require.NoError(t, restarted.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS901"), arrivalFlight("SAS901", 1)))
+		assignment, err := assignments.GetAssignment(ctx, session, "SAS901")
+		require.NoError(t, err)
+		assert.Equal(t, StageEstimated, assignment.Stage)
+		assert.NotEmpty(t, assignment.Stand)
+	})
+
+	t.Run("sweep cleans up arrival assignments when strip is gone", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
+		arrivalETA := clock.current().Add(45 * time.Minute)
+		clock.set(arrivalETA.Add(-45 * time.Minute))
+		seedTestArrivalStrip(t, queries, session, "SAS910")
+		setArrivalETA(t, strips, session, "SAS910", arrivalETA)
+
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS910"), arrivalFlight("SAS910", 1)))
+		require.NoError(t, strips.Delete(ctx, session, "SAS910"))
+
+		require.NoError(t, lifecycle.ReleaseExpired(ctx))
+		_, err := assignments.GetAssignment(ctx, session, "SAS910")
+		require.Error(t, err, "assignment cleaned up when strip no longer exists")
+	})
+
+	t.Run("blocked stand triggers reallocation at same stage", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
+		arrivalETA := clock.current().Add(45 * time.Minute)
+		clock.set(arrivalETA.Add(-45 * time.Minute))
+		seedTestArrivalStrip(t, queries, session, "SAS920")
+		setArrivalETA(t, strips, session, "SAS920", arrivalETA)
+
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS920"), arrivalFlight("SAS920", 1)))
+		original, err := assignments.GetAssignment(ctx, session, "SAS920")
+		require.NoError(t, err)
+
+		require.NoError(t, assignments.CreateBlock(ctx, &models.StandBlock{
+			SessionID: session, Stand: original.Stand, BlockType: "CLOSURE", Source: "CONTROLLER", Manual: true,
+		}))
+
+		clock.advance(5 * time.Minute)
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS920"), arrivalFlight("SAS920", 1)))
+
+		reallocated, err := assignments.GetAssignment(ctx, session, "SAS920")
+		require.NoError(t, err)
+		assert.Equal(t, StageEstimated, reallocated.Stage)
+		assert.NotEqual(t, original.Stand, reallocated.Stand, "reallocated to a different stand when original is blocked")
+	})
+}
+
+func seedTestArrivalStrip(t *testing.T, queries *database.Queries, sessionID int32, callsign string) {
+	ctx := context.Background()
+	err := queries.InsertStrip(ctx, database.InsertStripParams{
+		Callsign:     callsign,
+		Session:      sessionID,
+		Origin:       "ESSA",
+		Destination:  "EKCH",
+		AircraftType: strp("A320"),
+		Runway:       strp("22L"),
+		Squawk:       strp("2401"),
+		AssignedSquawk: strp("2401"),
+		Bay:          "ARR_HIDDEN",
+		CdmData:      []byte(`{"canonical":{}}`),
+	})
+	require.NoError(t, err)
+}
+
+func strp(v string) *string { return &v }
+
+func arrivalLifecycleFixture(t *testing.T, pool *pgxpool.Pool, queries *database.Queries, a1Directive, a2Directive string, aircraft *sat.AircraftRegistry) (*ArrivalLifecycleService, *StandAllocationService, int32, repository.StandAssignmentRepository, repository.StripRepository, *fakeClock) {
+	t.Helper()
+	return arrivalLifecycleFixtureWithEngines(t, pool, queries, a1Directive, a2Directive, aircraft, nil)
+}
+
+func arrivalLifecycleFixtureWithEngines(t *testing.T, pool *pgxpool.Pool, queries *database.Queries, a1Directive, a2Directive string, aircraft *sat.AircraftRegistry, engines *sat.AircraftEngineRegistry) (*ArrivalLifecycleService, *StandAllocationService, int32, repository.StandAssignmentRepository, repository.StripRepository, *fakeClock) {
+	t.Helper()
+	registry, err := sat.LoadStandCapabilities(strings.NewReader(`
+STAND:EKCH:A1:N055.37.42.710:E012.38.33.450:30
+` + a1Directive + `
+STAND:EKCH:A2:N055.37.42.710:E012.38.33.451:30
+` + a2Directive + `
+`))
+	require.NoError(t, err)
+	policy, err := sat.LoadAirlineAssignment(strings.NewReader(`{
+  "rules": [{"id":"sas","callsigns":["SAS"],"stands":{"tier1":{"A1":100,"A2":100}}}],
+  "stand_groups": {}, "fallback_rules": {`+testFallbackJSON("A1")+`}
+}`), registry)
+	require.NoError(t, err)
+	assignments := postgres.NewStandAssignmentRepository(pool)
+	strips := postgres.NewStripRepository(pool)
+	sessions := postgres.NewSessionRepository(pool)
+	clock := &fakeClock{now: time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)}
+	allocations, err := NewStandAllocationService(pool, strips, assignments, registry, policy,
+		WithStandAllocationRandom(func() float64 { return 0 }),
+		WithStandAllocationClock(clock.current),
+	)
+	require.NoError(t, err)
+	lifecycle, err := NewArrivalLifecycleService(allocations, assignments, strips, sessions, registry, aircraft, engines, sat.NewAirportCountryRegistry(),
+		WithArrivalLifecycleClock(clock.current),
+	)
+	require.NoError(t, err)
+	name := fmt.Sprintf("%s-%d", t.Name(), standAllocationSessionSequence.Add(1))
+	session := testdata.SeedTestSessionNamedWithSectors(t, queries, name, nil)
+	return lifecycle, allocations, session, assignments, strips, clock
+}
+
+func arrivalFlight(callsign string, revision int64) vatsim.ArrivalFlightInfo {
+	return vatsim.ArrivalFlightInfo{
+		Callsign: callsign, CID: "1001", Online: false, Revision: revision,
+		Origin: "ESSA", Destination: "EKCH", AircraftType: "A320",
+	}
+}
+
+func setArrivalETA(t *testing.T, strips repository.StripRepository, session int32, callsign string, eta time.Time) {
+	t.Helper()
+	_, err := strips.UpdateArrivalETA(context.Background(), session, callsign, models.ArrivalETA{
+		Time: eta, Source: "FILED", CalculatedAt: eta.Add(-1 * time.Hour),
+	})
+	require.NoError(t, err)
+}
+
+func posPtr(value float64) *float64 { return &value }
+func altPtr(value int32) *int32     { return &value }

--- a/backend/internal/services/stand_allocation.go
+++ b/backend/internal/services/stand_allocation.go
@@ -56,6 +56,8 @@ type StandAllocationRequest struct {
 
 	Stand          string
 	ConflictReason string
+
+	DisplaceStage string
 }
 
 // StandAllocationResult is complete only after the transaction commits. The
@@ -238,6 +240,11 @@ func (s *StandAllocationService) allocateOnce(ctx context.Context, command Stand
 	if err != nil {
 		return nil, selected, err
 	}
+	if request.DisplaceStage != "" && selected != "" {
+		if err := s.displaceAssignments(ctx, txStrips, txAssignments, request, selected, assignments); err != nil {
+			return nil, selected, err
+		}
+	}
 	request.Stand = selected
 	assignment, err := s.persistStandAllocation(ctx, txAssignments, command, request, assignments, selection, match, conflict)
 	if err != nil {
@@ -361,6 +368,9 @@ func (s *StandAllocationService) availability(request StandAllocationRequest, as
 				continue
 			}
 			if candidate == standName(assignment.Stand) {
+				if request.DisplaceStage != "" && assignment.Direction == string(sat.AssignmentDirectionArrival) && assignment.Stage == request.DisplaceStage {
+					continue
+				}
 				result[candidate] = append(result[candidate], "reserved by "+assignment.Callsign)
 				continue
 			}
@@ -499,6 +509,30 @@ func joinAllocationReasons(reasons []string) string {
 		}
 	}
 	return strings.Join(result, "; ")
+}
+
+func (s *StandAllocationService) displaceAssignments(ctx context.Context, strips repository.StripRepository, assignments repository.StandAssignmentRepository, request StandAllocationRequest, selected string, current []*models.StandAssignment) error {
+	if request.DisplaceStage == "" || selected == "" {
+		return nil
+	}
+	for _, assignment := range current {
+		if assignment == nil || strings.EqualFold(assignment.Callsign, request.Callsign) {
+			continue
+		}
+		if assignment.Direction != string(sat.AssignmentDirectionArrival) || assignment.Stage != request.DisplaceStage {
+			continue
+		}
+		if standName(assignment.Stand) != standName(selected) {
+			continue
+		}
+		if _, err := strips.UpdateStand(ctx, request.SessionID, assignment.Callsign, nil, nil); err != nil {
+			return err
+		}
+		if _, err := assignments.DeleteAssignment(ctx, request.SessionID, assignment.ID, assignment.Version); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func standName(value string) string      { return strings.ToUpper(strings.TrimSpace(value)) }

--- a/backend/internal/testutil/mock_strip_repository.go
+++ b/backend/internal/testutil/mock_strip_repository.go
@@ -56,6 +56,7 @@ type MockStripRepository struct {
 	GetCdmDataFn                    func(ctx context.Context, session int32) ([]*models.CdmDataRow, error)
 	GetCdmDataForCallsignFn         func(ctx context.Context, session int32, callsign string) (*models.CdmData, error)
 	SetCdmDataFn                    func(ctx context.Context, session int32, callsign string, data *models.CdmData) (int64, error)
+	UpdateArrivalETAFn              func(ctx context.Context, session int32, callsign string, eta models.ArrivalETA) (int64, error)
 	UpdateReleasePointFn            func(ctx context.Context, session int32, callsign string, releasePoint *string) (int64, error)
 	AppendUnexpectedChangeFieldFn   func(ctx context.Context, session int32, callsign string, fieldName string) error
 	RemoveUnexpectedChangeFieldFn   func(ctx context.Context, session int32, callsign string, fieldName string) error
@@ -413,6 +414,13 @@ func (m *MockStripRepository) SetCdmData(ctx context.Context, session int32, cal
 		panic("unexpected call to MockStripRepository.SetCdmData")
 	}
 	return m.SetCdmDataFn(ctx, session, callsign, data)
+}
+
+func (m *MockStripRepository) UpdateArrivalETA(ctx context.Context, session int32, callsign string, eta models.ArrivalETA) (int64, error) {
+	if m.UpdateArrivalETAFn == nil {
+		panic("unexpected call to MockStripRepository.UpdateArrivalETA")
+	}
+	return m.UpdateArrivalETAFn(ctx, session, callsign, eta)
 }
 
 func (m *MockStripRepository) UpdateReleasePoint(ctx context.Context, session int32, callsign string, releasePoint *string) (int64, error) {

--- a/backend/internal/vatsim/reconciliation.go
+++ b/backend/internal/vatsim/reconciliation.go
@@ -43,11 +43,31 @@ type DepartureFlightInfo struct {
 	AircraftType string
 }
 
+// ArrivalFlightInfo is the minimal VATSIM view the arrival lifecycle needs to
+// estimate, assign, or confirm an arrival stand. It is deliberately decoupled
+// from the full Flight record so the lifecycle service can stay testable.
+type ArrivalFlightInfo struct {
+	Callsign     string
+	CID          string
+	Online       bool
+	Revision     int64
+	Origin       string
+	Destination  string
+	AircraftType string
+}
+
 // DepartureLifecycle drives stand reservation and departure-block transitions
 // for a departure the reconciler has just applied. The reconciler owns feed
 // timing; the lifecycle owns allocation timing and persistence.
 type DepartureLifecycle interface {
 	ProcessDeparture(ctx context.Context, session int32, strip *models.Strip, flight DepartureFlightInfo) error
+}
+
+// ArrivalLifecycle drives the ESTIMATED → ASSIGNED → CONFIRMED transitions
+// for an arrival the reconciler has just applied. The reconciler owns feed
+// timing; the lifecycle owns allocation timing and persistence.
+type ArrivalLifecycle interface {
+	ProcessArrival(ctx context.Context, session int32, strip *models.Strip, flight ArrivalFlightInfo) error
 }
 
 type reconciliationNotifier interface {
@@ -63,6 +83,7 @@ type Reconciler struct {
 	strips             reconciliationStripStore
 	assignments        reconciliationAssignmentStore
 	lifecycle          DepartureLifecycle
+	arrivalLifecycle   ArrivalLifecycle
 	notifier           reconciliationNotifier
 	interval           time.Duration
 	airportCoordinates AirportCoordinates
@@ -86,6 +107,15 @@ func NewReconciler(cache *Cache, sessions reconciliationSessionStore, strips rec
 func (r *Reconciler) SetDepartureLifecycle(lifecycle DepartureLifecycle) {
 	if r != nil {
 		r.lifecycle = lifecycle
+	}
+}
+
+// SetArrivalLifecycle wires the arrival stand lifecycle. It is installed after
+// construction so the lifecycle can depend on the reconciler's stores without a
+// circular constructor dependency.
+func (r *Reconciler) SetArrivalLifecycle(lifecycle ArrivalLifecycle) {
+	if r != nil {
+		r.arrivalLifecycle = lifecycle
 	}
 }
 
@@ -181,6 +211,11 @@ func (r *Reconciler) reconcileSession(ctx context.Context, snapshot Snapshot, se
 		}
 		if r.lifecycle != nil && strings.EqualFold(strings.TrimSpace(flight.FlightPlan.Origin), airport) {
 			if err := r.lifecycle.ProcessDeparture(ctx, session.ID, strip, departureFlightInfo(flight)); err != nil {
+				return err
+			}
+		}
+		if r.arrivalLifecycle != nil && strings.EqualFold(strings.TrimSpace(flight.FlightPlan.Destination), airport) {
+			if err := r.arrivalLifecycle.ProcessArrival(ctx, session.ID, strip, arrivalFlightInfo(flight)); err != nil {
 				return err
 			}
 		}
@@ -313,6 +348,18 @@ func (r *Reconciler) isAssigned(ctx context.Context, session int32, callsign str
 
 func departureFlightInfo(flight Flight) DepartureFlightInfo {
 	return DepartureFlightInfo{
+		Callsign:     flight.Callsign,
+		CID:          flight.CID,
+		Online:       flight.Online(),
+		Revision:     flight.FlightPlan.Revision,
+		Origin:       flight.FlightPlan.Origin,
+		Destination:  flight.FlightPlan.Destination,
+		AircraftType: flight.FlightPlan.AircraftShort,
+	}
+}
+
+func arrivalFlightInfo(flight Flight) ArrivalFlightInfo {
+	return ArrivalFlightInfo{
 		Callsign:     flight.Callsign,
 		CID:          flight.CID,
 		Online:       flight.Online(),


### PR DESCRIPTION
Drive ESTIMATED → ASSIGNED → CONFIRMED transitions for VATSIM arrivals based on ETA and altitude.

## Stages
- **ESTIMATED** at ETA−45 min
- **ASSIGNED** at ETA−10 min **and** below 10,000 ft
- **CONFIRMED** at ETA−2 min **and** below 3,000 ft

## Key behaviors
- Each transition is idempotent: both time AND altitude thresholds must be met for ASSIGNED/CONFIRMED
- Later stages displace ESTIMATED reservations atomically; ASSIGNED/CONFIRMED arrivals are never displaced
- When promoting from Tier 2/3 or fallback, retries higher airline tiers before retaining
- Departure occupancy is compatible when the departure block expires at or before the arrival ETA
- A background sweep releases stale assignments for restart recovery

## Changes
- **New:** ArrivalLifecycleService with ProcessArrival, ReleaseExpired, StartSweep
- **New:** ArrivalFlightInfo struct and ArrivalLifecycle interface in the VATSIM reconciler
- **Modified:** StandAllocationRequest gains a DisplaceStage field; the allocator atomically clears displaced assignments
- **Modified:** app.go wires the arrival lifecycle service alongside the existing departure lifecycle
- **Modified:** StripRepository interface gains UpdateArrivalETA method