### PR TITLE
feat(stand): integrate EST board with SAT backend assignment and block metadata

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -219,7 +219,7 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 		pdcService.SetTransceiverLookup(transceiverLookup)
 	}
 
-	fsServer = server.NewServer(dbpool, euroscopeHub, frontendHub, cdmService, pdcService, transceiverLookup, stripRepo, controllerRepo, sessionRepo, sectorRepo, coordRepo, tacticalStripRepo)
+	fsServer = server.NewServer(dbpool, euroscopeHub, frontendHub, cdmService, pdcService, transceiverLookup, stripRepo, controllerRepo, sessionRepo, sectorRepo, coordRepo, tacticalStripRepo, standAssignmentRepo)
 
 	frontendHub.SetServer(fsServer)
 	euroscopeHub.SetServer(fsServer)

--- a/backend/internal/frontend/handlers.go
+++ b/backend/internal/frontend/handlers.go
@@ -9,6 +9,7 @@ import (
 	"FlightStrips/pkg/events/frontend"
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"time"
@@ -770,5 +771,76 @@ func handleSendPrivateMessage(ctx context.Context, client *Client, message Messa
 	}
 	euroscopeHub := client.hub.server.GetEuroscopeHub()
 	euroscopeHub.Send(client.session, client.GetCid(), event)
+	return nil
+}
+
+func handleStandOccupy(ctx context.Context, client *Client, message Message) error {
+	var action frontend.StandOccupyAction
+	if err := message.JsonUnmarshal(&action); err != nil {
+		return err
+	}
+
+	repo := client.hub.server.GetStandAssignmentRepository()
+	if repo == nil {
+		return errors.New("stand assignment is not enabled")
+	}
+
+	reason := action.Reason
+	createdBy := client.position
+
+	block := &internalModels.StandBlock{
+		SessionID: client.session,
+		Stand:     action.Stand,
+		BlockType: "MANUAL",
+		Source:    "CONTROLLER",
+		Reason:    &reason,
+		CreatedBy: &createdBy,
+		Manual:    true,
+	}
+
+	if err := repo.CreateBlock(ctx, block); err != nil {
+		return fmt.Errorf("create stand block: %w", err)
+	}
+
+	client.hub.SendStandBlockBroadcast(client.session, action.Stand, &frontend.StandBlockEntry{
+		Stand:     block.Stand,
+		BlockType: block.BlockType,
+		Reason:    block.Reason,
+		CreatedBy: block.CreatedBy,
+	})
+
+	return nil
+}
+
+func handleStandVacate(ctx context.Context, client *Client, message Message) error {
+	var action frontend.StandVacateAction
+	if err := message.JsonUnmarshal(&action); err != nil {
+		return err
+	}
+
+	repo := client.hub.server.GetStandAssignmentRepository()
+	if repo == nil {
+		return errors.New("stand assignment is not enabled")
+	}
+
+	blocks, err := repo.ListBlocksByStand(ctx, client.session, action.Stand)
+	if err != nil {
+		return fmt.Errorf("list stand blocks: %w", err)
+	}
+
+	deletedAny := false
+	for _, block := range blocks {
+		if block != nil && block.BlockType == "MANUAL" {
+			if _, err := repo.DeleteBlock(ctx, client.session, block.ID, block.Version); err != nil {
+				return fmt.Errorf("delete stand block: %w", err)
+			}
+			deletedAny = true
+		}
+	}
+
+	if deletedAny {
+		client.hub.SendStandBlockBroadcast(client.session, action.Stand, nil)
+	}
+
 	return nil
 }

--- a/backend/internal/frontend/hub.go
+++ b/backend/internal/frontend/hub.go
@@ -134,6 +134,8 @@ func NewHub(stripService shared.StripService, authenticationService shared.Authe
 	handlers.Add(frontend.AcknowledgeValidationStatus, handleAcknowledgeValidationStatus)
 	handlers.Add(frontend.ClxOverrideValidation, handleClxOverrideValidation)
 	handlers.Add(frontend.ClxUpdateTobt, handleClxUpdateTobt)
+	handlers.Add(frontend.ActionStandOccupy, handleStandOccupy)
+	handlers.Add(frontend.ActionStandVacate, handleStandVacate)
 
 	hub := &Hub{
 		send:                  make(chan internalMessage, hubSendQueueSize),
@@ -789,6 +791,26 @@ func (hub *Hub) SendStandEvent(session int32, callsign string, stand string) {
 	hub.Broadcast(session, event)
 }
 
+func (hub *Hub) SendStandAssignmentBroadcast(session int32, entry frontend.StandAssignmentEntry) {
+	hub.Broadcast(session, frontend.StandAssignmentUpdateEvent{
+		Assignment: entry,
+	})
+}
+
+func (hub *Hub) SendStandBlockBroadcast(session int32, stand string, block *frontend.StandBlockEntry) {
+	hub.Broadcast(session, frontend.StandBlockUpdateEvent{
+		Stand: stand,
+		Block: block,
+	})
+}
+
+func (hub *Hub) SendStandStatusSnapshot(session int32, assignments []frontend.StandAssignmentEntry, blocks []frontend.StandBlockEntry) {
+	hub.Broadcast(session, frontend.StandStatusSnapshotEvent{
+		Assignments: assignments,
+		Blocks:      blocks,
+	})
+}
+
 func (hub *Hub) SendSetHeadingEvent(session int32, callsign string, heading int32) {
 	event := frontend.SetHeadingEvent{
 		Callsign: callsign,
@@ -1087,17 +1109,19 @@ func (hub *Hub) getSnapshotBuilder() *SnapshotBuilder {
 	}
 
 	hub.snapshotBuilder = NewSnapshotBuilder(SnapshotBuilderDependencies{
-		ControllerRepo:     hub.server.GetControllerRepository(),
-		StripRepo:          hub.server.GetStripRepository(),
-		SectorRepo:         hub.server.GetSectorOwnerRepository(),
-		SessionRepo:        hub.server.GetSessionRepository(),
-		CoordinationRepo:   hub.server.GetCoordinationRepository(),
-		TacticalStripRepo:  hub.server.GetTacticalStripRepository(),
-		EuroscopeHub:       hub.server.GetEuroscopeHub(),
-		BuildClxContext:    hub.makeClxValidationContext,
-		PopulateNextStrips: hub.populateNextDisplaysContext,
-		LoadMessages:       hub.snapshotMessages,
-		LoadCachedAtis:     hub.cachedAtisEvent,
+		ControllerRepo:         hub.server.GetControllerRepository(),
+		StripRepo:              hub.server.GetStripRepository(),
+		SectorRepo:             hub.server.GetSectorOwnerRepository(),
+		SessionRepo:            hub.server.GetSessionRepository(),
+		CoordinationRepo:       hub.server.GetCoordinationRepository(),
+		TacticalStripRepo:      hub.server.GetTacticalStripRepository(),
+		StandAssignmentRepo:    hub.server.GetStandAssignmentRepository(),
+		StandAssignmentEnabled: hub.server.GetStandAssignmentRepository() != nil,
+		EuroscopeHub:           hub.server.GetEuroscopeHub(),
+		BuildClxContext:        hub.makeClxValidationContext,
+		PopulateNextStrips:     hub.populateNextDisplaysContext,
+		LoadMessages:           hub.snapshotMessages,
+		LoadCachedAtis:         hub.cachedAtisEvent,
 	})
 
 	return hub.snapshotBuilder

--- a/backend/internal/frontend/snapshot_builder.go
+++ b/backend/internal/frontend/snapshot_builder.go
@@ -23,46 +23,52 @@ type InitialSnapshotRequest struct {
 }
 
 type SnapshotBuilderDependencies struct {
-	ControllerRepo     repository.ControllerRepository
-	StripRepo          SnapshotStripStore
-	SectorRepo         repository.SectorOwnerRepository
-	SessionRepo        repository.SessionRepository
-	CoordinationRepo   repository.CoordinationRepository
-	TacticalStripRepo  repository.TacticalStripRepository
-	EuroscopeHub       shared.EuroscopeHub
-	BuildClxContext    func(sessionID int32) clx.Context
-	PopulateNextStrips func(ctx context.Context, strips []*internalModels.Strip, sessionID int32)
-	LoadMessages       func(sessionID int32) []frontendEvents.MessageReceivedEvent
-	LoadCachedAtis     func(sessionID int32) *frontendEvents.AtisUpdateEvent
+	ControllerRepo         repository.ControllerRepository
+	StripRepo              SnapshotStripStore
+	SectorRepo             repository.SectorOwnerRepository
+	SessionRepo            repository.SessionRepository
+	CoordinationRepo       repository.CoordinationRepository
+	TacticalStripRepo      repository.TacticalStripRepository
+	StandAssignmentRepo    repository.StandAssignmentRepository
+	StandAssignmentEnabled bool
+	EuroscopeHub           shared.EuroscopeHub
+	BuildClxContext        func(sessionID int32) clx.Context
+	PopulateNextStrips     func(ctx context.Context, strips []*internalModels.Strip, sessionID int32)
+	LoadMessages           func(sessionID int32) []frontendEvents.MessageReceivedEvent
+	LoadCachedAtis         func(sessionID int32) *frontendEvents.AtisUpdateEvent
 }
 
 type SnapshotBuilder struct {
-	controllerRepo     repository.ControllerRepository
-	stripRepo          SnapshotStripStore
-	sectorRepo         repository.SectorOwnerRepository
-	sessionRepo        repository.SessionRepository
-	coordinationRepo   repository.CoordinationRepository
-	tacticalStripRepo  repository.TacticalStripRepository
-	euroscopeHub       shared.EuroscopeHub
-	buildClxContext    func(sessionID int32) clx.Context
-	populateNextStrips func(ctx context.Context, strips []*internalModels.Strip, sessionID int32)
-	loadMessages       func(sessionID int32) []frontendEvents.MessageReceivedEvent
-	loadCachedAtis     func(sessionID int32) *frontendEvents.AtisUpdateEvent
+	controllerRepo         repository.ControllerRepository
+	stripRepo              SnapshotStripStore
+	sectorRepo             repository.SectorOwnerRepository
+	sessionRepo            repository.SessionRepository
+	coordinationRepo       repository.CoordinationRepository
+	tacticalStripRepo      repository.TacticalStripRepository
+	standAssignmentRepo    repository.StandAssignmentRepository
+	standAssignmentEnabled bool
+	euroscopeHub           shared.EuroscopeHub
+	buildClxContext        func(sessionID int32) clx.Context
+	populateNextStrips     func(ctx context.Context, strips []*internalModels.Strip, sessionID int32)
+	loadMessages           func(sessionID int32) []frontendEvents.MessageReceivedEvent
+	loadCachedAtis         func(sessionID int32) *frontendEvents.AtisUpdateEvent
 }
 
 func NewSnapshotBuilder(deps SnapshotBuilderDependencies) *SnapshotBuilder {
 	return &SnapshotBuilder{
-		controllerRepo:     deps.ControllerRepo,
-		stripRepo:          deps.StripRepo,
-		sectorRepo:         deps.SectorRepo,
-		sessionRepo:        deps.SessionRepo,
-		coordinationRepo:   deps.CoordinationRepo,
-		tacticalStripRepo:  deps.TacticalStripRepo,
-		euroscopeHub:       deps.EuroscopeHub,
-		buildClxContext:    deps.BuildClxContext,
-		populateNextStrips: deps.PopulateNextStrips,
-		loadMessages:       deps.LoadMessages,
-		loadCachedAtis:     deps.LoadCachedAtis,
+		controllerRepo:         deps.ControllerRepo,
+		stripRepo:              deps.StripRepo,
+		sectorRepo:             deps.SectorRepo,
+		sessionRepo:            deps.SessionRepo,
+		coordinationRepo:       deps.CoordinationRepo,
+		tacticalStripRepo:      deps.TacticalStripRepo,
+		standAssignmentRepo:    deps.StandAssignmentRepo,
+		standAssignmentEnabled: deps.StandAssignmentEnabled,
+		euroscopeHub:           deps.EuroscopeHub,
+		buildClxContext:        deps.BuildClxContext,
+		populateNextStrips:     deps.PopulateNextStrips,
+		loadMessages:           deps.LoadMessages,
+		loadCachedAtis:         deps.LoadCachedAtis,
 	}
 }
 
@@ -150,6 +156,17 @@ func (b *SnapshotBuilder) Build(ctx context.Context, request InitialSnapshotRequ
 		ReadOnly:           request.ReadOnly,
 		PositionAvailable:  positionAvailable,
 		LocalIP:            localIP,
+	}
+
+	if b.standAssignmentEnabled && b.standAssignmentRepo != nil {
+		event.StandAssignmentEnabled = true
+		assignments, blocks, err := b.loadStandStatus(ctx, request.SessionID)
+		if err != nil {
+			slog.Error("Failed to load stand status for snapshot", slog.Any("error", err), slog.Int("session", int(request.SessionID)))
+		} else {
+			event.StandAssignments = assignments
+			event.StandBlocks = blocks
+		}
 	}
 
 	return event, b.cachedAtisEvent(request.SessionID), nil
@@ -269,6 +286,53 @@ func (b *SnapshotBuilder) cachedAtisEvent(sessionID int32) *frontendEvents.AtisU
 		return nil
 	}
 	return b.loadCachedAtis(sessionID)
+}
+
+func (b *SnapshotBuilder) loadStandStatus(ctx context.Context, sessionID int32) ([]frontendEvents.StandAssignmentEntry, []frontendEvents.StandBlockEntry, error) {
+	assignments, err := b.standAssignmentRepo.ListAssignments(ctx, sessionID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list stand assignments: %w", err)
+	}
+
+	blocks, err := b.standAssignmentRepo.ListBlocks(ctx, sessionID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list stand blocks: %w", err)
+	}
+
+	assignmentEntries := make([]frontendEvents.StandAssignmentEntry, 0, len(assignments))
+	for _, a := range assignments {
+		if a == nil {
+			continue
+		}
+		entry := frontendEvents.StandAssignmentEntry{
+			Callsign:  a.Callsign,
+			Stand:     a.Stand,
+			Direction: a.Direction,
+			Stage:     a.Stage,
+			Source:    a.Source,
+			ETA:       a.ETA,
+			ExpiresAt: a.ExpiresAt,
+		}
+		assignmentEntries = append(assignmentEntries, entry)
+	}
+
+	blockEntries := make([]frontendEvents.StandBlockEntry, 0, len(blocks))
+	for _, blk := range blocks {
+		if blk == nil {
+			continue
+		}
+		entry := frontendEvents.StandBlockEntry{
+			Stand:     blk.Stand,
+			BlockType: blk.BlockType,
+			Reason:    blk.Reason,
+			Callsign:  blk.Callsign,
+			CreatedBy: blk.CreatedBy,
+			ExpiresAt: blk.ExpiresAt,
+		}
+		blockEntries = append(blockEntries, entry)
+	}
+
+	return assignmentEntries, blockEntries, nil
 }
 
 func cloneStringSlice(values []string) []string {

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -25,12 +25,13 @@ type Server struct {
 	sessionLocks      sessionRecalcLockManager
 
 	// Repositories
-	stripRepo         repository.StripRepository
-	controllerRepo    repository.ControllerRepository
-	sessionRepo       repository.SessionRepository
-	sectorRepo        repository.SectorOwnerRepository
-	coordRepo         repository.CoordinationRepository
-	tacticalStripRepo repository.TacticalStripRepository
+	stripRepo             repository.StripRepository
+	controllerRepo        repository.ControllerRepository
+	sessionRepo           repository.SessionRepository
+	sectorRepo            repository.SectorOwnerRepository
+	coordRepo             repository.CoordinationRepository
+	tacticalStripRepo     repository.TacticalStripRepository
+	standAssignmentRepo   repository.StandAssignmentRepository
 }
 
 type TransceiverLookup interface {
@@ -50,20 +51,22 @@ func NewServer(
 	sectorRepo repository.SectorOwnerRepository,
 	coordRepo repository.CoordinationRepository,
 	tacticalStripRepo repository.TacticalStripRepository,
+	standAssignmentRepo repository.StandAssignmentRepository,
 ) *Server {
 	server := Server{
-		dbPool:            dbPool,
-		euroscopeHub:      euroscopeHub,
-		frontendHub:       frontendHub,
-		cdmService:        cdmService,
-		pdcService:        pdcService,
-		transceiverLookup: transceiverLookup,
-		stripRepo:         stripRepo,
-		controllerRepo:    controllerRepo,
-		sessionRepo:       sessionRepo,
-		sectorRepo:        sectorRepo,
-		coordRepo:         coordRepo,
-		tacticalStripRepo: tacticalStripRepo,
+		dbPool:              dbPool,
+		euroscopeHub:        euroscopeHub,
+		frontendHub:         frontendHub,
+		cdmService:          cdmService,
+		pdcService:          pdcService,
+		transceiverLookup:   transceiverLookup,
+		stripRepo:           stripRepo,
+		controllerRepo:      controllerRepo,
+		sessionRepo:         sessionRepo,
+		sectorRepo:          sectorRepo,
+		coordRepo:           coordRepo,
+		tacticalStripRepo:   tacticalStripRepo,
+		standAssignmentRepo: standAssignmentRepo,
 	}
 
 	go server.monitorSessions()
@@ -97,6 +100,10 @@ func (s *Server) GetCoordinationRepository() repository.CoordinationRepository {
 
 func (s *Server) GetTacticalStripRepository() repository.TacticalStripRepository {
 	return s.tacticalStripRepo
+}
+
+func (s *Server) GetStandAssignmentRepository() repository.StandAssignmentRepository {
+	return s.standAssignmentRepo
 }
 
 func (s *Server) GetEuroscopeHub() shared.EuroscopeHub {

--- a/backend/internal/shared/server.go
+++ b/backend/internal/shared/server.go
@@ -43,6 +43,7 @@ type Server interface {
 	GetSectorOwnerRepository() repository.SectorOwnerRepository
 	GetCoordinationRepository() repository.CoordinationRepository
 	GetTacticalStripRepository() repository.TacticalStripRepository
+	GetStandAssignmentRepository() repository.StandAssignmentRepository
 
 	// TODO move to another service
 	UpdateSectors(sessionId int32) ([]SectorChange, error)

--- a/backend/internal/testutil/mock_server.go
+++ b/backend/internal/testutil/mock_server.go
@@ -70,6 +70,8 @@ func (m *MockServer) GetTacticalStripRepository() repository.TacticalStripReposi
 	return m.TacticalStripRepoVal
 }
 
+func (m *MockServer) GetStandAssignmentRepository() repository.StandAssignmentRepository { return nil }
+
 func (m *MockServer) UpdateSectors(sessionId int32) ([]shared.SectorChange, error) {
 	if m.UpdateSectorsFn != nil {
 		return m.UpdateSectorsFn(sessionId)

--- a/backend/pkg/events/frontend/events.go
+++ b/backend/pkg/events/frontend/events.go
@@ -106,6 +106,15 @@ const (
 	AcknowledgeValidationStatus EventType = "acknowledge_validation_status"
 	ClxOverrideValidation       EventType = "clx_override_validation"
 	ClxUpdateTobt               EventType = "clx_update_tobt"
+
+	// Stand Status events (broadcast to frontend)
+	StandStatusSnapshot   EventType = "stand_status_snapshot"
+	StandAssignmentUpdate EventType = "stand_assignment_update"
+	StandBlockUpdate      EventType = "stand_block_update"
+
+	// Stand action types (sent from frontend to backend)
+	ActionStandOccupy EventType = "stand_occupy"
+	ActionStandVacate EventType = "stand_vacate"
 )
 
 type OutgoingMessage interface {
@@ -255,22 +264,25 @@ type SyncCoordination struct {
 }
 
 type InitialEvent struct {
-	Contsollers        []Controller            `json:"controllers"`
-	Strips             []Strip                 `json:"strips"`
-	TacticalStrips     []TacticalStripPayload  `json:"tactical_strips"`
-	Me                 Controller              `json:"me"`
-	Layout             string                  `json:"layout"`
-	Airport            string                  `json:"airport"`
-	Callsign           string                  `json:"callsign"`
-	RunwaySetup        RunwayConfiguration     `json:"runway_setup"`
-	Coordinations      []SyncCoordination      `json:"coordinations"`
-	Messages           []MessageReceivedEvent  `json:"messages"`
-	AvailableSids      pkgModels.AvailableSids `json:"available_sids"`
-	InitialCFLByRunway map[string]int32        `json:"initial_cfl_by_runway"`
-	TransitionAltitude int32                   `json:"transition_altitude"`
-	ReadOnly           bool                    `json:"read_only"`
-	PositionAvailable  bool                    `json:"position_available"`
-	LocalIP            string                  `json:"local_ip,omitempty"`
+	Contsollers            []Controller            `json:"controllers"`
+	Strips                 []Strip                 `json:"strips"`
+	TacticalStrips         []TacticalStripPayload  `json:"tactical_strips"`
+	Me                     Controller              `json:"me"`
+	Layout                 string                  `json:"layout"`
+	Airport                string                  `json:"airport"`
+	Callsign               string                  `json:"callsign"`
+	RunwaySetup            RunwayConfiguration     `json:"runway_setup"`
+	Coordinations          []SyncCoordination      `json:"coordinations"`
+	Messages               []MessageReceivedEvent  `json:"messages"`
+	AvailableSids          pkgModels.AvailableSids `json:"available_sids"`
+	InitialCFLByRunway     map[string]int32        `json:"initial_cfl_by_runway"`
+	TransitionAltitude     int32                   `json:"transition_altitude"`
+	ReadOnly               bool                    `json:"read_only"`
+	PositionAvailable      bool                    `json:"position_available"`
+	LocalIP                string                  `json:"local_ip,omitempty"`
+	StandAssignmentEnabled bool                    `json:"stand_assignment_enabled"`
+	StandAssignments       []StandAssignmentEntry  `json:"stand_assignments"`
+	StandBlocks            []StandBlockEntry       `json:"stand_blocks"`
 }
 
 func (i InitialEvent) Marshal() ([]byte, error) {
@@ -1013,4 +1025,68 @@ func (e GoAroundEvent) GetType() EventType       { return GoAround }
 type MissedApproachRequestEvent struct {
 	Type     EventType `json:"type"`
 	Callsign string    `json:"callsign"`
+}
+
+// ---------- STAND STATUS EVENTS ----------
+
+// StandAssignmentEntry represents a single stand assignment for frontend consumption.
+type StandAssignmentEntry struct {
+	Callsign  string     `json:"callsign"`
+	Stand     string     `json:"stand"`
+	Direction string     `json:"direction"`
+	Stage     string     `json:"stage"`
+	Source    string     `json:"source"`
+	ETA       *time.Time `json:"eta,omitempty"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+}
+
+// StandBlockEntry represents a single stand block for frontend consumption.
+type StandBlockEntry struct {
+	Stand     string     `json:"stand"`
+	BlockType string     `json:"block_type"`
+	Reason    *string    `json:"reason,omitempty"`
+	Callsign  *string    `json:"callsign,omitempty"`
+	CreatedBy *string    `json:"created_by,omitempty"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+}
+
+// StandStatusSnapshotEvent is broadcast to a newly connected frontend to seed stand state.
+type StandStatusSnapshotEvent struct {
+	Assignments []StandAssignmentEntry `json:"assignments"`
+	Blocks      []StandBlockEntry      `json:"blocks"`
+}
+
+func (e StandStatusSnapshotEvent) Marshal() ([]byte, error) { return marshall(e) }
+func (e StandStatusSnapshotEvent) GetType() EventType       { return StandStatusSnapshot }
+
+// StandAssignmentUpdateEvent is broadcast when an assignment changes.
+type StandAssignmentUpdateEvent struct {
+	Assignment StandAssignmentEntry `json:"assignment"`
+}
+
+func (e StandAssignmentUpdateEvent) Marshal() ([]byte, error) { return marshall(e) }
+func (e StandAssignmentUpdateEvent) GetType() EventType       { return StandAssignmentUpdate }
+
+// StandBlockUpdateEvent is broadcast when a manual block changes.
+type StandBlockUpdateEvent struct {
+	Stand string `json:"stand"`
+	Block *StandBlockEntry `json:"block,omitempty"`
+}
+
+func (e StandBlockUpdateEvent) Marshal() ([]byte, error) { return marshall(e) }
+func (e StandBlockUpdateEvent) GetType() EventType       { return StandBlockUpdate }
+
+// ---------- STAND ACTION PAYLOADS ----------
+
+// StandOccupyAction is sent by a frontend controller to manually block a stand.
+type StandOccupyAction struct {
+	Type   EventType `json:"type"`
+	Stand  string    `json:"stand"`
+	Reason string    `json:"reason"`
+}
+
+// StandVacateAction is sent by a frontend controller to remove a manual block.
+type StandVacateAction struct {
+	Type  EventType `json:"type"`
+	Stand string    `json:"stand"`
 }

--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -39,6 +39,9 @@ export enum EventType {
   FrontendActionRejected = "action_rejected",
   FrontendAvailableSids = "available_sids",
   FrontendCoordinationTagRequestBroadcast = "coordination_tag_request_broadcast",
+  FrontendStandStatusSnapshot = "stand_status_snapshot",
+  FrontendStandAssignmentUpdate = "stand_assignment_update",
+  FrontendStandBlockUpdate = "stand_block_update",
 }
 
 export enum ActionType {
@@ -77,6 +80,8 @@ export enum ActionType {
   FrontendAcknowledgeValidationStatus = "acknowledge_validation_status",
   FrontendClxOverrideValidation = "clx_override_validation",
   FrontendClxUpdateTobt = "clx_update_tobt",
+  FrontendStandOccupy = "stand_occupy",
+  FrontendStandVacate = "stand_vacate",
 }
 
 export type PdcStatus = "NONE" | "REQUESTED" | "REQUESTED_WITH_FAULTS" | "CLEARED" | "CONFIRMED" | "NO_RESPONSE" | "FAILED" | "REVERT_TO_VOICE";
@@ -282,6 +287,9 @@ export interface FrontendInitialEvent {
   read_only: boolean;
   position_available: boolean;
   local_ip?: string;
+  stand_assignment_enabled: boolean;
+  stand_assignments: FrontendStandAssignmentEntry[];
+  stand_blocks: FrontendStandBlockEntry[];
 }
 
 export interface FrontendStripUpdateEvent {
@@ -643,12 +651,62 @@ export type WebSocketEvent =
   | FrontendMessageReceivedEvent
   | FrontendAtisUpdateEvent
   | ActionRejectedEvent
-  | FrontendBulkBayEvent;
+  | FrontendBulkBayEvent
+  | FrontendStandStatusSnapshotEvent
+  | FrontendStandAssignmentUpdateEvent
+  | FrontendStandBlockUpdateEvent;
 
 export interface ActionRejectedEvent {
   type: EventType.FrontendActionRejected;
   action: string;
   reason: string;
+}
+
+export interface FrontendStandAssignmentEntry {
+  callsign: string;
+  stand: string;
+  direction: string;
+  stage: string;
+  source: string;
+  eta?: string;
+  expires_at?: string;
+}
+
+export interface FrontendStandBlockEntry {
+  stand: string;
+  block_type: string;
+  reason?: string;
+  callsign?: string;
+  created_by?: string;
+  expires_at?: string;
+}
+
+export interface FrontendStandStatusSnapshotEvent {
+  type: EventType.FrontendStandStatusSnapshot;
+  assignments: FrontendStandAssignmentEntry[];
+  blocks: FrontendStandBlockEntry[];
+}
+
+export interface FrontendStandAssignmentUpdateEvent {
+  type: EventType.FrontendStandAssignmentUpdate;
+  assignment: FrontendStandAssignmentEntry;
+}
+
+export interface FrontendStandBlockUpdateEvent {
+  type: EventType.FrontendStandBlockUpdate;
+  stand: string;
+  block: FrontendStandBlockEntry | null;
+}
+
+export interface FrontendStandOccupyAction {
+  type: ActionType.FrontendStandOccupy;
+  stand: string;
+  reason: string;
+}
+
+export interface FrontendStandVacateAction {
+  type: ActionType.FrontendStandVacate;
+  stand: string;
 }
 
 export interface FrontendGoAroundEvent {
@@ -854,7 +912,7 @@ export interface FrontendClxUpdateTobtEvent {
 }
 
 // Union type for all events that can be sent
-export type FrontendSendEvent = FrontendUpdateRunwayStatusEvent | FrontendMissedApproachEvent |FrontendCreateManualFPLAction | FrontendCreateVFRFPLAction |FrontendAuthenticationEvent | FrontendMoveEvent | FrontendGenerateSquawkEvent | FrontendUpdateStripDataEvent | FrontendUpdateOrder | FrontendSendMessageEvent | FrontendSendPrivateMessageEvent | FrontendCdmReadyEvent | FrontendSendReleasePointEvent | FrontendSetStartReqAction | FrontendSendMarkedEvent | FrontendSendRunwayClearanceEvent | FrontendSendRunwayConfirmationEvent | FrontendIssuePdcClearanceRequest | FrontendRevertToVoiceRequest | FrontendCoordinationTransferRequestEvent | FrontendCoordinationAssumeRequestEvent | FrontendCoordinationForceAssumeRequestEvent | FrontendCoordinationFreeRequestEvent | FrontendCoordinationCancelTransferRequestEvent | FrontendCoordinationTagRequestEvent | FrontendCoordinationAcceptTagRequestEvent | FrontendCreateTacticalStripAction | FrontendDeleteTacticalStripAction | FrontendConfirmTacticalStripAction | FrontendStartTacticalTimerAction | FrontendMoveTacticalStripAction | FrontendAcknowledgeUnexpectedChangeEvent | FrontendAcknowledgeValidationStatusEvent | FrontendClxOverrideValidationEvent | FrontendClxUpdateTobtEvent;
+export type FrontendSendEvent = FrontendUpdateRunwayStatusEvent | FrontendMissedApproachEvent |FrontendCreateManualFPLAction | FrontendCreateVFRFPLAction |FrontendAuthenticationEvent | FrontendMoveEvent | FrontendGenerateSquawkEvent | FrontendUpdateStripDataEvent | FrontendUpdateOrder | FrontendSendMessageEvent | FrontendSendPrivateMessageEvent | FrontendCdmReadyEvent | FrontendSendReleasePointEvent | FrontendSetStartReqAction | FrontendSendMarkedEvent | FrontendSendRunwayClearanceEvent | FrontendSendRunwayConfirmationEvent | FrontendIssuePdcClearanceRequest | FrontendRevertToVoiceRequest | FrontendCoordinationTransferRequestEvent | FrontendCoordinationAssumeRequestEvent | FrontendCoordinationForceAssumeRequestEvent | FrontendCoordinationFreeRequestEvent | FrontendCoordinationCancelTransferRequestEvent | FrontendCoordinationTagRequestEvent | FrontendCoordinationAcceptTagRequestEvent | FrontendCreateTacticalStripAction | FrontendDeleteTacticalStripAction | FrontendConfirmTacticalStripAction | FrontendStartTacticalTimerAction | FrontendMoveTacticalStripAction | FrontendAcknowledgeUnexpectedChangeEvent | FrontendAcknowledgeValidationStatusEvent | FrontendClxOverrideValidationEvent | FrontendClxUpdateTobtEvent | FrontendStandOccupyAction | FrontendStandVacateAction;
 
 export type AnyStrip = FrontendStrip | TacticalStrip;
 export const isFlight = (s: AnyStrip): s is FrontendStrip => 'callsign' in s;

--- a/frontend/src/api/websocket.ts
+++ b/frontend/src/api/websocket.ts
@@ -27,6 +27,9 @@ import {
   type FrontendSetHeadingEvent,
   type FrontendSquawkEvent,
   type FrontendStandEvent,
+  type FrontendStandStatusSnapshotEvent,
+  type FrontendStandAssignmentUpdateEvent,
+  type FrontendStandBlockUpdateEvent,
   type FrontendStripUpdateEvent,
   type FrontendTacticalStripCreatedEvent,
   type FrontendTacticalStripDeletedEvent,
@@ -81,6 +84,9 @@ type EventMap = {
   [EventType.FrontendAtisUpdate]: FrontendAtisUpdateEvent;
   [EventType.FrontendActionRejected]: ActionRejectedEvent;
   [EventType.FrontendAvailableSids]: AvailableSidsEvent;
+  [EventType.FrontendStandStatusSnapshot]: FrontendStandStatusSnapshotEvent;
+  [EventType.FrontendStandAssignmentUpdate]: FrontendStandAssignmentUpdateEvent;
+  [EventType.FrontendStandBlockUpdate]: FrontendStandBlockUpdateEvent;
 };
 
 type WebSocketClientDelegate = {

--- a/frontend/src/components/est/EstStandCell.tsx
+++ b/frontend/src/components/est/EstStandCell.tsx
@@ -29,6 +29,7 @@ interface EstStandCellProps {
   strip?: FrontendStrip;
   selected: boolean;
   blocked: boolean;
+  blockReason?: string;
   actionActive: boolean;
   blinking: boolean;
   startReqActive: boolean;
@@ -42,6 +43,7 @@ export default function EstStandCell({
   stand,
   strip,
   blocked,
+  blockReason,
   actionActive,
   blinking,
   startReqActive,
@@ -52,7 +54,7 @@ export default function EstStandCell({
 }: EstStandCellProps) {
   const vgdsStatus = getVgdsStatus(stand.label);
   const bridgeStatus = getBridgeStatus(stand.label);
-  const tooltipContent = [vgdsStatus, bridgeStatus].filter(Boolean).join(" \u2022 ");
+  const tooltipContent = [vgdsStatus, bridgeStatus, blocked ? blockReason : undefined].filter(Boolean).join(" \u2022 ");
   const gridStyle =
     "column" in stand && "row" in stand && stand.column !== undefined && stand.row !== undefined
       ? { gridColumn: stand.column, gridRow: stand.row }

--- a/frontend/src/components/est/est-stand-cell.test.tsx
+++ b/frontend/src/components/est/est-stand-cell.test.tsx
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import EstStandCell from "./EstStandCell";
+import { Bay, type FrontendStrip } from "@/api/models";
+
+function makeStrip(overrides: Partial<FrontendStrip> = {}): FrontendStrip {
+  return {
+    callsign: "SAS123",
+    origin: "EKCH",
+    destination: "ENGM",
+    alternate: "",
+    route: "",
+    remarks: "",
+    runway: "22R",
+    squawk: "1000",
+    assigned_squawk: "1000",
+    sid: "",
+    cleared_altitude: 0,
+    requested_altitude: 0,
+    heading: 0,
+    aircraft_type: "A320",
+    aircraft_category: "",
+    stand: "A18",
+    capabilities: "",
+    communication_type: "",
+    eobt: "1420",
+    tobt: "1420",
+    tsat: "1425",
+    ctot: "",
+    eldt: "",
+    bay: Bay.NotCleared,
+    release_point: "",
+    version: 1,
+    sequence: 0,
+    next_controllers: [],
+    previous_controllers: [],
+    owner: "",
+    pdc_state: "NONE",
+    start_req: false,
+    marked: false,
+    runway_cleared: false,
+    runway_confirmed: false,
+    registration: "",
+    ...overrides,
+  } as FrontendStrip;
+}
+
+const stand = { label: "A18", left: 0, top: 0 };
+
+describe("EstStandCell", () => {
+  it("renders stand label", () => {
+    render(
+      <EstStandCell
+        stand={stand}
+        blocked={false}
+        selected={false}
+        actionActive={false}
+        blinking={false}
+        startReqActive={false}
+        ctotImproved={false}
+        nowMs={Date.now()}
+        onClick={() => {}}
+      />,
+    );
+    expect(screen.getByText("A18")).toBeDefined();
+  });
+
+  it("renders callsign when strip is present", () => {
+    render(
+      <EstStandCell
+        stand={stand}
+        strip={makeStrip()}
+        blocked={false}
+        selected={false}
+        actionActive={false}
+        blinking={false}
+        startReqActive={false}
+        ctotImproved={false}
+        nowMs={Date.now()}
+        onClick={() => {}}
+      />,
+    );
+    expect(screen.getByText("SAS123")).toBeDefined();
+  });
+
+  it("hides callsign when blocked", () => {
+    render(
+      <EstStandCell
+        stand={stand}
+        strip={makeStrip()}
+        blocked={true}
+        selected={false}
+        actionActive={false}
+        blinking={false}
+        startReqActive={false}
+        ctotImproved={false}
+        nowMs={Date.now()}
+        onClick={() => {}}
+      />,
+    );
+    expect(screen.queryByText("SAS123")).toBeNull();
+  });
+
+  it("shows blocked style when blocked", () => {
+    render(
+      <EstStandCell
+        stand={stand}
+        blocked={true}
+        selected={false}
+        actionActive={false}
+        blinking={false}
+        startReqActive={false}
+        ctotImproved={false}
+        nowMs={Date.now()}
+        onClick={() => {}}
+      />,
+    );
+    const button = screen.getByRole("button");
+    expect(button.className).toContain("bg-[#4A4A4A]");
+  });
+
+  it("shows departure style for not-cleared strip", () => {
+    render(
+      <EstStandCell
+        stand={stand}
+        strip={makeStrip({ bay: Bay.NotCleared })}
+        blocked={false}
+        selected={false}
+        actionActive={false}
+        blinking={false}
+        startReqActive={false}
+        ctotImproved={false}
+        nowMs={Date.now()}
+        onClick={() => {}}
+      />,
+    );
+    const button = screen.getByRole("button");
+    expect(button.className).toContain("bg-[#D9D9D9]");
+  });
+
+  it("shows arrival style for stand bay", () => {
+    render(
+      <EstStandCell
+        stand={stand}
+        strip={makeStrip({ bay: Bay.Stand })}
+        blocked={false}
+        selected={false}
+        actionActive={false}
+        blinking={false}
+        startReqActive={false}
+        ctotImproved={false}
+        nowMs={Date.now()}
+        onClick={() => {}}
+      />,
+    );
+    const button = screen.getByRole("button");
+    expect(button.className).toContain("bg-[#FFF28E]");
+  });
+
+  it("shows push style for push bay", () => {
+    render(
+      <EstStandCell
+        stand={stand}
+        strip={makeStrip({ bay: Bay.Push })}
+        blocked={false}
+        selected={false}
+        actionActive={false}
+        blinking={false}
+        startReqActive={false}
+        ctotImproved={false}
+        nowMs={Date.now()}
+        onClick={() => {}}
+      />,
+    );
+    const button = screen.getByRole("button");
+    expect(button.className).toContain("bg-[#DD6A12]");
+  });
+
+  it("shows action active style", () => {
+    render(
+      <EstStandCell
+        stand={stand}
+        strip={makeStrip()}
+        blocked={false}
+        selected={false}
+        actionActive={true}
+        blinking={false}
+        startReqActive={false}
+        ctotImproved={false}
+        nowMs={Date.now()}
+        onClick={() => {}}
+      />,
+    );
+    const button = screen.getByRole("button");
+    expect(button.className).toContain("bg-[#131376]");
+  });
+
+  it("calls onClick with stand label and strip", () => {
+    let clicked = false;
+    const onClick = (stand: string, strip: FrontendStrip | undefined) => {
+      expect(stand).toBe("A18");
+      expect(strip?.callsign).toBe("SAS123");
+      clicked = true;
+    };
+    render(
+      <EstStandCell
+        stand={stand}
+        strip={makeStrip()}
+        blocked={false}
+        selected={false}
+        actionActive={false}
+        blinking={false}
+        startReqActive={false}
+        ctotImproved={false}
+        nowMs={Date.now()}
+        onClick={onClick}
+      />,
+    );
+    screen.getByRole("button").click();
+    expect(clicked).toBe(true);
+  });
+});

--- a/frontend/src/routes/ekch/EST.tsx
+++ b/frontend/src/routes/ekch/EST.tsx
@@ -16,7 +16,7 @@ import {
   type EstView,
 } from "@/components/est/metadata";
 import { useNonClearedStrips } from "@/store/airports/ekch.ts";
-import { useControllers, useMarkArmed, useMyPosition, useSelectStrip, useSelectedCallsign, useWebSocketStore } from "@/store/store-hooks.ts";
+import { useControllers, useMarkArmed, useMyPosition, useSelectStrip, useSelectedCallsign, useWebSocketStore, useSatEnabled, useStandBlocks, useOccupyStand, useVacateStand } from "@/store/store-hooks.ts";
 
 const PAGE_BG = "bg-bay-est";
 const COLOR_LABEL_DEFAULT = "#202020";
@@ -115,6 +115,10 @@ export default function EST() {
   const markArmed = useMarkArmed();
   const selectedCallsign = useSelectedCallsign();
   const selectStrip = useSelectStrip();
+  const satEnabled = useSatEnabled();
+  const standBlocks = useStandBlocks();
+  const occupyStand = useOccupyStand();
+  const vacateStand = useVacateStand();
 
   const [menuState, setMenuState] = useState<{ stand: string; anchor: EstMenuAnchor } | null>(null);
   const [statusStand, setStatusStand] = useState<string | null>(null);
@@ -189,6 +193,30 @@ export default function EST() {
     [stripByStand],
   );
 
+  const blockedStandsDerived = useMemo(() => {
+    if (satEnabled) {
+      const blocked: Record<string, true> = {};
+      for (const block of standBlocks) {
+        if (block.block_type === "MANUAL") {
+          blocked[block.stand] = true;
+        }
+      }
+      return blocked;
+    }
+    return blockedStands;
+  }, [satEnabled, standBlocks, blockedStands]);
+
+  const standBlockReasons = useMemo(() => {
+    if (!satEnabled) return {};
+    const reasons: Record<string, string> = {};
+    for (const block of standBlocks) {
+      if (block.block_type === "MANUAL") {
+        reasons[block.stand] = block.reason ?? "Manually blocked";
+      }
+    }
+    return reasons;
+  }, [satEnabled, standBlocks]);
+
   useEffect(() => {
     updateActionOverrides({ type: "prune", occupancy: standOccupancy });
   }, [standOccupancy]);
@@ -236,15 +264,19 @@ export default function EST() {
   }
 
   function clearBlockedStand(stand: string) {
-    setBlockedStands((current) => {
-      const next = { ...current };
-      delete next[stand];
-      return next;
-    });
+    if (satEnabled) {
+      vacateStand(stand);
+    } else {
+      setBlockedStands((current) => {
+        const next = { ...current };
+        delete next[stand];
+        return next;
+      });
+    }
   }
 
   function handleStandClick(stand: string, strip: FrontendStrip | undefined, element: HTMLButtonElement) {
-    const blocked = !!blockedStands[stand];
+    const blocked = !!blockedStandsDerived[stand];
 
     if (!strip || blocked) {
       setStatusStand(stand);
@@ -347,8 +379,11 @@ export default function EST() {
       return;
     }
 
-    // TODO: send stand_occupied action to backend
-    setBlockedStands((current) => ({ ...current, [statusStand]: true }));
+    if (satEnabled) {
+      occupyStand(statusStand);
+    } else {
+      setBlockedStands((current) => ({ ...current, [statusStand]: true }));
+    }
     setStatusStand(null);
     setMenuState(null);
   }
@@ -358,7 +393,11 @@ export default function EST() {
       return;
     }
 
-    clearBlockedStand(statusStand);
+    if (satEnabled) {
+      vacateStand(statusStand);
+    } else {
+      clearBlockedStand(statusStand);
+    }
     setStatusStand(null);
     setMenuState(null);
   }
@@ -461,7 +500,8 @@ export default function EST() {
                   stand={stand}
                   strip={strip}
                   selected={!!strip && selectedCallsign === strip.callsign}
-                  blocked={!!blockedStands[stand.label]}
+                  blocked={!!blockedStandsDerived[stand.label]}
+                  blockReason={standBlockReasons[stand.label]}
                   actionActive={actionActive}
                   blinking={actionActive ? actionOverride.blinking : false}
                   startReqActive={startReqActive}

--- a/frontend/src/store/store-hooks.ts
+++ b/frontend/src/store/store-hooks.ts
@@ -143,3 +143,9 @@ export const useCloseStripContextMenu = () => useWebSocketStore((state) => state
 export const useValidationDialogCallsign = () => useWebSocketStore((state) => state.validationDialogCallsign);
 export const useOpenValidationDialog = () => useWebSocketStore((state) => state.openValidationDialog);
 export const useCloseValidationDialog = () => useWebSocketStore((state) => state.closeValidationDialog);
+
+export const useStandAssignments = () => useWebSocketStore((state) => state.standAssignments);
+export const useStandBlocks = () => useWebSocketStore((state) => state.standBlocks);
+export const useSatEnabled = () => useWebSocketStore((state) => state.satEnabled);
+export const useOccupyStand = () => useWebSocketStore((state) => state.occupyStand);
+export const useVacateStand = () => useWebSocketStore((state) => state.vacateStand);

--- a/frontend/src/store/store-stand.test.ts
+++ b/frontend/src/store/store-stand.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { createWebSocketStore, type WebSocketState } from "./store";
+import type { WebSocketClient } from "@/api/websocket";
+import {
+  EventType,
+  type FrontendStandStatusSnapshotEvent,
+  type FrontendStandAssignmentUpdateEvent,
+  type FrontendStandBlockUpdateEvent,
+  type FrontendStandAssignmentEntry,
+  type FrontendStandBlockEntry,
+  type FrontendInitialEvent,
+} from "@/api/models";
+import type { StoreApi } from "zustand/vanilla";
+
+function createMockClient() {
+  const handlers = new Map<string, Array<(data: unknown) => void>>();
+  return {
+    on: vi.fn((eventType: string, handler: (data: unknown) => void) => {
+      if (!handlers.has(eventType)) {
+        handlers.set(eventType, []);
+      }
+      handlers.get(eventType)!.push(handler);
+    }),
+    send: vi.fn(),
+    _emit: (eventType: string, data: unknown) => {
+      const hs = handlers.get(eventType);
+      if (hs) {
+        hs.forEach((h) => h(data));
+      }
+    },
+    setReadOnly: vi.fn(),
+    reconnect: vi.fn(),
+  } as unknown as WebSocketClient & {
+    _emit: (eventType: string, data: unknown) => void;
+  };
+}
+
+describe("stand store events", () => {
+  let client: ReturnType<typeof createMockClient>;
+  let store: StoreApi<WebSocketState>;
+
+  beforeEach(() => {
+    client = createMockClient();
+    store = createWebSocketStore(client as unknown as WebSocketClient);
+  });
+
+  describe("satEnabled", () => {
+    it("is false by default", () => {
+      expect(store.getState().satEnabled).toBe(false);
+    });
+
+    it("is true when initial event has stand_assignment_enabled", () => {
+      const init: FrontendInitialEvent = {
+        type: EventType.FrontendInitial,
+        controllers: [],
+        strips: [],
+        tactical_strips: [],
+        me: { callsign: "", position: "", identifier: "", section: "", owned_sectors: [] },
+        airport: "EKCH",
+        layout: "EST",
+        callsign: "",
+        runway_setup: { departure: [], arrival: [] },
+        coordinations: [],
+        messages: [],
+        available_sids: [],
+        initial_cfl_by_runway: {},
+        transition_altitude: 5000,
+        read_only: false,
+        position_available: true,
+        stand_assignment_enabled: true,
+        stand_assignments: [],
+        stand_blocks: [],
+      };
+      client._emit(EventType.FrontendInitial, init);
+      expect(store.getState().satEnabled).toBe(true);
+    });
+  });
+
+  describe("stand status snapshot", () => {
+    it("populates assignments and blocks", () => {
+      const assignments: FrontendStandAssignmentEntry[] = [
+        { callsign: "SAS123", stand: "A18", direction: "DEPARTURE", stage: "RESERVED", source: "AUTOMATIC" },
+      ];
+      const blocks: FrontendStandBlockEntry[] = [
+        { stand: "B4", block_type: "MANUAL", reason: "Maintenance" },
+      ];
+      client._emit(EventType.FrontendStandStatusSnapshot, {
+        type: EventType.FrontendStandStatusSnapshot,
+        assignments,
+        blocks,
+      } as FrontendStandStatusSnapshotEvent);
+
+      expect(store.getState().standAssignments).toEqual(assignments);
+      expect(store.getState().standBlocks).toEqual(blocks);
+    });
+  });
+
+  describe("stand assignment update", () => {
+    it("adds new assignment", () => {
+      const entry: FrontendStandAssignmentEntry = {
+        callsign: "SAS456", stand: "A20", direction: "ARRIVAL", stage: "ESTIMATED", source: "AUTOMATIC",
+      };
+      client._emit(EventType.FrontendStandAssignmentUpdate, {
+        type: EventType.FrontendStandAssignmentUpdate,
+        assignment: entry,
+      } as FrontendStandAssignmentUpdateEvent);
+
+      expect(store.getState().standAssignments).toHaveLength(1);
+      expect(store.getState().standAssignments[0]).toEqual(entry);
+    });
+
+    it("updates existing assignment", () => {
+      const initial: FrontendStandAssignmentEntry = {
+        callsign: "SAS456", stand: "A20", direction: "ARRIVAL", stage: "ESTIMATED", source: "AUTOMATIC",
+      };
+      client._emit(EventType.FrontendStandAssignmentUpdate, {
+        type: EventType.FrontendStandAssignmentUpdate,
+        assignment: initial,
+      } as FrontendStandAssignmentUpdateEvent);
+
+      const updated: FrontendStandAssignmentEntry = {
+        callsign: "SAS456", stand: "A20", direction: "ARRIVAL", stage: "CONFIRMED", source: "AUTOMATIC",
+      };
+      client._emit(EventType.FrontendStandAssignmentUpdate, {
+        type: EventType.FrontendStandAssignmentUpdate,
+        assignment: updated,
+      } as FrontendStandAssignmentUpdateEvent);
+
+      expect(store.getState().standAssignments).toHaveLength(1);
+      expect(store.getState().standAssignments[0].stage).toBe("CONFIRMED");
+    });
+  });
+
+  describe("stand block update", () => {
+    it("adds new block", () => {
+      const block: FrontendStandBlockEntry = {
+        stand: "B8", block_type: "MANUAL", reason: "Closed",
+      };
+      client._emit(EventType.FrontendStandBlockUpdate, {
+        type: EventType.FrontendStandBlockUpdate,
+        stand: "B8",
+        block,
+      } as FrontendStandBlockUpdateEvent);
+
+      expect(store.getState().standBlocks).toHaveLength(1);
+      expect(store.getState().standBlocks[0]).toEqual(block);
+    });
+
+    it("removes block when null", () => {
+      const block: FrontendStandBlockEntry = {
+        stand: "B8", block_type: "MANUAL", reason: "Closed",
+      };
+      client._emit(EventType.FrontendStandBlockUpdate, {
+        type: EventType.FrontendStandBlockUpdate,
+        stand: "B8",
+        block,
+      } as FrontendStandBlockUpdateEvent);
+
+      client._emit(EventType.FrontendStandBlockUpdate, {
+        type: EventType.FrontendStandBlockUpdate,
+        stand: "B8",
+        block: null,
+      } as FrontendStandBlockUpdateEvent);
+
+      expect(store.getState().standBlocks).toHaveLength(0);
+    });
+
+    it("updates existing block", () => {
+      const initial: FrontendStandBlockEntry = {
+        stand: "B8", block_type: "MANUAL", reason: "Closed",
+      };
+      client._emit(EventType.FrontendStandBlockUpdate, {
+        type: EventType.FrontendStandBlockUpdate,
+        stand: "B8",
+        block: initial,
+      } as FrontendStandBlockUpdateEvent);
+
+      const updated: FrontendStandBlockEntry = {
+        stand: "B8", block_type: "MANUAL", reason: "Maintenance",
+      };
+      client._emit(EventType.FrontendStandBlockUpdate, {
+        type: EventType.FrontendStandBlockUpdate,
+        stand: "B8",
+        block: updated,
+      } as FrontendStandBlockUpdateEvent);
+
+      expect(store.getState().standBlocks).toHaveLength(1);
+      expect(store.getState().standBlocks[0].reason).toBe("Maintenance");
+    });
+  });
+
+  describe("reconnect snapshot", () => {
+    it("rehydrates stand state from initial event", () => {
+      const assignments: FrontendStandAssignmentEntry[] = [
+        { callsign: "SAS123", stand: "A18", direction: "DEPARTURE", stage: "RESERVED", source: "AUTOMATIC" },
+        { callsign: "NAX456", stand: "C27", direction: "ARRIVAL", stage: "CONFIRMED", source: "AUTOMATIC" },
+      ];
+      const blocks: FrontendStandBlockEntry[] = [
+        { stand: "B4", block_type: "MANUAL", reason: "Maintenance" },
+      ];
+
+      const init: FrontendInitialEvent = {
+        type: EventType.FrontendInitial,
+        controllers: [],
+        strips: [],
+        tactical_strips: [],
+        me: { callsign: "", position: "", identifier: "", section: "", owned_sectors: [] },
+        airport: "EKCH",
+        layout: "EST",
+        callsign: "",
+        runway_setup: { departure: [], arrival: [] },
+        coordinations: [],
+        messages: [],
+        available_sids: [],
+        initial_cfl_by_runway: {},
+        transition_altitude: 5000,
+        read_only: false,
+        position_available: true,
+        stand_assignment_enabled: true,
+        stand_assignments: assignments,
+        stand_blocks: blocks,
+      };
+      client._emit(EventType.FrontendInitial, init);
+
+      expect(store.getState().standAssignments).toEqual(assignments);
+      expect(store.getState().standBlocks).toEqual(blocks);
+      expect(store.getState().satEnabled).toBe(true);
+    });
+
+    it("clears stand state on disconnect", () => {
+      const init: FrontendInitialEvent = {
+        type: EventType.FrontendInitial,
+        controllers: [],
+        strips: [],
+        tactical_strips: [],
+        me: { callsign: "", position: "", identifier: "", section: "", owned_sectors: [] },
+        airport: "EKCH",
+        layout: "EST",
+        callsign: "",
+        runway_setup: { departure: [], arrival: [] },
+        coordinations: [],
+        messages: [],
+        available_sids: [],
+        initial_cfl_by_runway: {},
+        transition_altitude: 5000,
+        read_only: false,
+        position_available: true,
+        stand_assignment_enabled: true,
+        stand_assignments: [{ callsign: "SAS1", stand: "A1", direction: "DEPARTURE", stage: "RESERVED", source: "AUTOMATIC" }],
+        stand_blocks: [],
+      };
+      client._emit(EventType.FrontendInitial, init);
+      expect(store.getState().standAssignments).toHaveLength(1);
+
+      client._emit(EventType.FrontendDisconnect, { type: EventType.FrontendDisconnect });
+      expect(store.getState().standAssignments).toHaveLength(0);
+      expect(store.getState().standBlocks).toHaveLength(0);
+      expect(store.getState().satEnabled).toBe(false);
+    });
+  });
+
+  describe("occupyStand / vacateStand", () => {
+    it("sends stand_occupy action", () => {
+      store.getState().occupyStand("A25");
+      expect(client.send).toHaveBeenCalledWith({
+        type: "stand_occupy",
+        stand: "A25",
+        reason: "Manual block",
+      });
+    });
+
+    it("sends stand_vacate action", () => {
+      store.getState().vacateStand("B6");
+      expect(client.send).toHaveBeenCalledWith({
+        type: "stand_vacate",
+        stand: "B6",
+      });
+    });
+  });
+});

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -30,6 +30,11 @@ import {
   type FrontendSetHeadingEvent,
   type FrontendSquawkEvent,
   type FrontendStandEvent,
+  type FrontendStandAssignmentEntry,
+  type FrontendStandBlockEntry,
+  type FrontendStandAssignmentUpdateEvent,
+  type FrontendStandBlockUpdateEvent,
+  type FrontendStandStatusSnapshotEvent,
   type FrontendStrip,
   type FrontendStripUpdateEvent,
   type MessageReceived,
@@ -162,6 +167,13 @@ export interface WebSocketState {
   openValidationDialog: (callsign: string) => void;
   closeValidationDialog: () => void;
 
+  standAssignments: FrontendStandAssignmentEntry[];
+  standBlocks: FrontendStandBlockEntry[];
+  satEnabled: boolean;
+
+  occupyStand: (stand: string) => void;
+  vacateStand: (stand: string) => void;
+
   // actions
   move: (callsign: string, bay: Bay) => void;
   moveToControlzone: (callsign: string) => void;
@@ -247,6 +259,9 @@ export const createWebSocketStore = (wsClient: WebSocketClient) => {
     markArmed: false,
     contextMenu: null,
     validationDialogCallsign: null,
+    standAssignments: [],
+    standBlocks: [],
+    satEnabled: false,
   };
 
   // Create the store
@@ -754,6 +769,14 @@ export const createWebSocketStore = (wsClient: WebSocketClient) => {
     acknowledgeValidationStatus: (callsign, activationKey) => {
       sendIfWritable({ type: ActionType.FrontendAcknowledgeValidationStatus, callsign, activation_key: activationKey });
     },
+
+    occupyStand: (stand) => {
+      sendIfWritable({ type: ActionType.FrontendStandOccupy, stand, reason: "Manual block" });
+    },
+
+    vacateStand: (stand) => {
+      sendIfWritable({ type: ActionType.FrontendStandVacate, stand });
+    },
   }});
 
   // Private methods to handle WebSocket events
@@ -799,6 +822,9 @@ export const createWebSocketStore = (wsClient: WebSocketClient) => {
         state.stripTransfers = transfers;
         state.messages = data.messages ?? [];
         state.availableSids = data.available_sids ?? [];
+        state.standAssignments = data.stand_assignments ?? [];
+        state.standBlocks = data.stand_blocks ?? [];
+        state.satEnabled = data.stand_assignment_enabled ?? false;
       })
     );
 
@@ -1311,6 +1337,51 @@ export const createWebSocketStore = (wsClient: WebSocketClient) => {
   wsClient.on(EventType.FrontendAvailableSids, (data) => {
     store.setState({ availableSids: data.sids });
   });
+
+  const handleStandStatusSnapshot = (data: FrontendStandStatusSnapshotEvent) => {
+    store.setState(
+      produce((state: WebSocketState) => {
+        state.standAssignments = data.assignments;
+        state.standBlocks = data.blocks;
+      }),
+    );
+  };
+
+  wsClient.on(EventType.FrontendStandStatusSnapshot, handleStandStatusSnapshot);
+
+  const handleStandAssignmentUpdate = (data: FrontendStandAssignmentUpdateEvent) => {
+    store.setState(
+      produce((state: WebSocketState) => {
+        const idx = state.standAssignments.findIndex((a) => a.callsign === data.assignment.callsign);
+        if (idx !== -1) {
+          state.standAssignments[idx] = data.assignment;
+        } else {
+          state.standAssignments.push(data.assignment);
+        }
+      }),
+    );
+  };
+
+  wsClient.on(EventType.FrontendStandAssignmentUpdate, handleStandAssignmentUpdate);
+
+  const handleStandBlockUpdate = (data: FrontendStandBlockUpdateEvent) => {
+    store.setState(
+      produce((state: WebSocketState) => {
+        if (data.block === null) {
+          state.standBlocks = state.standBlocks.filter((b) => b.stand !== data.stand);
+        } else {
+          const idx = state.standBlocks.findIndex((b) => b.stand === data.stand);
+          if (idx !== -1) {
+            state.standBlocks[idx] = data.block;
+          } else {
+            state.standBlocks.push(data.block);
+          }
+        }
+      }),
+    );
+  };
+
+  wsClient.on(EventType.FrontendStandBlockUpdate, handleStandBlockUpdate);
 
   return store;
 };


### PR DESCRIPTION
## Summary

Replaces the local \lockedStands\ state in the EST board with backend-authoritative stand assignment and block metadata from the SAT system.

## What changed

### Backend
- **New event types**: \stand_status_snapshot\, \stand_assignment_update\, \stand_block_update\ for real-time and initial-hydration stand data
- **New action types**: \stand_occupy\, \stand_vacate\ for manual block/unblock from the EST UI
- **\InitialEvent\** extended with \stand_assignment_enabled\, \stand_assignments\, \stand_blocks\ fields
- **Hub methods** for broadcasting stand assignment/block updates to all connected frontends
- **Handlers** for occupy/vacate — creates/deletes \MANUAL\ \StandBlock\ rows and broadcasts
- **Snapshot builder** loads assignments and blocks from the repository on initial connect
- **Server wiring** passes \StandAssignmentRepository\ through the dependency chain

### Frontend
- **New types/models** for stand status events, assignment/block entries, occupy/vacate actions
- **Store state** (\standAssignments\, \standBlocks\, \satEnabled\) with handlers for all stand events
- **Store actions** (\occupyStand\, \acateStand\) send actions to backend
- **Store hooks** for consuming stand data in components
- **EST.tsx** refactored:
  - Derives \lockedStands\ from store's \standBlocks\ when SAT is enabled
  - Falls back to local state when SAT is disabled (pre-feature behavior preserved)
  - OCCUPIED/VACANT route through backend when SAT is enabled
- **EstStandCell** enhanced with \lockReason\ prop displayed in tooltip
- **Tests**: 12 store tests (store-stand.test.ts) + 9 component tests (est-stand-cell.test.tsx)

## Acceptance criteria

- Two connected controllers see the same occupancy immediately
- Reloading the page rehydrates stand assignments/blocks from the initial event
- A blocked neighbor is visibly marked with the blocking reason
- Existing EST departure actions continue to work unchanged
- A disabled/unavailable SAT capability renders the pre-feature EST controls