### PR TITLE
feat(stand): handle wrong stand departures

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -190,6 +190,9 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 		standAllocationService.SetPublisher(frontendHub.PublishStandAllocation)
 	}
 	euroscopeHub := euroscope.NewHub(stripService, controllerService, authService)
+	if departureLifecycle != nil {
+		departureLifecycle.SetWrongStandMessenger(euroscopeHub)
+	}
 	var vatsimReconciler *vatsim.Reconciler
 	if standAssignmentReadiness.Ready && vatsimCache != nil && standAssignmentRepo != nil {
 		latitude, longitude := appconfig.GetAirportCoordinates()

--- a/backend/internal/euroscope/hub.go
+++ b/backend/internal/euroscope/hub.go
@@ -730,6 +730,17 @@ func (hub *Hub) resolveGenerateSquawkCid(ctx context.Context, session int32) str
 	return ""
 }
 
+// SendPrivateMessageFromDelivery routes an automated pilot message through an
+// operational DEL client when available, falling back to the session master.
+func (hub *Hub) SendPrivateMessageFromDelivery(session int32, callsign, message string) bool {
+	cid := hub.resolveGenerateSquawkCid(context.Background(), session)
+	if cid == "" {
+		return false
+	}
+	hub.Send(session, cid, euroscope.SendPrivateMessageEvent{Callsign: callsign, Message: message})
+	return true
+}
+
 func (hub *Hub) SendGroundState(session int32, cid string, callsign string, state string) {
 	event := euroscope.GroundStateEvent{
 		Callsign:    callsign,

--- a/backend/internal/euroscope/hub_squawk_test.go
+++ b/backend/internal/euroscope/hub_squawk_test.go
@@ -51,6 +51,32 @@ func TestResolveGenerateSquawkCid_PrefersConnectedDelOwner(t *testing.T) {
 	assert.Equal(t, delCid, hub.resolveGenerateSquawkCid(context.Background(), 7))
 }
 
+func TestSendPrivateMessageFromDelivery_TargetsDelWithoutBroadcast(t *testing.T) {
+	t.Cleanup(config.SetPositionsForTest([]config.Position{{Name: "EKCH_DEL", Frequency: "121.730"}}))
+	t.Cleanup(config.SetOwnerCallsignPrefixesForTest([]string{"EKCH"}))
+	delCid := "DEL-CID"
+	hub := &Hub{
+		send: make(chan internalMessage, 2),
+		server: &testutil.MockServer{
+			ControllerRepoVal: &testutil.MockControllerRepository{GetByPositionFn: func(context.Context, int32, string) ([]*models.Controller, error) {
+				return []*models.Controller{{Callsign: "EKCH_DEL", Position: "121.730", Cid: &delCid}}, nil
+			}},
+			SectorRepoVal: &testutil.MockSectorOwnerRepository{ListBySessionFn: func(context.Context, int32) ([]*models.SectorOwner, error) {
+				return []*models.SectorOwner{{Sector: []string{"DEL"}, Position: "121.730"}}, nil
+			}},
+		},
+		master: map[int32]*Client{7: {user: shared.NewAuthenticatedUser("MASTER-CID", 0, nil)}},
+	}
+
+	require.True(t, hub.SendPrivateMessageFromDelivery(7, "SAS123", "MOVE TO A1"))
+	sent := <-hub.send
+	require.NotNil(t, sent.cid, "targeted sends carry a CID; broadcasts do not")
+	assert.Equal(t, delCid, *sent.cid)
+	event := sent.message.(euroscopeEvents.SendPrivateMessageEvent)
+	assert.Equal(t, "SAS123", event.Callsign)
+	assert.Equal(t, "MOVE TO A1", event.Message)
+}
+
 func TestResolveGenerateSquawkCid_FallsBackToMasterWhenDelOwnerHasNoEsClient(t *testing.T) {
 	t.Cleanup(config.SetPositionsForTest([]config.Position{
 		{Name: "EKCH_DEL", Frequency: "121.730"},

--- a/backend/internal/services/departure_lifecycle.go
+++ b/backend/internal/services/departure_lifecycle.go
@@ -27,7 +27,11 @@ const (
 	defaultDepartureHoldDuration    = 15 * time.Minute
 	defaultDepartureBlockExtension  = 10 * time.Minute
 	defaultDepartureSweepInterval   = 30 * time.Second
+	defaultWrongStandDeadline       = 5 * time.Minute
 	departureClockRolloverThreshold = 12 * time.Hour
+	wrongStandAwaitingPrefix        = "WRONG_STAND_AWAITING_MESSAGE: observed "
+	wrongStandPendingPrefix         = "WRONG_STAND_PENDING: observed "
+	wrongStandForcedPrefix          = "WRONG_STAND_FORCED: observed "
 )
 
 // DepartureLifecycleService owns the timing rules that turn a prefiled
@@ -48,6 +52,21 @@ type DepartureLifecycleService struct {
 	hold           time.Duration
 	blockExtension time.Duration
 	sweepInterval  time.Duration
+	messenger      wrongStandMessenger
+}
+
+type wrongStandMessenger interface {
+	SendPrivateMessageFromDelivery(session int32, callsign, message string) bool
+}
+
+func (s *DepartureLifecycleService) SetWrongStandMessenger(messenger wrongStandMessenger) {
+	s.messenger = messenger
+}
+
+// CancelDeparture cancels transient wrong-stand state when a departure
+// disappears from the live feed.
+func (s *DepartureLifecycleService) CancelDeparture(ctx context.Context, session int32, callsign string) error {
+	return s.cancelWrongStandEpisode(ctx, session, callsign)
 }
 
 type lifecycleSessionLister interface {
@@ -142,6 +161,9 @@ func (s *DepartureLifecycleService) ProcessDeparture(ctx context.Context, sessio
 		}
 		return s.revalidateFacts(ctx, session, strip, flight)
 	}
+	if err := s.cancelWrongStandEpisode(ctx, session, strip.Callsign); err != nil {
+		return err
+	}
 	return s.ensureReservation(ctx, session, strip, flight)
 }
 
@@ -157,6 +179,9 @@ func (s *DepartureLifecycleService) activateObservedBlock(ctx context.Context, s
 			slog.String("callsign", strip.Callsign),
 			slog.Float64("latitude", flight.Latitude),
 			slog.Float64("longitude", flight.Longitude))
+		if err := s.cancelWrongStandEpisode(ctx, session, strip.Callsign); err != nil {
+			return false, err
+		}
 		return false, nil
 	}
 
@@ -179,12 +204,18 @@ func (s *DepartureLifecycleService) activateObservedBlock(ctx context.Context, s
 		return false, nil
 	}
 
-	reason := "WRONG_STAND_PENDING_TASK_19: observed " + observed.Name
-	if existing.ConflictReason != nil && *existing.ConflictReason == reason {
-		return false, nil
+	pendingReason := wrongStandPendingPrefix + observed.Name
+	awaitingReason := wrongStandAwaitingPrefix + observed.Name
+	if existing.ConflictReason != nil {
+		switch *existing.ConflictReason {
+		case pendingReason:
+			return false, nil
+		case awaitingReason:
+			return false, s.deliverWrongStandWarning(ctx, existing)
+		}
 	}
 	updated := *existing
-	updated.ConflictReason = &reason
+	updated.ConflictReason = &awaitingReason
 	updated.Acknowledged = false
 	updated.AcknowledgedAt = nil
 	updated.AcknowledgedBy = nil
@@ -197,7 +228,61 @@ func (s *DepartureLifecycleService) activateObservedBlock(ctx context.Context, s
 	if err := s.allocations.PublishAssignment(ctx, updated); err != nil {
 		return false, fmt.Errorf("publish observed stand mismatch for %s: %w", strip.Callsign, err)
 	}
-	return false, nil
+	return false, s.deliverWrongStandWarning(ctx, &updated)
+}
+
+func (s *DepartureLifecycleService) deliverWrongStandWarning(ctx context.Context, assignment *models.StandAssignment) error {
+	if assignment == nil || assignment.ConflictReason == nil ||
+		!strings.HasPrefix(*assignment.ConflictReason, wrongStandAwaitingPrefix) ||
+		s.messenger == nil {
+		return nil
+	}
+	if !s.messenger.SendPrivateMessageFromDelivery(assignment.SessionID, assignment.Callsign,
+		fmt.Sprintf("FLIGHTSTRIPS: PLEASE RELOCATE TO YOUR ASSIGNED STAND %s", assignment.Stand)) {
+		return nil
+	}
+	observed := strings.TrimSpace(strings.TrimPrefix(*assignment.ConflictReason, wrongStandAwaitingPrefix))
+	updated := *assignment
+	reason := wrongStandPendingPrefix + observed
+	updated.ConflictReason = &reason
+	deadline := s.now().Add(defaultWrongStandDeadline)
+	updated.ExpiresAt = &deadline
+	affected, err := s.assignments.UpdateAssignment(ctx, &updated)
+	if err != nil {
+		return err
+	}
+	if affected != 1 {
+		return fmt.Errorf("activate wrong stand deadline version conflict for %s", assignment.Callsign)
+	}
+	updated.Version++
+	return s.allocations.PublishAssignment(ctx, updated)
+}
+
+func (s *DepartureLifecycleService) cancelWrongStandEpisode(ctx context.Context, session int32, callsign string) error {
+	existing, err := s.assignments.GetAssignment(ctx, session, callsign)
+	if err != nil {
+		if isNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	if existing.ConflictReason == nil ||
+		(!strings.HasPrefix(*existing.ConflictReason, wrongStandPendingPrefix) &&
+			!strings.HasPrefix(*existing.ConflictReason, wrongStandAwaitingPrefix)) {
+		return nil
+	}
+	updated := *existing
+	updated.ConflictReason = nil
+	expiry := s.now().Add(s.hold)
+	updated.ExpiresAt = &expiry
+	affected, err := s.assignments.UpdateAssignment(ctx, &updated)
+	if err != nil {
+		return err
+	}
+	if affected != 1 {
+		return fmt.Errorf("cancel wrong stand episode version conflict for %s", callsign)
+	}
+	return nil
 }
 
 // ensureReservation allocates a 15-minute hold for a new offline prefile, and
@@ -286,6 +371,9 @@ func (s *DepartureLifecycleService) activateBlock(ctx context.Context, session i
 	updated := *existing
 	updated.Stage = StageDepartureBlock
 	updated.ExpiresAt = expiry
+	if updated.ConflictReason != nil && strings.HasPrefix(*updated.ConflictReason, wrongStandPendingPrefix) {
+		updated.ConflictReason = nil
+	}
 	updated.AssignedAt = &now
 	revision := flight.Revision
 	updated.VatsimRevision = &revision
@@ -398,10 +486,25 @@ func (s *DepartureLifecycleService) releaseIfDue(ctx context.Context, session in
 	if assignment.ExpiresAt == nil || assignment.ExpiresAt.After(now) {
 		return nil
 	}
+	if assignment.ConflictReason != nil && strings.HasPrefix(*assignment.ConflictReason, wrongStandPendingPrefix) {
+		return s.forceObservedStand(ctx, strip, assignment)
+	}
 	if _, err := s.strips.UpdateStand(ctx, session, assignment.Callsign, nil, nil); err != nil {
 		return err
 	}
 	_, err = s.assignments.DeleteAssignment(ctx, session, assignment.ID, assignment.Version)
+	return err
+}
+
+func (s *DepartureLifecycleService) forceObservedStand(ctx context.Context, strip *models.Strip, assignment *models.StandAssignment) error {
+	observed := strings.TrimSpace(strings.TrimPrefix(*assignment.ConflictReason, wrongStandPendingPrefix))
+	if observed == "" {
+		return nil
+	}
+	request := s.buildRequest(assignment.SessionID, strip, vatsim.DepartureFlightInfo{}, StageDepartureBlock, s.computeBlockExpiry(strip))
+	request.Stand = observed
+	request.ConflictReason = wrongStandForcedPrefix + observed + "; assigned " + assignment.Stand
+	_, err := s.allocations.OverrideManually(ctx, request)
 	return err
 }
 

--- a/backend/internal/services/departure_lifecycle.go
+++ b/backend/internal/services/departure_lifecycle.go
@@ -238,7 +238,7 @@ func (s *DepartureLifecycleService) deliverWrongStandWarning(ctx context.Context
 		return nil
 	}
 	if !s.messenger.SendPrivateMessageFromDelivery(assignment.SessionID, assignment.Callsign,
-		fmt.Sprintf("FLIGHTSTRIPS: PLEASE RELOCATE TO YOUR ASSIGNED STAND %s", assignment.Stand)) {
+		fmt.Sprintf("STAND ASSIGNMENT: PLEASE RELOCATE TO YOUR ASSIGNED STAND %s", assignment.Stand)) {
 		return nil
 	}
 	observed := strings.TrimSpace(strings.TrimPrefix(*assignment.ConflictReason, wrongStandAwaitingPrefix))

--- a/backend/internal/services/departure_lifecycle_test.go
+++ b/backend/internal/services/departure_lifecycle_test.go
@@ -28,10 +28,12 @@ func (c *fakeClock) advance(d time.Duration) { c.now = c.now.Add(d) }
 type wrongStandTestMessenger struct {
 	available bool
 	calls     int
+	message   string
 }
 
-func (m *wrongStandTestMessenger) SendPrivateMessageFromDelivery(int32, string, string) bool {
+func (m *wrongStandTestMessenger) SendPrivateMessageFromDelivery(_ int32, _ string, message string) bool {
 	m.calls++
+	m.message = message
 	return m.available
 }
 
@@ -241,6 +243,7 @@ func TestDepartureLifecycle(t *testing.T) {
 		assert.Contains(t, *active.ConflictReason, wrongStandPendingPrefix)
 		assert.Equal(t, clock.current().Add(5*time.Minute).UTC(), active.ExpiresAt.UTC())
 		assert.Equal(t, 2, messenger.calls)
+		assert.Equal(t, "STAND ASSIGNMENT: PLEASE RELOCATE TO YOUR ASSIGNED STAND A1", messenger.message)
 	})
 
 	t.Run("moving away cancels the wrong stand deadline", func(t *testing.T) {

--- a/backend/internal/services/departure_lifecycle_test.go
+++ b/backend/internal/services/departure_lifecycle_test.go
@@ -25,6 +25,16 @@ func (c *fakeClock) current() time.Time      { return c.now }
 func (c *fakeClock) set(value time.Time)     { c.now = value }
 func (c *fakeClock) advance(d time.Duration) { c.now = c.now.Add(d) }
 
+type wrongStandTestMessenger struct {
+	available bool
+	calls     int
+}
+
+func (m *wrongStandTestMessenger) SendPrivateMessageFromDelivery(int32, string, string) bool {
+	m.calls++
+	return m.available
+}
+
 func TestDepartureLifecycle(t *testing.T) {
 	pool, queries := testdata.SetupTestDB(t)
 	ctx := context.Background()
@@ -178,16 +188,78 @@ func TestDepartureLifecycle(t *testing.T) {
 		assert.Equal(t, StageReserved, assignment.Stage)
 		assert.Equal(t, "A1", assignment.Stand)
 		require.NotNil(t, assignment.ConflictReason)
-		assert.Contains(t, *assignment.ConflictReason, "WRONG_STAND_PENDING_TASK_19")
-		require.Len(t, published, 2, "reservation and first mismatch are both published")
-		assert.Equal(t, assignment.Version, published[1].Assignment.Version)
+		assert.Contains(t, *assignment.ConflictReason, wrongStandPendingPrefix)
+		require.NotNil(t, assignment.ExpiresAt)
+		assert.Equal(t, clock.current().Add(5*time.Minute).UTC(), assignment.ExpiresAt.UTC())
+		require.Len(t, published, 3, "reservation, awaiting delivery, and active deadline are published")
+		assert.Equal(t, assignment.Version, published[2].Assignment.Version)
 
 		version := assignment.Version
 		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS603"), onlineFlightAtA2("SAS603", 1)))
 		unchanged, err := assignments.GetAssignment(ctx, session, "SAS603")
 		require.NoError(t, err)
 		assert.Equal(t, version, unchanged.Version, "an unchanged mismatch must not churn the optimistic version")
-		assert.Len(t, published, 2, "an unchanged mismatch must not be republished")
+		assert.Len(t, published, 3, "an unchanged mismatch must not be republished")
+	})
+
+	t.Run("wrong stand timeout forces an explicit override", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := departureLifecycleFixture(t, pool, queries, "", "", nil)
+		testdata.SeedTestStrip(t, queries, session, "SAS604")
+		clock.set(time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC))
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS604"), offlineFlight("SAS604", 1)))
+		require.NoError(t, assignments.CreateBlock(ctx, &models.StandBlock{SessionID: session, Stand: "A2", BlockType: "MANUAL", Source: "CONTROLLER", Manual: true}))
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS604"), onlineFlightAtA2("SAS604", 1)))
+		clock.advance(5 * time.Minute)
+		require.NoError(t, lifecycle.ReleaseExpired(ctx))
+		forced, err := assignments.GetAssignment(ctx, session, "SAS604")
+		require.NoError(t, err)
+		assert.Equal(t, "A2", forced.Stand)
+		assert.Equal(t, StageDepartureBlock, forced.Stage)
+		require.NotNil(t, forced.ConflictReason)
+		assert.Contains(t, *forced.ConflictReason, wrongStandForcedPrefix)
+	})
+
+	t.Run("warning failure does not start deadline and retries", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := departureLifecycleFixture(t, pool, queries, "", "", nil)
+		messenger := &wrongStandTestMessenger{}
+		lifecycle.SetWrongStandMessenger(messenger)
+		testdata.SeedTestStrip(t, queries, session, "SAS606")
+		clock.set(time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC))
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS606"), offlineFlight("SAS606", 1)))
+		require.NoError(t, assignments.CreateBlock(ctx, &models.StandBlock{SessionID: session, Stand: "A2", BlockType: "MANUAL", Source: "CONTROLLER", Manual: true}))
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS606"), onlineFlightAtA2("SAS606", 1)))
+		awaiting, err := assignments.GetAssignment(ctx, session, "SAS606")
+		require.NoError(t, err)
+		require.NotNil(t, awaiting.ConflictReason)
+		assert.Contains(t, *awaiting.ConflictReason, wrongStandAwaitingPrefix)
+		assert.Equal(t, clock.current().Add(15*time.Minute).UTC(), awaiting.ExpiresAt.UTC())
+
+		messenger.available = true
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS606"), onlineFlightAtA2("SAS606", 1)))
+		active, err := assignments.GetAssignment(ctx, session, "SAS606")
+		require.NoError(t, err)
+		assert.Contains(t, *active.ConflictReason, wrongStandPendingPrefix)
+		assert.Equal(t, clock.current().Add(5*time.Minute).UTC(), active.ExpiresAt.UTC())
+		assert.Equal(t, 2, messenger.calls)
+	})
+
+	t.Run("moving away cancels the wrong stand deadline", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := departureLifecycleFixture(t, pool, queries, "", "", nil)
+		testdata.SeedTestStrip(t, queries, session, "SAS605")
+		clock.set(time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC))
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS605"), offlineFlight("SAS605", 1)))
+		require.NoError(t, assignments.CreateBlock(ctx, &models.StandBlock{SessionID: session, Stand: "A2", BlockType: "MANUAL", Source: "CONTROLLER", Manual: true}))
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS605"), onlineFlightAtA2("SAS605", 1)))
+		moved := onlineFlightAtA2("SAS605", 1)
+		moved.Latitude = 55.62
+		moved.Longitude = 12.65
+		clock.advance(time.Minute)
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS605"), moved))
+		cancelled, err := assignments.GetAssignment(ctx, session, "SAS605")
+		require.NoError(t, err)
+		assert.Nil(t, cancelled.ConflictReason)
+		require.NotNil(t, cancelled.ExpiresAt)
+		assert.Equal(t, clock.current().Add(15*time.Minute).UTC(), cancelled.ExpiresAt.UTC())
 	})
 
 	t.Run("TSAT controls block release when present", func(t *testing.T) {
@@ -339,6 +411,7 @@ STAND:EKCH:A2:N055.37.42.710:E012.38.36.450:30
 		WithDepartureLifecycleClock(clock.current),
 	)
 	require.NoError(t, err)
+	lifecycle.SetWrongStandMessenger(&wrongStandTestMessenger{available: true})
 	name := fmt.Sprintf("%s-%d", t.Name(), standAllocationSessionSequence.Add(1))
 	session := testdata.SeedTestSessionNamedWithSectors(t, queries, name, nil)
 	return lifecycle, allocations, session, assignments, strips, clock

--- a/backend/internal/vatsim/reconciliation.go
+++ b/backend/internal/vatsim/reconciliation.go
@@ -63,6 +63,7 @@ type ArrivalFlightInfo struct {
 // timing; the lifecycle owns allocation timing and persistence.
 type DepartureLifecycle interface {
 	ProcessDeparture(ctx context.Context, session int32, strip *models.Strip, flight DepartureFlightInfo) error
+	CancelDeparture(ctx context.Context, session int32, callsign string) error
 }
 
 // ArrivalLifecycle drives the ESTIMATED → ASSIGNED → CONFIRMED transitions
@@ -224,6 +225,12 @@ func (r *Reconciler) reconcileSession(ctx context.Context, snapshot Snapshot, se
 	}
 
 	for callsign, strip := range existing {
+		if relevant[callsign].Callsign == "" && r.lifecycle != nil &&
+			strings.EqualFold(strings.TrimSpace(strip.Origin), airport) {
+			if err := r.lifecycle.CancelDeparture(ctx, session.ID, callsign); err != nil {
+				return err
+			}
+		}
 		if strip.VatsimCID == nil || relevant[callsign].Callsign != "" || strip.EuroscopeSeenAt != nil || r.isAssigned(ctx, session.ID, strip.Callsign) {
 			continue
 		}

--- a/backend/internal/vatsim/reconciliation_test.go
+++ b/backend/internal/vatsim/reconciliation_test.go
@@ -107,6 +107,19 @@ func (n *reconciliationTestNotifier) SendStripUpdate(_ int32, callsign string) {
 	n.callsigns = append(n.callsigns, callsign)
 }
 
+type reconciliationTestDepartureLifecycle struct {
+	cancelled []string
+}
+
+func (*reconciliationTestDepartureLifecycle) ProcessDeparture(context.Context, int32, *models.Strip, DepartureFlightInfo) error {
+	return nil
+}
+
+func (l *reconciliationTestDepartureLifecycle) CancelDeparture(_ context.Context, _ int32, callsign string) error {
+	l.cancelled = append(l.cancelled, callsign)
+	return nil
+}
+
 func newReconciliationTestCache(now time.Time, flights ...Flight) *Cache {
 	cache := NewCache("", time.Second, nil)
 	snapshot := newCacheSnapshot(now, now)
@@ -193,6 +206,19 @@ func TestReconcileCleanupAndDisconnectRetentionRespectOtherOwners(t *testing.T) 
 	assert.Equal(t, []string{"SAS505"}, strips.deleted)
 	assert.True(t, reconciler.RetainsStrip(context.Background(), 7, "SAS606"))
 	assert.False(t, reconciler.RetainsStrip(context.Background(), 7, "SAS505"))
+}
+
+func TestReconcileCancelsDepartureLifecycleWhenFlightDisappears(t *testing.T) {
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	cid := "5"
+	strip := &models.Strip{Callsign: "SAS505", Session: 7, Origin: "EKCH", VatsimCID: &cid}
+	strips := &reconciliationTestStrips{bySession: map[int32][]*models.Strip{7: {strip}}}
+	reconciler := NewReconciler(newReconciliationTestCache(now), reconciliationTestSessions{items: []*models.Session{{ID: 7, Airport: "EKCH"}}}, strips, reconciliationTestAssignments{}, nil, time.Second)
+	lifecycle := &reconciliationTestDepartureLifecycle{}
+	reconciler.SetDepartureLifecycle(lifecycle)
+
+	require.NoError(t, reconciler.Reconcile(context.Background()))
+	assert.Equal(t, []string{"SAS505"}, lifecycle.cancelled)
 }
 
 func TestRetainsStripHonorsReservationExpiry(t *testing.T) {


### PR DESCRIPTION
## Summary

- detect departures logging on at a different configured stand
- immediately accept compatible, available observed stands
- send invalid-stand relocation warnings through Delivery, falling back to the EuroScope master
- persist warning delivery and the five-minute deadline across restarts
- force an explicit manual override when the aircraft remains at the observed stand after expiry
- cancel pending episodes when the aircraft moves or disconnects

## Impact

Departures at an incompatible, occupied, or adjacency-blocked stand are warned once and given five minutes to relocate. If they remain in place, the observed stand is accepted with a visible conflict and retained using the normal TSAT/TOBT block rule.

## Root cause

The departure lifecycle previously recorded a placeholder conflict for invalid observed stands but did not deliver the pilot warning, persist the deadline state, handle disconnect cancellation, or complete the forced-override transition.

## Validation

- `go test ./...` from `backend`
- `git diff --check`
