### PR TITLE
feat(stand): add strip assignment workflow

### DIFF
--- a/backend/internal/frontend/hub.go
+++ b/backend/internal/frontend/hub.go
@@ -95,6 +95,7 @@ type nextDisplayBatchComputer interface {
 
 type validationStatusAcknowledger interface {
 	AcknowledgeValidationStatus(ctx context.Context, session int32, callsign string, activationKey string, requestingPosition string) error
+	ReconcileStandAssignmentValidation(ctx context.Context, session int32, callsign string, blockedBy []string, conflictReason string) error
 }
 
 func NewHub(stripService shared.StripService, authenticationService shared.AuthenticationService) *Hub {
@@ -858,8 +859,9 @@ func (hub *Hub) enrichedStandAssignmentEntry(sessionID int32, assignment *intern
 	return entry
 }
 
-func (hub *Hub) PublishStandAllocation(_ context.Context, result services.StandAllocationResult) error {
+func (hub *Hub) PublishStandAllocation(ctx context.Context, result services.StandAllocationResult) error {
 	entry := mapStandAssignmentEntry(&result.Assignment)
+	publishEntries := []frontend.StandAssignmentEntry{entry}
 	if session, err := hub.server.GetSessionRepository().GetByID(context.Background(), result.Assignment.SessionID); err == nil {
 		all, _ := hub.server.GetStandAssignmentRepository().ListAssignments(context.Background(), result.Assignment.SessionID)
 		entries := make([]frontend.StandAssignmentEntry, 0, len(all))
@@ -869,6 +871,7 @@ func (hub *Hub) PublishStandAllocation(_ context.Context, result services.StandA
 			}
 		}
 		enrichStandAssignmentBlocking(entries, session.Airport)
+		publishEntries = entries
 		for _, candidate := range entries {
 			if candidate.Callsign == result.Assignment.Callsign {
 				entry = candidate
@@ -876,7 +879,18 @@ func (hub *Hub) PublishStandAllocation(_ context.Context, result services.StandA
 			}
 		}
 	}
-	hub.SendStandAssignmentBroadcast(result.Assignment.SessionID, entry)
+	for _, published := range publishEntries {
+		conflictReason := ""
+		if published.ConflictReason != nil {
+			conflictReason = *published.ConflictReason
+		}
+		if hub.validationService != nil {
+			if err := hub.validationService.ReconcileStandAssignmentValidation(ctx, result.Assignment.SessionID, published.Callsign, published.BlockedBy, conflictReason); err != nil {
+				slog.ErrorContext(ctx, "Failed to reconcile stand assignment validation", slog.String("callsign", published.Callsign), slog.Any("error", err))
+			}
+		}
+		hub.SendStandAssignmentBroadcast(result.Assignment.SessionID, published)
+	}
 	hub.SendStandEvent(result.Assignment.SessionID, result.Assignment.Callsign, result.Assignment.Stand)
 	hub.server.GetEuroscopeHub().Broadcast(result.Assignment.SessionID, euroscopeEvents.StandEvent{Callsign: result.Assignment.Callsign, Stand: result.Assignment.Stand})
 	return nil

--- a/backend/internal/services/strip_validation.go
+++ b/backend/internal/services/strip_validation.go
@@ -5,9 +5,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 )
+
+const standAssignmentValidationIssueType = "STAND ASSIGNMENT"
 
 type validationStripReader interface {
 	GetByCallsign(ctx context.Context, session int32, callsign string) (*internalModels.Strip, error)
@@ -91,6 +94,49 @@ func (s *StripValidationService) ClearValidationStatus(ctx context.Context, sess
 	}
 	s.sendStripUpdate(session, callsign)
 	return nil
+}
+
+// ReconcileStandAssignmentValidation keeps SAT conflicts in the same durable,
+// owner-scoped validation workflow as other strip issues without overwriting a
+// higher-priority validation produced by another subsystem.
+func (s *StripValidationService) ReconcileStandAssignmentValidation(ctx context.Context, session int32, callsign string, blockedBy []string, conflictReason string) error {
+	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
+	if err != nil {
+		return err
+	}
+	current := strip.ValidationStatus
+	blocked := len(blockedBy) > 0 || strings.TrimSpace(conflictReason) != ""
+	if !blocked {
+		if current != nil && current.IssueType == standAssignmentValidationIssueType {
+			return s.ClearValidationStatus(ctx, session, callsign)
+		}
+		return nil
+	}
+	if current != nil && current.IssueType != standAssignmentValidationIssueType {
+		return nil
+	}
+
+	message := strings.TrimSpace(conflictReason)
+	if message == "" {
+		message = "Assigned stand is blocked by " + strings.Join(blockedBy, ", ") + "."
+	}
+	owner := ""
+	if strip.Owner != nil {
+		owner = *strip.Owner
+	}
+	if current != nil && current.Message == message && current.OwningPosition == owner {
+		return nil
+	}
+	return s.SetValidationStatus(ctx, session, callsign, &internalModels.ValidationStatus{
+		IssueType:      standAssignmentValidationIssueType,
+		Message:        message,
+		OwningPosition: owner,
+		Active:         true,
+		CustomAction: &internalModels.ValidationAction{
+			Label:      "REQUEST NEW STAND",
+			ActionKind: "assign_stand",
+		},
+	})
 }
 
 // IsValidationBlocking returns true when the strip has an active (unacknowledged) validation.

--- a/backend/internal/services/strip_validation_test.go
+++ b/backend/internal/services/strip_validation_test.go
@@ -119,6 +119,44 @@ func TestStripValidationService_SetValidationStatusReturnsMissingStoreErrorWhenO
 	assert.EqualError(t, err, "strip validation service missing validation status store dependency")
 }
 
+func TestReconcileStandAssignmentValidationActivatesBlockedAssignment(t *testing.T) {
+	owner := "EKCH_APP"
+	var persisted *models.ValidationStatus
+	repo := &validationStoreFake{
+		getByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
+			return &models.Strip{Callsign: "SAS123", Owner: &owner}, nil
+		},
+		setValidationStatusFn: func(_ context.Context, _ int32, _ string, status *models.ValidationStatus) error {
+			persisted = status
+			return nil
+		},
+	}
+	svc := NewStripValidationService(repo, repo)
+
+	require.NoError(t, svc.ReconcileStandAssignmentValidation(context.Background(), 1, "SAS123", []string{"A22"}, ""))
+	require.NotNil(t, persisted)
+	require.Equal(t, standAssignmentValidationIssueType, persisted.IssueType)
+	require.Equal(t, "Assigned stand is blocked by A22.", persisted.Message)
+	require.Equal(t, owner, persisted.OwningPosition)
+	require.True(t, persisted.Active)
+	require.Equal(t, "assign_stand", persisted.CustomAction.ActionKind)
+}
+
+func TestReconcileStandAssignmentValidationClearsResolvedSatIssueOnly(t *testing.T) {
+	repo := &validationStoreFake{
+		getByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
+			return &models.Strip{Callsign: "SAS123", ValidationStatus: &models.ValidationStatus{IssueType: standAssignmentValidationIssueType}}, nil
+		},
+		clearValidationStatusFn: func(_ context.Context, _ int32, callsign string) error {
+			require.Equal(t, "SAS123", callsign)
+			return nil
+		},
+	}
+	svc := NewStripValidationService(repo, repo)
+
+	require.NoError(t, svc.ReconcileStandAssignmentValidation(context.Background(), 1, "SAS123", nil, ""))
+}
+
 func TestNewStripValidationService_ReturnsMissingReaderErrorWhenReaderNotInjected(t *testing.T) {
 	t.Parallel()
 

--- a/frontend/src/components/strip/ApnArrStrip.tsx
+++ b/frontend/src/components/strip/ApnArrStrip.tsx
@@ -9,6 +9,7 @@ import { ArrStandDialog } from "./ArrStandDialog";
 import { ApronTaxiMapDialog } from "../map-dialogs/ApronTaxiMapDialog";
 import { SIBox } from "./SIBox";
 import { ValidationStatusDialog } from "./ValidationStatusDialog";
+import { getStandAssignmentStyle } from "./standAssignmentStyle";
 
 // Height: 4.72dvh (51px at 1080p), matches FinalArrStrip ATC arrival strip spec
 const TOP_H = "3.15dvh"; // 2/3 of 4.72dvh
@@ -73,7 +74,11 @@ export function ApnArrStrip({
   const [taxiMapOpen, setTaxiMapOpen] = useState(false);
   const [fplOpen, setFplOpen] = useState(false);
   const acknowledgeUnexpectedChange = useWebSocketStore(s => s.acknowledgeUnexpectedChange);
-  const standYellow = unexpectedChangeFields?.includes("stand");
+  const satEnabled = useWebSocketStore(s => s.satEnabled);
+  const satAssignment = useWebSocketStore(s => s.standAssignments.find(a => a.callsign === callsign));
+  const acknowledgeStandAssignment = useWebSocketStore(s => s.acknowledgeStandAssignment);
+  const satStandStyle = getStandAssignmentStyle(satEnabled ? satAssignment : undefined);
+  const standYellow = !satEnabled && unexpectedChangeFields?.includes("stand");
   const runwayYellow = unexpectedChangeFields?.includes("runway");
   const nextFreq = useNextFrequencyDisplay(nextDisplay, nextControllers, myPosition);
 
@@ -162,9 +167,12 @@ export function ApnArrStrip({
       {/* Stand */}
       <div
         className="flex flex-col overflow-hidden min-w-0 cursor-pointer hover:brightness-95"
-        style={{ flexGrow: F_STAND, flexBasis: 0, height: "100%", backgroundColor: standYellow ? COLOR_UNEXPECTED_YELLOW : undefined, cursor: getValidationBlockedCursor(isValidationActive) }}
+        style={{ flexGrow: F_STAND, flexBasis: 0, height: "100%", backgroundColor: satStandStyle.backgroundColor ?? (standYellow ? COLOR_UNEXPECTED_YELLOW : undefined), cursor: getValidationBlockedCursor(isValidationActive) }}
+        title={satStandStyle.blocked ? satAssignment?.conflict_reason : undefined}
         onClick={(e) => guardValidationAction(e, () => {
-          if (standYellow) {
+          if (satStandStyle.changed && satAssignment?.version !== undefined) {
+            acknowledgeStandAssignment(callsign, satAssignment.version);
+          } else if (standYellow) {
             acknowledgeUnexpectedChange(callsign, "stand");
           } else {
             setStandOpen(true);
@@ -172,7 +180,7 @@ export function ApnArrStrip({
         })}
       >
         <div className="flex items-center justify-center" style={{ height: TOP_H }}>
-          <span className="truncate" style={{ fontWeight: "bold", fontSize: "1.04vw", color: getCellTextColor("stand", controllerModifiedFields) }}>{stand}</span>
+          <span className="truncate" style={{ fontWeight: "bold", fontSize: "1.04vw", color: satStandStyle.color ?? getCellTextColor("stand", controllerModifiedFields) }}>{stand}</span>
         </div>
         <div style={{ height: BOT_H }} />
       </div>

--- a/frontend/src/components/strip/ArrStandDialog.tsx
+++ b/frontend/src/components/strip/ArrStandDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import EstStandCell from "@/components/est/EstStandCell";
 import EstViewButtons from "@/components/est/EstViewButtons";
 import {
@@ -9,7 +9,7 @@ import {
   isCargoStand,
   type EstView,
 } from "@/components/est/metadata";
-import { Bay, type FrontendStrip } from "@/api/models";
+import { ActionType, Bay, type FrontendStrip } from "@/api/models";
 import { useStrips, useWebSocketStore } from "@/store/store-hooks";
 
 const COLOR_LABEL_DEFAULT = "#202020";
@@ -22,6 +22,92 @@ interface Props {
 }
 
 export function ArrStandDialog({ open, onOpenChange, callsign, currentStand }: Props) {
+  const satEnabled = useWebSocketStore(s => s.satEnabled);
+  return satEnabled
+    ? <SatStandAssignmentMenu open={open} onOpenChange={onOpenChange} callsign={callsign} />
+    : <LegacyArrStandDialog open={open} onOpenChange={onOpenChange} callsign={callsign} currentStand={currentStand} />;
+}
+
+function SatStandAssignmentMenu({ open, onOpenChange, callsign }: Omit<Props, "currentStand">) {
+  const [manualStand, setManualStand] = useState("");
+  const assignment = useWebSocketStore(s => s.standAssignments.find(a => a.callsign === callsign));
+  const rejection = useWebSocketStore(s => s.standActionRejection);
+  const requestAutomatic = useWebSocketStore(s => s.requestAutomaticStand);
+  const requestManual = useWebSocketStore(s => s.requestManualStand);
+  const confirmOverride = useWebSocketStore(s => s.confirmStandOverride);
+  const clearRejection = useWebSocketStore(s => s.clearStandActionRejection);
+  const submittedVersion = useRef<number | null>(null);
+  const version = assignment?.version ?? 0;
+  const relevantRejection = rejection?.callsign === callsign ? rejection : null;
+  const unsafeManual = relevantRejection?.action === ActionType.FrontendStandAssignmentManualRequest
+    && relevantRejection.code === "incompatible_or_occupied";
+
+  useEffect(() => {
+    if (open && submittedVersion.current !== null && assignment?.version !== submittedVersion.current) {
+      submittedVersion.current = null;
+      onOpenChange(false);
+    }
+  }, [assignment?.version, onOpenChange, open]);
+
+  if (!open) return null;
+
+  const close = () => {
+    setManualStand("");
+    submittedVersion.current = null;
+    clearRejection();
+    onOpenChange(false);
+  };
+  const send = () => {
+    submittedVersion.current = version;
+    const stand = manualStand.trim().toUpperCase();
+    if (stand) requestManual(callsign, stand, version);
+    else requestAutomatic(callsign, version);
+  };
+
+  if (relevantRejection) {
+    return (
+      <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/25" onMouseDown={close}>
+        <div className="w-[38rem] border border-black bg-[#e4e4e4] p-5 text-center shadow-lg" onMouseDown={e => e.stopPropagation()} role="alertdialog" aria-label="Stand assignment warning">
+          <h2 className="mb-5 text-2xl font-light">STAND ASSIGNMENT</h2>
+          <p className="mb-6 text-2xl text-red-600">{relevantRejection.code === "invalid_stand" ? "STAND NOT FOUND" : relevantRejection.reason}</p>
+          <div className="flex justify-center gap-4">
+            <MenuButton onClick={close}>ESC</MenuButton>
+            {unsafeManual && <MenuButton onClick={() => { submittedVersion.current = version; requestAutomatic(callsign, version); }}>AUTO ASSIGN</MenuButton>}
+            {unsafeManual && <MenuButton onClick={() => { submittedVersion.current = version; confirmOverride(callsign, manualStand.trim().toUpperCase(), version, relevantRejection.reason); }}>YES</MenuButton>}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/20" onMouseDown={close}>
+      <div className="w-[17.8rem] border border-black bg-[#b3b3b3] p-4 shadow-lg" onMouseDown={e => e.stopPropagation()} role="dialog" aria-label="Stand assignment">
+        <h2 className="mb-2 text-center text-2xl font-light">STAND ASSIGNMENT</h2>
+        <div className="flex flex-col gap-2">
+          <MenuButton onClick={send}>SEND REQ</MenuButton>
+          <button className={`h-[4.4rem] text-3xl ${manualStand ? "bg-[#3f3f3f] text-white" : "bg-[#00ff26] text-black"}`} onClick={() => setManualStand("")}>AUTOMATIC</button>
+          <input
+            className="h-[4.4rem] bg-[#fcfcfc] px-3 text-center text-3xl uppercase text-black outline-none"
+            aria-label="Manual stand"
+            value={manualStand}
+            maxLength={8}
+            onChange={e => setManualStand(e.target.value.toUpperCase())}
+            onKeyDown={e => { if (e.key === "Enter") send(); if (e.key === "Escape") close(); }}
+            autoFocus
+          />
+          <MenuButton onClick={close}>ESC</MenuButton>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MenuButton({ children, onClick }: { children: ReactNode; onClick: () => void }) {
+  return <button className="h-[4.4rem] bg-[#3f3f3f] px-5 text-2xl font-semibold text-white shadow" onClick={onClick}>{children}</button>;
+}
+
+function LegacyArrStandDialog({ open, onOpenChange, callsign, currentStand }: Props) {
   const updateStrip = useWebSocketStore(s => s.updateStrip);
   const strips = useStrips();
   const [boardScale, setBoardScale] = useState(1);

--- a/frontend/src/components/strip/FinalArrStrip.tsx
+++ b/frontend/src/components/strip/FinalArrStrip.tsx
@@ -9,6 +9,7 @@ import { SIBox } from "./SIBox";
 import { ArrStandDialog } from "./ArrStandDialog";
 import { TaxiMapDialog } from "@/components/map-dialogs/TaxiMapDialog";
 import { ValidationStatusDialog } from "./ValidationStatusDialog";
+import { getStandAssignmentStyle } from "./standAssignmentStyle";
 
 /** Gold cell borders — matches the yellow arrival strip design. */
 const CELL_BORDER = "var(--color-cell-border-arr)";
@@ -68,6 +69,10 @@ export function FinalArrStrip({
   const [taxiMapOpen, setTaxiMapOpen] = useState(false);
   const [fplOpen, setFplOpen] = useState(false);
   const nextFreq = useNextFrequencyDisplay(nextDisplay, nextControllers, myPosition);
+  const satEnabled = useWebSocketStore(s => s.satEnabled);
+  const satAssignment = useWebSocketStore(s => s.standAssignments.find(a => a.callsign === callsign));
+  const acknowledgeStandAssignment = useWebSocketStore(s => s.acknowledgeStandAssignment);
+  const satStandStyle = getStandAssignmentStyle(satEnabled ? satAssignment : undefined);
 
   // RWY cell color — only when cleared in RWY_ARR bay:
   // - runway_confirmed = true: green (controller acknowledged)
@@ -152,11 +157,15 @@ export function FinalArrStrip({
       {/* Stand (left of runway); stand in top 2/3, bottom 1/3 empty */}
       <div
         className="flex flex-col border-r-2 min-w-0 cursor-pointer hover:brightness-95"
-        style={{ flexGrow: F_TAXIWAY, flexBasis: 0, height: "100%", borderRightColor: cellBorderColor, cursor: isAssumed ? getValidationBlockedCursor(isValidationActive) : undefined }}
-        onClick={isAssumed ? (e) => guardValidationAction(e, () => setStandOpen(true)) : undefined}
+        style={{ flexGrow: F_TAXIWAY, flexBasis: 0, height: "100%", borderRightColor: cellBorderColor, backgroundColor: satStandStyle.backgroundColor, cursor: isAssumed ? getValidationBlockedCursor(isValidationActive) : undefined }}
+        title={satStandStyle.blocked ? satAssignment?.conflict_reason : undefined}
+        onClick={isAssumed ? (e) => guardValidationAction(e, () => {
+          if (satStandStyle.changed && satAssignment?.version !== undefined) acknowledgeStandAssignment(callsign, satAssignment.version);
+          else setStandOpen(true);
+        }) : undefined}
       >
         <div className="flex items-center justify-center" style={{ height: TOP_H }}>
-          <span className="truncate px-[0.21vw]" style={{ fontFamily: FONT, fontWeight: 600, fontSize: "0.83vw" }}>
+          <span className="truncate px-[0.21vw]" style={{ fontFamily: FONT, fontWeight: 600, fontSize: "0.83vw", color: satStandStyle.color }}>
             {stand}
           </span>
         </div>

--- a/frontend/src/components/strip/standAssignmentStyle.test.ts
+++ b/frontend/src/components/strip/standAssignmentStyle.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import type { FrontendStandAssignmentEntry } from "@/api/models";
+import { getStandAssignmentStyle, SAT_BLOCKED_ORANGE, SAT_CHANGED_YELLOW, SAT_MANUAL_BLUE } from "./standAssignmentStyle";
+
+function assignment(overrides: Partial<FrontendStandAssignmentEntry> = {}): FrontendStandAssignmentEntry {
+  return { callsign: "SAS123", stand: "A23", direction: "ARRIVAL", stage: "CONFIRMED", source: "AUTOMATIC", ...overrides };
+}
+
+describe("getStandAssignmentStyle", () => {
+  it("keeps free automatic assignments transparent", () => {
+    expect(getStandAssignmentStyle(assignment()).backgroundColor).toBeUndefined();
+  });
+
+  it("renders blocked automatic assignments orange", () => {
+    expect(getStandAssignmentStyle(assignment({ blocked_by: ["A22"] })).backgroundColor).toBe(SAT_BLOCKED_ORANGE);
+  });
+
+  it("gives changed yellow precedence while preserving manual blue text", () => {
+    const style = getStandAssignmentStyle(assignment({ source: "MANUAL_OVERRIDE", manual: true, conflict_reason: "occupied", pending_acknowledgement: true }));
+    expect(style.backgroundColor).toBe(SAT_CHANGED_YELLOW);
+    expect(style.color).toBe(SAT_MANUAL_BLUE);
+  });
+});

--- a/frontend/src/components/strip/standAssignmentStyle.ts
+++ b/frontend/src/components/strip/standAssignmentStyle.ts
@@ -1,0 +1,19 @@
+import type { FrontendStandAssignmentEntry } from "@/api/models";
+
+export const SAT_CHANGED_YELLOW = "#FFF500";
+export const SAT_BLOCKED_ORANGE = "#DD6A12";
+export const SAT_MANUAL_BLUE = "#0D4259";
+
+export function getStandAssignmentStyle(assignment?: FrontendStandAssignmentEntry) {
+  // A new assignment demanding acknowledgement has visual priority over a
+  // conflict. Manual source changes text colour independently of backgrounds.
+  const changed = assignment?.pending_acknowledgement === true;
+  const blocked = Boolean(assignment?.conflict_reason || assignment?.blocked_by?.length);
+  const manual = assignment?.manual === true || assignment?.source.toUpperCase().includes("MANUAL");
+  return {
+    backgroundColor: changed ? SAT_CHANGED_YELLOW : blocked ? SAT_BLOCKED_ORANGE : undefined,
+    color: manual ? SAT_MANUAL_BLUE : undefined,
+    changed,
+    blocked,
+  };
+}

--- a/frontend/src/store/store-stand.test.ts
+++ b/frontend/src/store/store-stand.test.ts
@@ -96,6 +96,37 @@ describe("stand store events", () => {
   });
 
   describe("stand assignment update", () => {
+    it("reconnects after a stale stand assignment version", () => {
+      client._emit(EventType.FrontendActionRejected, {
+        type: EventType.FrontendActionRejected,
+        action: "stand_assignment_manual_request",
+        code: "stale_version",
+        reason: "stand assignment version is stale",
+        callsign: "SAS456",
+        version: 2,
+      });
+
+      expect(client.reconnect).toHaveBeenCalledOnce();
+      expect(store.getState().standActionRejection?.code).toBe("stale_version");
+    });
+
+    it("does not clear another callsign's stand rejection", () => {
+      client._emit(EventType.FrontendActionRejected, {
+        type: EventType.FrontendActionRejected,
+        action: "stand_assignment_manual_request",
+        code: "incompatible_or_occupied",
+        reason: "occupied",
+        callsign: "SAS456",
+        version: 2,
+      });
+      client._emit(EventType.FrontendStandAssignmentUpdate, {
+        type: EventType.FrontendStandAssignmentUpdate,
+        assignment: { callsign: "NAX123", stand: "A20", direction: "ARRIVAL", stage: "CONFIRMED", source: "AUTOMATIC" },
+      } as FrontendStandAssignmentUpdateEvent);
+
+      expect(store.getState().standActionRejection?.callsign).toBe("SAS456");
+    });
+
     it("adds new assignment", () => {
       const entry: FrontendStandAssignmentEntry = {
         callsign: "SAS456", stand: "A20", direction: "ARRIVAL", stage: "ESTIMATED", source: "AUTOMATIC",
@@ -278,6 +309,23 @@ describe("stand store events", () => {
         stand: "A25",
         version: 4,
       });
+    });
+
+    it("sends automatic, confirmed override, and acknowledgement commands", () => {
+      store.getState().requestAutomaticStand("SAS123", 4);
+      expect(client.send).toHaveBeenCalledWith({ type: "stand_assignment_auto_request", callsign: "SAS123", version: 4 });
+
+      store.getState().confirmStandOverride("SAS123", "A25", 4, "A25 is occupied");
+      expect(client.send).toHaveBeenCalledWith({
+        type: "stand_assignment_confirmed_override",
+        callsign: "SAS123",
+        stand: "A25",
+        version: 4,
+        reason: "A25 is occupied",
+      });
+
+      store.getState().acknowledgeStandAssignment("SAS123", 5);
+      expect(client.send).toHaveBeenCalledWith({ type: "stand_assignment_acknowledge", callsign: "SAS123", version: 5 });
     });
 
     it("sends stand block create action", () => {

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -2,6 +2,7 @@ import {createStore} from 'zustand/vanilla';
 import {produce} from 'immer';
 import {
   ActionType,
+  type ActionRejectedEvent,
   Bay,
   EventType,
   type FrontendAircraftDisconnectEvent,
@@ -174,6 +175,11 @@ export interface WebSocketState {
   occupyStand: (stand: string) => void;
   vacateStand: (stand: string, blockId: number, version: number) => void;
   requestManualStand: (callsign: string, stand: string, version: number) => void;
+  requestAutomaticStand: (callsign: string, version: number) => void;
+  confirmStandOverride: (callsign: string, stand: string, version: number, reason: string) => void;
+  acknowledgeStandAssignment: (callsign: string, version: number) => void;
+  standActionRejection: ActionRejectedEvent | null;
+  clearStandActionRejection: () => void;
 
   // actions
   move: (callsign: string, bay: Bay) => void;
@@ -261,6 +267,7 @@ export const createWebSocketStore = (wsClient: WebSocketClient) => {
     contextMenu: null,
     validationDialogCallsign: null,
     standAssignments: [],
+    standActionRejection: null,
     standBlocks: [],
     satEnabled: false,
   };
@@ -779,8 +786,21 @@ export const createWebSocketStore = (wsClient: WebSocketClient) => {
       sendIfWritable({ type: ActionType.FrontendStandBlockRemove, stand, block_id: blockId, version });
     },
     requestManualStand: (callsign, stand, version) => {
+      store.setState({ standActionRejection: null });
       sendIfWritable({ type: ActionType.FrontendStandAssignmentManualRequest, callsign, stand, version });
     },
+    requestAutomaticStand: (callsign, version) => {
+      store.setState({ standActionRejection: null });
+      sendIfWritable({ type: ActionType.FrontendStandAssignmentAutomaticRequest, callsign, version });
+    },
+    confirmStandOverride: (callsign, stand, version, reason) => {
+      store.setState({ standActionRejection: null });
+      sendIfWritable({ type: ActionType.FrontendStandAssignmentConfirmedOverride, callsign, stand, version, reason });
+    },
+    acknowledgeStandAssignment: (callsign, version) => {
+      sendIfWritable({ type: ActionType.FrontendStandAssignmentAcknowledge, callsign, version });
+    },
+    clearStandActionRejection: () => store.setState({ standActionRejection: null }),
   }});
 
   // Private methods to handle WebSocket events
@@ -829,6 +849,7 @@ export const createWebSocketStore = (wsClient: WebSocketClient) => {
         state.standAssignments = data.stand_assignments ?? [];
         state.standBlocks = data.stand_blocks ?? [];
         state.satEnabled = data.stand_assignment_enabled ?? false;
+        state.standActionRejection = null;
       })
     );
 
@@ -1330,7 +1351,14 @@ export const createWebSocketStore = (wsClient: WebSocketClient) => {
 
   wsClient.on(EventType.FrontendAtisUpdate, handleAtisUpdateEvent);
 
-  const handleActionRejectedEvent = () => {
+  const handleActionRejectedEvent = (data: ActionRejectedEvent) => {
+    if (data.action.startsWith("stand_assignment_")) {
+      store.setState({ standActionRejection: data });
+      if (data.code === "stale_version") {
+        wsClient.reconnect();
+      }
+      return;
+    }
     // Reconnect to receive a fresh initial event from the server,
     // which overwrites any optimistic updates that were rejected.
     wsClient.reconnect();


### PR DESCRIPTION
## Summary

- add the SAT-backed automatic/manual stand assignment menu to arrival strips while preserving the legacy stand board when SAT is unavailable
- require explicit confirmation before overriding incompatible or occupied manual assignments
- render persisted automatic, blocked, manual, and unacknowledged assignment states with deterministic styling
- surface blocked assignments through the existing owner-scoped strip validation workflow
- recover from stale assignment versions and keep asynchronous action rejections scoped correctly

## Impact

Controllers get the documented strip stand-assignment workflow when the backend reports SAT ready. Deployments with the stand-assignment feature disabled retain the existing controller experience.

## Validation

- `go test ./internal/services ./internal/frontend ./internal/app`
- `npm test -- --run` (63 tests)
- `npm run build`
- ESLint on all modified frontend files

The broader `go test ./...` run passed all non-container packages. The PDC integration package could not start its PostgreSQL testcontainer because rootless Docker is unsupported on the current Windows environment.
