### PR TITLE
feat(stand): add observability and replay

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -22,6 +22,7 @@ import (
 	pkgEuroscope "FlightStrips/pkg/events/euroscope"
 	pkgFrontend "FlightStrips/pkg/events/frontend"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -244,7 +245,7 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 		dbpool:                   dbpool,
 		closeDB:                  closeDB,
 		standAssignmentReadiness: standAssignmentReadiness,
-		handler: buildHandler(buildHandlerConfig{
+			handler: buildHandler(buildHandlerConfig{
 			authService:                authService,
 			frontendHub:                frontendHub,
 			euroscopeHub:               euroscopeHub,
@@ -253,6 +254,8 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 			sessionRepo:                sessionRepo,
 			sequenceService:            sequenceService,
 			vatsimCache:                vatsimCache,
+			standAssignmentReadiness:   standAssignmentReadiness,
+			standAssignmentStaleAfter:  satStaleAfter(deps.VATSIMPollInterval),
 			requireLiveCIDVerification: requireLiveCIDVerification,
 			enableHTTPTracing:          cfg.EnableHTTPTracing,
 			enableALB:                  cfg.EnableALB,
@@ -504,6 +507,8 @@ type buildHandlerConfig struct {
 	sessionRepo                repository.SessionRepository
 	sequenceService            *cdm.SequenceService
 	vatsimCache                *vatsim.Cache
+	standAssignmentReadiness   appconfig.StandAssignmentReadiness
+	standAssignmentStaleAfter  time.Duration
 	requireLiveCIDVerification bool
 	enableHTTPTracing          bool
 	enableALB                  bool
@@ -519,7 +524,7 @@ func buildHandler(cfg buildHandlerConfig) http.Handler {
 	frontendUpgrader := websocket.NewConnectionUpgrader[pkgFrontend.EventType, *frontend.Client](cfg.frontendHub, cfg.authService)
 	euroscopeUpgrader := websocket.NewConnectionUpgrader[pkgEuroscope.EventType, *euroscope.Client](cfg.euroscopeHub, cfg.authService)
 
-	mux.HandleFunc("/healthz", healthz)
+	mux.HandleFunc("/healthz", satHealthz(cfg.standAssignmentReadiness, cfg.vatsimCache, cfg.standAssignmentStaleAfter))
 	mux.HandleFunc("/euroscopeEvents", euroscopeUpgrader.Upgrade)
 	mux.HandleFunc("/frontEndEvents", frontendUpgrader.Upgrade)
 	if cfg.enableALB {
@@ -551,8 +556,59 @@ func buildHandler(cfg buildHandlerConfig) http.Handler {
 	return handler
 }
 
-func healthz(w http.ResponseWriter, _ *http.Request) {
-	w.WriteHeader(http.StatusOK)
+type healthResponse struct {
+	Status string `json:"status"`
+	StandAssignment satHealth `json:"stand_assignment"`
+}
+
+type satHealth struct {
+	Enabled bool `json:"enabled"`
+	Ready bool `json:"ready"`
+	Status string `json:"status"`
+	Reason string `json:"reason,omitempty"`
+	SnapshotAgeSeconds *float64 `json:"snapshot_age_seconds,omitempty"`
+}
+
+func satHealthz(readiness appconfig.StandAssignmentReadiness, cache *vatsim.Cache, staleAfter time.Duration) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		result := healthResponse{Status: "ok", StandAssignment: satHealth{Enabled: readiness.Enabled, Ready: readiness.Ready, Status: "disabled"}}
+		sat := &result.StandAssignment
+		switch {
+		case !readiness.Enabled:
+		case !readiness.Ready:
+			result.Status, sat.Status, sat.Reason = "degraded", "invalid_config", readiness.Reason
+		case cache == nil:
+			result.Status, sat.Status, sat.Ready, sat.Reason = "degraded", "feed_unavailable", false, "VATSIM feed is unavailable"
+		default:
+			*sat = evaluateSATHealth(readiness, cache.Snapshot(), staleAfter)
+			if !sat.Ready { result.Status = "degraded" }
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK) // SAT degradation must not take unrelated features down.
+		_ = json.NewEncoder(w).Encode(result)
+	}
+}
+
+func evaluateSATHealth(readiness appconfig.StandAssignmentReadiness, snapshot vatsim.Snapshot, staleAfter time.Duration) satHealth {
+	result := satHealth{Enabled: readiness.Enabled, Ready: readiness.Ready, Status: "ready"}
+	age := snapshot.Age.Seconds()
+	result.SnapshotAgeSeconds = &age
+	switch {
+	case snapshot.Timestamp.IsZero():
+		result.Status, result.Ready, result.Reason = "feed_unavailable", false, "VATSIM feed has not produced a snapshot"
+	case snapshot.LastRefreshError != nil:
+		result.Status, result.Ready, result.Reason = "feed_failed", false, snapshot.LastRefreshError.Error()
+	case snapshot.Age > staleAfter:
+		result.Status, result.Ready, result.Reason = "feed_stale", false, "VATSIM snapshot is stale"
+	}
+	return result
+}
+
+func satStaleAfter(poll time.Duration) time.Duration {
+	if poll <= 0 { poll = 15 * time.Second }
+	threshold := 2 * poll
+	if threshold < time.Minute { return time.Minute }
+	return threshold
 }
 
 type noopTransceiverLookup struct{}

--- a/backend/internal/app/sat_health_test.go
+++ b/backend/internal/app/sat_health_test.go
@@ -1,0 +1,36 @@
+package app
+
+import (
+	appconfig "FlightStrips/internal/config"
+	"FlightStrips/internal/vatsim"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEvaluateSATHealthFeedStates(t *testing.T) {
+	ready := appconfig.StandAssignmentReadiness{Enabled: true, Ready: true}
+	now := time.Now().UTC()
+	tests := []struct {
+		name string
+		snapshot vatsim.Snapshot
+		wantStatus string
+		wantReady bool
+	}{
+		{name: "unavailable", snapshot: vatsim.Snapshot{}, wantStatus: "feed_unavailable"},
+		{name: "valid", snapshot: vatsim.Snapshot{Timestamp: now, Age: 10 * time.Second}, wantStatus: "ready", wantReady: true},
+		{name: "stale", snapshot: vatsim.Snapshot{Timestamp: now.Add(-2 * time.Minute), Age: 2 * time.Minute}, wantStatus: "feed_stale"},
+		{name: "failed", snapshot: vatsim.Snapshot{Timestamp: now, Age: 10 * time.Second, LastRefreshError: errors.New("network down")}, wantStatus: "feed_failed"},
+		{name: "recovered", snapshot: vatsim.Snapshot{Timestamp: now, Age: 5 * time.Second}, wantStatus: "ready", wantReady: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evaluateSATHealth(ready, tt.snapshot, time.Minute)
+			assert.Equal(t, tt.wantStatus, got.Status)
+			assert.Equal(t, tt.wantReady, got.Ready)
+		})
+	}
+}
+

--- a/backend/internal/metrics/metrics.go
+++ b/backend/internal/metrics/metrics.go
@@ -37,6 +37,12 @@ type instruments struct {
 	trafficTaxiing          metric.Int64Gauge
 	trafficArrivalRate15m   metric.Int64Gauge
 	trafficDepartureRate15m metric.Int64Gauge
+	satSnapshotAge          metric.Float64Gauge
+	satFeedRecords          metric.Int64Gauge
+	satAssignments          metric.Int64Counter
+	satOutcomes             metric.Int64Counter
+	satConflicts            metric.Int64Counter
+	satExpirations          metric.Int64Counter
 }
 
 func get() *instruments {
@@ -145,6 +151,12 @@ func get() *instruments {
 			metric.WithDescription("Departures (AOBT set) in the rolling last 15 minutes"),
 			metric.WithUnit("{aircraft}"),
 		)
+		satSnapshotAge, _ := meter.Float64Gauge("sat.vatsim.snapshot.age", metric.WithDescription("Age of the VATSIM snapshot used by SAT"), metric.WithUnit("s"))
+		satFeedRecords, _ := meter.Int64Gauge("sat.vatsim.records", metric.WithDescription("Relevant VATSIM records observed by SAT"), metric.WithUnit("{flight}"))
+		satAssignments, _ := meter.Int64Counter("sat.assignments", metric.WithDescription("Committed SAT assignments and reallocations"), metric.WithUnit("{assignment}"))
+		satOutcomes, _ := meter.Int64Counter("sat.allocation.outcomes", metric.WithDescription("SAT allocation outcomes"), metric.WithUnit("{result}"))
+		satConflicts, _ := meter.Int64Counter("sat.allocation.conflicts", metric.WithDescription("SAT allocation database and occupancy conflicts"), metric.WithUnit("{conflict}"))
+		satExpirations, _ := meter.Int64Counter("sat.assignments.expired", metric.WithDescription("SAT assignments expired or released"), metric.WithUnit("{assignment}"))
 
 		inst = &instruments{
 			activeConnections:       activeConnections,
@@ -167,9 +179,45 @@ func get() *instruments {
 			trafficTaxiing:          trafficTaxiing,
 			trafficArrivalRate15m:   trafficArrivalRate15m,
 			trafficDepartureRate15m: trafficDepartureRate15m,
+			satSnapshotAge: satSnapshotAge, satFeedRecords: satFeedRecords,
+			satAssignments: satAssignments, satOutcomes: satOutcomes,
+			satConflicts: satConflicts, satExpirations: satExpirations,
 		}
 	})
 	return inst
+}
+
+// RecordSATFeedSnapshot records only operational dimensions. Callsigns, CIDs,
+// names, and other pilot data are deliberately excluded from metric labels.
+func RecordSATFeedSnapshot(ctx context.Context, age time.Duration, pilots, prefiles int) {
+	i := get()
+	i.satSnapshotAge.Record(ctx, max(age.Seconds(), 0))
+	i.satFeedRecords.Record(ctx, int64(pilots), metric.WithAttributes(attribute.String("state", "online")))
+	i.satFeedRecords.Record(ctx, int64(prefiles), metric.WithAttributes(attribute.String("state", "prefile")))
+}
+
+func RecordSATRelevantFlights(ctx context.Context, sessionName, airport string, pilots, prefiles int) {
+	i := get()
+	i.satFeedRecords.Record(ctx, int64(pilots), sessionAttributes(sessionName, airport, attribute.String("state", "online")))
+	i.satFeedRecords.Record(ctx, int64(prefiles), sessionAttributes(sessionName, airport, attribute.String("state", "prefile")))
+}
+
+func RecordSATAssignment(ctx context.Context, stage, source, category string, tier int) {
+	attrs := []attribute.KeyValue{attribute.String("stage", stage), attribute.String("source", source), attribute.String("category", category)}
+	if tier > 0 { attrs = append(attrs, attribute.Int("tier", tier)) }
+	get().satAssignments.Add(ctx, 1, metric.WithAttributes(attrs...))
+}
+
+func RecordSATOutcome(ctx context.Context, outcome, category string) {
+	get().satOutcomes.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", outcome), attribute.String("category", category)))
+}
+
+func RecordSATConflict(ctx context.Context, kind string) {
+	get().satConflicts.Add(ctx, 1, metric.WithAttributes(attribute.String("kind", kind)))
+}
+
+func RecordSATExpiration(ctx context.Context, direction, stage string) {
+	get().satExpirations.Add(ctx, 1, metric.WithAttributes(attribute.String("direction", direction), attribute.String("stage", stage)))
 }
 
 func sessionAttributes(sessionName, airport string, extra ...attribute.KeyValue) metric.MeasurementOption {

--- a/backend/internal/metrics/metrics_test.go
+++ b/backend/internal/metrics/metrics_test.go
@@ -259,3 +259,25 @@ func TestEuroscopeSyncMetricsUseSessionNameAndAirport(t *testing.T) {
 		t.Fatalf("expected sync duration histogram sum 0.15, got %f", got)
 	}
 }
+
+func TestSATMetricsAvoidPersonalDataDimensions(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	previousProvider := otel.GetMeterProvider()
+	otel.SetMeterProvider(provider)
+	resetInstrumentsForTest()
+	t.Cleanup(func() { otel.SetMeterProvider(previousProvider); resetInstrumentsForTest() })
+
+	ctx := context.Background()
+	RecordSATFeedSnapshot(ctx, 5*time.Second, 7, 3)
+	RecordSATAssignment(ctx, "ASSIGNED", "AUTOMATIC", "airline_rule", 2)
+	RecordSATOutcome(ctx, "no_compatible_stand", "ARRIVAL")
+	RecordSATConflict(ctx, "database_contention")
+	RecordSATExpiration(ctx, "DEPARTURE", "RESERVED")
+	rm := collectMetrics(t, reader)
+
+	if got := findInt64MetricValue(t, rm, "sat.assignments", map[string]string{"stage": "ASSIGNED", "source": "AUTOMATIC", "category": "airline_rule"}); got != 1 { t.Fatalf("expected assignment counter 1, got %d", got) }
+	if got := findInt64MetricValue(t, rm, "sat.allocation.outcomes", map[string]string{"outcome": "no_compatible_stand", "category": "ARRIVAL"}); got != 1 { t.Fatalf("expected outcome counter 1, got %d", got) }
+	if got := findInt64MetricValue(t, rm, "sat.allocation.conflicts", map[string]string{"kind": "database_contention"}); got != 1 { t.Fatalf("expected conflict counter 1, got %d", got) }
+	if got := findInt64MetricValue(t, rm, "sat.assignments.expired", map[string]string{"direction": "DEPARTURE", "stage": "RESERVED"}); got != 1 { t.Fatalf("expected expiration counter 1, got %d", got) }
+}

--- a/backend/internal/services/arrival_lifecycle.go
+++ b/backend/internal/services/arrival_lifecycle.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"FlightStrips/internal/metrics"
 	"FlightStrips/internal/models"
 	"FlightStrips/internal/repository"
 	"FlightStrips/internal/sat"
@@ -233,6 +234,7 @@ func (s *ArrivalLifecycleService) updateStageInPlace(ctx context.Context, existi
 	if affected != 1 {
 		return fmt.Errorf("arrival stage update version conflict for %s", existing.Callsign)
 	}
+	slog.InfoContext(ctx, "SAT assignment stage changed", slog.String("callsign", existing.Callsign), slog.String("stand", existing.Stand), slog.String("from_stage", existing.Stage), slog.String("to_stage", stage))
 	return nil
 }
 
@@ -280,6 +282,7 @@ func (s *ArrivalLifecycleService) releaseIfDue(ctx context.Context, session int3
 	}
 	if strip == nil {
 		_, err := s.assignments.DeleteAssignment(ctx, session, assignment.ID, assignment.Version)
+		recordSATExpiry(ctx, assignment, "strip_removed", err)
 		return err
 	}
 	if assignment.ExpiresAt != nil && !assignment.ExpiresAt.After(now) {
@@ -287,6 +290,7 @@ func (s *ArrivalLifecycleService) releaseIfDue(ctx context.Context, session int3
 			return err
 		}
 		_, err = s.assignments.DeleteAssignment(ctx, session, assignment.ID, assignment.Version)
+		recordSATExpiry(ctx, assignment, "expired", err)
 		return err
 	}
 	if assignment.ETA != nil && now.After(assignment.ETA.Add(30*time.Minute)) {
@@ -294,9 +298,16 @@ func (s *ArrivalLifecycleService) releaseIfDue(ctx context.Context, session int3
 			return err
 		}
 		_, err = s.assignments.DeleteAssignment(ctx, session, assignment.ID, assignment.Version)
+		recordSATExpiry(ctx, assignment, "arrival_timeout", err)
 		return err
 	}
 	return nil
+}
+
+func recordSATExpiry(ctx context.Context, assignment *models.StandAssignment, reason string, err error) {
+	if err != nil || assignment == nil { return }
+	metrics.RecordSATExpiration(ctx, assignment.Direction, assignment.Stage)
+	slog.InfoContext(ctx, "SAT assignment expired", slog.String("callsign", assignment.Callsign), slog.String("stand", assignment.Stand), slog.String("stage", assignment.Stage), slog.String("reason", reason))
 }
 
 func (s *ArrivalLifecycleService) StartSweep(ctx context.Context) {

--- a/backend/internal/services/departure_lifecycle.go
+++ b/backend/internal/services/departure_lifecycle.go
@@ -382,6 +382,9 @@ func (s *DepartureLifecycleService) activateBlock(ctx context.Context, session i
 		return err
 	}
 	if affected == 1 {
+		if existing.Stage != StageDepartureBlock {
+			slog.InfoContext(ctx, "SAT assignment stage changed", slog.String("callsign", existing.Callsign), slog.String("stand", existing.Stand), slog.String("from_stage", existing.Stage), slog.String("to_stage", StageDepartureBlock))
+		}
 		return nil
 	}
 	reloaded, reloadErr := s.assignments.GetAssignment(ctx, session, strip.Callsign)
@@ -481,6 +484,7 @@ func (s *DepartureLifecycleService) releaseIfDue(ctx context.Context, session in
 	}
 	if strip == nil {
 		_, err := s.assignments.DeleteAssignment(ctx, session, assignment.ID, assignment.Version)
+		recordSATExpiry(ctx, assignment, "strip_removed", err)
 		return err
 	}
 	if assignment.ExpiresAt == nil || assignment.ExpiresAt.After(now) {
@@ -493,6 +497,7 @@ func (s *DepartureLifecycleService) releaseIfDue(ctx context.Context, session in
 		return err
 	}
 	_, err = s.assignments.DeleteAssignment(ctx, session, assignment.ID, assignment.Version)
+	recordSATExpiry(ctx, assignment, "expired", err)
 	return err
 }
 

--- a/backend/internal/services/sat_replay_test.go
+++ b/backend/internal/services/sat_replay_test.go
@@ -1,0 +1,68 @@
+package services
+
+import (
+	"FlightStrips/internal/models"
+	"FlightStrips/internal/pdc/testdata"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSATPhaseOneReplay is a deterministic, tower-independent replay of the
+// phase-one source-to-controller state machine. Repository reloads represent a
+// frontend reconnect: the authoritative assignment must survive unchanged.
+func TestSATPhaseOneReplay(t *testing.T) {
+	pool, queries := testdata.SetupTestDB(t)
+	ctx := context.Background()
+	lifecycle, allocations, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
+
+	const callsign = "SAS917"
+	seedTestArrivalStrip(t, queries, session, callsign)
+	eta := clock.current().Add(45 * time.Minute)
+	setArrivalETA(t, strips, session, callsign, eta)
+	reason := "deterministic replay closure"
+	require.NoError(t, allocations.CreateManualBlock(ctx, "EKCH", &models.StandBlock{
+		SessionID: session, Stand: "A2", BlockType: "CLOSURE", Source: "CONTROLLER", Reason: &reason, Manual: true,
+	}))
+
+	// Distant arrival / ETA reveal: the closure leaves only A1 available.
+	require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, callsign), arrivalFlight(callsign, 1)))
+	estimated, err := assignments.GetAssignment(ctx, session, callsign)
+	require.NoError(t, err)
+	assert.Equal(t, StageEstimated, estimated.Stage)
+	assert.Equal(t, "A1", estimated.Stand)
+
+	// EuroScope/live enrichment drives all remaining arrival stages.
+	clock.set(eta.Add(-10 * time.Minute))
+	flight := arrivalFlight(callsign, 2)
+	flight.Online = true
+	require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, callsign), flight))
+	assigned, err := assignments.GetAssignment(ctx, session, callsign)
+	require.NoError(t, err)
+	assert.Equal(t, StageAssigned, assigned.Stage)
+
+	clock.set(eta.Add(-2 * time.Minute))
+	require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, callsign), flight))
+	confirmed, err := assignments.GetAssignment(ctx, session, callsign)
+	require.NoError(t, err)
+	assert.Equal(t, StageConfirmed, confirmed.Stage)
+
+	// A controller knowingly reallocates onto the blocked stand. The override
+	// reason and durable version are what a reconnecting frontend receives.
+	request := lifecycle.buildRequest(session, loadStrip(t, strips, session, callsign), flight, StageConfirmed, &eta, nil)
+	request.Stand = "A2"
+	request.ConflictReason = "controller operational decision"
+	result, err := allocations.OverrideManually(ctx, request)
+	require.NoError(t, err)
+	assert.Equal(t, "A2", result.Assignment.Stand)
+	assert.Equal(t, "MANUAL_OVERRIDE", result.Assignment.Source)
+
+	reconnected, err := assignments.GetAssignment(ctx, session, callsign)
+	require.NoError(t, err)
+	assert.Equal(t, result.Assignment.Stand, reconnected.Stand)
+	assert.Equal(t, result.Assignment.Version, reconnected.Version)
+	assert.Equal(t, result.Assignment.ConflictReason, reconnected.ConflictReason)
+}

--- a/backend/internal/services/stand_allocation.go
+++ b/backend/internal/services/stand_allocation.go
@@ -1,12 +1,14 @@
 package services
 
 import (
+	"FlightStrips/internal/metrics"
 	"FlightStrips/internal/models"
 	"FlightStrips/internal/repository"
 	"FlightStrips/internal/sat"
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math/rand"
 	"slices"
 	"strings"
@@ -31,6 +33,7 @@ const (
 
 var (
 	ErrNoAvailableStand             = errors.New("no compatible stand is available")
+	ErrNoCompatibleStand            = errors.New("no stand is compatible with the flight")
 	ErrIncompatibleManualAssignment = errors.New("manual stand is not compatible or available")
 	ErrAllocationRetriesExhausted   = errors.New("stand allocation retries exhausted")
 	ErrUnknownManualOverrideStand   = errors.New("manual override stand is not configured")
@@ -238,6 +241,29 @@ func (s *StandAllocationService) allocate(ctx context.Context, command StandAllo
 	for attempt := 1; attempt <= s.attempts; attempt++ {
 		result, selected, err := s.allocateOnce(ctx, command, request, tried, attempt)
 		if err == nil {
+			tier := 0
+			rule := ""
+			category := "manual"
+			if result.Selection != nil {
+				tier, rule = result.Selection.Tier, result.Selection.RuleID
+				category = "airline_rule"
+				if result.Selection.FallbackUsed {
+					category = "fallback"
+				}
+			}
+			metrics.RecordSATAssignment(ctx, result.Assignment.Stage, result.Assignment.Source, category, tier)
+			metrics.RecordSATOutcome(ctx, "assigned", string(request.Direction))
+			if command == IncompatibleManualOverride {
+				metrics.RecordSATOutcome(ctx, "override", string(request.Direction))
+			}
+			if result.ConflictReason != "" {
+				metrics.RecordSATConflict(ctx, "operational")
+			}
+			slog.InfoContext(ctx, "SAT stand allocation committed",
+				slog.String("callsign", request.Callsign), slog.Int("session", int(request.SessionID)),
+				slog.String("command", string(command)), slog.String("stand", result.Assignment.Stand),
+				slog.String("stage", result.Assignment.Stage), slog.String("source", result.Assignment.Source),
+				slog.String("rule_id", rule), slog.Int("tier", tier), slog.Int("attempt", attempt))
 			if s.publish != nil {
 				if err := s.publish(ctx, *result); err != nil {
 					return result, fmt.Errorf("publish committed stand allocation: %w", err)
@@ -249,9 +275,21 @@ func (s *StandAllocationService) allocate(ctx context.Context, command StandAllo
 			tried[selected] = struct{}{}
 		}
 		if !retryableStandAllocationError(err) {
+			outcome := "error"
+			if errors.Is(err, ErrNoCompatibleStand) {
+				outcome = "no_compatible_stand"
+			}
+			if errors.Is(err, ErrNoAvailableStand) {
+				outcome = "no_available_stand"
+			}
+			metrics.RecordSATOutcome(ctx, outcome, string(request.Direction))
+			slog.WarnContext(ctx, "SAT stand allocation rejected", slog.String("callsign", request.Callsign), slog.String("command", string(command)), slog.String("outcome", outcome), slog.Any("error", err))
 			return nil, err
 		}
+		metrics.RecordSATConflict(ctx, "database_contention")
+		slog.WarnContext(ctx, "SAT allocation contention; retrying", slog.String("callsign", request.Callsign), slog.Int("attempt", attempt), slog.Any("error", err))
 	}
+	metrics.RecordSATOutcome(ctx, "database_contention", string(request.Direction))
 	return nil, fmt.Errorf("%w after %d attempts", ErrAllocationRetriesExhausted, s.attempts)
 }
 
@@ -388,6 +426,9 @@ func (s *StandAllocationService) selectStand(command StandAllocationCommand, req
 	matches := make(map[string]sat.StandCompatibilityMatch, len(evaluation.Matches))
 	for _, match := range evaluation.Matches {
 		matches[standName(match.Stand.Name)] = match
+	}
+	if len(matches) == 0 && command != IncompatibleManualOverride {
+		return "", nil, nil, nil, "", ErrNoCompatibleStand
 	}
 	availability := s.availability(request, assignments, blocks, matches)
 	if command == IncompatibleManualOverride {

--- a/backend/internal/vatsim/cache.go
+++ b/backend/internal/vatsim/cache.go
@@ -1,9 +1,11 @@
 package vatsim
 
 import (
+	"FlightStrips/internal/metrics"
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"slices"
 	"strings"
@@ -268,6 +270,7 @@ func (c *Cache) refresh(ctx context.Context) error {
 	snapshot, dataURL, err := c.fetch(ctx)
 	if err != nil {
 		c.recordRefreshError(err)
+		slog.WarnContext(ctx, "SAT VATSIM feed refresh failed", slog.Any("error", err))
 		return err
 	}
 
@@ -277,6 +280,14 @@ func (c *Cache) refresh(ctx context.Context) error {
 	c.dataURL = dataURL
 	c.lastRefreshError = nil
 	c.mu.Unlock()
+	age := time.Since(snapshot.timestamp)
+	if age < 0 { age = 0 }
+	pilots, prefiles := 0, 0
+	for _, flight := range snapshot.flightsByCallsign {
+		if flight.Prefile() { prefiles++ } else { pilots++ }
+	}
+	metrics.RecordSATFeedSnapshot(ctx, age, pilots, prefiles)
+	slog.InfoContext(ctx, "SAT VATSIM feed refreshed", slog.Time("snapshot_at", snapshot.timestamp), slog.Duration("snapshot_age", age), slog.Int("pilots", pilots), slog.Int("prefiles", prefiles))
 
 	return nil
 }

--- a/backend/internal/vatsim/reconciliation.go
+++ b/backend/internal/vatsim/reconciliation.go
@@ -1,8 +1,10 @@
 package vatsim
 
 import (
+	"FlightStrips/internal/metrics"
 	"FlightStrips/internal/models"
 	"context"
+	"log/slog"
 	"strings"
 	"time"
 )
@@ -179,11 +181,13 @@ func (r *Reconciler) reconcileSession(ctx context.Context, snapshot Snapshot, se
 
 	relevant := make(map[string]Flight)
 	airport := strings.ToUpper(strings.TrimSpace(session.Airport))
+	pilots, prefiles, changedCount := 0, 0, 0
 	for _, flight := range snapshot.Flights() {
 		if flight.Callsign == "" || (strings.ToUpper(strings.TrimSpace(flight.FlightPlan.Origin)) != airport && strings.ToUpper(strings.TrimSpace(flight.FlightPlan.Destination)) != airport) {
 			continue
 		}
 		relevant[flight.Callsign] = flight
+		if flight.Prefile() { prefiles++ } else { pilots++ }
 		strip := existing[flight.Callsign]
 		created := false
 		if strip == nil {
@@ -210,6 +214,7 @@ func (r *Reconciler) reconcileSession(ctx context.Context, snapshot Snapshot, se
 			changed = etaChanged || changed
 		}
 		if changed {
+			changedCount++
 			r.notify(session.ID, strip.Callsign)
 		}
 		if r.lifecycle != nil && strings.EqualFold(strings.TrimSpace(flight.FlightPlan.Origin), airport) {
@@ -223,6 +228,8 @@ func (r *Reconciler) reconcileSession(ctx context.Context, snapshot Snapshot, se
 			}
 		}
 	}
+	metrics.RecordSATRelevantFlights(ctx, session.Name, airport, pilots, prefiles)
+	slog.InfoContext(ctx, "SAT VATSIM reconciliation completed", slog.Int("session", int(session.ID)), slog.String("airport", airport), slog.Duration("snapshot_age", snapshot.Age), slog.Int("pilots", pilots), slog.Int("prefiles", prefiles), slog.Int("changed", changedCount))
 
 	for callsign, strip := range existing {
 		if relevant[callsign].Callsign == "" && r.lifecycle != nil &&

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -37,6 +37,9 @@ services:
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       SERVER_ADDR: "0.0.0.0:80"
       ENVIRONMENT: production
+      # Keep SAT release-safe. Enable only after /healthz reports
+      # stand_assignment.status=ready; rollback by restoring false and restarting.
+      ENABLE_STAND_ASSIGNMENT: ${ENABLE_STAND_ASSIGNMENT:-false}
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
       OTEL_EXPORTER_OTLP_PROTOCOL: ${OTEL_EXPORTER_OTLP_PROTOCOL:-}
       OTEL_EXPORTER_OTLP_HEADERS: ${OTEL_EXPORTER_OTLP_HEADERS:-}

--- a/docs/src/content/docs/dev/stand-assignment-operations.md
+++ b/docs/src/content/docs/dev/stand-assignment-operations.md
@@ -1,0 +1,55 @@
+---
+title: Stand assignment operations
+description: Production readiness, observability, enablement, and rollback for SAT.
+---
+
+The Stand Assignment Tool (SAT) is release-safe and disabled by default. Deploy
+the application and its database migrations with `ENABLE_STAND_ASSIGNMENT=false`.
+In this mode SAT does not load its configuration, start its VATSIM reconciliation
+or lifecycle workers, expose controller actions, or change the controller UI.
+Existing manual stand handling remains available.
+
+## Readiness
+
+`GET /healthz` remains an HTTP 200 liveness endpoint so a SAT input failure does
+not restart or remove otherwise healthy FlightStrips instances. Inspect the JSON
+body before enabling SAT:
+
+```json
+{
+  "status": "ok",
+  "stand_assignment": {
+    "enabled": true,
+    "ready": true,
+    "status": "ready",
+    "snapshot_age_seconds": 4.2
+  }
+}
+```
+
+SAT can report `disabled`, `invalid_config`, `feed_unavailable`, `feed_failed`,
+or `feed_stale`. Do not enable production controller access unless the status is
+`ready`. A stale or failed feed degrades SAT readiness but does not take unrelated
+FlightStrips features down.
+
+Useful OpenTelemetry instruments are:
+
+- `sat.vatsim.snapshot.age` and `sat.vatsim.records` for feed freshness and relevant online/prefile volume;
+- `sat.assignments`, labelled by stage, source, category, and tier;
+- `sat.allocation.outcomes` for assigned, override, no-compatible-stand, and contention results;
+- `sat.allocation.conflicts` and `sat.assignments.expired`.
+
+SAT logs use callsign and session where operational correlation is required.
+They do not log pilot names, and metric dimensions never contain callsigns or CIDs.
+
+## Enablement and rollback
+
+1. Deploy with `ENABLE_STAND_ASSIGNMENT=false`; allow migrations to complete.
+2. Validate the SAT configuration files in the mounted configuration directory.
+3. Set the flag to `true` on one instance and restart it.
+4. Wait for `/healthz` to report `stand_assignment.status=ready`, then roll the same change to the remaining instances.
+5. Watch feed age, allocation outcomes, contention, expiry, and structured SAT errors during the rollout.
+
+To roll back, set `ENABLE_STAND_ASSIGNMENT=false` and restart all backend
+instances. Do not revert the SAT migrations: disabled code ignores the SAT tables,
+and existing manual stand behavior remains available.


### PR DESCRIPTION
## Summary

- expose SAT configuration and VATSIM feed readiness through the existing health endpoint without affecting application liveness
- add structured SAT feed, reconciliation, allocation, lifecycle, conflict, and expiry logs
- add OpenTelemetry metrics for feed freshness, relevant flights, allocation outcomes, assignment dimensions, conflicts, overrides, and expirations
- add a deterministic tower-independent phase-one replay covering arrival stages, blocking, controller reallocation, and reconnect persistence
- document production enablement and rollback, with SAT remaining disabled by default in Docker Compose

## Why

Phase-one stand assignment needs to be diagnosable and replayable before production enablement. Operators must be able to distinguish invalid configuration, stale or failed feed input, incompatible traffic, unavailable stands, and database contention without taking unrelated FlightStrips features down.

## Impact

SAT remains disabled by default. Operators can enable it on a canary, verify `stand_assignment.status=ready` from `/healthz`, and roll back by restoring `ENABLE_STAND_ASSIGNMENT=false` and restarting without reverting migrations.

## Validation

- `go test ./...`
- `go test ./internal/services ./internal/metrics ./internal/app ./internal/vatsim`
- `npm test -- --run src/store/store-stand.test.ts` (17 tests)
- `docker compose -f docker-compose.prod.yml config --quiet`
- `git diff --check`