### PR TITLE
fix(cdm): initialize new sessions as master

### DIFF
--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -7,6 +7,7 @@ import (
 	"FlightStrips/internal/shared"
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -25,13 +26,13 @@ type Server struct {
 	sessionLocks      sessionRecalcLockManager
 
 	// Repositories
-	stripRepo             repository.StripRepository
-	controllerRepo        repository.ControllerRepository
-	sessionRepo           repository.SessionRepository
-	sectorRepo            repository.SectorOwnerRepository
-	coordRepo             repository.CoordinationRepository
-	tacticalStripRepo     repository.TacticalStripRepository
-	standAssignmentRepo   repository.StandAssignmentRepository
+	stripRepo           repository.StripRepository
+	controllerRepo      repository.ControllerRepository
+	sessionRepo         repository.SessionRepository
+	sectorRepo          repository.SectorOwnerRepository
+	coordRepo           repository.CoordinationRepository
+	tacticalStripRepo   repository.TacticalStripRepository
+	standAssignmentRepo repository.StandAssignmentRepository
 }
 
 type TransceiverLookup interface {
@@ -149,7 +150,11 @@ func (s *Server) GetOrCreateSession(airport string, name string) (shared.Session
 
 		}
 
-		return shared.Session{Name: name, Airport: airport, Id: id}, err
+		if err := s.cdmService.SetSessionCdmMaster(context.Background(), id, true); err != nil {
+			return shared.Session{}, fmt.Errorf("initialize CDM master for new session %d: %w", id, err)
+		}
+
+		return shared.Session{Name: name, Airport: airport, Id: id}, nil
 	}
 
 	return shared.Session{}, nil

--- a/backend/internal/server/server_test.go
+++ b/backend/internal/server/server_test.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"FlightStrips/internal/models"
+	"FlightStrips/internal/repository"
+	"FlightStrips/internal/shared"
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+type createSessionRepository struct {
+	repository.SessionRepository
+	created *models.Session
+	id      int32
+}
+
+func (r *createSessionRepository) Get(context.Context, string, string) (*models.Session, error) {
+	return nil, pgx.ErrNoRows
+}
+
+func (r *createSessionRepository) Create(_ context.Context, session *models.Session) (int32, error) {
+	r.created = session
+	return r.id, nil
+}
+
+type recordingCdmMasterService struct {
+	shared.CdmService
+	sessionID int32
+	master    bool
+	called    bool
+}
+
+func (s *recordingCdmMasterService) SetSessionCdmMaster(_ context.Context, sessionID int32, master bool) error {
+	s.sessionID = sessionID
+	s.master = master
+	s.called = true
+	return nil
+}
+
+func TestGetOrCreateSessionInitializesNewSessionAsCdmMaster(t *testing.T) {
+	sessionRepo := &createSessionRepository{id: 42}
+	cdmService := &recordingCdmMasterService{}
+	server := &Server{sessionRepo: sessionRepo, cdmService: cdmService}
+
+	session, err := server.GetOrCreateSession("EKCH", "LIVE")
+	if err != nil {
+		t.Fatalf("GetOrCreateSession returned an error: %v", err)
+	}
+
+	if sessionRepo.created == nil || !sessionRepo.created.CdmMaster {
+		t.Fatalf("expected the new session to be persisted as CDM master, got %#v", sessionRepo.created)
+	}
+	if !cdmService.called || cdmService.sessionID != 42 || !cdmService.master {
+		t.Fatalf("expected CDM master initialization for session 42, got called=%t session=%d master=%t", cdmService.called, cdmService.sessionID, cdmService.master)
+	}
+	if session.Id != 42 || session.Name != "LIVE" || session.Airport != "EKCH" {
+		t.Fatalf("unexpected returned session: %#v", session)
+	}
+}


### PR DESCRIPTION
## Summary

- initialize newly created sessions in the CDM service as master immediately
- trigger the initial CDM recalculation through the existing master transition
- add regression coverage for the new-session initialization path

## Root cause

New sessions were persisted with `cdm_master=true`, but session creation did not update the CDM service's in-memory master cache. The session was therefore treated as non-master until the next synchronization, or indefinitely when external CDM synchronization was unavailable.

## Impact

CDM now starts running immediately for a newly created session instead of waiting for a later synchronization or backend restart.

## Validation

- `go test ./internal/server ./internal/cdm`
- `git diff --check`
- `go test ./...` (all runnable packages passed; the PDC integration suite is unavailable because rootless Docker is unsupported on Windows)
