### PR TITLE
fix(cdm): restrict sequencing to EuroScope flights

### DIFF
--- a/backend/internal/cdm/sequence.go
+++ b/backend/internal/cdm/sequence.go
@@ -414,6 +414,13 @@ func sequenceSortKey(strip *models.Strip) string {
 }
 
 func shouldSkipStrip(strip *models.Strip) bool {
+	// CDM only sequences operational flights currently supplied by EuroScope.
+	// EuroscopeSeenAt is populated when EuroScope reports the aircraft and is
+	// cleared after the aircraft disconnect grace period expires.
+	if strip.EuroscopeSeenAt == nil {
+		return true
+	}
+
 	state := strings.ToUpper(strings.TrimSpace(valueOrEmpty(strip.State)))
 	if state == "ARR" || state == "DEPA" {
 		return true

--- a/backend/internal/cdm/sequence_test.go
+++ b/backend/internal/cdm/sequence_test.go
@@ -135,6 +135,58 @@ func TestSequenceService_RecalculateAirportPersistsAndBroadcasts(t *testing.T) {
 	}
 }
 
+func TestSequenceService_RecalculateAirportSkipsVatsimOnlyFlights(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	tobt := addMinutes(timeToClock(now), 10)
+	vatsimSeenAt := now.Add(-time.Minute)
+	euroscopeSeenAt := now
+	vatsimOnly := &models.Strip{
+		Callsign:     "VATSIM1",
+		Origin:       "EKCH",
+		Runway:       testStringPtr("04L"),
+		VatsimSeenAt: &vatsimSeenAt,
+		CdmData:      &models.CdmData{Tobt: testStringPtr(tobt)},
+	}
+	connected := &models.Strip{
+		Callsign:        "ES1",
+		Origin:          "EKCH",
+		Runway:          testStringPtr("04L"),
+		VatsimSeenAt:    &vatsimSeenAt,
+		EuroscopeSeenAt: &euroscopeSeenAt,
+		CdmData:         &models.CdmData{Tobt: testStringPtr(tobt)},
+	}
+
+	var persistedCallsigns []string
+	stripRepo := &testutil.MockStripRepository{
+		ListByOriginFn: func(context.Context, int32, string) ([]*models.Strip, error) {
+			return []*models.Strip{vatsimOnly, connected}, nil
+		},
+		SetCdmDataFn: func(_ context.Context, _ int32, callsign string, _ *models.CdmData) (int64, error) {
+			persistedCallsigns = append(persistedCallsigns, callsign)
+			return 1, nil
+		},
+	}
+	sessionRepo := &testutil.MockSessionRepository{
+		GetByIDFn: func(_ context.Context, id int32) (*models.Session, error) {
+			return &models.Session{ID: id, Airport: "EKCH", ActiveRunways: pkgModels.ActiveRunways{DepartureRunways: []string{"04L"}}}, nil
+		},
+	}
+	service := NewSequenceService(stripRepo, sessionRepo, NewCdmConfigStore("", "", "", 0, CdmConfigDefaults{}, nil), &testutil.MockFrontendHub{}, &testutil.MockEuroscopeHub{})
+
+	if err := service.RecalculateAirport(context.Background(), 7, "EKCH"); err != nil {
+		t.Fatalf("RecalculateAirport returned error: %v", err)
+	}
+
+	if len(persistedCallsigns) != 1 || persistedCallsigns[0] != "ES1" {
+		t.Fatalf("expected only the EuroScope-connected flight to receive CDM data, got %v", persistedCallsigns)
+	}
+	if got := valueOrEmpty(vatsimOnly.EffectiveTsat()); got != "" {
+		t.Fatalf("expected VATSIM-only flight to have no TSAT, got %q", got)
+	}
+}
+
 func TestSequenceService_RecalculateAirport_SortsEqualBaseTimesByNaturalTtot(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/cdm/webapi_test.go
+++ b/backend/internal/cdm/webapi_test.go
@@ -391,10 +391,12 @@ func TestBuildPersistedSequenceRows_IncludesEobtCappedReasonMarker(t *testing.T)
 	t.Parallel()
 
 	eobt := "1030"
+	euroscopeSeenAt := time.Now().UTC()
 	rows := buildPersistedSequenceRows([]*models.Strip{{
-		Callsign:    "SAS131",
-		Origin:      "EKCH",
-		Destination: "ESSA",
+		Callsign:        "SAS131",
+		Origin:          "EKCH",
+		Destination:     "ESSA",
+		EuroscopeSeenAt: &euroscopeSeenAt,
 		CdmData: (&models.CdmData{
 			Eobt: &eobt,
 			Calculation: &models.CdmCalculation{

--- a/backend/internal/testutil/mock_strip_repository.go
+++ b/backend/internal/testutil/mock_strip_repository.go
@@ -154,7 +154,21 @@ func (m *MockStripRepository) ListByOrigin(ctx context.Context, session int32, o
 	if m.ListByOriginFn == nil {
 		panic("unexpected call to MockStripRepository.ListByOrigin")
 	}
-	return m.ListByOriginFn(ctx, session, origin)
+	strips, err := m.ListByOriginFn(ctx, session, origin)
+	if err != nil {
+		return nil, err
+	}
+	// Older CDM fixtures predate strip provenance. Treat provenance-less mock
+	// strips as EuroScope observations; tests that model VATSIM records set
+	// VatsimSeenAt explicitly and remain unconnected unless they also set
+	// EuroscopeSeenAt.
+	for _, strip := range strips {
+		if strip != nil && strip.VatsimSeenAt == nil && strip.EuroscopeSeenAt == nil {
+			seenAt := time.Now()
+			strip.EuroscopeSeenAt = &seenAt
+		}
+	}
+	return strips, nil
 }
 
 func (m *MockStripRepository) GetBay(ctx context.Context, session int32, callsign string) (string, error) {


### PR DESCRIPTION
## Summary

- require an active EuroScope provenance marker before a flight enters CDM sequencing
- exclude VATSIM-only and disconnected retained strips from TSAT/TTOT assignment and slot consumption
- add regression coverage for VATSIM-only and EuroScope-connected flights

## Root cause

CDM selected every departure strip returned for an airport without checking whether EuroScope currently supplied that flight. Strips created or retained by VATSIM reconciliation could therefore receive a TSAT despite not being connected in EuroScope.

## Impact

CDM now sequences only operational flights observed by EuroScope. VATSIM API data may still retain or enrich strips for its own purposes, but cannot independently create CDM slots.

## Validation

- `go test ./internal/cdm ./internal/services ./internal/euroscope ./internal/frontend`
- `git diff --check`
