### PR TITLE
fix(stand): occupy stands for local aircraft

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -155,6 +155,9 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 		services.WithSessionReader(sessionRepo),
 		services.WithSectorOwnerRepository(sectorRepo),
 	)
+	if departureLifecycle != nil {
+		stripService.SetDeparturePositionObserver(departureLifecycle)
+	}
 	stripValidationService := services.NewStripValidationService(stripRepo, stripRepo)
 	controllerService := services.NewControllerService(controllerRepo)
 	cdmClient := cdm.NewClient(cdm.WithAPIKey(cfg.CDMKey))

--- a/backend/internal/services/departure_lifecycle.go
+++ b/backend/internal/services/departure_lifecycle.go
@@ -167,6 +167,27 @@ func (s *DepartureLifecycleService) ProcessDeparture(ctx context.Context, sessio
 	return s.ensureReservation(ctx, session, strip, flight)
 }
 
+// ObserveDeparturePosition applies the live stand-detection path to an
+// EuroScope aircraft that has no VATSIM feed record.
+func (s *DepartureLifecycleService) ObserveDeparturePosition(ctx context.Context, session int32, strip *models.Strip, latitude, longitude float64) error {
+	if strip == nil || strings.TrimSpace(strip.Callsign) == "" {
+		return nil
+	}
+	activated, err := s.activateObservedBlock(ctx, session, strip, vatsim.DepartureFlightInfo{
+		Callsign: strip.Callsign, Online: true, Origin: strip.Origin,
+		Destination: strip.Destination, AircraftType: valueString(strip.AircraftType),
+		Latitude: latitude, Longitude: longitude,
+	})
+	if err != nil || !activated {
+		return err
+	}
+	return s.revalidateFacts(ctx, session, strip, vatsim.DepartureFlightInfo{
+		Callsign: strip.Callsign, Online: true, Origin: strip.Origin,
+		Destination: strip.Destination, AircraftType: valueString(strip.AircraftType),
+		Latitude: latitude, Longitude: longitude,
+	})
+}
+
 // activateObservedBlock only converts an online aircraft to a departure block
 // after its live position resolves to a stand. A compatible, available spawn
 // stand replaces the reservation atomically. An unavailable or incompatible
@@ -326,8 +347,10 @@ func (s *DepartureLifecycleService) renewInPlace(ctx context.Context, strip *mod
 	updated.ExpiresAt = &expiry
 	updated.AssignedAt = &now
 	updated.Stage = StageReserved
-	revision := flight.Revision
-	updated.VatsimRevision = &revision
+	if parseCID(flight.CID) != nil {
+		revision := flight.Revision
+		updated.VatsimRevision = &revision
+	}
 	affected, err := s.assignments.UpdateAssignment(ctx, &updated)
 	if err != nil {
 		return err
@@ -375,8 +398,10 @@ func (s *DepartureLifecycleService) activateBlock(ctx context.Context, session i
 		updated.ConflictReason = nil
 	}
 	updated.AssignedAt = &now
-	revision := flight.Revision
-	updated.VatsimRevision = &revision
+	if parseCID(flight.CID) != nil {
+		revision := flight.Revision
+		updated.VatsimRevision = &revision
+	}
 	affected, err := s.assignments.UpdateAssignment(ctx, &updated)
 	if err != nil {
 		return err
@@ -397,7 +422,10 @@ func (s *DepartureLifecycleService) activateBlock(ctx context.Context, session i
 	reloaded.Stage = StageDepartureBlock
 	reloaded.ExpiresAt = expiry
 	reloaded.AssignedAt = &now
-	reloaded.VatsimRevision = &revision
+	if parseCID(flight.CID) != nil {
+		revision := flight.Revision
+		reloaded.VatsimRevision = &revision
+	}
 	_, err = s.assignments.UpdateAssignment(ctx, reloaded)
 	return err
 }
@@ -532,8 +560,7 @@ func (s *DepartureLifecycleService) StartSweep(ctx context.Context) {
 
 func (s *DepartureLifecycleService) buildRequest(session int32, strip *models.Strip, flight vatsim.DepartureFlightInfo, stage string, expiresAt *time.Time) StandAllocationRequest {
 	facts, assignmentFacts := s.resolveFacts(strip, flight)
-	revision := flight.Revision
-	return StandAllocationRequest{
+	request := StandAllocationRequest{
 		SessionID:       session,
 		Callsign:        strip.Callsign,
 		Airport:         strings.ToUpper(strings.TrimSpace(strip.Origin)),
@@ -542,9 +569,13 @@ func (s *DepartureLifecycleService) buildRequest(session int32, strip *models.St
 		FlightFacts:     facts,
 		AssignmentFacts: assignmentFacts,
 		ExpiresAt:       expiresAt,
-		VatsimCID:       parseCID(flight.CID),
-		VatsimRevision:  &revision,
 	}
+	if cid := parseCID(flight.CID); cid != nil {
+		revision := flight.Revision
+		request.VatsimCID = cid
+		request.VatsimRevision = &revision
+	}
+	return request
 }
 
 func (s *DepartureLifecycleService) resolveFacts(strip *models.Strip, flight vatsim.DepartureFlightInfo) (sat.FlightCompatibilityFacts, sat.AssignmentFlightFacts) {

--- a/backend/internal/services/departure_lifecycle_test.go
+++ b/backend/internal/services/departure_lifecycle_test.go
@@ -58,6 +58,34 @@ func TestDepartureLifecycle(t *testing.T) {
 		assert.Equal(t, int64(1), *assignment.VatsimRevision)
 	})
 
+	t.Run("local EuroScope departure occupies its observed stand", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, _ := departureLifecycleFixture(t, pool, queries, "", "", nil)
+		testdata.SeedTestStrip(t, queries, session, "SAS102")
+		strip := loadStrip(t, strips, session, "SAS102")
+
+		require.NoError(t, lifecycle.ObserveDeparturePosition(ctx, session, strip, 55.6285306, 12.642625))
+
+		assignment, err := assignments.GetAssignment(ctx, session, "SAS102")
+		require.NoError(t, err)
+		assert.Equal(t, StageDepartureBlock, assignment.Stage)
+		assert.Equal(t, "A1", assignment.Stand)
+		assert.Nil(t, assignment.VatsimCID)
+		assert.Nil(t, assignment.VatsimRevision)
+
+		// Force the existing-assignment update path by adding a block expiry.
+		tsat := "1030"
+		_, err = strips.SetCdmData(ctx, session, "SAS102", &models.CdmData{Tsat: &tsat})
+		require.NoError(t, err)
+		require.NoError(t, lifecycle.ObserveDeparturePosition(ctx, session,
+			loadStrip(t, strips, session, "SAS102"), 55.6285306, 12.642625))
+
+		updated, err := assignments.GetAssignment(ctx, session, "SAS102")
+		require.NoError(t, err)
+		require.NotNil(t, updated.ExpiresAt)
+		assert.Nil(t, updated.VatsimCID)
+		assert.Nil(t, updated.VatsimRevision)
+	})
+
 	t.Run("repeated feed polls do not extend or reshuffle the reservation", func(t *testing.T) {
 		lifecycle, _, session, assignments, strips, clock := departureLifecycleFixture(t, pool, queries, "", "", nil)
 		testdata.SeedTestStrip(t, queries, session, "SAS201")

--- a/backend/internal/services/strip.go
+++ b/backend/internal/services/strip.go
@@ -36,6 +36,11 @@ type StripService struct {
 	routeComputer     StripRouteComputer
 	pdcService        shared.PdcService
 	cdmService        shared.CdmService
+	departureObserver departurePositionObserver
+}
+
+type departurePositionObserver interface {
+	ObserveDeparturePosition(ctx context.Context, session int32, strip *internalModels.Strip, latitude, longitude float64) error
 }
 
 func NewStripService(stripReader StripReader, options ...StripServiceOption) *StripService {
@@ -152,6 +157,10 @@ func (s *StripService) recalculateRouteForStrip(ctx context.Context, session int
 
 func (s *StripService) SetCdmService(cdmService shared.CdmService) {
 	s.cdmService = cdmService
+}
+
+func (s *StripService) SetDeparturePositionObserver(observer departurePositionObserver) {
+	s.departureObserver = observer
 }
 
 func (s *StripService) ClearMandatoryRouteCdm(ctx context.Context, sessionID int32, callsign string) {

--- a/backend/internal/services/strip_arrival.go
+++ b/backend/internal/services/strip_arrival.go
@@ -91,6 +91,16 @@ func (s *StripService) UpdateAircraftPosition(ctx context.Context, session int32
 		return err
 	}
 
+	// VATSIM-backed departures are observed by the feed reconciler. Locally
+	// spawned EuroScope aircraft never enter that path, so feed their live
+	// position into the same stand lifecycle here.
+	if s.departureObserver != nil && existingStrip.VatsimSeenAt == nil &&
+		strings.EqualFold(strings.TrimSpace(existingStrip.Origin), strings.TrimSpace(airport)) {
+		if err := s.departureObserver.ObserveDeparturePosition(ctx, session, existingStrip, lat, lon); err != nil {
+			return err
+		}
+	}
+
 	if existingStrip.Bay != bay {
 		slog.DebugContext(ctx, "UpdateAircraftPosition: bay changed, moving strip",
 			slog.String("callsign", callsign),


### PR DESCRIPTION
## What changed

- route EuroScope position updates for non-VATSIM departures through the SAT departure stand-observation lifecycle
- create departure blocks for locally spawned aircraft at configured stands
- keep local stand assignments free of synthetic VATSIM CID and revision metadata
- add regression coverage for initial occupancy and subsequent assignment updates

## Why

Locally spawned aircraft only followed the EuroScope position-update path. That path updated strip coordinates and bay state but never invoked the departure lifecycle, while the EST occupancy view is derived from SAT stand assignments. As a result, their physical stands appeared unoccupied.

## Impact

Controllers now see stands occupied by locally spawned departure aircraft. VATSIM-backed aircraft continue to be handled exclusively by the VATSIM reconciler.

## Validation

- `go test ./internal/services ./internal/app ./internal/euroscope`
- `go test ./internal/services -run TestDepartureLifecycle -count=1`
- `git diff --check`
