### PR TITLE
fix(stand): keep VATSIM-only departures hidden

### DIFF
--- a/backend/internal/vatsim/reconciliation.go
+++ b/backend/internal/vatsim/reconciliation.go
@@ -12,9 +12,8 @@ import (
 const reconciliationSequenceSpacing int32 = 1000
 
 const (
-	plannedDepartureBay = "NOT_CLEARED"
-	hiddenDepartureBay  = "DEP_HIDDEN"
-	hiddenArrivalBay    = "ARR_HIDDEN"
+	hiddenDepartureBay = "DEP_HIDDEN"
+	hiddenArrivalBay   = "ARR_HIDDEN"
 )
 
 type reconciliationSessionStore interface {
@@ -307,9 +306,6 @@ func (r *Reconciler) newStrip(session *models.Session, flight Flight, seenAt tim
 	bay := hiddenArrivalBay
 	if strings.EqualFold(strings.TrimSpace(flight.FlightPlan.Origin), strings.TrimSpace(session.Airport)) {
 		bay = hiddenDepartureBay
-		if flight.Online() {
-			bay = plannedDepartureBay
-		}
 	}
 	strip := &models.Strip{Callsign: flight.Callsign, Session: session.ID, Bay: bay, Sequence: &sequence, HasFP: true}
 	r.applyFlight(strip, flight, seenAt)
@@ -419,25 +415,19 @@ func nextSequence(strips []*models.Strip, flight Flight, airport string) int32 {
 	bay := hiddenArrivalBay
 	if strings.EqualFold(strings.TrimSpace(flight.FlightPlan.Origin), airport) {
 		bay = hiddenDepartureBay
-		if flight.Online() {
-			bay = plannedDepartureBay
-		}
 	}
 	return nextSequenceForBay(strips, bay)
 }
 
-// apiDepartureBay owns only the visibility transition for departures that have
-// not yet been seen by EuroScope. Prefiles stay out of CLX until the pilot is
-// connected; once EuroScope has supplied the strip, its operational bay wins.
+// apiDepartureBay keeps departures known only through the VATSIM API out of all
+// operational bays. Once EuroScope has supplied the strip, its operational bay
+// wins and the reconciler no longer changes it.
 func apiDepartureBay(strip *models.Strip, flight Flight, airport string) string {
 	if strip == nil || strip.EuroscopeSeenAt != nil ||
 		!strings.EqualFold(strings.TrimSpace(flight.FlightPlan.Origin), airport) {
 		return ""
 	}
-	if flight.Online() && strip.Bay == hiddenDepartureBay {
-		return plannedDepartureBay
-	}
-	if flight.Prefile() && strip.Bay == plannedDepartureBay {
+	if strip.Bay != hiddenDepartureBay {
 		return hiddenDepartureBay
 	}
 	return ""

--- a/backend/internal/vatsim/reconciliation_test.go
+++ b/backend/internal/vatsim/reconciliation_test.go
@@ -169,7 +169,7 @@ func TestReconcileCreatesPrefileDepartureAndHiddenArrivals(t *testing.T) {
 	assert.Len(t, notifier.callsigns, 3)
 }
 
-func TestReconcilePromotesAPIDepartureWhenPilotConnects(t *testing.T) {
+func TestReconcileKeepsOnlineAPIDepartureHidden(t *testing.T) {
 	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
 	sequence := int32(1000)
 	existing := &models.Strip{Callsign: "SAS101", Session: 7, Origin: "EKCH", Destination: "EGLL", Bay: hiddenDepartureBay, Sequence: &sequence}
@@ -178,13 +178,13 @@ func TestReconcilePromotesAPIDepartureWhenPilotConnects(t *testing.T) {
 	reconciler := NewReconciler(cache, reconciliationTestSessions{items: []*models.Session{{ID: 7, Airport: "EKCH"}}}, strips, reconciliationTestAssignments{}, nil, time.Second)
 
 	require.NoError(t, reconciler.Reconcile(context.Background()))
-	assert.Equal(t, plannedDepartureBay, existing.Bay)
+	assert.Equal(t, hiddenDepartureBay, existing.Bay)
 }
 
 func TestReconcileMovesExistingAPIPrefileOutOfCLX(t *testing.T) {
 	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
 	sequence := int32(1000)
-	existing := &models.Strip{Callsign: "SAS101", Session: 7, Origin: "EKCH", Destination: "EGLL", Bay: plannedDepartureBay, Sequence: &sequence}
+	existing := &models.Strip{Callsign: "SAS101", Session: 7, Origin: "EKCH", Destination: "EGLL", Bay: "NOT_CLEARED", Sequence: &sequence}
 	cache := newReconciliationTestCache(now, Flight{CID: "1", Callsign: "SAS101", State: FlightStatePrefile, LastUpdated: now, FlightPlan: FlightPlan{Origin: "EKCH", Destination: "EGLL", Revision: 4}})
 	strips := &reconciliationTestStrips{bySession: map[int32][]*models.Strip{7: {existing}}}
 	reconciler := NewReconciler(cache, reconciliationTestSessions{items: []*models.Session{{ID: 7, Airport: "EKCH"}}}, strips, reconciliationTestAssignments{}, nil, time.Second)
@@ -195,13 +195,13 @@ func TestReconcileMovesExistingAPIPrefileOutOfCLX(t *testing.T) {
 
 func TestReconcileDoesNotMoveEuroscopeOwnedPrefileToHidden(t *testing.T) {
 	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
-	existing := &models.Strip{Callsign: "SAS101", Session: 7, Origin: "EKCH", Destination: "EGLL", Bay: plannedDepartureBay, EuroscopeSeenAt: &now}
+	existing := &models.Strip{Callsign: "SAS101", Session: 7, Origin: "EKCH", Destination: "EGLL", Bay: "NOT_CLEARED", EuroscopeSeenAt: &now}
 	cache := newReconciliationTestCache(now, Flight{CID: "1", Callsign: "SAS101", State: FlightStatePrefile, LastUpdated: now, FlightPlan: FlightPlan{Origin: "EKCH", Destination: "EGLL", Revision: 4}})
 	strips := &reconciliationTestStrips{bySession: map[int32][]*models.Strip{7: {existing}}}
 	reconciler := NewReconciler(cache, reconciliationTestSessions{items: []*models.Session{{ID: 7, Airport: "EKCH"}}}, strips, reconciliationTestAssignments{}, nil, time.Second)
 
 	require.NoError(t, reconciler.Reconcile(context.Background()))
-	assert.Equal(t, plannedDepartureBay, existing.Bay)
+	assert.Equal(t, "NOT_CLEARED", existing.Bay)
 }
 
 func TestReconcileKeepsEuroscopeFieldsAndProtectsControllerEdits(t *testing.T) {
@@ -210,7 +210,7 @@ func TestReconcileKeepsEuroscopeFieldsAndProtectsControllerEdits(t *testing.T) {
 	controllerRoute := "CONTROLLER ROUTE"
 	existing := &models.Strip{
 		Callsign: "SAS404", Session: 7, Origin: "EKCH", Destination: "EDDF", Route: &controllerRoute,
-		Stand: ptr("A12"), Bay: plannedDepartureBay, EuroscopeSeenAt: &euroscopeSeen,
+		Stand: ptr("A12"), Bay: "NOT_CLEARED", EuroscopeSeenAt: &euroscopeSeen,
 		ControllerModifiedFields: []string{"route", "stand"},
 	}
 	cache := newReconciliationTestCache(now, Flight{CID: "4", Callsign: "SAS404", State: FlightStateOnline, LastUpdated: now, FlightPlan: FlightPlan{Origin: "EKCH", Destination: "EDDF", Route: "VATSIM ROUTE", Revision: 7}})
@@ -228,7 +228,7 @@ func TestReconcileUsesNewerVatsimFieldsWhenEuroScopeDataIsOlder(t *testing.T) {
 	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
 	euroscopeSeen := now.Add(-time.Minute)
 	oldRoute := "OLD ROUTE"
-	existing := &models.Strip{Callsign: "SAS707", Session: 7, Origin: "EKCH", Destination: "EDDF", Route: &oldRoute, Bay: plannedDepartureBay, EuroscopeSeenAt: &euroscopeSeen}
+	existing := &models.Strip{Callsign: "SAS707", Session: 7, Origin: "EKCH", Destination: "EDDF", Route: &oldRoute, Bay: "NOT_CLEARED", EuroscopeSeenAt: &euroscopeSeen}
 	cache := newReconciliationTestCache(now, Flight{CID: "7", Callsign: "SAS707", State: FlightStateOnline, LastUpdated: now, FlightPlan: FlightPlan{Origin: "EKCH", Destination: "EDDF", Route: "NEW ROUTE", Revision: 8}})
 	strips := &reconciliationTestStrips{bySession: map[int32][]*models.Strip{7: {existing}}}
 	reconciler := NewReconciler(cache, reconciliationTestSessions{items: []*models.Session{{ID: 7, Airport: "EKCH"}}}, strips, reconciliationTestAssignments{}, nil, time.Second)

--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -128,6 +128,7 @@ export enum Bay {
   Final = "FINAL",
   Stand = "STAND",
   Hidden = "HIDDEN",
+  DepHidden = "DEP_HIDDEN",
   ArrHidden = "ARR_HIDDEN",
   RwyDep = Depart, // alias — kept for backwards compat, same value
   RwyArr = "RWY_ARR",

--- a/frontend/src/routes/ekch/EST.tsx
+++ b/frontend/src/routes/ekch/EST.tsx
@@ -192,7 +192,7 @@ export default function EST() {
     if (satEnabled) {
       for (const assignment of standAssignments) {
         const strip = stripsByCallsign.get(assignment.callsign);
-        if (strip && strip.bay !== Bay.Hidden) mapping.set(assignment.stand, strip);
+        if (strip && strip.bay !== Bay.Hidden && strip.bay !== Bay.DepHidden) mapping.set(assignment.stand, strip);
       }
       return mapping;
     }


### PR DESCRIPTION
## What changed

- keep departures sourced only from the VATSIM API in `DEP_HIDDEN`, whether prefiled or online
- preserve normal operational bay selection once EuroScope supplies the flight
- let EST show a relevant SAT stand allocation without treating the hidden VATSIM strip as an interactive EST strip

## Why

Online VATSIM-only departures were promoted into `NOT_CLEARED`, causing them to appear in CLX before EuroScope had supplied them. VATSIM feed presence alone should not make a departure operationally visible.

## Validation

- `go test ./internal/vatsim`
- `npm test` (63 tests)
- `npm run build`
