### PR TITLE
fix(stand): normalize VATSIM aircraft types

### DIFF
--- a/backend/internal/sat/aircraft_reference.go
+++ b/backend/internal/sat/aircraft_reference.go
@@ -247,5 +247,9 @@ func parseAircraftAliases(value, canonicalType string) ([]string, error) {
 }
 
 func normalizeAircraftToken(value string) string {
+	value = strings.TrimSpace(value)
+	if designator, _, found := strings.Cut(value, "/"); found {
+		value = designator
+	}
 	return strings.ToUpper(strings.TrimSpace(value))
 }

--- a/backend/internal/sat/aircraft_reference_test.go
+++ b/backend/internal/sat/aircraft_reference_test.go
@@ -32,6 +32,10 @@ func TestLoadAircraftReferenceParsesSixAndSevenColumnRecords(t *testing.T) {
 	withoutAliases, ok := registry.Lookup("b738")
 	require.True(t, ok)
 	assert.Empty(t, withoutAliases.Aliases)
+
+	withEquipment, ok := registry.Lookup("A20N/M-SDE3FGHIRWY/LB1")
+	require.True(t, ok)
+	assert.Equal(t, canonical, withEquipment)
 }
 
 func TestLoadAircraftReferenceRejectsInvalidRows(t *testing.T) {

--- a/backend/internal/sat/flight_compatibility_test.go
+++ b/backend/internal/sat/flight_compatibility_test.go
@@ -95,6 +95,25 @@ func TestResolveFlightCompatibilityFactsPrefersLiveEngineAndUsesCorrectBorderEnd
 	assert.Equal(t, "EKCH", departure.BorderEndpoint)
 }
 
+func TestResolveFlightCompatibilityFactsCanonicalizesVatsimAircraftEquipment(t *testing.T) {
+	aircraft := testAircraftRegistry(t)
+	engines, err := LoadAircraftEngineReference(strings.NewReader(testICAOAircraftJSON), aircraft)
+	require.NoError(t, err)
+
+	facts := ResolveFlightCompatibilityFacts(FlightCompatibilityInput{
+		Direction:    Departure,
+		Origin:       "EKCH",
+		Destination:  "EKBI",
+		AircraftType: "A20N/M-SDE3FGHIRWY/LB1",
+	}, aircraft, engines, NewAirportCountryRegistry())
+
+	require.True(t, facts.Complete())
+	assert.True(t, facts.AircraftKnown)
+	assert.Equal(t, "A20N", facts.Aircraft.Type)
+	assert.Equal(t, EngineJet, facts.EngineType)
+	assert.Equal(t, "M", facts.WTC)
+}
+
 func TestResolveFlightCompatibilityFactsReportsUnknownFacts(t *testing.T) {
 	aircraft := testAircraftRegistry(t)
 	engines, err := LoadAircraftEngineReference(strings.NewReader(testICAOAircraftJSON), aircraft)


### PR DESCRIPTION
## What changed

- Canonicalize VATSIM aircraft equipment strings to the ICAO designator before SAT registry lookups.
- Add regression coverage for aircraft and compatibility resolution with suffixed equipment values.

## Why

VATSIM flight plans can provide aircraft values such as `A333/H-SADE1E2E3GHIJ3J5M1P2RW`. SAT previously used the complete value for exact aircraft, engine, and WTC lookups. Those facts became unknown, causing physically compatible stands such as C28 to be rejected.

## Impact

SAT now resolves the aircraft as `A333`, allowing compatibility evaluation to use the correct engine type, WTC, dimensions, and aircraft metadata.

## Validation

- `go test ./internal/sat ./internal/services`
- `go test ./...`
- `git diff --check`