### PR TITLE
fix(stand): synchronize lifecycle removals and adjacency

### DIFF
--- a/backend/internal/frontend/handlers.go
+++ b/backend/internal/frontend/handlers.go
@@ -789,6 +789,7 @@ func handleStandOccupy(ctx context.Context, client *Client, message Message) err
 		Stand:     block.Stand,
 		ID:        block.ID,
 		BlockType: block.BlockType,
+		Blocks:    standBlockNeighbors(client.airport, block.Stand),
 		Reason:    block.Reason,
 		CreatedBy: block.CreatedBy,
 		Version:   block.Version,

--- a/backend/internal/frontend/hub.go
+++ b/backend/internal/frontend/hub.go
@@ -834,6 +834,10 @@ func (hub *Hub) SendStandAssignmentBroadcast(session int32, entry frontend.Stand
 	})
 }
 
+func (hub *Hub) SendStandAssignmentRemoved(session int32, callsign string) {
+	hub.Broadcast(session, frontend.StandAssignmentRemovedEvent{Callsign: callsign})
+}
+
 func (hub *Hub) enrichedStandAssignmentEntry(sessionID int32, assignment *internalModels.StandAssignment) frontend.StandAssignmentEntry {
 	entry := mapStandAssignmentEntry(assignment)
 	session, err := hub.server.GetSessionRepository().GetByID(context.Background(), sessionID)
@@ -860,39 +864,105 @@ func (hub *Hub) enrichedStandAssignmentEntry(sessionID int32, assignment *intern
 }
 
 func (hub *Hub) PublishStandAllocation(ctx context.Context, result services.StandAllocationResult) error {
-	entry := mapStandAssignmentEntry(&result.Assignment)
-	publishEntries := []frontend.StandAssignmentEntry{entry}
-	if session, err := hub.server.GetSessionRepository().GetByID(context.Background(), result.Assignment.SessionID); err == nil {
-		all, _ := hub.server.GetStandAssignmentRepository().ListAssignments(context.Background(), result.Assignment.SessionID)
-		entries := make([]frontend.StandAssignmentEntry, 0, len(all))
-		for _, item := range all {
-			if item != nil {
-				entries = append(entries, mapStandAssignmentEntry(item))
+	sessionID := result.Assignment.SessionID
+	publishEntries := []frontend.StandAssignmentEntry{}
+	if !result.Removed {
+		publishEntries = append(publishEntries, mapStandAssignmentEntry(&result.Assignment))
+	}
+	blockEntries := []frontend.StandBlockEntry{}
+	assignmentStatusReady := false
+	snapshotReady := false
+
+	session, err := hub.server.GetSessionRepository().GetByID(ctx, sessionID)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to enrich committed stand allocation publication", slog.Int("session", int(sessionID)), slog.Any("error", err))
+	} else if repo := hub.server.GetStandAssignmentRepository(); repo != nil {
+		all, assignmentsErr := repo.ListAssignments(ctx, sessionID)
+		if assignmentsErr != nil {
+			slog.ErrorContext(ctx, "Failed to list committed stand assignments for publication", slog.Int("session", int(sessionID)), slog.Any("error", assignmentsErr))
+		} else {
+			publishEntries = make([]frontend.StandAssignmentEntry, 0, len(all))
+			for _, item := range all {
+				if item != nil {
+					publishEntries = append(publishEntries, mapStandAssignmentEntry(item))
+				}
 			}
+			enrichStandAssignmentBlocking(publishEntries, session.Airport)
+			assignmentStatusReady = true
 		}
-		enrichStandAssignmentBlocking(entries, session.Airport)
-		publishEntries = entries
-		for _, candidate := range entries {
-			if candidate.Callsign == result.Assignment.Callsign {
-				entry = candidate
-				break
+
+		blocks, blocksErr := repo.ListBlocks(ctx, sessionID)
+		if blocksErr != nil {
+			slog.ErrorContext(ctx, "Failed to list committed stand blocks for publication", slog.Int("session", int(sessionID)), slog.Any("error", blocksErr))
+		} else {
+			blockEntries = make([]frontend.StandBlockEntry, 0, len(blocks))
+			for _, block := range blocks {
+				if block != nil {
+					blockEntries = append(blockEntries, mapStandBlockEntry(block, session.Airport))
+				}
 			}
+			snapshotReady = assignmentStatusReady
 		}
 	}
+
 	for _, published := range publishEntries {
 		conflictReason := ""
 		if published.ConflictReason != nil {
 			conflictReason = *published.ConflictReason
 		}
-		if hub.validationService != nil {
+		if assignmentStatusReady && hub.validationService != nil {
 			if err := hub.validationService.ReconcileStandAssignmentValidation(ctx, result.Assignment.SessionID, published.Callsign, published.BlockedBy, conflictReason); err != nil {
 				slog.ErrorContext(ctx, "Failed to reconcile stand assignment validation", slog.String("callsign", published.Callsign), slog.Any("error", err))
 			}
 		}
-		hub.SendStandAssignmentBroadcast(result.Assignment.SessionID, published)
+		hub.SendStandAssignmentBroadcast(sessionID, published)
 	}
-	hub.SendStandEvent(result.Assignment.SessionID, result.Assignment.Callsign, result.Assignment.Stand)
-	hub.server.GetEuroscopeHub().Broadcast(result.Assignment.SessionID, euroscopeEvents.StandEvent{Callsign: result.Assignment.Callsign, Stand: result.Assignment.Stand})
+
+	removed := make([]internalModels.StandAssignment, 0, len(result.RemovedAssignments)+1)
+	seenRemoved := map[string]struct{}{}
+	addRemoved := func(assignment internalModels.StandAssignment) {
+		key := strings.ToUpper(strings.TrimSpace(assignment.Callsign))
+		if key == "" {
+			return
+		}
+		if _, exists := seenRemoved[key]; exists {
+			return
+		}
+		seenRemoved[key] = struct{}{}
+		removed = append(removed, assignment)
+	}
+	if result.Removed {
+		addRemoved(result.Assignment)
+	}
+	for _, assignment := range result.RemovedAssignments {
+		addRemoved(assignment)
+	}
+	for _, assignment := range removed {
+		if hub.validationService != nil {
+			if err := hub.validationService.ReconcileStandAssignmentValidation(ctx, sessionID, assignment.Callsign, nil, ""); err != nil {
+				slog.ErrorContext(ctx, "Failed to clear removed stand assignment validation", slog.String("callsign", assignment.Callsign), slog.Any("error", err))
+			}
+		}
+		hub.SendStandAssignmentRemoved(sessionID, assignment.Callsign)
+	}
+
+	if snapshotReady {
+		hub.SendStandStatusSnapshot(sessionID, publishEntries, blockEntries)
+	}
+
+	euroscopeHub := hub.server.GetEuroscopeHub()
+	for _, assignment := range removed {
+		hub.SendStandEvent(sessionID, assignment.Callsign, "")
+		if euroscopeHub != nil {
+			euroscopeHub.Broadcast(sessionID, euroscopeEvents.StandEvent{Callsign: assignment.Callsign, Stand: ""})
+		}
+	}
+	if !result.Removed {
+		hub.SendStandEvent(sessionID, result.Assignment.Callsign, result.Assignment.Stand)
+		if euroscopeHub != nil {
+			euroscopeHub.Broadcast(sessionID, euroscopeEvents.StandEvent{Callsign: result.Assignment.Callsign, Stand: result.Assignment.Stand})
+		}
+	}
 	return nil
 }
 

--- a/backend/internal/frontend/snapshot_builder.go
+++ b/backend/internal/frontend/snapshot_builder.go
@@ -5,6 +5,7 @@ import (
 	"FlightStrips/internal/config"
 	internalModels "FlightStrips/internal/models"
 	"FlightStrips/internal/repository"
+	"FlightStrips/internal/sat"
 	"FlightStrips/internal/shared"
 	frontendEvents "FlightStrips/pkg/events/frontend"
 	pkgModels "FlightStrips/pkg/models"
@@ -161,7 +162,7 @@ func (b *SnapshotBuilder) Build(ctx context.Context, request InitialSnapshotRequ
 
 	if b.standAssignmentEnabled && b.standAssignmentRepo != nil {
 		event.StandAssignmentEnabled = true
-		assignments, blocks, err := b.loadStandStatus(ctx, request.SessionID)
+		assignments, blocks, err := b.loadStandStatus(ctx, request.SessionID, request.Airport)
 		if err != nil {
 			slog.Error("Failed to load stand status for snapshot", slog.Any("error", err), slog.Int("session", int(request.SessionID)))
 		} else {
@@ -300,7 +301,7 @@ func (b *SnapshotBuilder) cachedAtisEvent(sessionID int32) *frontendEvents.AtisU
 	return b.loadCachedAtis(sessionID)
 }
 
-func (b *SnapshotBuilder) loadStandStatus(ctx context.Context, sessionID int32) ([]frontendEvents.StandAssignmentEntry, []frontendEvents.StandBlockEntry, error) {
+func (b *SnapshotBuilder) loadStandStatus(ctx context.Context, sessionID int32, airport string) ([]frontendEvents.StandAssignmentEntry, []frontendEvents.StandBlockEntry, error) {
 	assignments, err := b.standAssignmentRepo.ListAssignments(ctx, sessionID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("list stand assignments: %w", err)
@@ -325,20 +326,57 @@ func (b *SnapshotBuilder) loadStandStatus(ctx context.Context, sessionID int32) 
 		if blk == nil {
 			continue
 		}
-		entry := frontendEvents.StandBlockEntry{
-			ID:        blk.ID,
-			Stand:     blk.Stand,
-			BlockType: blk.BlockType,
-			Reason:    blk.Reason,
-			Callsign:  blk.Callsign,
-			CreatedBy: blk.CreatedBy,
-			ExpiresAt: blk.ExpiresAt,
-			Version:   blk.Version,
-		}
-		blockEntries = append(blockEntries, entry)
+		blockEntries = append(blockEntries, mapStandBlockEntry(blk, airport))
 	}
 
 	return assignmentEntries, blockEntries, nil
+}
+
+func mapStandBlockEntry(blk *internalModels.StandBlock, airport string) frontendEvents.StandBlockEntry {
+	return frontendEvents.StandBlockEntry{
+		ID:        blk.ID,
+		Stand:     blk.Stand,
+		BlockType: blk.BlockType,
+		Blocks:    standBlockNeighbors(airport, blk.Stand),
+		Reason:    blk.Reason,
+		Callsign:  blk.Callsign,
+		CreatedBy: blk.CreatedBy,
+		ExpiresAt: blk.ExpiresAt,
+		Version:   blk.Version,
+	}
+}
+
+func standBlockNeighbors(airport, blockedStand string) []string {
+	return standBlockNeighborsFromRegistry(config.GetStandCapabilities(), airport, blockedStand)
+}
+
+func standBlockNeighborsFromRegistry(registry *sat.StandCapabilityRegistry, airport, blockedStand string) []string {
+	seen := map[string]struct{}{}
+	neighbors := []string{}
+	add := func(stand string) {
+		stand = strings.TrimSpace(stand)
+		if stand == "" || strings.EqualFold(stand, blockedStand) {
+			return
+		}
+		key := strings.ToUpper(stand)
+		if _, exists := seen[key]; exists {
+			return
+		}
+		seen[key] = struct{}{}
+		neighbors = append(neighbors, stand)
+	}
+	for _, stand := range registry.Stands(airport) {
+		if strings.EqualFold(stand.Name, blockedStand) {
+			for _, neighbor := range stand.Blocks {
+				add(neighbor)
+			}
+			continue
+		}
+		if containsStandName(stand.Blocks, blockedStand) {
+			add(stand.Name)
+		}
+	}
+	return neighbors
 }
 
 func mapStandAssignmentEntry(a *internalModels.StandAssignment) frontendEvents.StandAssignmentEntry {

--- a/backend/internal/frontend/snapshot_builder_test.go
+++ b/backend/internal/frontend/snapshot_builder_test.go
@@ -2,13 +2,29 @@ package frontend
 
 import (
 	internalModels "FlightStrips/internal/models"
+	"FlightStrips/internal/sat"
 	"FlightStrips/internal/testutil"
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestStandBlockNeighborsAreBidirectional(t *testing.T) {
+	registry, err := sat.LoadStandCapabilities(strings.NewReader(`
+STAND:EKCH:A1:N055.37.42.710:E012.38.33.450:30
+BLOCKS:A2
+STAND:EKCH:A2:N055.37.42.710:E012.38.33.451:30
+STAND:EKCH:A3:N055.37.42.710:E012.38.33.452:30
+BLOCKS:A1
+`))
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []string{"A2", "A3"}, standBlockNeighborsFromRegistry(registry, "EKCH", "A1"))
+	assert.Equal(t, []string{"A1"}, standBlockNeighborsFromRegistry(registry, "EKCH", "A2"))
+}
 
 func TestSnapshotBuilder_Build_IncludesAssociatedLocalIP(t *testing.T) {
 	ctx := context.WithValue(context.Background(), "request-id", "snapshot-test")

--- a/backend/internal/services/arrival_lifecycle.go
+++ b/backend/internal/services/arrival_lifecycle.go
@@ -234,8 +234,9 @@ func (s *ArrivalLifecycleService) updateStageInPlace(ctx context.Context, existi
 	if affected != 1 {
 		return fmt.Errorf("arrival stage update version conflict for %s", existing.Callsign)
 	}
+	updated.Version++
 	slog.InfoContext(ctx, "SAT assignment stage changed", slog.String("callsign", existing.Callsign), slog.String("stand", existing.Stand), slog.String("from_stage", existing.Stage), slog.String("to_stage", stage))
-	return nil
+	return s.allocations.PublishAssignment(ctx, updated)
 }
 
 func (s *ArrivalLifecycleService) ReleaseExpired(ctx context.Context) error {
@@ -281,23 +282,17 @@ func (s *ArrivalLifecycleService) releaseIfDue(ctx context.Context, session int3
 		return err
 	}
 	if strip == nil {
-		_, err := s.assignments.DeleteAssignment(ctx, session, assignment.ID, assignment.Version)
+		err := s.allocations.ReleaseAssignment(ctx, assignment)
 		recordSATExpiry(ctx, assignment, "strip_removed", err)
 		return err
 	}
 	if assignment.ExpiresAt != nil && !assignment.ExpiresAt.After(now) {
-		if _, err := s.strips.UpdateStand(ctx, session, assignment.Callsign, nil, nil); err != nil {
-			return err
-		}
-		_, err = s.assignments.DeleteAssignment(ctx, session, assignment.ID, assignment.Version)
+		err = s.allocations.ReleaseAssignment(ctx, assignment)
 		recordSATExpiry(ctx, assignment, "expired", err)
 		return err
 	}
 	if assignment.ETA != nil && now.After(assignment.ETA.Add(30*time.Minute)) {
-		if _, err := s.strips.UpdateStand(ctx, session, assignment.Callsign, nil, nil); err != nil {
-			return err
-		}
-		_, err = s.assignments.DeleteAssignment(ctx, session, assignment.ID, assignment.Version)
+		err = s.allocations.ReleaseAssignment(ctx, assignment)
 		recordSATExpiry(ctx, assignment, "arrival_timeout", err)
 		return err
 	}
@@ -305,7 +300,9 @@ func (s *ArrivalLifecycleService) releaseIfDue(ctx context.Context, session int3
 }
 
 func recordSATExpiry(ctx context.Context, assignment *models.StandAssignment, reason string, err error) {
-	if err != nil || assignment == nil { return }
+	if err != nil || assignment == nil {
+		return
+	}
 	metrics.RecordSATExpiration(ctx, assignment.Direction, assignment.Stage)
 	slog.InfoContext(ctx, "SAT assignment expired", slog.String("callsign", assignment.Callsign), slog.String("stand", assignment.Stand), slog.String("stage", assignment.Stage), slog.String("reason", reason))
 }

--- a/backend/internal/services/arrival_lifecycle_test.go
+++ b/backend/internal/services/arrival_lifecycle_test.go
@@ -66,13 +66,19 @@ func TestArrivalLifecycle(t *testing.T) {
 	})
 
 	t.Run("transitions to ASSIGNED at ETA−10 min and below 10000 ft", func(t *testing.T) {
-		lifecycle, _, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
+		lifecycle, allocations, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
+		var published []StandAllocationResult
+		allocations.SetPublisher(func(_ context.Context, result StandAllocationResult) error {
+			published = append(published, result)
+			return nil
+		})
 		arrivalETA := clock.current().Add(45 * time.Minute)
 		clock.set(arrivalETA.Add(-45 * time.Minute))
 		seedTestArrivalStrip(t, queries, session, "SAS301")
 		setArrivalETA(t, strips, session, "SAS301", arrivalETA)
 
 		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS301"), arrivalFlight("SAS301", 1)))
+		published = nil
 
 		_, err := strips.UpdateAircraftPosition(ctx, session, "SAS301", posPtr(0), posPtr(0), altPtr(8000), "FINAL", nil)
 		require.NoError(t, err)
@@ -84,6 +90,9 @@ func TestArrivalLifecycle(t *testing.T) {
 		assignment, err := assignments.GetAssignment(ctx, session, "SAS301")
 		require.NoError(t, err)
 		assert.Equal(t, StageAssigned, assignment.Stage, "promoted to ASSIGNED at ETA−5 min below 8000 ft")
+		require.Len(t, published, 1, "an in-place lifecycle transition is published")
+		assert.Equal(t, StageAssigned, published[0].Assignment.Stage)
+		assert.Equal(t, assignment.Version, published[0].Assignment.Version)
 	})
 
 	t.Run("transitions to CONFIRMED at ETA−2 min and below 3000 ft", func(t *testing.T) {
@@ -384,16 +393,16 @@ func TestArrivalLifecycle(t *testing.T) {
 func seedTestArrivalStrip(t *testing.T, queries *database.Queries, sessionID int32, callsign string) {
 	ctx := context.Background()
 	err := queries.InsertStrip(ctx, database.InsertStripParams{
-		Callsign:     callsign,
-		Session:      sessionID,
-		Origin:       "ESSA",
-		Destination:  "EKCH",
-		AircraftType: strp("A320"),
-		Runway:       strp("22L"),
-		Squawk:       strp("2401"),
+		Callsign:       callsign,
+		Session:        sessionID,
+		Origin:         "ESSA",
+		Destination:    "EKCH",
+		AircraftType:   strp("A320"),
+		Runway:         strp("22L"),
+		Squawk:         strp("2401"),
 		AssignedSquawk: strp("2401"),
-		Bay:          "ARR_HIDDEN",
-		CdmData:      []byte(`{"canonical":{}}`),
+		Bay:            "ARR_HIDDEN",
+		CdmData:        []byte(`{"canonical":{}}`),
 	})
 	require.NoError(t, err)
 }

--- a/backend/internal/services/departure_lifecycle.go
+++ b/backend/internal/services/departure_lifecycle.go
@@ -303,7 +303,8 @@ func (s *DepartureLifecycleService) cancelWrongStandEpisode(ctx context.Context,
 	if affected != 1 {
 		return fmt.Errorf("cancel wrong stand episode version conflict for %s", callsign)
 	}
-	return nil
+	updated.Version++
+	return s.allocations.PublishAssignment(ctx, updated)
 }
 
 // ensureReservation allocates a 15-minute hold for a new offline prefile, and
@@ -356,7 +357,8 @@ func (s *DepartureLifecycleService) renewInPlace(ctx context.Context, strip *mod
 		return err
 	}
 	if affected == 1 {
-		return nil
+		updated.Version++
+		return s.allocations.PublishAssignment(ctx, updated)
 	}
 	request := s.buildRequest(existing.SessionID, strip, flight, StageReserved, &expiry)
 	_, err = s.allocations.Reallocate(ctx, request)
@@ -410,7 +412,8 @@ func (s *DepartureLifecycleService) activateBlock(ctx context.Context, session i
 		if existing.Stage != StageDepartureBlock {
 			slog.InfoContext(ctx, "SAT assignment stage changed", slog.String("callsign", existing.Callsign), slog.String("stand", existing.Stand), slog.String("from_stage", existing.Stage), slog.String("to_stage", StageDepartureBlock))
 		}
-		return nil
+		updated.Version++
+		return s.allocations.PublishAssignment(ctx, updated)
 	}
 	reloaded, reloadErr := s.assignments.GetAssignment(ctx, session, strip.Callsign)
 	if reloadErr != nil || reloaded == nil {
@@ -426,8 +429,15 @@ func (s *DepartureLifecycleService) activateBlock(ctx context.Context, session i
 		revision := flight.Revision
 		reloaded.VatsimRevision = &revision
 	}
-	_, err = s.assignments.UpdateAssignment(ctx, reloaded)
-	return err
+	affected, err = s.assignments.UpdateAssignment(ctx, reloaded)
+	if err != nil {
+		return err
+	}
+	if affected != 1 {
+		return fmt.Errorf("activate departure block version conflict for %s", strip.Callsign)
+	}
+	reloaded.Version++
+	return s.allocations.PublishAssignment(ctx, *reloaded)
 }
 
 // revalidateFacts re-runs compatibility against the strip's current aircraft and
@@ -511,7 +521,7 @@ func (s *DepartureLifecycleService) releaseIfDue(ctx context.Context, session in
 		return err
 	}
 	if strip == nil {
-		_, err := s.assignments.DeleteAssignment(ctx, session, assignment.ID, assignment.Version)
+		err := s.allocations.ReleaseAssignment(ctx, assignment)
 		recordSATExpiry(ctx, assignment, "strip_removed", err)
 		return err
 	}
@@ -521,10 +531,7 @@ func (s *DepartureLifecycleService) releaseIfDue(ctx context.Context, session in
 	if assignment.ConflictReason != nil && strings.HasPrefix(*assignment.ConflictReason, wrongStandPendingPrefix) {
 		return s.forceObservedStand(ctx, strip, assignment)
 	}
-	if _, err := s.strips.UpdateStand(ctx, session, assignment.Callsign, nil, nil); err != nil {
-		return err
-	}
-	_, err = s.assignments.DeleteAssignment(ctx, session, assignment.ID, assignment.Version)
+	err = s.allocations.ReleaseAssignment(ctx, assignment)
 	recordSATExpiry(ctx, assignment, "expired", err)
 	return err
 }

--- a/backend/internal/services/departure_lifecycle_test.go
+++ b/backend/internal/services/departure_lifecycle_test.go
@@ -146,10 +146,16 @@ func TestDepartureLifecycle(t *testing.T) {
 	})
 
 	t.Run("expired offline reservations are released idempotently", func(t *testing.T) {
-		lifecycle, _, session, assignments, strips, clock := departureLifecycleFixture(t, pool, queries, "", "", nil)
+		lifecycle, allocations, session, assignments, strips, clock := departureLifecycleFixture(t, pool, queries, "", "", nil)
+		var published []StandAllocationResult
+		allocations.SetPublisher(func(_ context.Context, result StandAllocationResult) error {
+			published = append(published, result)
+			return nil
+		})
 		testdata.SeedTestStrip(t, queries, session, "SAS501")
 		clock.set(time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC))
 		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS501"), offlineFlight("SAS501", 1)))
+		published = nil
 		strip := loadStrip(t, strips, session, "SAS501")
 		require.NotNil(t, strip.Stand)
 
@@ -160,8 +166,18 @@ func TestDepartureLifecycle(t *testing.T) {
 		require.Error(t, err, "the reservation is removed once it expires")
 		updated := loadStrip(t, strips, session, "SAS501")
 		require.Nil(t, updated.Stand, "the operational stand is cleared")
+		var matching []StandAllocationResult
+		for _, result := range published {
+			if result.Assignment.SessionID == session && result.Assignment.Callsign == "SAS501" {
+				matching = append(matching, result)
+			}
+		}
+		require.Len(t, matching, 1)
+		assert.True(t, matching[0].Removed, "the lifecycle publishes the removal after it commits")
 
+		publishedBeforeSecondSweep := len(published)
 		require.NoError(t, lifecycle.ReleaseExpired(ctx), "a second sweep is a no-op")
+		assert.Len(t, published, publishedBeforeSecondSweep, "an idempotent second sweep does not publish another removal")
 	})
 
 	t.Run("coming online converts the reservation to a departure block", func(t *testing.T) {

--- a/backend/internal/services/stand_allocation.go
+++ b/backend/internal/services/stand_allocation.go
@@ -69,6 +69,8 @@ type StandAllocationRequest struct {
 type StandAllocationResult struct {
 	Command             StandAllocationCommand
 	Assignment          models.StandAssignment
+	Removed             bool
+	RemovedAssignments  []models.StandAssignment
 	Selection           *sat.StandSelection
 	MatchedVariant      *sat.StandCompatibilityMatch
 	Compatibility       sat.StandCompatibilityEvaluation
@@ -109,10 +111,84 @@ func (s *StandAllocationService) SetPublisher(publisher StandAllocationPublisher
 }
 
 func (s *StandAllocationService) PublishAssignment(ctx context.Context, assignment models.StandAssignment) error {
+	s.publishCommitted(ctx, StandAllocationResult{Assignment: assignment})
+	return nil
+}
+
+func (s *StandAllocationService) publishCommitted(ctx context.Context, result StandAllocationResult) {
 	if s.publish == nil {
+		return
+	}
+	if err := s.publish(ctx, result); err != nil {
+		slog.ErrorContext(ctx, "Failed to publish committed stand allocation",
+			slog.Int("session", int(result.Assignment.SessionID)),
+			slog.String("callsign", result.Assignment.Callsign),
+			slog.Any("error", err))
+	}
+}
+
+// ReleaseAssignment clears the operational strip stand and removes the SAT
+// assignment in one transaction. Publishing happens only after commit so
+// connected clients never observe a removal that was rolled back.
+func (s *StandAllocationService) ReleaseAssignment(ctx context.Context, assignment *models.StandAssignment) error {
+	if assignment == nil || assignment.SessionID <= 0 || strings.TrimSpace(assignment.Callsign) == "" {
+		return errors.New("stand assignment release requires an assignment")
+	}
+
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	if _, err := tx.Exec(ctx, "SELECT id FROM sessions WHERE id = $1 FOR UPDATE", assignment.SessionID); err != nil {
+		return err
+	}
+
+	txStrips := s.strips.WithTx(tx)
+	txAssignments := s.assignments.WithTx(tx)
+	strip, err := txStrips.LockByCallsign(ctx, assignment.SessionID, assignment.Callsign)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return err
+	}
+	currentAssignments, err := txAssignments.LockAssignments(ctx, assignment.SessionID, assignment.Callsign)
+	if err != nil {
+		return err
+	}
+	var current *models.StandAssignment
+	for _, candidate := range currentAssignments {
+		if candidate != nil && strings.EqualFold(candidate.Callsign, assignment.Callsign) {
+			current = candidate
+			break
+		}
+	}
+	if current == nil {
 		return nil
 	}
-	return s.publish(ctx, StandAllocationResult{Assignment: assignment})
+	if current.ID != assignment.ID || current.Version != assignment.Version {
+		return errAllocationVersionConflict
+	}
+
+	if strip != nil && strip.Stand != nil && strings.EqualFold(strings.TrimSpace(*strip.Stand), strings.TrimSpace(current.Stand)) {
+		updated, err := txStrips.UpdateStand(ctx, assignment.SessionID, assignment.Callsign, nil, nil)
+		if err != nil {
+			return err
+		}
+		if updated != 1 {
+			return errAllocationVersionConflict
+		}
+	}
+	deleted, err := txAssignments.DeleteAssignment(ctx, assignment.SessionID, current.ID, current.Version)
+	if err != nil {
+		return err
+	}
+	if deleted != 1 {
+		return errAllocationVersionConflict
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+	s.publishCommitted(ctx, StandAllocationResult{Assignment: *current, Removed: true})
+	return nil
 }
 
 // WithStandAllocationAttempts bounds retries for serialization, uniqueness,
@@ -264,11 +340,7 @@ func (s *StandAllocationService) allocate(ctx context.Context, command StandAllo
 				slog.String("command", string(command)), slog.String("stand", result.Assignment.Stand),
 				slog.String("stage", result.Assignment.Stage), slog.String("source", result.Assignment.Source),
 				slog.String("rule_id", rule), slog.Int("tier", tier), slog.Int("attempt", attempt))
-			if s.publish != nil {
-				if err := s.publish(ctx, *result); err != nil {
-					return result, fmt.Errorf("publish committed stand allocation: %w", err)
-				}
-			}
+			s.publishCommitted(ctx, *result)
 			return result, nil
 		}
 		if selected != "" {
@@ -352,8 +424,10 @@ func (s *StandAllocationService) allocateOnce(ctx context.Context, command Stand
 	if err != nil {
 		return nil, selected, err
 	}
+	var removedAssignments []models.StandAssignment
 	if request.DisplaceStage != "" && selected != "" {
-		if err := s.displaceAssignments(ctx, txStrips, txAssignments, request, selected, assignments); err != nil {
+		removedAssignments, err = s.displaceAssignments(ctx, txStrips, txAssignments, request, selected, assignments)
+		if err != nil {
 			return nil, selected, err
 		}
 	}
@@ -377,6 +451,7 @@ func (s *StandAllocationService) allocateOnce(ctx context.Context, command Stand
 	return &StandAllocationResult{
 		Command: command, Assignment: *assignment, Selection: selection, MatchedVariant: match,
 		Compatibility: evaluation, ConflictReason: conflict, Attempts: attempt, AvailableCandidates: available,
+		RemovedAssignments: removedAssignments,
 	}, selected, nil
 }
 
@@ -494,16 +569,34 @@ func (s *StandAllocationService) availability(request StandAllocationRequest, as
 			}
 		}
 		for _, block := range blocks {
-			if block != nil && candidate == standName(block.Stand) {
-				reason := "manually blocked"
-				if block.Reason != nil && strings.TrimSpace(*block.Reason) != "" {
-					reason += ": " + strings.TrimSpace(*block.Reason)
-				}
-				result[candidate] = append(result[candidate], reason)
+			if block == nil {
+				continue
 			}
+			blockedStand := standName(block.Stand)
+			directlyBlocked := candidate == blockedStand
+			adjacencyBlocked := blocksEachOther(s.configuredStandBlocks(request.Airport, candidate), s.configuredStandBlocks(request.Airport, blockedStand), candidate, blockedStand)
+			if !directlyBlocked && !adjacencyBlocked {
+				continue
+			}
+			reason := "manually blocked"
+			if adjacencyBlocked && !directlyBlocked {
+				reason = "blocked by manual block " + blockedStand
+			}
+			if block.Reason != nil && strings.TrimSpace(*block.Reason) != "" {
+				reason += ": " + strings.TrimSpace(*block.Reason)
+			}
+			result[candidate] = append(result[candidate], reason)
 		}
 	}
 	return result
+}
+
+func (s *StandAllocationService) configuredStandBlocks(airport, standName string) []string {
+	stand, found := s.stands.Lookup(airport, standName)
+	if !found {
+		return nil
+	}
+	return stand.Blocks
 }
 
 func (s *StandAllocationService) assignedBlocks(airport string, assignment *models.StandAssignment) []string {
@@ -626,10 +719,11 @@ func joinAllocationReasons(reasons []string) string {
 	return strings.Join(result, "; ")
 }
 
-func (s *StandAllocationService) displaceAssignments(ctx context.Context, strips repository.StripRepository, assignments repository.StandAssignmentRepository, request StandAllocationRequest, selected string, current []*models.StandAssignment) error {
+func (s *StandAllocationService) displaceAssignments(ctx context.Context, strips repository.StripRepository, assignments repository.StandAssignmentRepository, request StandAllocationRequest, selected string, current []*models.StandAssignment) ([]models.StandAssignment, error) {
 	if request.DisplaceStage == "" || selected == "" {
-		return nil
+		return nil, nil
 	}
+	removed := []models.StandAssignment{}
 	for _, assignment := range current {
 		if assignment == nil || strings.EqualFold(assignment.Callsign, request.Callsign) {
 			continue
@@ -641,13 +735,18 @@ func (s *StandAllocationService) displaceAssignments(ctx context.Context, strips
 			continue
 		}
 		if _, err := strips.UpdateStand(ctx, request.SessionID, assignment.Callsign, nil, nil); err != nil {
-			return err
+			return nil, err
 		}
-		if _, err := assignments.DeleteAssignment(ctx, request.SessionID, assignment.ID, assignment.Version); err != nil {
-			return err
+		deleted, err := assignments.DeleteAssignment(ctx, request.SessionID, assignment.ID, assignment.Version)
+		if err != nil {
+			return nil, err
 		}
+		if deleted != 1 {
+			return nil, errAllocationVersionConflict
+		}
+		removed = append(removed, *assignment)
 	}
-	return nil
+	return removed, nil
 }
 
 func standName(value string) string      { return strings.ToUpper(strings.TrimSpace(value)) }

--- a/backend/internal/services/stand_allocation_test.go
+++ b/backend/internal/services/stand_allocation_test.go
@@ -48,6 +48,86 @@ func TestStandAllocationServiceTransactions(t *testing.T) {
 		}
 	})
 
+	t.Run("does not report a committed allocation as failed when publication fails", func(t *testing.T) {
+		service, session, assignments := standAllocationFixture(t, pool, queries, "", "")
+		testdata.SeedTestStrip(t, queries, session, "SAS103")
+		service.SetPublisher(func(context.Context, StandAllocationResult) error {
+			return errors.New("publisher unavailable")
+		})
+
+		result, err := service.Allocate(ctx, standAllocationRequest(session, "SAS103"))
+		require.NoError(t, err)
+		persisted, err := assignments.GetAssignment(ctx, session, "SAS103")
+		require.NoError(t, err)
+		assert.Equal(t, result.Assignment.ID, persisted.ID)
+	})
+
+	t.Run("releases strip and assignment atomically before publishing removal", func(t *testing.T) {
+		service, session, assignments := standAllocationFixture(t, pool, queries, "", "")
+		testdata.SeedTestStrip(t, queries, session, "SAS102")
+		allocated, err := service.Allocate(ctx, standAllocationRequest(session, "SAS102"))
+		require.NoError(t, err)
+
+		stale := allocated.Assignment
+		stale.Version--
+		require.ErrorIs(t, service.ReleaseAssignment(ctx, &stale), errAllocationVersionConflict)
+		retained, err := assignments.GetAssignment(ctx, session, "SAS102")
+		require.NoError(t, err, "a stale release rolls back the assignment deletion")
+		strip, err := queries.GetStrip(ctx, database.GetStripParams{Session: session, Callsign: "SAS102"})
+		require.NoError(t, err)
+		require.NotNil(t, strip.Stand, "a stale release rolls back the strip update")
+		assert.Equal(t, retained.Stand, *strip.Stand)
+
+		published := make(chan StandAllocationResult, 1)
+		service.SetPublisher(func(_ context.Context, result StandAllocationResult) error {
+			published <- result
+			return errors.New("publisher unavailable")
+		})
+		require.NoError(t, service.ReleaseAssignment(ctx, retained))
+		_, err = assignments.GetAssignment(ctx, session, "SAS102")
+		require.Error(t, err)
+		strip, err = queries.GetStrip(ctx, database.GetStripParams{Session: session, Callsign: "SAS102"})
+		require.NoError(t, err)
+		assert.Nil(t, strip.Stand)
+		select {
+		case event := <-published:
+			assert.True(t, event.Removed)
+			assert.Equal(t, retained.ID, event.Assignment.ID)
+		default:
+			t.Fatal("removal was not published after commit")
+		}
+	})
+
+	t.Run("reports displaced assignments after commit", func(t *testing.T) {
+		service, session, assignments := standAllocationFixture(t, pool, queries, "", "")
+		testdata.SeedTestStrip(t, queries, session, "SAS104")
+		testdata.SeedTestStrip(t, queries, session, "SAS105")
+		estimatedRequest := withStand(standAllocationRequest(session, "SAS104"), "A1")
+		estimatedRequest.Stage = StageEstimated
+		_, err := service.AssignManually(ctx, estimatedRequest)
+		require.NoError(t, err)
+
+		var published StandAllocationResult
+		service.SetPublisher(func(_ context.Context, result StandAllocationResult) error {
+			published = result
+			return nil
+		})
+		assignedRequest := standAllocationRequest(session, "SAS105")
+		assignedRequest.Stage = StageAssigned
+		assignedRequest.DisplaceStage = StageEstimated
+		result, err := service.Allocate(ctx, assignedRequest)
+		require.NoError(t, err)
+		require.Len(t, result.RemovedAssignments, 1)
+		assert.Equal(t, "SAS104", result.RemovedAssignments[0].Callsign)
+		require.Len(t, published.RemovedAssignments, 1)
+		assert.Equal(t, "SAS104", published.RemovedAssignments[0].Callsign)
+		_, err = assignments.GetAssignment(ctx, session, "SAS104")
+		require.Error(t, err)
+		displacedStrip, err := queries.GetStrip(ctx, database.GetStripParams{Session: session, Callsign: "SAS104"})
+		require.NoError(t, err)
+		assert.Nil(t, displacedStrip.Stand)
+	})
+
 	t.Run("rejects direct occupancy and one-way or two-way blocks", func(t *testing.T) {
 		for _, directives := range []struct{ a1, a2 string }{
 			{a1: "BLOCKS:A2"},
@@ -73,6 +153,33 @@ func TestStandAllocationServiceTransactions(t *testing.T) {
 		}))
 		_, err := service.AssignManually(ctx, withStand(standAllocationRequest(session, "SAS301"), "A1"))
 		require.ErrorIs(t, err, ErrIncompatibleManualAssignment)
+	})
+
+	t.Run("manual blocks make configured neighbors unavailable bidirectionally", func(t *testing.T) {
+		for _, testCase := range []struct {
+			blocked  string
+			neighbor string
+		}{
+			{blocked: "A1", neighbor: "A2"},
+			{blocked: "A2", neighbor: "A1"},
+		} {
+			t.Run(testCase.blocked, func(t *testing.T) {
+				service, session, assignments := standAllocationFixture(t, pool, queries, "BLOCKS:A2", "")
+				testdata.SeedTestStrip(t, queries, session, "SAS311")
+				reason := "marshaller closed"
+				require.NoError(t, assignments.CreateBlock(ctx, &models.StandBlock{
+					SessionID: session, Stand: testCase.blocked, BlockType: "CLOSURE", Source: "CONTROLLER", Reason: &reason, Manual: true,
+				}))
+
+				available, err := service.StandAvailable(ctx, standAllocationRequest(session, "SAS311"), testCase.neighbor)
+				require.NoError(t, err)
+				assert.False(t, available)
+				_, err = service.AssignManually(ctx, withStand(standAllocationRequest(session, "SAS311"), testCase.neighbor))
+				require.ErrorIs(t, err, ErrIncompatibleManualAssignment)
+				_, err = service.Allocate(ctx, standAllocationRequest(session, "SAS311"))
+				require.ErrorIs(t, err, ErrNoAvailableStand)
+			})
+		}
 	})
 
 	t.Run("manual blocks use allocation occupancy and adjacency locks", func(t *testing.T) {

--- a/backend/pkg/events/frontend/events.go
+++ b/backend/pkg/events/frontend/events.go
@@ -108,9 +108,10 @@ const (
 	ClxUpdateTobt               EventType = "clx_update_tobt"
 
 	// Stand Status events (broadcast to frontend)
-	StandStatusSnapshot   EventType = "stand_status_snapshot"
-	StandAssignmentUpdate EventType = "stand_assignment_update"
-	StandBlockUpdate      EventType = "stand_block_update"
+	StandStatusSnapshot    EventType = "stand_status_snapshot"
+	StandAssignmentUpdate  EventType = "stand_assignment_update"
+	StandAssignmentRemoved EventType = "stand_assignment_removed"
+	StandBlockUpdate       EventType = "stand_block_update"
 
 	// Stand action types (sent from frontend to backend)
 	ActionStandOccupy            EventType = "stand_block_create"
@@ -1064,6 +1065,7 @@ type StandBlockEntry struct {
 	ID        int64      `json:"id"`
 	Stand     string     `json:"stand"`
 	BlockType string     `json:"block_type"`
+	Blocks    []string   `json:"blocks"`
 	Reason    *string    `json:"reason,omitempty"`
 	Callsign  *string    `json:"callsign,omitempty"`
 	CreatedBy *string    `json:"created_by,omitempty"`
@@ -1087,6 +1089,15 @@ type StandAssignmentUpdateEvent struct {
 
 func (e StandAssignmentUpdateEvent) Marshal() ([]byte, error) { return marshall(e) }
 func (e StandAssignmentUpdateEvent) GetType() EventType       { return StandAssignmentUpdate }
+
+// StandAssignmentRemovedEvent removes an assignment without requiring a full
+// status reload. It is emitted for lifecycle releases and displaced arrivals.
+type StandAssignmentRemovedEvent struct {
+	Callsign string `json:"callsign"`
+}
+
+func (e StandAssignmentRemovedEvent) Marshal() ([]byte, error) { return marshall(e) }
+func (e StandAssignmentRemovedEvent) GetType() EventType       { return StandAssignmentRemoved }
 
 // StandBlockUpdateEvent is broadcast when a manual block changes.
 type StandBlockUpdateEvent struct {

--- a/backend/pkg/events/frontend/events_test.go
+++ b/backend/pkg/events/frontend/events_test.go
@@ -96,6 +96,20 @@ func TestStandAssignmentUpdateMarshalIncludesAuthoritativeMetadata(t *testing.T)
 	}
 }
 
+func TestStandAssignmentRemovedMarshalIncludesCallsign(t *testing.T) {
+	payload, err := (StandAssignmentRemovedEvent{Callsign: "SAS123"}).Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded["type"] != string(StandAssignmentRemoved) || decoded["callsign"] != "SAS123" {
+		t.Fatalf("unexpected removal payload: %#v", decoded)
+	}
+}
+
 func TestStandBlockRemovalMarshalIncludesStableID(t *testing.T) {
 	payload, err := (StandBlockUpdateEvent{Stand: "A1", BlockID: 81}).Marshal()
 	if err != nil {

--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -41,6 +41,7 @@ export enum EventType {
   FrontendCoordinationTagRequestBroadcast = "coordination_tag_request_broadcast",
   FrontendStandStatusSnapshot = "stand_status_snapshot",
   FrontendStandAssignmentUpdate = "stand_assignment_update",
+  FrontendStandAssignmentRemoved = "stand_assignment_removed",
   FrontendStandBlockUpdate = "stand_block_update",
 }
 
@@ -662,6 +663,7 @@ export type WebSocketEvent =
   | FrontendBulkBayEvent
   | FrontendStandStatusSnapshotEvent
   | FrontendStandAssignmentUpdateEvent
+  | FrontendStandAssignmentRemovedEvent
   | FrontendStandBlockUpdateEvent;
 
 export interface ActionRejectedEvent {
@@ -738,6 +740,7 @@ export interface FrontendStandBlockEntry {
   id?: number;
   stand: string;
   block_type: string;
+  blocks?: string[];
   reason?: string;
   callsign?: string;
   created_by?: string;
@@ -754,6 +757,11 @@ export interface FrontendStandStatusSnapshotEvent {
 export interface FrontendStandAssignmentUpdateEvent {
   type: EventType.FrontendStandAssignmentUpdate;
   assignment: FrontendStandAssignmentEntry;
+}
+
+export interface FrontendStandAssignmentRemovedEvent {
+  type: EventType.FrontendStandAssignmentRemoved;
+  callsign: string;
 }
 
 export interface FrontendStandBlockUpdateEvent {

--- a/frontend/src/api/websocket.ts
+++ b/frontend/src/api/websocket.ts
@@ -29,6 +29,7 @@ import {
   type FrontendStandEvent,
   type FrontendStandStatusSnapshotEvent,
   type FrontendStandAssignmentUpdateEvent,
+  type FrontendStandAssignmentRemovedEvent,
   type FrontendStandBlockUpdateEvent,
   type FrontendStripUpdateEvent,
   type FrontendTacticalStripCreatedEvent,
@@ -86,6 +87,7 @@ type EventMap = {
   [EventType.FrontendAvailableSids]: AvailableSidsEvent;
   [EventType.FrontendStandStatusSnapshot]: FrontendStandStatusSnapshotEvent;
   [EventType.FrontendStandAssignmentUpdate]: FrontendStandAssignmentUpdateEvent;
+  [EventType.FrontendStandAssignmentRemoved]: FrontendStandAssignmentRemovedEvent;
   [EventType.FrontendStandBlockUpdate]: FrontendStandBlockUpdateEvent;
 };
 

--- a/frontend/src/components/est/standBlocking.test.ts
+++ b/frontend/src/components/est/standBlocking.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveEstStandBlocking } from "./standBlocking";
+
+describe("deriveEstStandBlocking", () => {
+  it("marks manual-block neighbors with an explanation", () => {
+    const state = deriveEstStandBlocking([], [
+      {
+        id: 7,
+        stand: "A1",
+        block_type: "MANUAL",
+        blocks: ["A2"],
+        reason: "Marshaller closed",
+        version: 1,
+      },
+    ]);
+
+    expect(state.blocked).toEqual({ A1: true, A2: true });
+    expect(state.reasons.A1).toBe("Marshaller closed");
+    expect(state.reasons.A2).toBe("Blocked by manual block A1: Marshaller closed");
+  });
+
+  it("combines assignment and manual-block adjacency reasons", () => {
+    const state = deriveEstStandBlocking(
+      [{ callsign: "SAS123", stand: "A3", direction: "ARRIVAL", stage: "ASSIGNED", source: "AUTOMATIC", blocks: ["A2"] }],
+      [{ stand: "A1", block_type: "MANUAL", blocks: ["A2"] }],
+    );
+
+    expect(state.reasons.A2).toBe("Blocked by manual block A1; Blocked by A3 (SAS123)");
+  });
+});

--- a/frontend/src/components/est/standBlocking.ts
+++ b/frontend/src/components/est/standBlocking.ts
@@ -1,0 +1,40 @@
+import type { FrontendStandAssignmentEntry, FrontendStandBlockEntry } from "@/api/models";
+
+export interface EstStandBlockingState {
+  blocked: Record<string, true>;
+  reasons: Record<string, string>;
+}
+
+const addReason = (reasons: Record<string, string>, stand: string, reason: string) => {
+  reasons[stand] = reasons[stand] ? `${reasons[stand]}; ${reason}` : reason;
+};
+
+export function deriveEstStandBlocking(
+  assignments: FrontendStandAssignmentEntry[],
+  blocks: FrontendStandBlockEntry[],
+): EstStandBlockingState {
+  const blocked: Record<string, true> = {};
+  const reasons: Record<string, string> = {};
+
+  for (const block of blocks) {
+    blocked[block.stand] = true;
+    const cause = block.callsign ? ` by ${block.callsign}` : "";
+    const directReason = block.reason ?? `${block.block_type.replace(/_/g, " ")}${cause}`;
+    addReason(reasons, block.stand, directReason);
+
+    for (const neighbor of block.blocks ?? []) {
+      blocked[neighbor] = true;
+      const adjacencyReason = `Blocked by manual block ${block.stand}${block.reason ? `: ${block.reason}` : ""}`;
+      addReason(reasons, neighbor, adjacencyReason);
+    }
+  }
+
+  for (const assignment of assignments) {
+    for (const neighbor of assignment.blocks ?? []) {
+      blocked[neighbor] = true;
+      addReason(reasons, neighbor, `Blocked by ${assignment.stand} (${assignment.callsign})`);
+    }
+  }
+
+  return { blocked, reasons };
+}

--- a/frontend/src/routes/ekch/EST.tsx
+++ b/frontend/src/routes/ekch/EST.tsx
@@ -7,6 +7,7 @@ import EstStandCell from "@/components/est/EstStandCell";
 import EstStandMenu, { type EstMenuAnchor } from "@/components/est/EstStandMenu";
 import EstStandStatusDialog from "@/components/est/EstStandStatusDialog";
 import EstViewButtons from "@/components/est/EstViewButtons";
+import { deriveEstStandBlocking } from "@/components/est/standBlocking";
 import {
   EST_BACKGROUND_BOXES,
   EST_BOARD_HEIGHT,
@@ -213,36 +214,12 @@ export default function EST() {
     [stripByStand],
   );
 
-  const blockedStandsDerived = useMemo(() => {
-    if (satEnabled) {
-      const blocked: Record<string, true> = {};
-      for (const block of standBlocks) {
-        blocked[block.stand] = true;
-      }
-	  for (const assignment of standAssignments) {
-		for (const neighbor of assignment.blocks ?? []) blocked[neighbor] = true;
-	  }
-      return blocked;
-    }
-    return blockedStands;
-  }, [satEnabled, standAssignments, standBlocks, blockedStands]);
-
-  const standBlockReasons = useMemo(() => {
-    if (!satEnabled) return {};
-    const reasons: Record<string, string> = {};
-    for (const block of standBlocks) {
-      const cause = block.callsign ? ` by ${block.callsign}` : "";
-      const reason = block.reason ?? `${block.block_type.replace(/_/g, " ")}${cause}`;
-      reasons[block.stand] = reasons[block.stand] ? `${reasons[block.stand]}; ${reason}` : reason;
-    }
-	for (const assignment of standAssignments) {
-	  for (const neighbor of assignment.blocks ?? []) {
-		const reason = `Blocked by ${assignment.stand} (${assignment.callsign})`;
-		reasons[neighbor] = reasons[neighbor] ? `${reasons[neighbor]}; ${reason}` : reason;
-	  }
-	}
-    return reasons;
-  }, [satEnabled, standAssignments, standBlocks]);
+  const satStandBlocking = useMemo(
+    () => deriveEstStandBlocking(standAssignments, standBlocks),
+    [standAssignments, standBlocks],
+  );
+  const blockedStandsDerived = satEnabled ? satStandBlocking.blocked : blockedStands;
+  const standBlockReasons = satEnabled ? satStandBlocking.reasons : {};
 
   useEffect(() => {
     updateActionOverrides({ type: "prune", occupancy: standOccupancy });

--- a/frontend/src/store/store-stand.test.ts
+++ b/frontend/src/store/store-stand.test.ts
@@ -5,6 +5,7 @@ import {
   EventType,
   type FrontendStandStatusSnapshotEvent,
   type FrontendStandAssignmentUpdateEvent,
+  type FrontendStandAssignmentRemovedEvent,
   type FrontendStandBlockUpdateEvent,
   type FrontendStandAssignmentEntry,
   type FrontendStandBlockEntry,
@@ -159,6 +160,27 @@ describe("stand store events", () => {
 
       expect(store.getState().standAssignments).toHaveLength(1);
       expect(store.getState().standAssignments[0].stage).toBe("CONFIRMED");
+    });
+
+    it("removes a displaced assignment by callsign", () => {
+      const retained: FrontendStandAssignmentEntry = {
+        callsign: "SAS456", stand: "A20", direction: "ARRIVAL", stage: "ASSIGNED", source: "AUTOMATIC",
+      };
+      const displaced: FrontendStandAssignmentEntry = {
+        callsign: "NAX123", stand: "A21", direction: "ARRIVAL", stage: "ESTIMATED", source: "AUTOMATIC",
+      };
+      client._emit(EventType.FrontendStandStatusSnapshot, {
+        type: EventType.FrontendStandStatusSnapshot,
+        assignments: [retained, displaced],
+        blocks: [],
+      } as FrontendStandStatusSnapshotEvent);
+
+      client._emit(EventType.FrontendStandAssignmentRemoved, {
+        type: EventType.FrontendStandAssignmentRemoved,
+        callsign: "nax123",
+      } as FrontendStandAssignmentRemovedEvent);
+
+      expect(store.getState().standAssignments).toEqual([retained]);
     });
   });
 

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -34,6 +34,7 @@ import {
   type FrontendStandAssignmentEntry,
   type FrontendStandBlockEntry,
   type FrontendStandAssignmentUpdateEvent,
+  type FrontendStandAssignmentRemovedEvent,
   type FrontendStandBlockUpdateEvent,
   type FrontendStandStatusSnapshotEvent,
   type FrontendStrip,
@@ -1395,6 +1396,18 @@ export const createWebSocketStore = (wsClient: WebSocketClient) => {
   };
 
   wsClient.on(EventType.FrontendStandAssignmentUpdate, handleStandAssignmentUpdate);
+
+  const handleStandAssignmentRemoved = (data: FrontendStandAssignmentRemovedEvent) => {
+    store.setState(
+      produce((state: WebSocketState) => {
+        state.standAssignments = state.standAssignments.filter(
+          (assignment) => assignment.callsign.toUpperCase() !== data.callsign.toUpperCase(),
+        );
+      }),
+    );
+  };
+
+  wsClient.on(EventType.FrontendStandAssignmentRemoved, handleStandAssignmentRemoved);
 
   const handleStandBlockUpdate = (data: FrontendStandBlockUpdateEvent) => {
     store.setState(


### PR DESCRIPTION
## Summary
- publish SAT lifecycle updates and removals only after committed state changes
- clear displaced assignments consistently in the frontend and EuroScope
- enforce bidirectional manual-block adjacency and expose blocking reasons in EST

## Why
Lifecycle updates and removals could bypass authoritative publication, while assignment cleanup was split across separate database operations. Manual stand blocks also blocked only their own stand, so configured `BLOCKS` neighbors remained selectable and unexplained.

## Impact
Controllers now receive consistent stand state across connected clients and EuroScope. Expired or displaced assignments are removed explicitly, committed actions are not falsely rejected when enrichment publication fails, and manually blocked neighboring stands are unavailable and visibly explained.

## Validation
- `go test ./...`
- `go test -race ./internal/sat ./internal/services ./internal/vatsim ./internal/frontend`
- `npm test -- --run`
- `npm run build`