### PR TITLE
fix(cdm): preserve TSAT after startup

### DIFF
--- a/backend/internal/cdm/action_service.go
+++ b/backend/internal/cdm/action_service.go
@@ -810,7 +810,12 @@ func applyConfirmedTobtUpdate(updated *models.CdmData, tobt string, sourcePositi
 
 func groundStateAllowsAsat(groundState string) bool {
 	switch strings.ToUpper(strings.TrimSpace(groundState)) {
-	case "STUP", "ST-UP", "PUSH", "TAXI", "DEPA":
+	case "STUP",
+		euroscopeEvents.GroundStateStartup,
+		euroscopeEvents.GroundStatePush,
+		euroscopeEvents.GroundStateTaxi,
+		euroscopeEvents.GroundStateLineup,
+		euroscopeEvents.GroundStateDepart:
 		return true
 	default:
 		return false

--- a/backend/internal/cdm/sequence.go
+++ b/backend/internal/cdm/sequence.go
@@ -125,7 +125,7 @@ func (s *SequenceService) recalculateAirport(ctx context.Context, session int32,
 			slot:        slot,
 			hasSlot:     hasSlot,
 			hasCtot:     strings.TrimSpace(valueOrEmpty(strip.EffectiveCtot())) != "",
-			started:     valueOrEmpty(strip.EffectiveAsat()) != "" || valueOrEmpty(strip.EffectiveAobt()) != "",
+			started:     stripHasStarted(strip),
 			staleBase:   shouldInvalidateStaleTobt(calcInput, nowHHMMSS),
 		})
 	}
@@ -171,7 +171,7 @@ func (s *SequenceService) recalculateAirport(ctx context.Context, session int32,
 		strip := candidate.strip
 		if !shouldRecalculateStrip(strip, now) {
 			if slot, ok := existingSlotEntry(strip); ok {
-				if valueOrEmpty(strip.EffectiveAsat()) != "" || valueOrEmpty(strip.EffectiveAobt()) != "" || canRetainExistingSlot(candidate, slot, slots, config, now) {
+				if candidate.started || canRetainExistingSlot(candidate, slot, slots, config, now) {
 					slots = append(slots, slot)
 					continue
 				}
@@ -437,7 +437,7 @@ func shouldRecalculateStrip(strip *models.Strip, now time.Time) bool {
 	if data == nil {
 		return true
 	}
-	if valueOrEmpty(data.EffectiveAsat()) != "" || valueOrEmpty(data.EffectiveAobt()) != "" {
+	if stripHasStarted(strip) {
 		return false
 	}
 	if data.NeedsLocalRecalculation() {
@@ -454,6 +454,16 @@ func shouldRecalculateStrip(strip *models.Strip, now time.Time) bool {
 		return true
 	}
 	return false
+}
+
+func stripHasStarted(strip *models.Strip) bool {
+	if strip == nil {
+		return false
+	}
+	if valueOrEmpty(strip.EffectiveAsat()) != "" || valueOrEmpty(strip.EffectiveAobt()) != "" {
+		return true
+	}
+	return groundStateAllowsAsat(valueOrEmpty(strip.State))
 }
 
 func isTsatSpecificallyExpired(strip *models.Strip, now time.Time) bool {

--- a/backend/internal/cdm/sequence_test.go
+++ b/backend/internal/cdm/sequence_test.go
@@ -939,6 +939,65 @@ func TestSequenceService_RecalculateAirport_SkipsAircraftWithAobtAndPreservesExi
 	}
 }
 
+func TestSequenceService_RecalculateAirport_GroundStateFreezesTsatBeforeCdmTimestampsArrive(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	lockedTobt := addMinutes(timeToClock(now), 10)
+	lockedTtot := addMinutes(lockedTobt, 10)
+	activeTobt := addMinutes(lockedTobt, 2)
+	startupState := euroscopeEvents.GroundStateStartup
+
+	// Ground-state persistence and CDM timestamp persistence are separate writes.
+	// The operational state must freeze the assigned slot during that window.
+	locked := &models.Strip{
+		Callsign: "SASSTATE",
+		Origin:   "EKCH",
+		Runway:   testStringPtr("04L"),
+		State:    &startupState,
+		CdmData: &models.CdmData{
+			Tobt:        testStringPtr(lockedTobt),
+			Tsat:        testStringPtr(lockedTobt),
+			Ttot:        testStringPtr(lockedTtot),
+			Recalculate: true,
+		},
+	}
+	active := &models.Strip{
+		Callsign: "SASACTIVE",
+		Origin:   "EKCH",
+		Runway:   testStringPtr("04L"),
+		CdmData:  &models.CdmData{Tobt: testStringPtr(activeTobt)},
+	}
+
+	persisted := map[string]*models.CdmData{}
+	stripRepo := &testutil.MockStripRepository{
+		ListByOriginFn: func(context.Context, int32, string) ([]*models.Strip, error) {
+			return []*models.Strip{locked, active}, nil
+		},
+		SetCdmDataFn: func(_ context.Context, _ int32, callsign string, data *models.CdmData) (int64, error) {
+			persisted[callsign] = data.Clone()
+			return 1, nil
+		},
+	}
+	sessionRepo := &testutil.MockSessionRepository{
+		GetByIDFn: func(_ context.Context, id int32) (*models.Session, error) {
+			return &models.Session{ID: id, Airport: "EKCH"}, nil
+		},
+	}
+
+	service := NewSequenceService(stripRepo, sessionRepo, NewCdmConfigStore("", "", "", 0, CdmConfigDefaults{}, nil), &testutil.MockFrontendHub{}, &testutil.MockEuroscopeHub{})
+
+	if err := service.RecalculateAirport(context.Background(), 7, "EKCH"); err != nil {
+		t.Fatalf("RecalculateAirport returned error: %v", err)
+	}
+	if _, ok := persisted[locked.Callsign]; ok {
+		t.Fatalf("expected startup-state strip to preserve TSAT %q, got persisted update %#v", lockedTobt, persisted[locked.Callsign])
+	}
+	if persisted[active.Callsign] == nil {
+		t.Fatal("expected mutable strip to be recalculated")
+	}
+}
+
 func TestSequenceService_RecalculateAirport_ExpiredTsatDoesNotInvalidateStartedStrip(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/cdm/webapi.go
+++ b/backend/internal/cdm/webapi.go
@@ -189,7 +189,7 @@ func buildSequenceSnapshotRows(strips []*models.Strip, config *CdmAirportConfig,
 			slot:        slot,
 			hasSlot:     hasSlot,
 			hasCtot:     strings.TrimSpace(valueOrEmpty(strip.EffectiveCtot())) != "",
-			started:     valueOrEmpty(strip.EffectiveAsat()) != "" || valueOrEmpty(strip.EffectiveAobt()) != "",
+			started:     stripHasStarted(strip),
 			staleBase:   shouldInvalidateStaleTobt(calcInput, timeToClock(now)),
 		})
 	}


### PR DESCRIPTION
## Summary

- treat startup and later movement states as a started-flight fallback while ASAT/AOBT persistence catches up
- use the same started-flight predicate in recalculation and sequence snapshot logic
- add regression coverage proving a pending recalculation cannot move a startup-state strip

## Root cause

The strip ground state is persisted before the separate ASAT/AOBT update. A recalculation in that window only checked ASAT/AOBT, so it could move an already assigned TSAT even though the strip had reached startup.

## Impact

Once a strip reaches startup, push, taxi, lineup, or departure state, its existing TSAT/TTOT remains frozen even if the CDM timestamps have not been written yet.

## Validation

- `go test ./internal/cdm`
- `go test ./...`
