### PR TITLE
fix(cdm): restore EOBT clamping during strip sync

### DIFF
--- a/backend/internal/cdm/action_service.go
+++ b/backend/internal/cdm/action_service.go
@@ -18,6 +18,18 @@ type ActionService struct {
 	service *Service
 }
 
+type preparedEobtUpdate struct {
+	updated                  *models.CdmData
+	normalizedEobt           string
+	previousEobt             string
+	previousTobt             string
+	clamped                  bool
+	markerChanged            bool
+	shouldForceRecalculate   bool
+	shouldTriggerRecalculate bool
+	shouldSyncTobt           bool
+}
+
 func (c *ActionService) HandleTobtUpdate(ctx context.Context, session int32, callsign string, tobt string, sourcePosition string, sourceRole string) error {
 	s := c.service
 	callsign = strings.TrimSpace(callsign)
@@ -67,22 +79,40 @@ func (c *ActionService) HandleEobtUpdate(ctx context.Context, session int32, cal
 		return nil
 	}
 
-	before := snapshotCdm(cdmData)
-	updated := cdmData.Clone()
 	now := time.Now().UTC()
-	normalizedEobt, clamped := s.normalizeMasterEobtValue(session, eobt, now)
-	markerChanged := setEobtCapReasonMarker(updated, clamped, true)
-	shouldForceRecalculate := shouldForceRecalculateForStaleSequence(updated, now)
-	previousEobt := helpers.ValueOrDefault(updated.EffectiveEobt())
-	if previousEobt == normalizedEobt && !shouldForceRecalculate && !markerChanged {
-		if clamped && eobt != normalizedEobt {
-			c.pushCorrectedEobtToEuroscope(ctx, session, callsign, normalizedEobt)
+	before := snapshotCdm(cdmData)
+	prepared := c.prepareEobtUpdate(session, cdmData, eobt, now, true)
+	if prepared.previousEobt == prepared.normalizedEobt && !prepared.shouldForceRecalculate && !prepared.markerChanged {
+		if prepared.clamped && eobt != prepared.normalizedEobt {
+			c.pushCorrectedEobtToEuroscope(ctx, session, callsign, prepared.normalizedEobt)
 		}
 		return nil
 	}
 
-	updated.Eobt = &normalizedEobt
+	if err := s.persistCdmUpdate(ctx, session, callsign, before, prepared.updated); err != nil {
+		return err
+	}
+	if prepared.clamped && eobt != prepared.normalizedEobt {
+		c.pushCorrectedEobtToEuroscope(ctx, session, callsign, prepared.normalizedEobt)
+	}
+
+	if prepared.shouldTriggerRecalculate {
+		s.TriggerRecalculate(ctx, session, strip.Origin)
+		if prepared.shouldSyncTobt {
+			c.pushTobtAsync(ctx, session, callsign, prepared.previousTobt, prepared.normalizedEobt)
+		}
+	}
+	return nil
+}
+
+func (c *ActionService) prepareEobtUpdate(session int32, data *models.CdmData, eobt string, now time.Time, replaceCapMarker bool) preparedEobtUpdate {
+	updated := data.Clone()
+	normalizedEobt, clamped := c.normalizeMasterEobtValue(session, eobt, now)
+	markerChanged := setEobtCapReasonMarker(updated, clamped, replaceCapMarker)
+	shouldForceRecalculate := shouldForceRecalculateForStaleSequence(updated, now)
+	previousEobt := helpers.ValueOrDefault(updated.EffectiveEobt())
 	previousTobt := helpers.ValueOrDefault(updated.EffectiveTobt())
+	updated.Eobt = &normalizedEobt
 	shouldAlignTobtWithEobt := shouldSyncEobtToTobt(normalizedEobt, now)
 	shouldSyncTobt := shouldAlignTobtWithEobt && !hasProtectedConfirmedTobt(updated, previousEobt)
 	shouldTriggerRecalculate := clamped || shouldAlignTobtWithEobt || shouldForceRecalculate
@@ -93,20 +123,26 @@ func (c *ActionService) HandleEobtUpdate(ctx context.Context, session int32, cal
 		updated.MarkLocalRecalculationPending()
 	}
 
-	if err := s.persistCdmUpdate(ctx, session, callsign, before, updated); err != nil {
-		return err
+	return preparedEobtUpdate{
+		updated:                  updated,
+		normalizedEobt:           normalizedEobt,
+		previousEobt:             previousEobt,
+		previousTobt:             previousTobt,
+		clamped:                  clamped,
+		markerChanged:            markerChanged,
+		shouldForceRecalculate:   shouldForceRecalculate,
+		shouldTriggerRecalculate: shouldTriggerRecalculate,
+		shouldSyncTobt:           shouldSyncTobt,
 	}
-	if clamped && eobt != normalizedEobt {
-		c.pushCorrectedEobtToEuroscope(ctx, session, callsign, normalizedEobt)
-	}
+}
 
-	if shouldTriggerRecalculate {
-		s.TriggerRecalculate(ctx, session, strip.Origin)
-		if shouldSyncTobt {
-			c.pushTobtAsync(ctx, session, callsign, previousTobt, normalizedEobt)
-		}
-	}
-	return nil
+// PrepareEuroscopeEobtSync applies the same EOBT/TOBT rules used by controller
+// EOBT actions before an incoming EuroScope strip is persisted. This keeps the
+// initial session sync from bypassing master-session clamping and confirmation
+// metadata cleanup.
+func (c *ActionService) PrepareEuroscopeEobtSync(session int32, data *models.CdmData, eobt string, now time.Time) (*models.CdmData, string, bool) {
+	prepared := c.prepareEobtUpdate(session, data, strings.TrimSpace(eobt), now.UTC(), true)
+	return prepared.updated, prepared.normalizedEobt, prepared.clamped
 }
 
 func (c *ActionService) normalizeMasterEobtValue(session int32, eobt string, now time.Time) (string, bool) {

--- a/backend/internal/cdm/service.go
+++ b/backend/internal/cdm/service.go
@@ -96,6 +96,10 @@ func (s *Service) HandleEobtUpdate(ctx context.Context, session int32, callsign 
 	return s.actionService.HandleEobtUpdate(ctx, session, callsign, eobt, sourcePosition, sourceRole)
 }
 
+func (s *Service) PrepareEuroscopeEobtSync(session int32, data *models.CdmData, eobt string, now time.Time) (*models.CdmData, string, bool) {
+	return s.actionService.PrepareEuroscopeEobtSync(session, data, eobt, now)
+}
+
 func (s *Service) normalizeMasterEobtValue(session int32, eobt string, now time.Time) (string, bool) {
 	return s.actionService.normalizeMasterEobtValue(session, eobt, now)
 }

--- a/backend/internal/cdm/service_test.go
+++ b/backend/internal/cdm/service_test.go
@@ -701,6 +701,81 @@ func TestHandleEobtUpdate_MasterSession_ClampsFarFutureValueSyncsBackAndMarksRea
 	assert.Equal(t, expectedClamped, euroscopeHub.Eobts[0].Eobt)
 }
 
+func TestPrepareEuroscopeEobtSync_MasterSessionClampsBeforeInitialSequenceAndLeavesTobtUnconfirmed(t *testing.T) {
+	const sessionID = int32(146)
+	now := time.Date(2026, time.July, 13, 10, 0, 0, 0, time.UTC)
+	rawFutureEobt := truncateCDMClockValue(addMinutes(timeToClock(now), 60))
+	expectedClamped := truncateCDMClockValue(addMinutes(timeToClock(now), masterEobtClampTarget))
+
+	service := NewCdmService(newTestClientWithAirportMasters(nil), &testutil.MockStripRepository{}, &testutil.MockSessionRepository{}, &testutil.MockControllerRepository{})
+	service.sessionMaster.Store(sessionID, true)
+
+	updated, corrected, clamped := service.PrepareEuroscopeEobtSync(sessionID, &models.CdmData{}, rawFutureEobt, now)
+
+	require.True(t, clamped)
+	assert.Equal(t, expectedClamped, corrected)
+	assert.Equal(t, expectedClamped, valueOrEmpty(updated.Eobt))
+	assert.Equal(t, expectedClamped, valueOrEmpty(updated.Tobt))
+	assert.True(t, updated.TobtAutoSynced)
+	assert.False(t, updated.TobtManuallyConfirmed)
+	assert.Empty(t, valueOrEmpty(updated.TobtConfirmedBy))
+	assert.Empty(t, valueOrEmpty(updated.TobtSetBy))
+	assert.True(t, updated.Recalculate)
+	require.NotNil(t, updated.Calculation)
+	require.Len(t, updated.Calculation.ReasonMarkers, 1)
+	assert.Equal(t, eobtCappedReasonKind, updated.Calculation.ReasonMarkers[0].Kind)
+}
+
+func TestPrepareEuroscopeEobtSync_ClearsLegacyAutoConfirmationButPreservesManualConfirmation(t *testing.T) {
+	const sessionID = int32(149)
+	now := time.Date(2026, time.July, 13, 10, 0, 0, 0, time.UTC)
+	previousEobt := truncateCDMClockValue(addMinutes(timeToClock(now), 15))
+	rawFutureEobt := truncateCDMClockValue(addMinutes(timeToClock(now), 60))
+	expectedClamped := truncateCDMClockValue(addMinutes(timeToClock(now), masterEobtClampTarget))
+	atc := models.TobtConfirmedByATC
+	pilot := models.TobtConfirmedByPilot
+	setBy := "EKCH_DEL"
+
+	service := NewCdmService(newTestClientWithAirportMasters(nil), &testutil.MockStripRepository{}, &testutil.MockSessionRepository{}, &testutil.MockControllerRepository{})
+	service.sessionMaster.Store(sessionID, true)
+
+	t.Run("legacy auto-follow metadata is cleared", func(t *testing.T) {
+		updated, corrected, clamped := service.PrepareEuroscopeEobtSync(sessionID, &models.CdmData{
+			Eobt:            &previousEobt,
+			Tobt:            &previousEobt,
+			TobtSetBy:       &setBy,
+			TobtConfirmedBy: &atc,
+		}, rawFutureEobt, now)
+
+		require.True(t, clamped)
+		assert.Equal(t, expectedClamped, corrected)
+		assert.Equal(t, expectedClamped, valueOrEmpty(updated.Tobt))
+		assert.True(t, updated.TobtAutoSynced)
+		assert.False(t, updated.TobtManuallyConfirmed)
+		assert.Empty(t, valueOrEmpty(updated.TobtConfirmedBy))
+		assert.Empty(t, valueOrEmpty(updated.TobtSetBy))
+	})
+
+	t.Run("manual confirmation remains protected", func(t *testing.T) {
+		updated, corrected, clamped := service.PrepareEuroscopeEobtSync(sessionID, &models.CdmData{
+			Eobt:                  &previousEobt,
+			Tobt:                  &previousEobt,
+			TobtSetBy:             &setBy,
+			TobtConfirmedBy:       &pilot,
+			TobtManuallyConfirmed: true,
+		}, rawFutureEobt, now)
+
+		require.True(t, clamped)
+		assert.Equal(t, expectedClamped, corrected)
+		assert.Equal(t, expectedClamped, valueOrEmpty(updated.Eobt))
+		assert.Equal(t, previousEobt, valueOrEmpty(updated.Tobt))
+		assert.False(t, updated.TobtAutoSynced)
+		assert.True(t, updated.TobtManuallyConfirmed)
+		assert.Equal(t, models.TobtConfirmedByPilot, valueOrEmpty(updated.TobtConfirmedBy))
+		assert.Equal(t, setBy, valueOrEmpty(updated.TobtSetBy))
+	})
+}
+
 func TestHandleEobtUpdate_MasterSession_ClampsEmptyValueToNowPlus30(t *testing.T) {
 	const sessionID = int32(149)
 	const callsign = "SAS131"

--- a/backend/internal/services/dependencies.go
+++ b/backend/internal/services/dependencies.go
@@ -4,7 +4,18 @@ import (
 	internalModels "FlightStrips/internal/models"
 	"FlightStrips/internal/shared"
 	"context"
+	"time"
 )
+
+type StripCdmService interface {
+	shared.CdmService
+	PrepareEuroscopeEobtSync(session int32, data *internalModels.CdmData, eobt string, now time.Time) (*internalModels.CdmData, string, bool)
+}
+
+type StripEuroscopeCommander interface {
+	shared.EuroscopeStripCommander
+	SendEobt(session int32, cid string, callsign string, eobt string)
+}
 
 type StripLifecycleStore interface {
 	Create(ctx context.Context, strip *internalModels.Strip) error

--- a/backend/internal/services/strip.go
+++ b/backend/internal/services/strip.go
@@ -28,14 +28,14 @@ type StripService struct {
 	tacticalRepo      repository.TacticalStripRepository
 	sectorOwnerRepo   repository.SectorOwnerRepository
 	publisher         shared.StripEventPublisher
-	esCommander       shared.EuroscopeStripCommander
+	esCommander       StripEuroscopeCommander
 	coordRepo         CoordinationStore
 	controllerRepo    ControllerReader
 	sessionRepo       SessionReader
 	routeRecalculator RouteRecalculator
 	routeComputer     StripRouteComputer
 	pdcService        shared.PdcService
-	cdmService        shared.CdmService
+	cdmService        StripCdmService
 	departureObserver departurePositionObserver
 }
 
@@ -83,7 +83,7 @@ func (s *StripService) SetFrontendHub(publisher shared.StripEventPublisher) {
 	s.publisher = publisher
 }
 
-func (s *StripService) SetEuroscopeHub(esCommander shared.EuroscopeStripCommander) {
+func (s *StripService) SetEuroscopeHub(esCommander StripEuroscopeCommander) {
 	s.esCommander = esCommander
 }
 
@@ -155,7 +155,7 @@ func (s *StripService) recalculateRouteForStrip(ctx context.Context, session int
 	return routeRecalculator.UpdateRouteForStripContext(ctx, callsign, session, false)
 }
 
-func (s *StripService) SetCdmService(cdmService shared.CdmService) {
+func (s *StripService) SetCdmService(cdmService StripCdmService) {
 	s.cdmService = cdmService
 }
 

--- a/backend/internal/services/strip_options.go
+++ b/backend/internal/services/strip_options.go
@@ -13,7 +13,7 @@ func WithStripEventPublisher(publisher shared.StripEventPublisher) StripServiceO
 	}
 }
 
-func WithEuroscopeCommander(esCommander shared.EuroscopeStripCommander) StripServiceOption {
+func WithEuroscopeCommander(esCommander StripEuroscopeCommander) StripServiceOption {
 	return func(s *StripService) {
 		s.esCommander = esCommander
 	}
@@ -70,7 +70,7 @@ func WithPdcService(pdcService shared.PdcService) StripServiceOption {
 	}
 }
 
-func WithCdmService(cdmService shared.CdmService) StripServiceOption {
+func WithCdmService(cdmService StripCdmService) StripServiceOption {
 	return func(s *StripService) {
 		s.cdmService = cdmService
 	}

--- a/backend/internal/services/strip_sync.go
+++ b/backend/internal/services/strip_sync.go
@@ -94,6 +94,8 @@ func (s *StripService) syncEuroscopeStrip(ctx context.Context, session int32, ci
 	needsStripBroadcast := false
 	needsPdcValidation := false
 	restartLifecycle := false
+	correctedEobt := ""
+	eobtClamped := false
 
 	if errors.Is(err, pgx.ErrNoRows) {
 		// Strip doesn't exist, so insert
@@ -109,6 +111,17 @@ func (s *StripService) syncEuroscopeStrip(ctx context.Context, session int32, ci
 		if newClearedAlt == 0 && bay == shared.BAY_NOT_CLEARED {
 			if autoCfl, ok := config.GetInitialCFLForRunway(runwayForStrip); ok {
 				newClearedAlt = int32(autoCfl)
+			}
+		}
+
+		cdmData := internalModels.NewLegacyCdmData(&strip.Eobt, nil, nil, nil, nil, nil, &strip.Eobt, nil)
+		if isLocalCdmDeparture(strip.Origin, airport) {
+			var normalizedEobt string
+			cdmData, normalizedEobt, eobtClamped = s.prepareEuroscopeEobtSync(session, &internalModels.CdmData{}, strip.Eobt, time.Now().UTC())
+			if eobtClamped && normalizedEobt != strings.TrimSpace(strip.Eobt) {
+				correctedEobt = normalizedEobt
+			} else {
+				eobtClamped = false
 			}
 		}
 
@@ -138,7 +151,7 @@ func (s *StripService) syncEuroscopeStrip(ctx context.Context, session int32, ci
 			Stand:              &strip.Stand,
 			Capabilities:       &strip.Capabilities,
 			CommunicationType:  &strip.CommunicationType,
-			CdmData:            internalModels.NewLegacyCdmData(&strip.Eobt, nil, nil, nil, nil, nil, &strip.Eobt, nil),
+			CdmData:            cdmData,
 			Bay:                bay,
 			TrackingController: strip.TrackingController,
 			EngineType:         strip.EngineType,
@@ -338,6 +351,15 @@ func (s *StripService) syncEuroscopeStrip(ctx context.Context, session int32, ci
 
 		if restartLifecycle {
 			cdmData = internalModels.NewLegacyCdmData(&strip.Eobt, nil, nil, nil, nil, nil, &strip.Eobt, nil)
+			if isLocalCdmDeparture(origin, airport) {
+				var normalizedEobt string
+				cdmData, normalizedEobt, eobtClamped = s.prepareEuroscopeEobtSync(session, &internalModels.CdmData{}, strip.Eobt, time.Now().UTC())
+				if eobtClamped && normalizedEobt != strings.TrimSpace(strip.Eobt) {
+					correctedEobt = normalizedEobt
+				} else {
+					eobtClamped = false
+				}
+			}
 			pdcData = (&internalModels.PdcData{}).Normalize()
 			nextOwners = []string{}
 			previousOwners = []string{}
@@ -356,13 +378,16 @@ func (s *StripService) syncEuroscopeStrip(ctx context.Context, session int32, ci
 			fplType = nil
 			language = nil
 		} else if strip.Eobt != "" {
-			cdmData.Eobt = &strip.Eobt
-			if shouldForceSyncStripRecalculation(cdmData, time.Now().UTC()) {
-				cdmData.Recalculate = true
-			}
-			if shouldSyncUpdatedEobtToTobt(strip.Eobt, helpers.ValueOrDefault(cdmData.Tobt)) {
-				cdmData.Tobt = &strip.Eobt
-				cdmData.Recalculate = true
+			if isLocalCdmDeparture(origin, airport) {
+				var normalizedEobt string
+				cdmData, normalizedEobt, eobtClamped = s.prepareEuroscopeEobtSync(session, cdmData, strip.Eobt, time.Now().UTC())
+				if eobtClamped && normalizedEobt != strings.TrimSpace(strip.Eobt) {
+					correctedEobt = normalizedEobt
+				} else {
+					eobtClamped = false
+				}
+			} else {
+				cdmData = prepareEuroscopeEobtWithoutCdm(cdmData, strip.Eobt, time.Now().UTC())
 			}
 		}
 
@@ -485,6 +510,7 @@ func (s *StripService) syncEuroscopeStrip(ctx context.Context, session int32, ci
 		primaryChange := syncStripChanged(existingStrip, updateStrip)
 
 		if !primaryChange {
+			s.sendCorrectedEuroscopeEobt(session, cid, strip.Callsign, correctedEobt, eobtClamped)
 			return nil
 		}
 
@@ -515,6 +541,8 @@ func (s *StripService) syncEuroscopeStrip(ctx context.Context, session int32, ci
 		needsStripBroadcast = true
 		needsPdcValidation = true
 	}
+
+	s.sendCorrectedEuroscopeEobt(session, cid, strip.Callsign, correctedEobt, eobtClamped)
 
 	if syncState != nil {
 		if routeNeedsUpdate {
@@ -564,6 +592,60 @@ func (s *StripService) syncEuroscopeStrip(ctx context.Context, session int32, ci
 	}
 
 	return nil
+}
+
+func (s *StripService) prepareEuroscopeEobtSync(session int32, data *internalModels.CdmData, eobt string, now time.Time) (*internalModels.CdmData, string, bool) {
+	if s.cdmService != nil {
+		return s.cdmService.PrepareEuroscopeEobtSync(session, data, eobt, now)
+	}
+	return prepareEuroscopeEobtWithoutCdm(data, eobt, now), strings.TrimSpace(eobt), false
+}
+
+func prepareEuroscopeEobtWithoutCdm(data *internalModels.CdmData, eobt string, now time.Time) *internalModels.CdmData {
+	updated := data.Clone()
+	normalizedEobt := strings.TrimSpace(eobt)
+	previousEobt := helpers.ValueOrDefault(updated.EffectiveEobt())
+	previousTobt := helpers.ValueOrDefault(updated.Tobt)
+	updated.Eobt = &normalizedEobt
+	if shouldSyncUpdatedEobtToTobt(normalizedEobt, previousTobt) && !hasProtectedSyncedTobt(updated, previousEobt) {
+		updated.Tobt = &normalizedEobt
+		updated.TobtSetBy = nil
+		updated.TobtConfirmedBy = nil
+		updated.TobtAutoSynced = true
+		updated.TobtManuallyConfirmed = false
+		updated.Recalculate = true
+	}
+	if shouldForceSyncStripRecalculation(updated, now) {
+		updated.Recalculate = true
+	}
+	return updated
+}
+
+func hasProtectedSyncedTobt(data *internalModels.CdmData, previousEobt string) bool {
+	if data == nil || data.TobtAutoSynced {
+		return false
+	}
+	currentTobt := strings.TrimSpace(helpers.ValueOrDefault(data.EffectiveTobt()))
+	confirmedBy := strings.TrimSpace(helpers.ValueOrDefault(data.TobtConfirmedBy))
+	if currentTobt == "" || confirmedBy == "" {
+		return false
+	}
+	if data.TobtManuallyConfirmed {
+		return true
+	}
+	return !(confirmedBy == internalModels.TobtConfirmedByATC && currentTobt == strings.TrimSpace(previousEobt))
+}
+
+func (s *StripService) sendCorrectedEuroscopeEobt(session int32, cid string, callsign string, correctedEobt string, clamped bool) {
+	if !clamped || correctedEobt == "" || s.esCommander == nil {
+		return
+	}
+	s.esCommander.SendEobt(session, cid, callsign, correctedEobt)
+}
+
+func isLocalCdmDeparture(origin string, airport string) bool {
+	normalizedAirport := strings.TrimSpace(airport)
+	return normalizedAirport != "" && strings.EqualFold(strings.TrimSpace(origin), normalizedAirport)
 }
 
 func shouldSyncUpdatedEobtToTobt(eobt string, currentTobt string) bool {

--- a/backend/internal/services/strip_sync_test.go
+++ b/backend/internal/services/strip_sync_test.go
@@ -3,11 +3,13 @@ package services
 import (
 	"context"
 	"testing"
+	"time"
 
 	"FlightStrips/internal/models"
 	"FlightStrips/internal/shared"
 	"FlightStrips/internal/testutil"
 	"FlightStrips/pkg/events/euroscope"
+	"FlightStrips/pkg/helpers"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
@@ -52,6 +54,90 @@ func TestSyncEuroscopeStrip_NewLocalDepartureWithoutPositionStartsInNotCleared(t
 	require.NotNil(t, createdStrip)
 	assert.Equal(t, callsign, createdStrip.Callsign)
 	assert.Equal(t, shared.BAY_NOT_CLEARED, createdStrip.Bay)
+}
+
+func TestSyncEuroscopeStrip_PreparesInitialEobtBeforePersistingAndCorrectsEuroscope(t *testing.T) {
+	ctx := context.Background()
+	const (
+		session       = int32(1)
+		callsign      = "SAS130"
+		cid           = "1234567"
+		rawEobt       = "1200"
+		correctedEobt = "1030"
+	)
+
+	var createdStrip *models.Strip
+	stripRepo := &testutil.MockStripRepository{
+		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
+			return nil, pgx.ErrNoRows
+		},
+		CreateFn: func(_ context.Context, strip *models.Strip) error {
+			createdStrip = strip
+			return nil
+		},
+	}
+
+	svc, _, esHub := newSyncTestFixture(t, nil, stripRepo)
+	cdmService := &spyStripCdmService{
+		prepareEobtSyncFn: func(gotSession int32, data *models.CdmData, eobt string, _ time.Time) (*models.CdmData, string, bool) {
+			assert.Equal(t, session, gotSession)
+			assert.Equal(t, rawEobt, eobt)
+			updated := data.Clone()
+			correctedEobtValue := correctedEobt
+			correctedTobtValue := correctedEobt
+			updated.Eobt = &correctedEobtValue
+			updated.Tobt = &correctedTobtValue
+			updated.TobtAutoSynced = true
+			updated.TobtConfirmedBy = nil
+			updated.TobtManuallyConfirmed = false
+			return updated, correctedEobt, true
+		},
+	}
+	svc.SetCdmService(cdmService)
+
+	err := svc.syncEuroscopeStrip(ctx, session, cid, euroscope.Strip{
+		Callsign: callsign,
+		Origin:   "EKCH",
+		Eobt:     rawEobt,
+	}, "EKCH")
+	require.NoError(t, err)
+
+	require.NotNil(t, createdStrip)
+	require.NotNil(t, createdStrip.CdmData)
+	assert.Equal(t, correctedEobt, helpers.ValueOrDefault(createdStrip.CdmData.Eobt))
+	assert.Equal(t, correctedEobt, helpers.ValueOrDefault(createdStrip.CdmData.Tobt))
+	assert.True(t, createdStrip.CdmData.TobtAutoSynced)
+	assert.Empty(t, helpers.ValueOrDefault(createdStrip.CdmData.TobtConfirmedBy))
+	assert.False(t, createdStrip.CdmData.TobtManuallyConfirmed)
+	assert.Equal(t, 1, cdmService.prepareEobtSyncCalls)
+	require.Len(t, esHub.Eobts, 1)
+	assert.Equal(t, session, esHub.Eobts[0].Session)
+	assert.Equal(t, cid, esHub.Eobts[0].Cid)
+	assert.Equal(t, callsign, esHub.Eobts[0].Callsign)
+	assert.Equal(t, correctedEobt, esHub.Eobts[0].Eobt)
+}
+
+func TestPrepareEuroscopeEobtWithoutCdm_PreservesManualConfirmation(t *testing.T) {
+	now := time.Date(2026, time.July, 13, 9, 0, 0, 0, time.UTC)
+	previousEobt := "1000"
+	confirmedTobt := "1015"
+	confirmedBy := models.TobtConfirmedByPilot
+	setBy := "PILOT"
+
+	updated := prepareEuroscopeEobtWithoutCdm(&models.CdmData{
+		Eobt:                  &previousEobt,
+		Tobt:                  &confirmedTobt,
+		TobtSetBy:             &setBy,
+		TobtConfirmedBy:       &confirmedBy,
+		TobtManuallyConfirmed: true,
+	}, "1030", now)
+
+	assert.Equal(t, "1030", helpers.ValueOrDefault(updated.Eobt))
+	assert.Equal(t, confirmedTobt, helpers.ValueOrDefault(updated.Tobt))
+	assert.Equal(t, confirmedBy, helpers.ValueOrDefault(updated.TobtConfirmedBy))
+	assert.Equal(t, setBy, helpers.ValueOrDefault(updated.TobtSetBy))
+	assert.True(t, updated.TobtManuallyConfirmed)
+	assert.False(t, updated.TobtAutoSynced)
 }
 
 func TestSyncEuroscopeStrip_NewStripWithFlightPlanDoesNotCallSeparateHasFPUpdate(t *testing.T) {
@@ -898,16 +984,18 @@ func TestSyncEuroscopeStrip_ArrivalDoesNotTriggerCdmRecalculation(t *testing.T) 
 	ctx := context.Background()
 	const session = int32(1)
 
+	var createdStrip *models.Strip
 	stripRepo := &testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
 			return nil, pgx.ErrNoRows
 		},
 		CreateFn: func(_ context.Context, strip *models.Strip) error {
+			createdStrip = strip
 			return nil
 		},
 	}
 
-	svc, _, _ := newSyncTestFixture(t, nil, stripRepo)
+	svc, _, esHub := newSyncTestFixture(t, nil, stripRepo)
 	cdmService := &spyStripCdmService{}
 	svc.SetCdmService(cdmService)
 
@@ -918,6 +1006,12 @@ func TestSyncEuroscopeStrip_ArrivalDoesNotTriggerCdmRecalculation(t *testing.T) 
 	}, "EKCH")
 	require.NoError(t, err)
 	assert.False(t, cdmService.recalcTriggered)
+	assert.Zero(t, cdmService.prepareEobtSyncCalls)
+	require.NotNil(t, createdStrip)
+	require.NotNil(t, createdStrip.CdmData)
+	assert.Empty(t, helpers.ValueOrDefault(createdStrip.CdmData.Eobt))
+	assert.Empty(t, helpers.ValueOrDefault(createdStrip.CdmData.Tobt))
+	assert.Empty(t, esHub.Eobts)
 }
 
 func TestSyncEuroscopeStrip_NewStrip_TaxiNoGndOnline_InsertsTaxiLwr(t *testing.T) {

--- a/backend/internal/services/strip_test.go
+++ b/backend/internal/services/strip_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"FlightStrips/internal/models"
 	"FlightStrips/internal/shared"
@@ -16,12 +17,14 @@ import (
 )
 
 type spyStripCdmService struct {
-	callsign        string
-	groundState     string
-	recalcAirport   string
-	recalcSession   int32
-	called          bool
-	recalcTriggered bool
+	callsign             string
+	groundState          string
+	recalcAirport        string
+	recalcSession        int32
+	called               bool
+	recalcTriggered      bool
+	prepareEobtSyncCalls int
+	prepareEobtSyncFn    func(session int32, data *models.CdmData, eobt string, now time.Time) (*models.CdmData, string, bool)
 }
 
 func (s *spyStripCdmService) TriggerRecalculate(_ context.Context, session int32, airport string) {
@@ -39,6 +42,15 @@ func (s *spyStripCdmService) HandleReadyRequest(_ context.Context, _ int32, _ st
 }
 func (s *spyStripCdmService) HandleEobtUpdate(_ context.Context, _ int32, _ string, _ string, _ string, _ string) error {
 	panic("unexpected")
+}
+func (s *spyStripCdmService) PrepareEuroscopeEobtSync(session int32, data *models.CdmData, eobt string, now time.Time) (*models.CdmData, string, bool) {
+	s.prepareEobtSyncCalls++
+	if s.prepareEobtSyncFn != nil {
+		return s.prepareEobtSyncFn(session, data, eobt, now)
+	}
+	updated := data.Clone()
+	updated.Eobt = &eobt
+	return updated, eobt, false
 }
 func (s *spyStripCdmService) HandleTobtUpdate(_ context.Context, _ int32, _ string, _ string, _ string, _ string) error {
 	panic("unexpected")


### PR DESCRIPTION
## Summary

- clamp master-session EOBTs during initial and reconnect EuroScope strip synchronization before sequencing
- keep auto-synced TOBTs unconfirmed while preserving manual and pilot confirmations
- restrict local CDM normalization to departures and make strip-sync dependencies explicit

## Root cause

Initial strip synchronization persisted EOBT and TOBT values directly instead of applying the CDM normalization used by controller actions. New sessions become CDM master before their first strip batch, so far-future values could be sequenced and exported without the 45-minute rule, while legacy ATC confirmation metadata remained attached.

## Impact

EOBTs more than 45 minutes ahead are corrected to now plus 30 minutes before sequencing and sent back to the originating EuroScope client. Auto-synced TOBTs remain unconfirmed, genuine manual or pilot confirmations are preserved, and arrival strips are left unchanged.

## Validation

- `go test ./...` from `backend`
- `git diff --cached --check`