### PR TITLE
fix(websocket): normalize EuroScope disconnect logs

### DIFF
--- a/backend/internal/websocket/client.go
+++ b/backend/internal/websocket/client.go
@@ -127,33 +127,34 @@ func ReadPump[TType comparable, TClient Client, THub Hub[TType, TClient]](hub TH
 }
 
 func logReadError(client Client, err error) {
+	attrs := []any{
+		slog.String("source", client.GetSource()),
+		slog.String("cid", client.GetCid()),
+		slog.Int("session", int(client.GetSession())),
+	}
+	if sessionName := client.GetSessionName(); sessionName != "" {
+		attrs = append(attrs, slog.String("session_name", sessionName))
+	}
+	if airport := client.GetAirport(); airport != "" {
+		attrs = append(attrs, slog.String("airport", airport))
+	}
+	if callsign := client.GetCallsign(); callsign != "" {
+		attrs = append(attrs, slog.String("callsign", callsign))
+	}
+	if position := client.GetPosition(); position != "" {
+		attrs = append(attrs, slog.String("position", position))
+	}
+
 	var closeErr *websocket.CloseError
 	if errors.As(err, &closeErr) {
-		attrs := []any{
-			slog.String("source", client.GetSource()),
-			slog.String("cid", client.GetCid()),
-			slog.Int("session", int(client.GetSession())),
-			slog.Int("close_code", closeErr.Code),
-		}
-		if sessionName := client.GetSessionName(); sessionName != "" {
-			attrs = append(attrs, slog.String("session_name", sessionName))
-		}
-		if airport := client.GetAirport(); airport != "" {
-			attrs = append(attrs, slog.String("airport", airport))
-		}
-		if callsign := client.GetCallsign(); callsign != "" {
-			attrs = append(attrs, slog.String("callsign", callsign))
-		}
-		if position := client.GetPosition(); position != "" {
-			attrs = append(attrs, slog.String("position", position))
-		}
+		attrs = append(attrs, slog.Int("close_code", closeErr.Code))
 		if closeErr.Text != "" {
 			attrs = append(attrs, slog.String("reason", closeErr.Text))
 		}
 
 		if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway, websocket.CloseAbnormalClosure, websocket.CloseNoStatusReceived) {
 			attrs = append(attrs, slog.Any("error", err))
-			slog.Warn("Unexpected websocket close", attrs...)
+			slog.Warn("Websocket connection closed", attrs...)
 			return
 		}
 
@@ -161,14 +162,8 @@ func logReadError(client Client, err error) {
 		return
 	}
 
-	if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway, websocket.CloseAbnormalClosure, websocket.CloseNoStatusReceived) {
-		slog.Warn("Unexpected websocket close",
-			slog.String("source", client.GetSource()),
-			slog.String("cid", client.GetCid()),
-			slog.Int("session", int(client.GetSession())),
-			slog.Any("error", err),
-		)
-	}
+	attrs = append(attrs, slog.Any("error", err))
+	slog.Warn("Websocket connection closed", attrs...)
 }
 
 func shouldTrackMessageDBOperations(source string, msgType string) bool {

--- a/backend/internal/websocket/client_test.go
+++ b/backend/internal/websocket/client_test.go
@@ -4,6 +4,7 @@ import (
 	"FlightStrips/internal/shared"
 	"FlightStrips/pkg/events"
 	"bytes"
+	"errors"
 	"log/slog"
 	"strings"
 	"testing"
@@ -59,7 +60,7 @@ func TestLogReadError_LogsCloseReason(t *testing.T) {
 
 	logReadError(testClient{}, &gorilla.CloseError{
 		Code: gorilla.CloseNormalClosure,
-		Text: "plugin shutdown",
+		Text: "CloudFlare WebSocket proxy restarting",
 	})
 
 	output := strings.TrimSpace(buffer.String())
@@ -67,7 +68,26 @@ func TestLogReadError_LogsCloseReason(t *testing.T) {
 	assert.Contains(t, output, `"level":"INFO"`)
 	assert.Contains(t, output, `"source":"euroscope"`)
 	assert.Contains(t, output, `"close_code":1000`)
-	assert.Contains(t, output, `"reason":"plugin shutdown"`)
+	assert.Contains(t, output, `"reason":"CloudFlare WebSocket proxy restarting"`)
+	assert.Contains(t, output, `"callsign":"EKCH_APP"`)
+}
+
+func TestLogReadError_LogsNonCloseErrorWithClientDetails(t *testing.T) {
+	var buffer bytes.Buffer
+	previousLogger := slog.Default()
+	logger := slog.New(slog.NewJSONHandler(&buffer, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	slog.SetDefault(logger)
+	t.Cleanup(func() {
+		slog.SetDefault(previousLogger)
+	})
+
+	logReadError(testClient{}, errors.New("unexpected EOF"))
+
+	output := strings.TrimSpace(buffer.String())
+	assert.Contains(t, output, `"msg":"Websocket connection closed"`)
+	assert.Contains(t, output, `"level":"WARN"`)
+	assert.Contains(t, output, `"source":"euroscope"`)
+	assert.Contains(t, output, `"error":"unexpected EOF"`)
 	assert.Contains(t, output, `"callsign":"EKCH_APP"`)
 }
 


### PR DESCRIPTION
## What changed

Normalize server-side EuroScope WebSocket disconnect records in `logReadError`.

- Preserve close-frame reasons such as `CloudFlare WebSocket proxy restarting` in the structured `reason` field.
- Emit the same `Websocket connection closed` message for unexpected EOF/network errors.
- Include available client metadata, including callsign, on unexpected disconnects.
- Add regression coverage for the Cloudflare reason and unexpected EOF paths.

## Why

The backend already received Cloudflare-provided close text for some FS connections, but unexpected disconnects used a different log message and omitted callsign/client context. This makes Grafana correlation inconsistent.

## Validation

- `go test ./internal/websocket ./internal/euroscope`
- `go test ./...`
