### PR TITLE
fix(strip): sync reassigned runways from EuroScope

### DIFF
--- a/euroscope-plugin/src/plugin/flightplan/FlightPlan.h
+++ b/euroscope-plugin/src/plugin/flightplan/FlightPlan.h
@@ -78,6 +78,8 @@ namespace FlightStrips::flightplan {
         std::string squawk{};
         std::string stand{};
         std::string tracking_controller{};
+        std::string runway{};
+        bool runway_initialized{false};
         CdmState cdm{};
         std::string pdc_state{};
         std::string pdc_request_remarks{};
@@ -92,6 +94,15 @@ namespace FlightStrips::flightplan {
 
         [[nodiscard]] bool KeepsEuroScopeStripUncleared() const {
             return IsPdcCleared();
+        }
+
+        [[nodiscard]] bool HasRunwayChanged(const std::string& current_runway) const {
+            return runway_initialized && runway != current_runway;
+        }
+
+        void MarkRunwaySynced(const std::string& synced_runway) {
+            runway = synced_runway;
+            runway_initialized = true;
         }
     };
 }

--- a/euroscope-plugin/src/plugin/flightplan/FlightPlanService.cpp
+++ b/euroscope-plugin/src/plugin/flightplan/FlightPlanService.cpp
@@ -210,6 +210,7 @@ namespace FlightStrips::flightplan {
             {flightPlanData.GetEngineType()}
         };
         m_websocketService->SendEvent(event);
+        plan.MarkRunwaySynced(runway);
     }
 
     void FlightPlanService::ControllerFlightPlanDataEvent(EuroScopePlugIn::CFlightPlan flightPlan, int dataType) {
@@ -384,19 +385,32 @@ namespace FlightStrips::flightplan {
             m_lastPositionFlushCounter = counter;
         }
 
-        // Poll for tracking controller changes every tick.
-        // OnFlightPlanControllerAssignedDataUpdate does not fire when a tracking controller is
-        // assumed or dropped, so we must detect the transition here instead.
+        // Poll values whose EuroScope changes do not reliably emit plugin callbacks.
         if (!m_websocketService->ShouldSend()) return;
         for (auto it = m_flightStripsPlugin->FlightPlanSelectFirst(); it.IsValid();
              it = m_flightStripsPlugin->FlightPlanSelectNext(it)) {
             if (it.GetSimulated()) continue;
             const auto callsign = std::string(it.GetCallsign());
-            const auto trackingController = std::string(it.GetTrackingControllerCallsign());
             auto &plan = m_flightPlans.try_emplace(callsign).first->second;
-            if (plan.tracking_controller == trackingController) continue;
-            plan.tracking_controller = trackingController;
-            m_websocketService->SendEvent(TrackingControllerChangedEvent(callsign, trackingController));
+
+            const auto trackingController = std::string(it.GetTrackingControllerCallsign());
+            if (plan.tracking_controller != trackingController) {
+                plan.tracking_controller = trackingController;
+                m_websocketService->SendEvent(TrackingControllerChangedEvent(callsign, trackingController));
+            }
+
+            if (!m_flightStripsPlugin->IsRelevant(it)) continue;
+            const auto flightPlanData = it.GetFlightPlanData();
+            const auto isArrival = strcmp(flightPlanData.GetDestination(),
+                                          m_flightStripsPlugin->GetConnectionState().relevant_airport.c_str()) == 0;
+            const auto runway = std::string(isArrival
+                                                ? flightPlanData.GetArrivalRwy()
+                                                : flightPlanData.GetDepartureRwy());
+            if (!plan.runway_initialized) {
+                plan.MarkRunwaySynced(runway);
+            } else if (plan.HasRunwayChanged(runway)) {
+                FlightPlanEvent(it);
+            }
         }
     }
 

--- a/euroscope-plugin/test/plugin/flightplan/FlightPlanServiceTest.cpp
+++ b/euroscope-plugin/test/plugin/flightplan/FlightPlanServiceTest.cpp
@@ -102,6 +102,28 @@ TEST(FlightPlanStructTest, FieldAssignment_RoundTrips) {
     EXPECT_EQ(fp.tracking_controller, "EK_APP");
 }
 
+TEST(FlightPlanStructTest, MarkRunwaySynced_InitializesRunwayState) {
+    FlightPlan fp;
+
+    EXPECT_FALSE(fp.HasRunwayChanged("04L"));
+    fp.MarkRunwaySynced("04L");
+    EXPECT_TRUE(fp.runway_initialized);
+    EXPECT_EQ(fp.runway, "04L");
+}
+
+TEST(FlightPlanStructTest, HasRunwayChanged_DoesNotConsumeAssignedRunwayChange) {
+    FlightPlan fp;
+    fp.MarkRunwaySynced("04L");
+
+    EXPECT_TRUE(fp.HasRunwayChanged("04R"));
+    EXPECT_TRUE(fp.HasRunwayChanged("04R"));
+    EXPECT_EQ(fp.runway, "04L");
+
+    fp.MarkRunwaySynced("04R");
+    EXPECT_EQ(fp.runway, "04R");
+    EXPECT_FALSE(fp.HasRunwayChanged("04R"));
+}
+
 TEST(FlightPlanServiceStateTest, ApplyCdmUpdate_PopulatesBackendFields) {
     FlightPlanService service(
         std::shared_ptr<FlightStrips::websocket::WebSocketService>{},


### PR DESCRIPTION
## Summary

- track the last runway successfully synchronized from EuroScope
- poll assigned runway changes alongside tracking-controller changes
- resend the full strip when an arrival or departure runway is reassigned
- retain pending changes when a strip update cannot yet be dispatched

## Root cause

EuroScope can update its calculated or assigned runway without reliably emitting the flight-plan-data callback used by FlightStrips. The initial runway therefore remained stored even after EuroScope displayed a reassigned runway. Manually amending the flight plan emitted the callback and made the runway update appear.

## Impact

Inbound strips now follow runway reassignments such as `04L` to `04R` without requiring a manual flight-plan amendment. This reuses the existing strip update path and does not add a protocol event.

## Validation

- built `FlightStripsPluginCore.dll` and `FlightStripsCoreTests.exe` with Ninja/MSVC
- `ctest --test-dir build --output-on-failure --build-config Release -j8`
- 353 tests passed
