### PR TITLE
fix(pdc): clear pending state on EuroScope clearance

### DIFF
--- a/backend/internal/services/strip_fields.go
+++ b/backend/internal/services/strip_fields.go
@@ -234,6 +234,20 @@ func (s *StripService) UpdateClearedFlag(ctx context.Context, session int32, cal
 		return err
 	}
 
+	// A cleared flag received from EuroScope is authoritative voice/manual
+	// clearance. Clear any pending or failed PDC state before moving the strip so
+	// the cleared bay cannot retain a misleading PDC background or keep waiting
+	// for a pilot acknowledgement. Preserve only an already-confirmed PDC exchange.
+	if shouldConfirmVoiceClearanceForEuroscopeClear(existingStrip, cleared) {
+		pdcService := s.getPdcService()
+		if pdcService == nil {
+			return errors.New("PDC service not available")
+		}
+		if err := pdcService.ConfirmVoiceClearance(ctx, callsign, session); err != nil {
+			return err
+		}
+	}
+
 	if existingStrip.Cleared == cleared {
 		return nil
 	}
@@ -265,6 +279,19 @@ func (s *StripService) UpdateClearedFlag(ctx context.Context, session int32, cal
 	}
 
 	return nil
+}
+
+func shouldConfirmVoiceClearanceForEuroscopeClear(strip *internalModels.Strip, cleared bool) bool {
+	if !cleared || strip == nil {
+		return false
+	}
+
+	switch strip.PdcState {
+	case "", internalModels.PdcStateNone, "CONFIRMED":
+		return false
+	default:
+		return true
+	}
 }
 
 // UpdateStand updates the stand for a strip, notifies the frontend, and triggers route recalculation.

--- a/backend/internal/services/strip_fields_pdc_test.go
+++ b/backend/internal/services/strip_fields_pdc_test.go
@@ -1,0 +1,113 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	internalModels "FlightStrips/internal/models"
+	"FlightStrips/internal/shared"
+	"FlightStrips/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateClearedFlag_EuroscopeClearConfirmsStalePdcAsVoiceClearance(t *testing.T) {
+	const (
+		session  = int32(1)
+		callsign = "EZY13EJ"
+	)
+
+	strip := &internalModels.Strip{
+		Callsign: callsign,
+		Bay:      shared.BAY_NOT_CLEARED,
+		Cleared:  false,
+		PdcState: "NO_RESPONSE",
+	}
+	var updatedCleared bool
+	var updatedBay string
+
+	repo := &testutil.MockStripRepository{
+		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*internalModels.Strip, error) {
+			return strip, nil
+		},
+		UpdateClearedFlagFn: func(_ context.Context, _ int32, _ string, cleared bool, bay string, _ *int32) (int64, error) {
+			updatedCleared = cleared
+			updatedBay = bay
+			return 1, nil
+		},
+		GetMaxSequenceInBayFn: func(_ context.Context, _ int32, _ string) (int32, error) {
+			return 0, nil
+		},
+		UpdateBayAndSequenceFn: func(_ context.Context, _ int32, _ string, bay string, _ int32) (int64, error) {
+			updatedBay = bay
+			return 1, nil
+		},
+	}
+	pdcSpy := &frontendMovePdcSpy{}
+	svc := NewStripService(repo, WithPdcService(pdcSpy))
+	svc.SetFrontendHub(&testutil.MockFrontendHub{})
+
+	err := svc.UpdateClearedFlag(context.Background(), session, callsign, true)
+
+	require.NoError(t, err)
+	require.Len(t, pdcSpy.confirmCalls, 1)
+	assert.Equal(t, callsign, pdcSpy.confirmCalls[0].callsign)
+	assert.Equal(t, session, pdcSpy.confirmCalls[0].session)
+	assert.True(t, updatedCleared)
+	assert.Equal(t, shared.BAY_CLEARED, updatedBay)
+}
+
+func TestUpdateClearedFlag_EuroscopeClearConfirmsPendingPdcAsVoiceClearance(t *testing.T) {
+	strip := &internalModels.Strip{
+		Callsign: "SAS123",
+		Bay:      shared.BAY_NOT_CLEARED,
+		Cleared:  false,
+		PdcState: "CLEARED",
+	}
+	repo := &testutil.MockStripRepository{
+		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*internalModels.Strip, error) {
+			return strip, nil
+		},
+		UpdateClearedFlagFn: func(_ context.Context, _ int32, _ string, _ bool, _ string, _ *int32) (int64, error) {
+			return 1, nil
+		},
+		GetMaxSequenceInBayFn: func(_ context.Context, _ int32, _ string) (int32, error) {
+			return 0, nil
+		},
+		UpdateBayAndSequenceFn: func(_ context.Context, _ int32, _ string, _ string, _ int32) (int64, error) {
+			return 1, nil
+		},
+	}
+	pdcSpy := &frontendMovePdcSpy{}
+	svc := NewStripService(repo, WithPdcService(pdcSpy))
+	svc.SetFrontendHub(&testutil.MockFrontendHub{})
+
+	err := svc.UpdateClearedFlag(context.Background(), 1, strip.Callsign, true)
+
+	require.NoError(t, err)
+	require.Len(t, pdcSpy.confirmCalls, 1)
+	assert.Equal(t, strip.Callsign, pdcSpy.confirmCalls[0].callsign)
+}
+
+func TestUpdateClearedFlag_EuroscopeClearReconcilesStalePdcWhenFlagAlreadySet(t *testing.T) {
+	strip := &internalModels.Strip{
+		Callsign: "SAS456",
+		Bay:      shared.BAY_CLEARED,
+		Cleared:  true,
+		PdcState: "FAILED",
+	}
+	repo := &testutil.MockStripRepository{
+		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*internalModels.Strip, error) {
+			return strip, nil
+		},
+	}
+	pdcSpy := &frontendMovePdcSpy{}
+	svc := NewStripService(repo, WithPdcService(pdcSpy))
+
+	err := svc.UpdateClearedFlag(context.Background(), 1, strip.Callsign, true)
+
+	require.NoError(t, err)
+	require.Len(t, pdcSpy.confirmCalls, 1)
+	assert.Equal(t, strip.Callsign, pdcSpy.confirmCalls[0].callsign)
+}


### PR DESCRIPTION
## What changed

- Treat an authoritative EuroScope `cleared=true` update as voice/manual clearance.
- Reset pending and failed PDC states, including `CLEARED`, to `NONE` and cancel the acknowledgement timeout.
- Preserve only an already completed `CONFIRMED` PDC exchange.
- Reconcile stale PDC state even if the strip cleared flag is already set.
- Add regression coverage for `NO_RESPONSE`, pending `CLEARED`, and already-cleared stale-state cases.

## Why

A PDC that timed out could later receive a cleared flag from EuroScope. The strip moved into the cleared pile while retaining its PDC state, leaving misleading PDC styling and an acknowledgement wait even though the aircraft had been cleared by another method.

## Impact

EuroScope clearance is now authoritative: the strip enters the cleared workflow without stale PDC presentation or timeout state.

## Validation

- `go test ./internal/services ./internal/pdc ./internal/euroscope`
- `git diff --check`
