### PR TITLE
fix(stand): prefer current stand occupants in SEQ

### DIFF
--- a/frontend/src/components/est/standDisplay.test.ts
+++ b/frontend/src/components/est/standDisplay.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { Bay, type FrontendStandAssignmentEntry, type FrontendStrip } from "@/api/models";
+import { deriveEstStandDisplay } from "./standDisplay";
+
+function strip(callsign: string, stand: string, bay: Bay): FrontendStrip {
+  return { callsign, stand, bay } as FrontendStrip;
+}
+
+function assignment(callsign: string, stand: string): FrontendStandAssignmentEntry {
+  return {
+    callsign,
+    stand,
+    direction: "ARRIVAL",
+    stage: "ASSIGNED",
+    source: "AUTOMATIC",
+  };
+}
+
+describe("deriveEstStandDisplay", () => {
+  it.each([Bay.NotCleared, Bay.Cleared, Bay.Push, Bay.Stand])(
+    "shows the aircraft occupying the stand in %s instead of an inbound assignment",
+    (bay) => {
+      const inbound = strip("SAS100", "A18", Bay.Final);
+      const occupant = strip("NAX200", "A18", bay);
+
+      const display = deriveEstStandDisplay(
+        [inbound, occupant],
+        [assignment(inbound.callsign, "A18")],
+        true,
+      );
+
+      expect(display.stripsByStand.get("A18")?.callsign).toBe("NAX200");
+      expect(display.assignmentsByStand.has("A18")).toBe(false);
+    },
+  );
+
+  it("does not let another inbound strip override the assigned arrival", () => {
+    const assignedInbound = strip("SAS100", "A18", Bay.Final);
+    const otherInbound = strip("NAX200", "A18", Bay.Final);
+    const assigned = assignment(assignedInbound.callsign, "A18");
+
+    const display = deriveEstStandDisplay([assignedInbound, otherInbound], [assigned], true);
+
+    expect(display.stripsByStand.get("A18")?.callsign).toBe("SAS100");
+    expect(display.assignmentsByStand.get("A18")).toBe(assigned);
+  });
+
+  it("retains the occupant's assignment metadata when it matches the displayed stand", () => {
+    const occupant = strip("NAX200", "A18", Bay.Cleared);
+    const occupantAssignment = assignment(occupant.callsign, "A18");
+
+    const display = deriveEstStandDisplay([occupant], [occupantAssignment], true);
+
+    expect(display.stripsByStand.get("A18")).toBe(occupant);
+    expect(display.assignmentsByStand.get("A18")).toBe(occupantAssignment);
+  });
+
+  it("preserves ordinary strip-based stand display when SAT is disabled", () => {
+    const occupant = strip("NAX200", "A18", Bay.Cleared);
+    const inbound = strip("SAS100", "A18", Bay.Final);
+
+    const display = deriveEstStandDisplay([occupant, inbound], [], false);
+
+    expect(display.stripsByStand.get("A18")).toBe(occupant);
+    expect(display.assignmentsByStand.size).toBe(0);
+  });
+});

--- a/frontend/src/components/est/standDisplay.ts
+++ b/frontend/src/components/est/standDisplay.ts
@@ -1,0 +1,78 @@
+import { Bay, type FrontendStandAssignmentEntry, type FrontendStrip } from "@/api/models";
+
+export interface EstStandDisplay {
+  assignmentsByStand: Map<string, FrontendStandAssignmentEntry>;
+  stripsByStand: Map<string, FrontendStrip>;
+}
+
+const OCCUPYING_BAYS = new Set<string>([
+  Bay.NotCleared,
+  Bay.Cleared,
+  Bay.Push,
+  Bay.Stand,
+]);
+
+function isOccupyingStand(strip: FrontendStrip) {
+  return !!strip.stand && OCCUPYING_BAYS.has(strip.bay);
+}
+
+export function deriveEstStandDisplay(
+  strips: FrontendStrip[],
+  assignments: FrontendStandAssignmentEntry[],
+  satEnabled: boolean,
+): EstStandDisplay {
+  const assignmentsByStand = new Map<string, FrontendStandAssignmentEntry>();
+  const stripsByStand = new Map<string, FrontendStrip>();
+
+  if (!satEnabled) {
+    for (const strip of strips) {
+      if (strip.stand && strip.bay !== Bay.Hidden) {
+        stripsByStand.set(strip.stand, strip);
+      }
+    }
+
+    for (const strip of strips) {
+      if (isOccupyingStand(strip)) {
+        stripsByStand.set(strip.stand, strip);
+      }
+    }
+
+    return { assignmentsByStand, stripsByStand };
+  }
+
+  const stripsByCallsign = new Map(strips.map((strip) => [strip.callsign, strip]));
+  const assignmentsByCallsign = new Map(assignments.map((assignment) => [assignment.callsign, assignment]));
+
+  for (const assignment of assignments) {
+    assignmentsByStand.set(assignment.stand, assignment);
+
+    const strip = stripsByCallsign.get(assignment.callsign);
+    if (strip && strip.bay !== Bay.Hidden && strip.bay !== Bay.DepHidden) {
+      stripsByStand.set(assignment.stand, strip);
+    }
+  }
+
+  // A live strip parked at a stand is the operational occupant. It must take
+  // display precedence over an arrival that only has a reservation there.
+  for (const strip of strips) {
+    if (isOccupyingStand(strip)) {
+      stripsByStand.set(strip.stand, strip);
+    }
+  }
+
+  for (const [stand, strip] of stripsByStand) {
+    const displayedAssignment = assignmentsByStand.get(stand);
+    if (displayedAssignment?.callsign === strip.callsign) {
+      continue;
+    }
+
+    const occupantAssignment = assignmentsByCallsign.get(strip.callsign);
+    if (occupantAssignment?.stand === stand) {
+      assignmentsByStand.set(stand, occupantAssignment);
+    } else {
+      assignmentsByStand.delete(stand);
+    }
+  }
+
+  return { assignmentsByStand, stripsByStand };
+}

--- a/frontend/src/routes/ekch/EST.tsx
+++ b/frontend/src/routes/ekch/EST.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useReducer, useRef, useState } from "react";
 
-import { Bay, type FrontendStandAssignmentEntry, type FrontendStrip } from "@/api/models";
+import { Bay, type FrontendStrip } from "@/api/models";
 import FlightPlanDialog from "@/components/FlightPlanDialog";
 import EstDeIceDialog from "@/components/est/EstDeIceDialog";
 import EstStandCell from "@/components/est/EstStandCell";
@@ -8,6 +8,7 @@ import EstStandMenu, { type EstMenuAnchor } from "@/components/est/EstStandMenu"
 import EstStandStatusDialog from "@/components/est/EstStandStatusDialog";
 import EstViewButtons from "@/components/est/EstViewButtons";
 import { deriveEstStandBlocking } from "@/components/est/standBlocking";
+import { deriveEstStandDisplay } from "@/components/est/standDisplay";
 import {
   EST_BACKGROUND_BOXES,
   EST_BOARD_HEIGHT,
@@ -177,37 +178,12 @@ export default function EST() {
     updateCtotState(strips);
   }, [strips]);
 
-  const stripsByCallsign = useMemo(() => new Map(strips.map((strip) => [strip.callsign, strip])), [strips]);
-
-  const assignmentByStand = useMemo(() => {
-    const mapping = new Map<string, FrontendStandAssignmentEntry>();
-    if (satEnabled) {
-      for (const assignment of standAssignments) mapping.set(assignment.stand, assignment);
-    }
-    return mapping;
-  }, [satEnabled, standAssignments]);
-
-  const stripByStand = useMemo(() => {
-    const mapping = new Map<string, FrontendStrip>();
-
-    if (satEnabled) {
-      for (const assignment of standAssignments) {
-        const strip = stripsByCallsign.get(assignment.callsign);
-        if (strip && strip.bay !== Bay.Hidden && strip.bay !== Bay.DepHidden) mapping.set(assignment.stand, strip);
-      }
-      return mapping;
-    }
-
-    for (const strip of strips) {
-      if (!strip.stand || strip.bay === Bay.Hidden) {
-        continue;
-      }
-
-      mapping.set(strip.stand, strip);
-    }
-
-    return mapping;
-  }, [satEnabled, standAssignments, strips, stripsByCallsign]);
+  const standDisplay = useMemo(
+    () => deriveEstStandDisplay(strips, standAssignments, satEnabled),
+    [satEnabled, standAssignments, strips],
+  );
+  const assignmentByStand = standDisplay.assignmentsByStand;
+  const stripByStand = standDisplay.stripsByStand;
 
   const standOccupancy = useMemo(
     () => Object.fromEntries([...stripByStand.entries()].map(([stand, strip]) => [stand, strip.callsign])),


### PR DESCRIPTION
## Summary

- make SEQ prefer the aircraft currently occupying a stand over an inbound aircraft assigned to it
- apply the same occupant precedence whether SAT is enabled or disabled
- suppress mismatched inbound assignment metadata when the displayed aircraft is the current occupant
- add regression coverage for parked, cleared, pushing, and stand-bay occupants

## Root cause

SEQ previously resolved duplicate stand entries by assignment or strip iteration order. With SAT enabled, committed assignments were always authoritative, so an approaching aircraft could remain displayed even after another aircraft logged on at that stand. Without SAT, the last strip in the snapshot won, which made the same collision order-dependent.

## Impact

Controllers now see the aircraft operationally occupying the stand. An inbound reservation remains visible only while no aircraft is parked there.

## Validation

- `npm test -- --run` (83 tests)
- `npm run build`
- `npx eslint src/components/est/standDisplay.ts src/components/est/standDisplay.test.ts src/routes/ekch/EST.tsx`
- `git diff --check`
