### PR TITLE
feat(strip): show arrival STAR in EFB

### DIFF
--- a/backend/internal/efb/webapi.go
+++ b/backend/internal/efb/webapi.go
@@ -102,6 +102,7 @@ type snapshot struct {
 	Phase                  string       `json:"phase"`
 	Runway                 *string      `json:"runway"`
 	SID                    *string      `json:"sid"`
+	STAR                   *string      `json:"star"`
 	ClearedAltitude        *int32       `json:"cleared_altitude"`
 	Squawk                 *string      `json:"squawk"`
 	DepartureFrequency     *string      `json:"departure_frequency"`
@@ -156,7 +157,7 @@ func (a *WebAPI) buildSnapshot(ctx context.Context, match pdc.WebStripMatch, ses
 	if state == "REQUESTED_WITH_FAULTS" {
 		state = "REQUESTED"
 	}
-	result := snapshot{Callsign: s.Callsign, AircraftType: s.AircraftType, Origin: s.Origin, Destination: s.Destination, Route: s.Route, Phase: phase, Runway: s.Runway, SID: s.Sid, ClearedAltitude: s.ClearedAltitude, Squawk: s.AssignedSquawk, Stand: nonEmptyString(s.Stand), EOBT: s.EffectiveEobt(), TOBT: s.EffectiveTobt(), TSAT: normalizeClock(s.EffectiveTsat()), TTOT: s.EffectiveTtot(), CTOT: s.EffectiveCtot(), PDCState: state, PDCAvailable: a.pdcReady && departure && !s.Cleared, PDCCanSubmit: a.pdcReady && departure && !s.Cleared && pdc.WebPDCCanSubmit(s.PdcState), PDCRequiresPilotAction: state == "CLEARED", Capabilities: capabilities{PDC: a.pdcReady && departure, TOBT: a.cdmReady && departure, Stand: a.stands != nil && a.assignments != nil}}
+	result := snapshot{Callsign: s.Callsign, AircraftType: s.AircraftType, Origin: s.Origin, Destination: s.Destination, Route: s.Route, Phase: phase, Runway: s.Runway, SID: s.Sid, STAR: s.Star, ClearedAltitude: s.ClearedAltitude, Squawk: s.AssignedSquawk, Stand: nonEmptyString(s.Stand), EOBT: s.EffectiveEobt(), TOBT: s.EffectiveTobt(), TSAT: normalizeClock(s.EffectiveTsat()), TTOT: s.EffectiveTtot(), CTOT: s.EffectiveCtot(), PDCState: state, PDCAvailable: a.pdcReady && departure && !s.Cleared, PDCCanSubmit: a.pdcReady && departure && !s.Cleared && pdc.WebPDCCanSubmit(s.PdcState), PDCRequiresPilotAction: state == "CLEARED", Capabilities: capabilities{PDC: a.pdcReady && departure, TOBT: a.cdmReady && departure, Stand: a.stands != nil && a.assignments != nil}}
 	if departure && a.routes != nil {
 		if display, err := a.routes.ComputeNextDisplayForStripContext(ctx, s, match.SessionID); err == nil && display != nil {
 			result.DepartureFrequency = nonEmptyString(&display.Frequency)

--- a/backend/internal/efb/webapi_test.go
+++ b/backend/internal/efb/webapi_test.go
@@ -144,6 +144,18 @@ func TestSnapshotOnlyIncludesComputedDepartureFrequency(t *testing.T) {
 	}
 }
 
+func TestSnapshotIncludesSynchronizedArrivalSTAR(t *testing.T) {
+	star := "LUXAL2A"
+	api := NewWebAPI(WebAPIConfig{Auth: authStub{}})
+	result := api.buildSnapshot(context.Background(), pdc.WebStripMatch{Strip: &models.Strip{
+		Callsign: "SAS123", Origin: "ESSA", Destination: "EKCH", Star: &star,
+	}}, &models.Session{Airport: "EKCH"})
+
+	if result.STAR == nil || *result.STAR != star {
+		t.Fatalf("expected synchronized STAR %q, got %v", star, result.STAR)
+	}
+}
+
 func TestSnapshotDisablesTOBTWhenCDMIsNotReady(t *testing.T) {
 	api := NewWebAPI(WebAPIConfig{Auth: authStub{}, CDM: &cdmStub{}, CDMReady: false})
 	result := api.buildSnapshot(context.Background(), pdc.WebStripMatch{Strip: &models.Strip{

--- a/frontend/src/pages/efb.test.tsx
+++ b/frontend/src/pages/efb.test.tsx
@@ -109,7 +109,7 @@ describe('EFB page interactions', () => {
       if (String(input).includes('/api/efb/me')) return jsonResponse({ live_mode: false, online_callsign: null });
       return jsonResponse({
         callsign: 'SAS790', aircraft_type: 'A320', origin: 'ESSA', destination: 'EKCH', phase: 'ARRIVAL',
-        stand: 'A12', runway: '22L', sid: null, pdc_state: '', pdc_requires_pilot_action: false,
+        stand: 'A12', runway: '22L', sid: null, star: 'LUXAL2A', pdc_state: '', pdc_requires_pilot_action: false,
         pdc_available: false, pdc_can_submit: false, capabilities: { pdc: false, tobt_update: false, stand_reassignment: false },
       });
     });
@@ -120,6 +120,7 @@ describe('EFB page interactions', () => {
     fireEvent.click(screen.getByRole('button', { name: 'LOAD' }));
 
     expect(await screen.findByText('COMING SOON')).toBeInTheDocument();
+    expect(screen.getByText('LUXAL2A')).toBeInTheDocument();
     fireEvent.click(screen.getByLabelText('Arrival briefing coming soon'));
     expect(screen.queryByRole('dialog', { name: /brief/i })).not.toBeInTheDocument();
   });

--- a/frontend/src/pages/efb.tsx
+++ b/frontend/src/pages/efb.tsx
@@ -62,6 +62,7 @@ interface ApiFlight {
   departure_frequency?: string | null;
   runway?: string | null;
   sid?: string | null;
+  star?: string | null;
   destination: string;
   phase: 'DEPARTURE' | 'ARRIVAL';
   pdc_state: string;
@@ -144,6 +145,7 @@ export default function EFBPage() {
     assignedRunway: apiFlight.runway || 'NIL',
     depFrequency: apiFlight.departure_frequency?.trim() || 'NIL',
     sid: apiFlight.sid || 'NIL',
+    star: apiFlight.star || 'NIL',
     arrivalAirport: apiFlight.destination,
     arrivalRunway: apiFlight.runway || 'NIL',
     atisBetter: apiFlight.atis?.code || '',


### PR DESCRIPTION
## Summary

- expose the synchronized arrival STAR through the EFB flight snapshot
- bind the STAR to the existing arrival display
- cover the backend contract and visible EFB result with regression tests

## Why

EuroScope STAR updates were already synchronized into the strip model, but `/api/efb/flight` omitted the field. As a result, the EFB arrival view continued to show `NIL` instead of the controller-synchronized STAR.

## Validation

- `go test ./internal/efb ./internal/services`
- `npm test -- --run src/pages/efb.test.tsx`
- `npm run build`