### PR TITLE
fix(cdm): align EST startup states

### DIFF
--- a/backend/internal/cdm/action_service.go
+++ b/backend/internal/cdm/action_service.go
@@ -489,6 +489,9 @@ func (c *ActionService) HandleReadyRequest(ctx context.Context, session int32, c
 	if strip == nil || cdmData == nil {
 		return nil
 	}
+	if isTsatWithinReadyWindow(helpers.ValueOrDefault(cdmData.EffectiveTsat()), now) {
+		return s.SetReady(ctx, session, callsign)
+	}
 
 	updated := cdmData.Clone()
 	previousEobt := helpers.ValueOrDefault(updated.EffectiveEobt())

--- a/backend/internal/cdm/service_test.go
+++ b/backend/internal/cdm/service_test.go
@@ -1745,6 +1745,45 @@ func TestHandleReadyRequest_UpdatesFutureTobtToNow(t *testing.T) {
 	assert.Equal(t, "EKCH_DEL", *persisted.TobtSetBy)
 }
 
+func TestHandleReadyRequest_PreservesTobtWithinTsatWindow(t *testing.T) {
+	const callsign = "SAS210"
+	const sessionID = int32(210)
+
+	previousTobt := time.Now().UTC().Add(15 * time.Minute).Format("1504")
+	activeTsat := time.Now().UTC().Add(5 * time.Minute).Format("1504")
+	var persisted *models.CdmData
+
+	service := NewCdmService(
+		newTestClientWithAirportMasters(nil),
+		&testutil.MockStripRepository{
+			GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
+				return &models.Strip{Callsign: callsign, Origin: "EKCH"}, nil
+			},
+			GetCdmDataForCallsignFn: func(_ context.Context, _ int32, _ string) (*models.CdmData, error) {
+				if persisted != nil {
+					return persisted.Clone(), nil
+				}
+				return (&models.CdmData{Tobt: stringPtr(previousTobt), Tsat: stringPtr(activeTsat)}).Normalize(), nil
+			},
+			SetCdmDataFn: func(_ context.Context, _ int32, _ string, data *models.CdmData) (int64, error) {
+				persisted = data.Clone()
+				return 1, nil
+			},
+		},
+		&testutil.MockSessionRepository{},
+		&testutil.MockControllerRepository{},
+	)
+	service.client.isValid = false
+	service.SetFrontendHub(&testutil.MockFrontendHub{})
+
+	require.NoError(t, service.HandleReadyRequest(context.Background(), sessionID, callsign, "EKCH_DEL", "ATC"))
+	require.NotNil(t, persisted)
+	require.NotNil(t, persisted.Tobt)
+	assert.Equal(t, previousTobt, *persisted.Tobt)
+	require.NotNil(t, persisted.Status)
+	assert.Equal(t, "REA", *persisted.Status)
+}
+
 func TestHandleReadyRequest_UpdatesPastTobtToNowWithActiveTsat(t *testing.T) {
 	const callsign = "SAS212"
 	const sessionID = int32(212)

--- a/backend/internal/cdm/time_math.go
+++ b/backend/internal/cdm/time_math.go
@@ -106,6 +106,14 @@ func isMoreThanMinutesPast(value, reference string, threshold float64) bool {
 	return minutesBetween(value, reference) > threshold
 }
 
+func isTsatWithinReadyWindow(tsat string, now time.Time) bool {
+	if _, ok := parseClock(tsat); !ok {
+		return false
+	}
+
+	return math.Abs(minutesBetween(timeToClock(now), tsat)) < 6
+}
+
 func timeToClock(now time.Time) string {
 	return now.UTC().Format("150405")
 }

--- a/backend/internal/frontend/handlers.go
+++ b/backend/internal/frontend/handlers.go
@@ -415,6 +415,18 @@ func handleStartReq(ctx context.Context, client *Client, message Message) error 
 	if err := message.JsonUnmarshal(&event); err != nil {
 		return err
 	}
+	if event.StartReq {
+		strip, err := client.hub.server.GetStripRepository().GetByCallsign(ctx, client.session, event.Callsign)
+		if err != nil {
+			return err
+		}
+		if !strip.StartReq {
+			cdmService := client.hub.server.GetCdmService()
+			if err := cdmService.HandleReadyRequest(ctx, client.session, event.Callsign, client.position, "ATC"); err != nil {
+				return err
+			}
+		}
+	}
 	return client.hub.stripService.UpdateStartReq(ctx, client.session, event.Callsign, event.StartReq)
 }
 

--- a/backend/internal/frontend/handlers_cdm_test.go
+++ b/backend/internal/frontend/handlers_cdm_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"FlightStrips/internal/models"
+	"FlightStrips/internal/services"
 	"FlightStrips/internal/testutil"
 	frontendEvents "FlightStrips/pkg/events/frontend"
 
@@ -113,6 +114,57 @@ func TestHandleCdmReady_UsesOrchestrationMethod(t *testing.T) {
 	assert.Equal(t, "SAS321", cdmService.callsign)
 	assert.Equal(t, "EKCH_DEL", cdmService.sourcePos)
 	assert.Equal(t, "ATC", cdmService.sourceRole)
+}
+
+func TestHandleStartReq_ReportsReadyAndPersistsStartRequest(t *testing.T) {
+	cdmService := &spyCdmService{}
+	frontendHub := &testutil.MockFrontendHub{}
+	startReqPersisted := false
+	stripRepo := &testutil.MockStripRepository{
+		GetByCallsignFn: func(_ context.Context, session int32, callsign string) (*models.Strip, error) {
+			assert.Equal(t, int32(42), session)
+			assert.Equal(t, "SAS321", callsign)
+			return &models.Strip{Session: session, Callsign: callsign}, nil
+		},
+		UpdateStartReqFn: func(_ context.Context, session int32, callsign string, startReq bool, _ *int32) (int64, error) {
+			assert.Equal(t, int32(42), session)
+			assert.Equal(t, "SAS321", callsign)
+			startReqPersisted = startReq
+			return 1, nil
+		},
+	}
+	stripService := services.NewStripService(stripRepo, services.WithStripEventPublisher(frontendHub))
+	server := &testutil.MockServer{CdmServiceVal: cdmService, StripRepoVal: stripRepo}
+	hub := &Hub{server: server, stripService: stripService}
+	client := &Client{hub: hub, session: 42, position: "EKCH_DEL"}
+
+	payload, err := json.Marshal(frontendEvents.StartReqEvent{Callsign: "SAS321", StartReq: true})
+	require.NoError(t, err)
+	require.NoError(t, handleStartReq(context.Background(), client, Message{Message: payload}))
+
+	assert.True(t, cdmService.called)
+	assert.Equal(t, int32(42), cdmService.session)
+	assert.Equal(t, "SAS321", cdmService.callsign)
+	assert.Equal(t, "EKCH_DEL", cdmService.sourcePos)
+	assert.True(t, startReqPersisted)
+}
+
+func TestHandleStartReq_DoesNotReportReadyAgainWhenAlreadyActive(t *testing.T) {
+	cdmService := &spyCdmService{}
+	stripRepo := &testutil.MockStripRepository{
+		GetByCallsignFn: func(_ context.Context, session int32, callsign string) (*models.Strip, error) {
+			return &models.Strip{Session: session, Callsign: callsign, StartReq: true}, nil
+		},
+	}
+	stripService := services.NewStripService(stripRepo)
+	server := &testutil.MockServer{CdmServiceVal: cdmService, StripRepoVal: stripRepo}
+	client := &Client{hub: &Hub{server: server, stripService: stripService}, session: 42, position: "EKCH_DEL"}
+
+	payload, err := json.Marshal(frontendEvents.StartReqEvent{Callsign: "SAS321", StartReq: true})
+	require.NoError(t, err)
+	require.NoError(t, handleStartReq(context.Background(), client, Message{Message: payload}))
+
+	assert.False(t, cdmService.called)
 }
 
 func TestHandleClxUpdateTobt_UsesClxOrchestrationMethod(t *testing.T) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,7 +13,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Barlow+Semi+Condensed:wght@400;500;600;700&family=IBM+Plex+Sans:ital,wght@0,300;0,400;0,500;0,600;1,400&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Barlow+Semi+Condensed:wght@400;500;600;700&family=IBM+Plex+Sans:ital,wght@0,300;0,400;0,500;0,600;1,400&family=Roboto:wght@700&family=Rubik:wght@400;700&display=swap" rel="stylesheet" />
     <title>FlightStrips</title>
     <link rel="preload" as="image" href="/taxi_map.webp" />
     <link rel="preload" as="image" href="/apron_push.webp" />

--- a/frontend/src/components/est/EstStandCell.tsx
+++ b/frontend/src/components/est/EstStandCell.tsx
@@ -1,10 +1,10 @@
 import type { CSSProperties } from "react";
 
 import { Bay, type FrontendStandAssignmentEntry, type FrontendStrip } from "@/api/models";
-import { COLOR_BTN_YELLOW, SELECTION_COLOR } from "@/components/strip/shared";
-import { cn } from "@/lib/utils";
+import { SELECTION_COLOR } from "@/components/strip/shared";
+import { cn, getSimpleAircraftType } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { CTOT_BLUE, computeCDMColors, hasManualTobtSource } from "@/lib/cdmColors";
+import { CDM_GREEN, CTOT_BLUE, computeCDMColors, computeCTOTColors, hasManualTobtSource } from "@/lib/cdmColors";
 
 import {
   EST_CELL_HEIGHT,
@@ -15,14 +15,21 @@ import {
   type EstCanvasStand,
 } from "@/components/est/metadata";
 
-const LABEL_TOP = EST_CELL_HEIGHT * 0.14;
-const CALLSIGN_TOP = EST_CELL_HEIGHT * 0.31;
-const TOBT_ROW_TOP = EST_CELL_HEIGHT * 0.555;
-const TSAT_ROW_TOP = EST_CELL_HEIGHT * 0.673;
-const CTOT_ROW_TOP = EST_CELL_HEIGHT * 0.797;
-const ROW_HEIGHT = EST_CELL_HEIGHT * 0.108;
+const STAND_ROW_TOP = 0;
+const STAND_ROW_HEIGHT = 27.5;
+const CALLSIGN_ROW_TOP = 27.5;
+const CALLSIGN_ROW_HEIGHT = 21;
+const DETAILS_ROW_TOP = 50.5;
+const DETAILS_ROW_HEIGHT = 20;
+const READY_ROW_TOP = 72;
+const TOBT_ROW_TOP = 88;
+const TSAT_ROW_TOP = 104;
+const CTOT_ROW_TOP = 120;
+const ROW_HEIGHT = 15;
 const LABEL_FONT_SIZE = 20;
-const CONTENT_FONT_SIZE = 13;
+const DETAILS_FONT_SIZE = 14;
+const CONTENT_FONT_SIZE = 12;
+const CONTENT_FONT = "Rubik, sans-serif";
 
 interface EstStandCellProps {
   stand: { label: string; column?: number; row?: number } | EstCanvasStand;
@@ -34,6 +41,7 @@ interface EstStandCellProps {
   actionActive: boolean;
   blinking: boolean;
   startReqActive: boolean;
+  departureTransferActive?: boolean;
   ctotImproved: boolean;
   nowMs: number;
   containerStyle?: CSSProperties;
@@ -49,6 +57,7 @@ export default function EstStandCell({
   actionActive,
   blinking,
   startReqActive,
+  departureTransferActive = false,
   ctotImproved,
   nowMs,
   containerStyle,
@@ -99,11 +108,16 @@ export default function EstStandCell({
   const { tobtBg: tobtBarColor, tsatBg: tsatBarColor } = strip && isDeparture
     ? computeCDMColors(strip.tsat, strip.tobt, nowMs, strip.bay as Bay, strip.phase)
     : { tobtBg: "", tsatBg: "" };
+  const ctotColors = strip ? computeCTOTColors(strip.ctot, nowMs) : null;
   const emphasizeTobtTime = strip ? hasManualTobtSource(strip.req_tobt_type, strip.tobt_set_by) : false;
 
-  const showTobt = isDeparture && !!strip && strip.tobt !== "";
-  const showTsat = isDeparture && !!strip && strip.tsat !== "";
-  const showCtot = isClearedDeparture && !!strip?.ctot.trim();
+  const showTobt = isDeparture && !departureTransferActive && !!strip && strip.tobt !== "";
+  const showTsat = isDeparture && !departureTransferActive && !!strip && strip.tsat !== "";
+  const showCtot = isClearedDeparture && !!strip?.ctot.trim() && (ctotImproved || !!ctotColors?.showCtot);
+  const showReady = isDeparture && !!strip?.start_req;
+  const showReleasePoint = isPushing && !!strip?.release_point.trim();
+  const ctotBarColor = ctotImproved ? CTOT_BLUE : ctotColors?.ctotBg;
+  const ctotTextColor = ctotImproved ? "#FFFFFF" : ctotColors?.ctotColor;
 
   const ctotLabel =
     showCtot && strip?.ctot
@@ -115,11 +129,8 @@ export default function EstStandCell({
   const showMark = isClearedDeparture && !!strip?.marked;
   const showCtotText = ctotLabel !== "";
   const boxShadows: string[] = [];
-  if (startReqActive) {
-    boxShadows.push(`0 0 0 4px ${COLOR_BTN_YELLOW}`);
-  }
   if (showMark) {
-    boxShadows.push(`0 0 0 ${startReqActive ? 8 : 4}px ${SELECTION_COLOR}`);
+    boxShadows.push(`0 0 0 4px ${SELECTION_COLOR}`);
   }
   const buttonStyle: CSSProperties = {
     width: EST_CELL_WIDTH,
@@ -135,7 +146,7 @@ export default function EstStandCell({
             type="button"
             onClick={(event) => onClick(stand.label, strip, event.currentTarget)}
             className={cn(
-              "relative overflow-hidden rounded-xl border-2 border-black/15 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-white",
+              "relative overflow-hidden rounded-xl transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-white",
               backgroundClass,
               textClass,
               blinking && "animate-pulse",
@@ -158,25 +169,39 @@ export default function EstStandCell({
             {showCtot && (
               <div
                 className="absolute left-0 right-0"
-                style={{ top: CTOT_ROW_TOP, height: ROW_HEIGHT, backgroundColor: CTOT_BLUE }}
+                data-testid="est-ctot-background"
+                style={{ top: CTOT_ROW_TOP, height: ROW_HEIGHT, backgroundColor: ctotBarColor }}
+              />
+            )}
+            {showReady && (
+              <div
+                className="absolute left-0 right-0"
+                data-testid="est-ready-background"
+                style={{ top: READY_ROW_TOP, height: ROW_HEIGHT, backgroundColor: CDM_GREEN }}
               />
             )}
             {/* Stand label */}
-             <div
-               className="absolute left-0 right-0 text-center font-bold"
-               style={{ top: LABEL_TOP, fontSize: LABEL_FONT_SIZE, lineHeight: `${LABEL_FONT_SIZE}px` }}
-             >
-               {stand.label}
-             </div>
+            <div
+              className="absolute left-0 right-0 flex items-center justify-center text-center font-bold"
+              style={{
+                top: STAND_ROW_TOP,
+                height: STAND_ROW_HEIGHT,
+                fontFamily: "Roboto, sans-serif",
+                fontSize: LABEL_FONT_SIZE,
+              }}
+            >
+              {stand.label}
+            </div>
 
             {/* Callsign */}
             {(assignment || (strip && !blocked)) && (
                <div
-                 className="absolute left-0 right-0 flex items-center justify-center overflow-hidden px-0.5 text-center"
+                 className="absolute left-0 right-0 flex items-center justify-center overflow-hidden px-0.5 text-center font-bold"
                  style={{
-                  top: CALLSIGN_TOP,
-                  height: ROW_HEIGHT,
-                  fontSize: CONTENT_FONT_SIZE,
+                  top: CALLSIGN_ROW_TOP,
+                  height: CALLSIGN_ROW_HEIGHT,
+                  fontFamily: CONTENT_FONT,
+                  fontSize: DETAILS_FONT_SIZE,
                   backgroundColor: showMark ? SELECTION_COLOR : undefined,
                   color: showMark ? "#000000" : undefined,
                 }}
@@ -185,10 +210,43 @@ export default function EstStandCell({
               </div>
             )}
 
+            {showReleasePoint && (
+              <div
+                className="absolute left-0 right-0 flex items-center justify-center"
+                style={{ top: READY_ROW_TOP, height: ROW_HEIGHT, fontFamily: CONTENT_FONT, fontSize: DETAILS_FONT_SIZE }}
+              >
+                {strip!.release_point}
+              </div>
+            )}
+
+            {strip && !blocked && (
+              <div
+                className="absolute left-0 right-0 flex items-center justify-between overflow-hidden px-1"
+                style={{
+                  top: DETAILS_ROW_TOP,
+                  height: DETAILS_ROW_HEIGHT,
+                  fontFamily: CONTENT_FONT,
+                  fontSize: DETAILS_FONT_SIZE,
+                }}
+              >
+                <span className="truncate text-left">{getSimpleAircraftType(strip.aircraft_type)}</span>
+                <span className="truncate text-right">{strip.runway}</span>
+              </div>
+            )}
+
+            {showReady && (
+              <div
+                className="absolute left-0 right-0 flex items-center justify-center"
+                style={{ top: READY_ROW_TOP, height: ROW_HEIGHT, fontFamily: CONTENT_FONT, fontSize: CONTENT_FONT_SIZE }}
+              >
+                READY
+              </div>
+            )}
+
             {assignment && !showTobt && (
               <div
                 className="absolute left-0 right-0 flex items-center justify-center truncate px-1 uppercase"
-                style={{ top: TOBT_ROW_TOP, height: ROW_HEIGHT, fontSize: 10 }}
+                style={{ top: TOBT_ROW_TOP, height: ROW_HEIGHT, fontFamily: CONTENT_FONT, fontSize: 10 }}
               >
                 {assignment.stage} · {assignment.source}
               </div>
@@ -197,7 +255,7 @@ export default function EstStandCell({
             {assignment?.eta && !showTsat && (
               <div
                 className="absolute left-0 right-0 flex items-center justify-center"
-                style={{ top: TSAT_ROW_TOP, height: ROW_HEIGHT, fontSize: 10 }}
+                style={{ top: TSAT_ROW_TOP, height: ROW_HEIGHT, fontFamily: CONTENT_FONT, fontSize: 10 }}
               >
                 ETA {formatTimeLabel(assignment.eta).replace(":", "")}
               </div>
@@ -206,7 +264,7 @@ export default function EstStandCell({
             {assignment?.expires_at && !showCtot && (
               <div
                 className="absolute left-0 right-0 flex items-center justify-center"
-                style={{ top: CTOT_ROW_TOP, height: ROW_HEIGHT, fontSize: 10 }}
+                style={{ top: CTOT_ROW_TOP, height: ROW_HEIGHT, fontFamily: CONTENT_FONT, fontSize: 10 }}
               >
                 EXP {formatTimeLabel(assignment.expires_at).replace(":", "")}
               </div>
@@ -216,7 +274,7 @@ export default function EstStandCell({
              {showTobt && (
                 <div
                   className="absolute left-0 right-0 flex items-center justify-center gap-1"
-                  style={{ top: TOBT_ROW_TOP, height: ROW_HEIGHT, fontSize: CONTENT_FONT_SIZE }}
+                  style={{ top: TOBT_ROW_TOP, height: ROW_HEIGHT, fontFamily: CONTENT_FONT, fontSize: CONTENT_FONT_SIZE }}
                 >
                   <span>TOBT:</span>
                   <span style={{ fontWeight: emphasizeTobtTime ? 700 : undefined }}>
@@ -229,7 +287,7 @@ export default function EstStandCell({
             {showTsat && (
                <div
                  className="absolute left-0 right-0 flex items-center justify-center"
-                 style={{ top: TSAT_ROW_TOP, height: ROW_HEIGHT, fontSize: CONTENT_FONT_SIZE }}
+                 style={{ top: TSAT_ROW_TOP, height: ROW_HEIGHT, fontFamily: CONTENT_FONT, fontSize: CONTENT_FONT_SIZE }}
                >
                  {`TSAT: ${formatTimeLabel(strip!.tsat).replace(":", "")}`}
                </div>
@@ -239,7 +297,7 @@ export default function EstStandCell({
             {showCtotText && (
               <div
                 className="absolute left-0 right-0 flex items-center justify-center font-bold"
-                style={{ top: CTOT_ROW_TOP, height: ROW_HEIGHT, fontSize: CONTENT_FONT_SIZE, color: "#FFFFFF" }}
+                style={{ top: CTOT_ROW_TOP, height: ROW_HEIGHT, fontFamily: CONTENT_FONT, fontSize: CONTENT_FONT_SIZE, color: ctotTextColor }}
               >
                 {ctotLabel}
               </div>

--- a/frontend/src/components/est/EstStandMenu.tsx
+++ b/frontend/src/components/est/EstStandMenu.tsx
@@ -21,7 +21,6 @@ interface EstStandMenuProps {
   anchor: EstMenuAnchor | null;
   strip: FrontendStrip;
   onClose: () => void;
-  onSendReady: () => void;
   onStartTransfer: () => void;
   startTransferDisabled: boolean;
   onStartRequest: () => void;
@@ -40,7 +39,6 @@ export default function EstStandMenu({
   anchor,
   strip,
   onClose,
-  onSendReady,
   onStartTransfer,
   startTransferDisabled,
   onStartRequest,
@@ -107,20 +105,11 @@ export default function EstStandMenu({
           </div>
           <Button
             variant="trf"
-            type="button"
-            className="mt-1 w-full px-2 py-2 text-sm font-semibold"
-            onClick={onSendReady}
-          >
-            SEND RDY MSG
-          </Button>
-
-          <Button
-            variant="trf"
-            className="h-11 text-sm font-semibold"
+            className="mt-1 h-11 text-sm font-semibold"
             onClick={onStartTransfer}
             disabled={startTransferDisabled}
           >
-            START+TRF
+            START REQ+TRF
           </Button>
           <Button variant="trf" className="h-11 text-sm font-semibold" onClick={onStartRequest}>
             {strip.start_req ? "REMOVE START REQ" : "START REQ"}

--- a/frontend/src/components/est/est-stand-cell.test.tsx
+++ b/frontend/src/components/est/est-stand-cell.test.tsx
@@ -69,7 +69,7 @@ describe("EstStandCell", () => {
     render(
       <EstStandCell
         stand={stand}
-        strip={makeStrip()}
+        strip={makeStrip({ aircraft_type: "A320/H-SDE2E3FGHIRWXY" })}
         blocked={false}
         selected={false}
         actionActive={false}
@@ -81,6 +81,93 @@ describe("EstStandCell", () => {
       />,
     );
     expect(screen.getByText("SAS123")).toBeDefined();
+    expect(screen.getByText("A320")).toBeDefined();
+    expect(screen.queryByText("A320/H-SDE2E3FGHIRWXY")).toBeNull();
+    expect(screen.getByText("22R")).toBeDefined();
+  });
+
+  it("shows READY in the same green used by green TOBT states", () => {
+    render(
+      <EstStandCell
+        stand={stand}
+        strip={makeStrip({ start_req: true })}
+        blocked={false}
+        selected={false}
+        actionActive={false}
+        blinking={false}
+        startReqActive
+        ctotImproved={false}
+        nowMs={Date.now()}
+        onClick={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("READY")).toBeDefined();
+    expect(screen.getByTestId("est-ready-background").style.backgroundColor).toBe("rgb(0, 255, 38)");
+  });
+
+  it("hides TOBT and TSAT during transfer to APRON but retains CTOT", () => {
+    render(
+      <EstStandCell
+        stand={stand}
+        strip={makeStrip({ bay: Bay.Cleared, ctot: "1430" })}
+        blocked={false}
+        selected={false}
+        actionActive={false}
+        blinking={false}
+        startReqActive={false}
+        departureTransferActive
+        ctotImproved={false}
+        nowMs={Date.UTC(2026, 6, 14, 14, 25, 0)}
+        onClick={() => {}}
+      />,
+    );
+
+    expect(screen.queryByText(/TOBT:/)).toBeNull();
+    expect(screen.queryByText(/TSAT:/)).toBeNull();
+    expect(screen.getByText("CTOT: 1430")).toBeDefined();
+  });
+
+  it("shows a future CTOT in yellow with black text", () => {
+    render(
+      <EstStandCell
+        stand={stand}
+        strip={makeStrip({ bay: Bay.Cleared, ctot: "1430" })}
+        blocked={false}
+        selected={false}
+        actionActive={false}
+        blinking={false}
+        startReqActive={false}
+        ctotImproved={false}
+        nowMs={Date.UTC(2026, 6, 14, 14, 0, 0)}
+        onClick={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId("est-ctot-background").style.backgroundColor).toBe("rgb(243, 234, 31)");
+    expect(screen.getByText("CTOT: 1430").style.color).toBe("black");
+  });
+
+  it("shows the release point instead of READY and times during pushback", () => {
+    render(
+      <EstStandCell
+        stand={stand}
+        strip={makeStrip({ bay: Bay.Push, release_point: "J4", start_req: false })}
+        blocked={false}
+        selected={false}
+        actionActive={false}
+        blinking={false}
+        startReqActive={false}
+        ctotImproved={false}
+        nowMs={Date.now()}
+        onClick={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("J4")).toBeDefined();
+    expect(screen.queryByText("READY")).toBeNull();
+    expect(screen.queryByText(/TOBT:/)).toBeNull();
+    expect(screen.queryByText(/TSAT:/)).toBeNull();
   });
 
   it("renders backend assignment metadata without a matching strip", () => {

--- a/frontend/src/components/est/transferState.test.ts
+++ b/frontend/src/components/est/transferState.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { isEstDepartureTransferActive } from "./transferState";
+
+describe("isEstDepartureTransferActive", () => {
+  it("recognizes the active START REQ transfer to APRON", () => {
+    expect(
+      isEstDepartureTransferActive(
+        { from: "EKCH_DEL", to: "EKCH_A_GND", isTagRequest: false },
+        "EKCH_DEL",
+        "EKCH_A_GND",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not treat a tag request as a START REQ transfer", () => {
+    expect(
+      isEstDepartureTransferActive(
+        { from: "EKCH_DEL", to: "EKCH_A_GND", isTagRequest: true },
+        "EKCH_DEL",
+        "EKCH_A_GND",
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects transfers from another position or to another target", () => {
+    expect(
+      isEstDepartureTransferActive(
+        { from: "EKCH_B_GND", to: "EKCH_A_GND", isTagRequest: false },
+        "EKCH_DEL",
+        "EKCH_A_GND",
+      ),
+    ).toBe(false);
+    expect(
+      isEstDepartureTransferActive(
+        { from: "EKCH_DEL", to: "EKCH_TWR", isTagRequest: false },
+        "EKCH_DEL",
+        "EKCH_A_GND",
+      ),
+    ).toBe(false);
+  });
+});

--- a/frontend/src/components/est/transferState.ts
+++ b/frontend/src/components/est/transferState.ts
@@ -1,0 +1,20 @@
+interface CoordinationTransferState {
+  from: string;
+  to: string;
+  isTagRequest: boolean;
+}
+
+export function isEstDepartureTransferActive(
+  transfer: CoordinationTransferState | undefined,
+  sourcePosition: string,
+  targetPosition: string,
+): boolean {
+  return Boolean(
+    transfer &&
+      !transfer.isTagRequest &&
+      sourcePosition &&
+      targetPosition &&
+      transfer.from === sourcePosition &&
+      transfer.to === targetPosition,
+  );
+}

--- a/frontend/src/lib/cdmColors.test.ts
+++ b/frontend/src/lib/cdmColors.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { hasManualTobtSource } from "./cdmColors";
+import { Bay } from "@/api/models";
+import { CDM_GREEN, CDM_YELLOW, computeCDMColors, hasManualTobtSource, isTsatWithinStartRequestWindow } from "./cdmColors";
 
 describe("hasManualTobtSource", () => {
   it("returns true for pilot-filed TOBT requests", () => {
@@ -13,5 +14,51 @@ describe("hasManualTobtSource", () => {
 
   it("returns false for auto-synced TOBT values", () => {
     expect(hasManualTobtSource("", "")).toBe(false);
+  });
+});
+
+describe("isTsatWithinStartRequestWindow", () => {
+  it("accepts TSAT values less than six minutes from now", () => {
+    const now = Date.UTC(2026, 6, 14, 10, 0, 0);
+
+    expect(isTsatWithinStartRequestWindow("1005", now)).toBe(true);
+    expect(isTsatWithinStartRequestWindow("0955", now)).toBe(true);
+  });
+
+  it("rejects TSAT values outside the window", () => {
+    const now = Date.UTC(2026, 6, 14, 10, 0, 0);
+
+    expect(isTsatWithinStartRequestWindow("1006", now)).toBe(false);
+    expect(isTsatWithinStartRequestWindow("0954", now)).toBe(false);
+    expect(isTsatWithinStartRequestWindow("", now)).toBe(false);
+  });
+
+  it("handles the TSAT window across midnight", () => {
+    expect(isTsatWithinStartRequestWindow("0002", Date.UTC(2026, 6, 14, 23, 58, 0))).toBe(true);
+    expect(isTsatWithinStartRequestWindow("2358", Date.UTC(2026, 6, 15, 0, 2, 0))).toBe(true);
+  });
+});
+
+describe("computeCDMColors", () => {
+  it("uses the design green token", () => {
+    expect(CDM_GREEN).toBe("#00FF26");
+  });
+
+  it("makes both TOBT and TSAT green inside the startup window", () => {
+    const now = Date.UTC(2026, 6, 14, 10, 0, 0);
+
+    expect(computeCDMColors("1003", "0955", now, Bay.Cleared)).toEqual({
+      tobtBg: CDM_GREEN,
+      tsatBg: CDM_GREEN,
+    });
+  });
+
+  it("keeps TOBT green and makes TSAT yellow in the last minute", () => {
+    const now = Date.UTC(2026, 6, 14, 10, 5, 0);
+
+    expect(computeCDMColors("1000", "0955", now, Bay.Cleared)).toEqual({
+      tobtBg: CDM_GREEN,
+      tsatBg: CDM_YELLOW,
+    });
   });
 });

--- a/frontend/src/lib/cdmColors.ts
+++ b/frontend/src/lib/cdmColors.ts
@@ -4,7 +4,7 @@ import { normalizeCdmTime } from "@/lib/cdmTime";
 const MINUTE_MS = 60_000;
 
 // ── Shared colour tokens ────────────────────────────────────────────────────
-export const CDM_GREEN  = "#16a34a";
+export const CDM_GREEN  = "#00FF26";
 export const CDM_YELLOW = "#F3EA1F";
 export const CDM_RED    = "#dc2626";
 export const CDM_ORANGE = "#DD6A12";
@@ -23,8 +23,17 @@ function parseHHMM(hhmm: string, refMs: number): number {
   const m = parseInt(normalizedTime.slice(2, 4), 10);
   const d = new Date(refMs);
   d.setUTCHours(h, m, 0, 0);
-  if (refMs - d.getTime() > 12 * 60 * 60 * 1000) d.setUTCDate(d.getUTCDate() + 1);
+  const offsetMs = d.getTime() - refMs;
+  if (offsetMs <= -12 * 60 * 60 * 1000) d.setUTCDate(d.getUTCDate() + 1);
+  if (offsetMs > 12 * 60 * 60 * 1000) d.setUTCDate(d.getUTCDate() - 1);
   return d.getTime();
+}
+
+export function isTsatWithinStartRequestWindow(tsat: string, nowMs: number): boolean {
+  const normalizedTsat = normalizeCdmTime(tsat);
+  if (!normalizedTsat) return false;
+
+  return Math.abs(parseHHMM(normalizedTsat, nowMs) - nowMs) < 6 * MINUTE_MS;
 }
 
 // ── TOBT / TSAT ────────────────────────────────────────────────────────────
@@ -73,8 +82,8 @@ export function computeCDMColors(
   const diffMs = nowMs - tsatMs;
 
   if (diffMs > 5 * MINUTE_MS)  return { tobtBg: CDM_RED,    tsatBg: ""          };
-  if (diffMs > 4 * MINUTE_MS)  return { tobtBg: "",          tsatBg: CDM_YELLOW  };
-  if (diffMs > -5 * MINUTE_MS) return { tobtBg: "",          tsatBg: CDM_GREEN   };
+  if (diffMs > 4 * MINUTE_MS)  return { tobtBg: CDM_GREEN,   tsatBg: CDM_YELLOW  };
+  if (diffMs > -5 * MINUTE_MS) return { tobtBg: CDM_GREEN,   tsatBg: CDM_GREEN   };
   if (tobtMs !== null && Math.abs(tsatMs - tobtMs) > 5 * MINUTE_MS)
     return { tobtBg: CDM_ORANGE, tsatBg: "" };
   return { tobtBg: "", tsatBg: "" };

--- a/frontend/src/routes/ekch/EST.tsx
+++ b/frontend/src/routes/ekch/EST.tsx
@@ -7,6 +7,8 @@ import EstStandCell from "@/components/est/EstStandCell";
 import EstStandMenu, { type EstMenuAnchor } from "@/components/est/EstStandMenu";
 import EstStandStatusDialog from "@/components/est/EstStandStatusDialog";
 import EstViewButtons from "@/components/est/EstViewButtons";
+import { isEstDepartureTransferActive } from "@/components/est/transferState";
+import { isTsatWithinStartRequestWindow } from "@/lib/cdmColors";
 import { deriveEstStandBlocking } from "@/components/est/standBlocking";
 import {
   EST_BACKGROUND_BOXES,
@@ -17,7 +19,7 @@ import {
   type EstView,
 } from "@/components/est/metadata";
 import { useNonClearedStrips } from "@/store/airports/ekch.ts";
-import { useControllers, useMarkArmed, useMyPosition, useSelectStrip, useSelectedCallsign, useWebSocketStore, useSatEnabled, useStandAssignments, useStandBlocks, useOccupyStand, useVacateStand, useRequestManualStand } from "@/store/store-hooks.ts";
+import { useControllers, useMarkArmed, useMyPosition, useSelectStrip, useSelectedCallsign, useWebSocketStore, useSatEnabled, useStandAssignments, useStandBlocks, useOccupyStand, useVacateStand, useRequestManualStand, useStripTransfers } from "@/store/store-hooks.ts";
 
 const PAGE_BG = "bg-bay-est";
 const COLOR_LABEL_DEFAULT = "#202020";
@@ -109,7 +111,6 @@ export default function EST() {
   const transferStrip = useWebSocketStore((state) => state.transferStrip);
   const setStartReq = useWebSocketStore((state) => state.setStartReq);
   const toggleMarked = useWebSocketStore((state) => state.toggleMarked);
-  const cdmReady = useWebSocketStore((state) => state.cdmReady);
   const controllers = useControllers();
   const myPosition = useMyPosition();
   const nonClearedStrips = useNonClearedStrips();
@@ -122,6 +123,7 @@ export default function EST() {
   const occupyStand = useOccupyStand();
   const vacateStand = useVacateStand();
   const requestManualStand = useRequestManualStand();
+  const stripTransfers = useStripTransfers();
 
   const [menuState, setMenuState] = useState<{ stand: string; anchor: EstMenuAnchor } | null>(null);
   const [statusStand, setStatusStand] = useState<string | null>(null);
@@ -313,15 +315,6 @@ export default function EST() {
     setStatusStand(null);
     setStatusAnchor(null);
     setDeIceOpen(false);
-  }
-
-  function handleSendReady() {
-    if (!menuStrip || !menuState) {
-      return;
-    }
-
-    cdmReady(menuStrip.callsign);
-    closeMenu();
   }
 
   function handleStartTransfer() {
@@ -530,6 +523,11 @@ export default function EST() {
                   actionActive={actionActive}
                   blinking={actionActive ? actionOverride.blinking : false}
                   startReqActive={startReqActive}
+                  departureTransferActive={isEstDepartureTransferActive(
+                    strip ? stripTransfers[strip.callsign] : undefined,
+                    myPosition,
+                    apronDepartureTransferTarget,
+                  )}
                   ctotImproved={strip ? !!ctotState.flags[strip.callsign] : false}
                   nowMs={nowMs}
                   containerStyle={{
@@ -551,9 +549,12 @@ export default function EST() {
           anchor={menuState.anchor}
           strip={menuStrip}
           onClose={closeMenu}
-          onSendReady={handleSendReady}
           onStartTransfer={handleStartTransfer}
-          startTransferDisabled={!apronDepartureTransferTarget}
+          startTransferDisabled={
+            !apronDepartureTransferTarget ||
+            !menuStrip.start_req ||
+            !isTsatWithinStartRequestWindow(menuStrip.tsat, nowMs)
+          }
           onStartRequest={handleStartRequest}
           onPush={handlePush}
           onTaxi={handleTaxi}


### PR DESCRIPTION
## Summary

- Redesign the EST stand item rows to match the Figma startup states, including aircraft type trimming, row spacing, transfer visibility, and removal of the yellow START REQ outline.
- Share the exact `#00FF26` CDM green across READY, TOBT, and TSAT states in both designs.
- Make START REQ use the existing ready flow safely, including duplicate-event protection and preserving TOBT when TSAT is inside the ready window.

## Validation

- `go test ./internal/frontend ./internal/cdm`
- `go test ./...`
- `npm test -- --run`
- `npm run build`
- changed frontend ESLint passed
- `git diff --check`

Closes #242
Closes #243