### PR TITLE
fix(cdm): synchronize startup request timing

### DIFF
--- a/backend/internal/cdm/action_service.go
+++ b/backend/internal/cdm/action_service.go
@@ -496,7 +496,8 @@ func (c *ActionService) HandleReadyRequest(ctx context.Context, session int32, c
 	updated := cdmData.Clone()
 	previousEobt := helpers.ValueOrDefault(updated.EffectiveEobt())
 	previousTobt := helpers.ValueOrDefault(updated.EffectiveTobt())
-	applyConfirmedTobtUpdate(updated, tobt, sourcePosition)
+	applyConfirmedTobtUpdate(updated, tobt, sourcePosition, sourceRole)
+	updated.Asrt = &tobt
 	currentEobt := normalizeCalculationClock(helpers.ValueOrDefault(updated.EffectiveEobt()))
 	if currentEobt == "" || !isAfterOrEqual(tobt, currentEobt) {
 		updated.Eobt = &tobt
@@ -540,6 +541,7 @@ func (c *ActionService) HandleReadyRequest(ctx context.Context, session int32, c
 
 func (c *ActionService) SetReady(ctx context.Context, session int32, callsign string) error {
 	s := c.service
+	masterViffSession := s.client.isValid && s.usesViffSession(session) && s.isMasterSession(session)
 	if s.client.isValid && s.usesViffSession(session) {
 		if err := s.client.IFPSDpi(ctx, callsign, "REA/1"); err != nil {
 			return err
@@ -553,16 +555,32 @@ func (c *ActionService) SetReady(ctx context.Context, session int32, callsign st
 	if err != nil {
 		return err
 	}
-	if cdmData.EffectiveStatus() != nil && *cdmData.EffectiveStatus() == "REA" {
-		return nil
+	alreadyReady := cdmData.EffectiveStatus() != nil && *cdmData.EffectiveStatus() == "REA" && helpers.ValueOrDefault(cdmData.Asrt) != ""
+	updated := cdmData
+	if !alreadyReady {
+		before := snapshotCdm(cdmData)
+		updated = cdmData.Clone()
+		rea := "REA"
+		updated.Status = &rea
+		if helpers.ValueOrDefault(updated.Asrt) == "" {
+			now := time.Now().UTC().Format("1504")
+			updated.Asrt = &now
+		}
+		if err := s.persistCdmUpdate(ctx, session, callsign, before, updated); err != nil {
+			return err
+		}
 	}
-
-	before := snapshotCdm(cdmData)
-	updated := cdmData.Clone()
-	rea := "REA"
-	updated.Status = &rea
-	if err := s.persistCdmUpdate(ctx, session, callsign, before, updated); err != nil {
-		return err
+	if _, exportable := buildViffPushState(callsign, nil, updated); masterViffSession && exportable {
+		strip, err := s.stripRepo.GetByCallsign(ctx, session, callsign)
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return err
+		}
+		if err := s.pushViffAfterRecalc(ctx, callsign, strip, updated); err != nil {
+			return err
+		}
+	}
+	if alreadyReady {
+		return nil
 	}
 
 	if s.publisher != nil {

--- a/backend/internal/cdm/service_test.go
+++ b/backend/internal/cdm/service_test.go
@@ -1530,6 +1530,75 @@ func TestSetReady_SendsRea1ViaDpi(t *testing.T) {
 	assert.Equal(t, "REA", frontendHub.CdmUpdates[len(frontendHub.CdmUpdates)-1].Event.Status)
 }
 
+func TestSetReady_MasterPersistsAndExportsAsrt(t *testing.T) {
+	t.Parallel()
+	const callsign = "SAS123"
+	const sessionID = int32(123)
+
+	dpiCh := make(chan string, 1)
+	setCdmCh := make(chan url.Values, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/ifps/dpi":
+			dpiCh <- r.URL.Query().Get("value")
+		case "/ifps/setCdmData":
+			setCdmCh <- r.URL.Query()
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	runway := "22R"
+	stored := (&models.CdmData{
+		Tobt: stringPtr("1010"),
+		Tsat: stringPtr("1015"),
+		Ttot: stringPtr("1025"),
+	}).Normalize()
+	service := NewCdmService(
+		NewClient(WithAPIKey("test-key"), WithBaseURL(server.URL)),
+		&testutil.MockStripRepository{
+			GetCdmDataForCallsignFn: func(_ context.Context, _ int32, _ string) (*models.CdmData, error) {
+				return stored.Clone(), nil
+			},
+			SetCdmDataFn: func(_ context.Context, _ int32, _ string, data *models.CdmData) (int64, error) {
+				stored = data.Clone()
+				return 1, nil
+			},
+			GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
+				return &models.Strip{Callsign: callsign, Runway: &runway}, nil
+			},
+		},
+		&testutil.MockSessionRepository{},
+		&testutil.MockControllerRepository{},
+	)
+	service.SetFrontendHub(&testutil.MockFrontendHub{})
+	service.sessionMaster.Store(sessionID, true)
+	markSessionLive(service, sessionID)
+
+	beforeNow := time.Now().UTC().Format("1504")
+	require.NoError(t, service.SetReady(context.Background(), sessionID, callsign))
+	afterNow := time.Now().UTC().Format("1504")
+
+	require.NotNil(t, stored.Asrt)
+	assert.Contains(t, []string{beforeNow, afterNow}, *stored.Asrt)
+	assert.Equal(t, "REA", valueOrEmpty(stored.Status))
+	select {
+	case dpi := <-dpiCh:
+		assert.Equal(t, "REA/1", dpi)
+	case <-time.After(time.Second):
+		t.Fatal("expected ready DPI to be sent to vIFF")
+	}
+	select {
+	case setCdm := <-setCdmCh:
+		assert.Equal(t, *stored.Asrt+"00", setCdm.Get("asrt"))
+		assert.Equal(t, "22R", setCdm.Get("depInfo"))
+	case <-time.After(time.Second):
+		t.Fatal("expected ASRT to be exported to vIFF")
+	}
+}
+
 func TestSetReady_WithoutValidClient_PersistsLocalReadyStatus(t *testing.T) {
 	t.Parallel()
 	const callsign = "SAS938"
@@ -1743,6 +1812,10 @@ func TestHandleReadyRequest_UpdatesFutureTobtToNow(t *testing.T) {
 	assert.Equal(t, "REA", *persisted.Status)
 	require.NotNil(t, persisted.TobtSetBy)
 	assert.Equal(t, "EKCH_DEL", *persisted.TobtSetBy)
+	require.NotNil(t, persisted.TobtConfirmedBy)
+	assert.Equal(t, models.TobtConfirmedByATC, *persisted.TobtConfirmedBy)
+	assert.True(t, persisted.TobtManuallyConfirmed)
+	assert.False(t, persisted.TobtAutoSynced)
 }
 
 func TestHandleReadyRequest_PreservesTobtWithinTsatWindow(t *testing.T) {
@@ -1790,6 +1863,8 @@ func TestHandleReadyRequest_UpdatesPastTobtToNowWithActiveTsat(t *testing.T) {
 
 	pastTobt := time.Now().UTC().Add(-5 * time.Minute).Format("1504")
 	activeTsat := time.Now().UTC().Add(10 * time.Minute).Format("1504")
+	previousAsrt := time.Now().UTC().Add(-5 * time.Minute).Format("1504")
+	readyStatus := "REA"
 	var persisted *models.CdmData
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1807,7 +1882,12 @@ func TestHandleReadyRequest_UpdatesPastTobtToNowWithActiveTsat(t *testing.T) {
 				if persisted != nil {
 					return persisted.Clone(), nil
 				}
-				return (&models.CdmData{Tobt: stringPtr(pastTobt), Tsat: stringPtr(activeTsat)}).Normalize(), nil
+				return (&models.CdmData{
+					Tobt:   stringPtr(pastTobt),
+					Tsat:   stringPtr(activeTsat),
+					Asrt:   stringPtr(previousAsrt),
+					Status: stringPtr(readyStatus),
+				}).Normalize(), nil
 			},
 			SetCdmDataFn: func(_ context.Context, _ int32, _ string, data *models.CdmData) (int64, error) {
 				persisted = data.Clone()
@@ -1829,6 +1909,8 @@ func TestHandleReadyRequest_UpdatesPastTobtToNowWithActiveTsat(t *testing.T) {
 	require.NotNil(t, persisted)
 	require.NotNil(t, persisted.Tobt)
 	assert.Contains(t, []string{beforeNow, afterNow}, *persisted.Tobt)
+	require.NotNil(t, persisted.Asrt)
+	assert.Contains(t, []string{beforeNow, afterNow}, *persisted.Asrt)
 	require.NotNil(t, persisted.Status)
 	assert.Equal(t, "REA", *persisted.Status)
 }

--- a/backend/internal/frontend/handlers.go
+++ b/backend/internal/frontend/handlers.go
@@ -416,15 +416,9 @@ func handleStartReq(ctx context.Context, client *Client, message Message) error 
 		return err
 	}
 	if event.StartReq {
-		strip, err := client.hub.server.GetStripRepository().GetByCallsign(ctx, client.session, event.Callsign)
-		if err != nil {
+		cdmService := client.hub.server.GetCdmService()
+		if err := cdmService.HandleReadyRequest(ctx, client.session, event.Callsign, client.position, "ATC"); err != nil {
 			return err
-		}
-		if !strip.StartReq {
-			cdmService := client.hub.server.GetCdmService()
-			if err := cdmService.HandleReadyRequest(ctx, client.session, event.Callsign, client.position, "ATC"); err != nil {
-				return err
-			}
 		}
 	}
 	return client.hub.stripService.UpdateStartReq(ctx, client.session, event.Callsign, event.StartReq)

--- a/backend/internal/frontend/handlers_cdm_test.go
+++ b/backend/internal/frontend/handlers_cdm_test.go
@@ -149,7 +149,7 @@ func TestHandleStartReq_ReportsReadyAndPersistsStartRequest(t *testing.T) {
 	assert.True(t, startReqPersisted)
 }
 
-func TestHandleStartReq_DoesNotReportReadyAgainWhenAlreadyActive(t *testing.T) {
+func TestHandleStartReq_ReportsReadyAgainWhenAlreadyActive(t *testing.T) {
 	cdmService := &spyCdmService{}
 	stripRepo := &testutil.MockStripRepository{
 		GetByCallsignFn: func(_ context.Context, session int32, callsign string) (*models.Strip, error) {
@@ -164,7 +164,9 @@ func TestHandleStartReq_DoesNotReportReadyAgainWhenAlreadyActive(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, handleStartReq(context.Background(), client, Message{Message: payload}))
 
-	assert.False(t, cdmService.called)
+	assert.True(t, cdmService.called)
+	assert.Equal(t, int32(42), cdmService.session)
+	assert.Equal(t, "SAS321", cdmService.callsign)
 }
 
 func TestHandleClxUpdateTobt_UsesClxOrchestrationMethod(t *testing.T) {

--- a/backend/internal/services/strip_fields.go
+++ b/backend/internal/services/strip_fields.go
@@ -392,18 +392,23 @@ func (s *StripService) applyClearedFlagForMoveWithOptions(ctx context.Context, s
 // UpdateGroundStateForMove handles the frontend "move to general bay" action.
 // It computes the new ground state, updates the DB, and notifies EuroScope.
 func (s *StripService) UpdateGroundStateForMove(ctx context.Context, session int32, callsign string, bay string, cid string, airport string) error {
-	return s.updateGroundStateForMoveWithOptions(ctx, session, callsign, bay, cid, airport, bay, true)
-}
-
-func (s *StripService) updateGroundStateForMoveWithOptions(ctx context.Context, session int32, callsign string, targetBay string, cid string, airport string, persistedBay string, reevaluate bool) error {
-	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
+	state, err := s.updateGroundStateForMoveWithOptions(ctx, session, callsign, bay, cid, airport, bay, true)
 	if err != nil {
 		return err
+	}
+	s.syncAsatForGroundStateBestEffort(ctx, session, callsign, state)
+	return nil
+}
+
+func (s *StripService) updateGroundStateForMoveWithOptions(ctx context.Context, session int32, callsign string, targetBay string, cid string, airport string, persistedBay string, reevaluate bool) (*string, error) {
+	strip, err := s.stripReader.GetByCallsign(ctx, session, callsign)
+	if err != nil {
+		return nil, err
 	}
 
 	if strip.StartReq && shouldResetStartReqOnMove(strip.Bay, targetBay) {
 		if err := s.setStartReqState(ctx, session, callsign, false, false, strip); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
@@ -420,10 +425,10 @@ func (s *StripService) updateGroundStateForMoveWithOptions(ctx context.Context, 
 
 	count, err := s.fieldStore.UpdateGroundState(ctx, session, callsign, state, persistedBay, nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if count != 1 {
-		return errors.New("failed to update strip bay/ground state")
+		return nil, errors.New("failed to update strip bay/ground state")
 	}
 
 	if state != strip.State && state != nil && s.esCommander != nil {
@@ -434,18 +439,32 @@ func (s *StripService) updateGroundStateForMoveWithOptions(ctx context.Context, 
 	// action behaves like a fresh clearance instead of a confirmation.
 	if strip.RunwayCleared && shouldResetRunwayClearanceOnMove(strip.Bay, targetBay) {
 		if _, err := s.fieldStore.ResetRunwayClearance(ctx, session, callsign); err != nil {
-			return err
+			return nil, err
 		}
 		s.publisher.SendStripUpdate(session, callsign)
 	}
 
 	if reevaluate {
 		if err := s.reevaluateStripValidationPrecedence(ctx, session, callsign, true, true); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return nil
+	return state, nil
+}
+
+func (s *StripService) syncAsatForGroundStateBestEffort(ctx context.Context, session int32, callsign string, state *string) {
+	if state == nil || s.cdmService == nil {
+		return
+	}
+	if err := s.cdmService.SyncAsatForGroundState(ctx, session, callsign, *state); err != nil {
+		slog.WarnContext(ctx, "Failed to synchronize ASAT after strip move",
+			slog.Int("session", int(session)),
+			slog.String("callsign", callsign),
+			slog.String("ground_state", *state),
+			slog.Any("error", err),
+		)
+	}
 }
 
 // UpdateReleasePoint updates the release point for a strip and broadcasts to all frontend clients.

--- a/backend/internal/services/strip_frontend_move.go
+++ b/backend/internal/services/strip_frontend_move.go
@@ -63,7 +63,8 @@ func (s *StripService) MoveFrontendStrip(ctx context.Context, session int32, cal
 		strip.PdcState != "" &&
 		strip.PdcState != internalModels.PdcStateNone
 
-	if err := s.applyFrontendMoveState(ctx, session, strip, targetBay, cid, airport); err != nil {
+	groundState, err := s.applyFrontendMoveState(ctx, session, strip, targetBay, cid, airport)
+	if err != nil {
 		return err
 	}
 
@@ -75,25 +76,24 @@ func (s *StripService) MoveFrontendStrip(ctx context.Context, session int32, cal
 		s.ClearMandatoryRouteCdm(ctx, session, callsign)
 	}
 
-	if !shouldConfirmVoiceClearance {
-		return nil
-	}
-
-	pdcService := s.getPdcService()
-	if pdcService == nil {
-		return errors.New("PDC service not available")
-	}
-
-	if err := pdcService.ConfirmVoiceClearance(ctx, callsign, session); err != nil {
-		if rollbackErr := s.MoveToBay(ctx, session, callsign, previousBay, true); rollbackErr != nil {
-			return errors.Join(err, rollbackErr)
+	if shouldConfirmVoiceClearance {
+		pdcService := s.getPdcService()
+		if pdcService == nil {
+			return errors.New("PDC service not available")
 		}
-		if rollbackErr := s.applyClearedFlagForMoveWithOptions(ctx, session, callsign, previousCleared, previousBay, previousBay == shared.BAY_NOT_CLEARED, cid, false, false); rollbackErr != nil {
-			return errors.Join(err, rollbackErr)
+
+		if err := pdcService.ConfirmVoiceClearance(ctx, callsign, session); err != nil {
+			if rollbackErr := s.MoveToBay(ctx, session, callsign, previousBay, true); rollbackErr != nil {
+				return errors.Join(err, rollbackErr)
+			}
+			if rollbackErr := s.applyClearedFlagForMoveWithOptions(ctx, session, callsign, previousCleared, previousBay, previousBay == shared.BAY_NOT_CLEARED, cid, false, false); rollbackErr != nil {
+				return errors.Join(err, rollbackErr)
+			}
+			return err
 		}
-		return err
 	}
 
+	s.syncAsatForGroundStateBestEffort(ctx, session, callsign, groundState)
 	return nil
 }
 
@@ -133,9 +133,9 @@ func (s *StripService) authorizeFrontendMove(ctx context.Context, session int32,
 	return nil
 }
 
-func (s *StripService) applyFrontendMoveState(ctx context.Context, session int32, strip *internalModels.Strip, targetBay string, cid string, airport string) error {
+func (s *StripService) applyFrontendMoveState(ctx context.Context, session int32, strip *internalModels.Strip, targetBay string, cid string, airport string) (*string, error) {
 	if targetBay == shared.BAY_NOT_CLEARED || targetBay == shared.BAY_CLEARED {
-		return s.applyClearedFlagForMoveWithOptions(ctx, session, strip.Callsign, targetBay == shared.BAY_CLEARED, strip.Bay, targetBay == shared.BAY_NOT_CLEARED, cid, false, true)
+		return nil, s.applyClearedFlagForMoveWithOptions(ctx, session, strip.Callsign, targetBay == shared.BAY_CLEARED, strip.Bay, targetBay == shared.BAY_NOT_CLEARED, cid, false, true)
 	}
 
 	return s.updateGroundStateForMoveWithOptions(ctx, session, strip.Callsign, targetBay, cid, airport, strip.Bay, false)

--- a/backend/internal/services/strip_frontend_move_test.go
+++ b/backend/internal/services/strip_frontend_move_test.go
@@ -215,6 +215,8 @@ func TestMoveFrontendStrip_ToGeneralBayUsesSingleBayWrite(t *testing.T) {
 		Destination: "ESSA",
 		StartReq:    true,
 	})
+	cdmService := &spyStripCdmService{}
+	fixture.svc.SetCdmService(cdmService)
 
 	err := fixture.svc.MoveFrontendStrip(fixture.ctx, 1, "SAS125", shared.BAY_PUSH, "1234567", "EKCH", "EKCH_DEL")
 	require.NoError(t, err)
@@ -226,6 +228,36 @@ func TestMoveFrontendStrip_ToGeneralBayUsesSingleBayWrite(t *testing.T) {
 	assert.Equal(t, shared.BAY_PUSH, fixture.strip.Bay)
 	require.Len(t, fixture.esHub.GroundStates, 1)
 	assert.Equal(t, euroscope.GroundStatePush, fixture.esHub.GroundStates[0].GroundState)
+	assert.True(t, cdmService.called)
+	assert.Equal(t, "SAS125", cdmService.callsign)
+	assert.Equal(t, euroscope.GroundStatePush, cdmService.groundState)
+}
+
+func TestMoveFrontendStrip_AsatSyncFailureDoesNotRejectCompletedMove(t *testing.T) {
+	fixture := newFrontendMoveFixture(&internalModels.Strip{
+		Callsign:    "SAS132",
+		Bay:         shared.BAY_STAND,
+		Origin:      "EKCH",
+		Destination: "ESSA",
+	})
+	bayWhenAsatSynced := ""
+	cdmService := &spyStripCdmService{
+		syncAsatErr: assert.AnError,
+		syncAsatFn: func() {
+			bayWhenAsatSynced = fixture.strip.Bay
+		},
+	}
+	fixture.svc.SetCdmService(cdmService)
+
+	err := fixture.svc.MoveFrontendStrip(fixture.ctx, 1, "SAS132", shared.BAY_PUSH, "1234567", "EKCH", "EKCH_DEL")
+	require.NoError(t, err)
+
+	assert.Equal(t, shared.BAY_PUSH, fixture.strip.Bay)
+	assert.Equal(t, []string{shared.BAY_PUSH}, fixture.updateBayTargets)
+	require.Len(t, fixture.esHub.GroundStates, 1)
+	assert.Equal(t, euroscope.GroundStatePush, fixture.esHub.GroundStates[0].GroundState)
+	assert.True(t, cdmService.called)
+	assert.Equal(t, shared.BAY_PUSH, bayWhenAsatSynced)
 }
 
 func TestMoveFrontendStrip_DepartureToArrivalBayRejected(t *testing.T) {

--- a/backend/internal/services/strip_test.go
+++ b/backend/internal/services/strip_test.go
@@ -25,6 +25,8 @@ type spyStripCdmService struct {
 	recalcTriggered      bool
 	prepareEobtSyncCalls int
 	prepareEobtSyncFn    func(session int32, data *models.CdmData, eobt string, now time.Time) (*models.CdmData, string, bool)
+	syncAsatErr          error
+	syncAsatFn           func()
 }
 
 func (s *spyStripCdmService) TriggerRecalculate(_ context.Context, session int32, airport string) {
@@ -80,7 +82,10 @@ func (s *spyStripCdmService) SyncAsatForGroundState(_ context.Context, _ int32, 
 	s.called = true
 	s.callsign = callsign
 	s.groundState = groundState
-	return nil
+	if s.syncAsatFn != nil {
+		s.syncAsatFn()
+	}
+	return s.syncAsatErr
 }
 func (s *spyStripCdmService) RequestBetterTobt(_ context.Context, _ int32, _ string) error {
 	panic("unexpected")

--- a/frontend/src/components/strip/ApnPushStrip.tsx
+++ b/frontend/src/components/strip/ApnPushStrip.tsx
@@ -107,7 +107,7 @@ export function ApnPushStrip({
   const [taxiMapOpen, setTaxiMapOpen] = useState(false);
   const [runwayOpen, setRunwayOpen] = useState(false);
   const [fplOpen, setFplOpen] = useState(false);
-  const cdmReady = useWebSocketStore(s => s.cdmReady);
+  const setStartReq = useWebSocketStore(s => s.setStartReq);
   const acknowledgeUnexpectedChange = useWebSocketStore(s => s.acknowledgeUnexpectedChange);
   const standYellow = unexpectedChangeFields?.includes("stand");
   const runwayYellow = unexpectedChangeFields?.includes("runway");
@@ -223,7 +223,7 @@ export function ApnPushStrip({
             style={{ height: HALF_H, borderBottomColor: cellBorderColor, backgroundColor: tsatBg || undefined, cursor: canSendCdmReady ? getValidationBlockedCursor(isValidationActive, "pointer", true) : undefined }}
             onClick={canSendCdmReady ? (e) => {
               e.stopPropagation();
-              cdmReady(callsign);
+              setStartReq(callsign, true);
             } : undefined}
           >
             <span className="shrink-0" style={{ fontFamily: FONT, fontSize: "0.63vw" }}>TSAT</span>
@@ -234,7 +234,7 @@ export function ApnPushStrip({
             style={{ height: HALF_H, backgroundColor: ctotBg || undefined, color: ctotColor, cursor: canSendCdmReady ? getValidationBlockedCursor(isValidationActive, "pointer", true) : undefined }}
             onClick={canSendCdmReady ? (e) => {
               e.stopPropagation();
-              cdmReady(callsign);
+              setStartReq(callsign, true);
             } : undefined}
           >
             <span className="shrink-0" style={{ fontFamily: FONT, fontSize: "0.63vw" }}>{showCtot ? "CTOT" : ""}</span>

--- a/frontend/src/components/strip/ClxClearedStrip.tsx
+++ b/frontend/src/components/strip/ClxClearedStrip.tsx
@@ -99,7 +99,7 @@ export function ClxClearedStrip({
     bay,
   );
   const showClearedCallsignHighlight = usePdcClearedCallsignBlink(pdcStatus);
-  const cdmReady = useWebSocketStore(s => s.cdmReady);
+  const setStartReq = useWebSocketStore(s => s.setStartReq);
   const acknowledgeUnexpectedChange = useWebSocketStore(s => s.acknowledgeUnexpectedChange);
   const standYellow = unexpectedChangeFields?.includes("stand");
   const { tobtBg, tsatBg } = useCDMColors({ bay: bay ?? Bay.Unknown, tsat: tsat ?? "", tobt: tobt ?? "", phase });
@@ -196,7 +196,7 @@ export function ClxClearedStrip({
               style={{ height: HALF_H, fontFamily: FONT, fontSize: "0.73vw", borderBottomColor: cellBorderColor, backgroundColor: tobtBg, cursor: getValidationBlockedCursor(isValidationActive, "pointer", true) }}
               onClick={(e) => {
                 e.stopPropagation();
-                cdmReady(callsign);
+                setStartReq(callsign, true);
               }}
             >
               <span className={`${textWhite ? "text-white" : "text-black"} shrink-0`}>TOBT</span>
@@ -205,7 +205,7 @@ export function ClxClearedStrip({
             <div className="flex items-center justify-between px-[0.21vw] overflow-hidden" style={{ height: HALF_H, fontFamily: FONT, fontSize: "0.73vw", backgroundColor: tsatBg, cursor: getValidationBlockedCursor(isValidationActive, "pointer", true) }}
               onClick={(e) => {
                 e.stopPropagation();
-                cdmReady(callsign);
+                setStartReq(callsign, true);
               }}
             >
               <span className={`${textWhite ? "text-white" : "text-black"} shrink-0`}>TSAT</span>

--- a/frontend/src/components/strip/DelStrip.tsx
+++ b/frontend/src/components/strip/DelStrip.tsx
@@ -67,7 +67,7 @@ export function DelStrip({
     setValidationDialogOpen,
     validationStatus,
   } = useStripCallsignInteraction({ callsign, selectable, bay, owner, myPosition });
-  const cdmReady = useWebSocketStore(s => s.cdmReady);
+  const setStartReq = useWebSocketStore(s => s.setStartReq);
   const acknowledgeUnexpectedChange = useWebSocketStore(s => s.acknowledgeUnexpectedChange);
   const stripTransfers = useStripTransfers();
   const isTagRequest = !!stripTransfers[callsign]?.isTagRequest;
@@ -163,7 +163,7 @@ export function DelStrip({
               style={{ height: HALF_H, fontFamily: FONT, fontSize: "0.73vw", borderBottomColor: cellBorderColor, backgroundColor: tobtBg, cursor: getValidationBlockedCursor(isValidationActive, "pointer", true) }}
               onClick={(e) => {
                 e.stopPropagation();
-                cdmReady(callsign);
+                setStartReq(callsign, true);
               }}
             >
               <span className="shrink-0">TOBT</span>
@@ -172,7 +172,7 @@ export function DelStrip({
             <div className="flex items-center justify-between px-[0.21vw] overflow-hidden" style={{ height: HALF_H, fontFamily: FONT, fontSize: "0.73vw", backgroundColor: tsatBg, cursor: getValidationBlockedCursor(isValidationActive, "pointer", true) }}
               onClick={(e) => {
                 e.stopPropagation();
-                cdmReady(callsign);
+                setStartReq(callsign, true);
               }}
             >
               <span className="shrink-0">TSAT</span>

--- a/frontend/src/routes/ekch/EST.tsx
+++ b/frontend/src/routes/ekch/EST.tsx
@@ -302,6 +302,7 @@ export default function EST() {
       return;
     }
 
+    setStartReq(menuStrip.callsign, true);
     setActionState(menuState.stand, menuStrip);
     transferStrip(menuStrip.callsign, apronDepartureTransferTarget);
     closeMenu();
@@ -528,7 +529,6 @@ export default function EST() {
           onStartTransfer={handleStartTransfer}
           startTransferDisabled={
             !apronDepartureTransferTarget ||
-            !menuStrip.start_req ||
             !isTsatWithinStartRequestWindow(menuStrip.tsat, nowMs)
           }
           onStartRequest={handleStartRequest}


### PR DESCRIPTION
## Summary

- route strip CDM-field clicks and EST START REQ actions through the persisted START REQ workflow
- record ASRT locally and export it through vIFF `setCdmData` while continuing to send `REA/1`
- refresh and ATC-confirm TOBT when a repeated START REQ requires a new ready calculation
- synchronize ASAT/AOBT after successful frontend ground-state moves without rejecting a completed move when CDM synchronization fails

## Why

FlightStrips maintained its own CDM state, so sending only the readiness DPI could leave vIFF without the locally derived ASRT. The strip CDM-field click also used the legacy ready-only event instead of setting START REQ, and repeated START REQ events were skipped once the flag was already active. Frontend bay moves could additionally depend on a later EuroScope echo before ASAT/AOBT was synchronized.

This change makes START REQ the common controller action, persists and exports the associated request time, and performs approval-time synchronization after the authoritative move has completed. ASAT synchronization is treated as a derived best-effort side effect so a transient CDM failure cannot leave the strip move partially rejected.

## Controller impact

- START REQ and START REQ+TRF now set ASRT and send `REA/1` consistently.
- Clicking TOBT/TSAT on the applicable strips uses the same START REQ behavior.
- Repeating START REQ reruns readiness handling while preserving TOBT when TSAT is already within the valid window.
- Moving a departure into an active ground state synchronizes ASAT/AOBT directly from the frontend move path.

## Validation

- `go test ./internal/services -run "Test(MoveFrontendStrip|UpdateGroundStateForMove)" -count=1`
- `go test ./internal/cdm ./internal/frontend -count=1`
- `go vet ./internal/services ./internal/cdm ./internal/frontend`
- frontend unit tests: 96 passed
- frontend lint for touched files
- frontend production build
- `git diff --check`

The complete `go test ./internal/services` run is blocked locally because Testcontainers reports that rootless Docker is unsupported on Windows; the focused service tests pass.
