### PR TITLE
feat(stand): add system status diagnostics

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -18,6 +18,8 @@ import (
 	"FlightStrips/internal/server"
 	"FlightStrips/internal/services"
 	"FlightStrips/internal/shared"
+	"FlightStrips/internal/standdiagnostics"
+	"FlightStrips/internal/standstatus"
 	"FlightStrips/internal/vatsim"
 	"FlightStrips/internal/websocket"
 	pkgEuroscope "FlightStrips/pkg/events/euroscope"
@@ -134,6 +136,7 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	standActionService := satGraph.actions
 	departureLifecycle := satGraph.departures
 	arrivalLifecycle := satGraph.arrivals
+	standAssignmentFailures := satGraph.failures
 
 	stripService := services.NewStripService(
 		stripRepo,
@@ -343,7 +346,10 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 			sessionRepo:                sessionRepo,
 			sequenceService:            sequenceService,
 			vatsimCache:                vatsimCache,
+			standAssignmentRepo:        standAssignmentRepo,
 			standAssignmentReadiness:   standAssignmentReadiness,
+			standAssignmentDiagnostics: standAssignmentDiagnostics(),
+			standAssignmentFailures:    standAssignmentFailures,
 			standAssignmentStaleAfter:  satStaleAfter(deps.VATSIMPollInterval),
 			requireLiveCIDVerification: requireLiveCIDVerification,
 			enableHTTPTracing:          cfg.EnableHTTPTracing,
@@ -425,11 +431,15 @@ type satAssembly struct {
 	actions     *services.StandActionService
 	departures  *services.DepartureLifecycleService
 	arrivals    *services.ArrivalLifecycleService
+	failures    *standdiagnostics.AllocationFailureLog
 }
 
 func assembleSAT(cfg Config, readiness appconfig.StandAssignmentReadiness, dbpool *pgxpool.Pool, core coreRepositories) (satAssembly, error) {
+	graph := satAssembly{
+		failures: standdiagnostics.NewAllocationFailureLog(100),
+	}
 	if !readiness.Ready {
-		return satAssembly{}, nil
+		return graph, nil
 	}
 
 	assignments := postgres.NewStandAssignmentRepository(dbpool)
@@ -439,6 +449,7 @@ func assembleSAT(cfg Config, readiness appconfig.StandAssignmentReadiness, dbpoo
 	borders := appconfig.GetAirportCountries()
 	allocations, err := services.NewStandAllocationService(
 		dbpool, core.strips, assignments, stands, appconfig.GetAirlineAssignment(),
+		services.WithStandAllocationFailureLog(graph.failures),
 	)
 	if err != nil {
 		return satAssembly{}, fmt.Errorf("initialize stand allocation service: %w", err)
@@ -460,13 +471,12 @@ func assembleSAT(cfg Config, readiness appconfig.StandAssignmentReadiness, dbpoo
 		return satAssembly{}, fmt.Errorf("initialize arrival lifecycle service: %w", err)
 	}
 
-	return satAssembly{
-		assignments: assignments,
-		allocations: allocations,
-		actions:     services.NewStandActionService(allocations, assignments, core.strips, aircraft, engines, borders),
-		departures:  departures,
-		arrivals:    arrivals,
-	}, nil
+	graph.assignments = assignments
+	graph.allocations = allocations
+	graph.actions = services.NewStandActionService(allocations, assignments, core.strips, aircraft, engines, borders)
+	graph.departures = departures
+	graph.arrivals = arrivals
+	return graph, nil
 }
 
 type transportAssembly struct {
@@ -533,6 +543,26 @@ func configureStandAssignment(enabled bool) appconfig.StandAssignmentReadiness {
 		slog.Error("Stand Assignment Tool unavailable", slog.String("reason", readiness.Reason))
 	}
 	return readiness
+}
+
+func standAssignmentDiagnostics() standstatus.WebAPIDiagnostics {
+	diagnostics := standstatus.WebAPIDiagnostics{}
+	if registry := appconfig.GetAircraftReference(); registry != nil {
+		diagnostics.AircraftTypes = len(registry.Types())
+	}
+	if registry := appconfig.GetStandCapabilities(); registry != nil {
+		stands := registry.AllStands()
+		diagnostics.Stands = len(stands)
+		for _, stand := range stands {
+			diagnostics.StandVariants += len(stand.Variants)
+		}
+	}
+	if policy := appconfig.GetAirlineAssignment(); policy != nil {
+		diagnostics.AirlineRules = len(policy.Rules)
+		diagnostics.StandGroups = len(policy.StandGroups)
+		diagnostics.FallbackRules = len(policy.FallbackRules)
+	}
+	return diagnostics
 }
 
 func (a *App) Handler() http.Handler {
@@ -733,7 +763,10 @@ type buildHandlerConfig struct {
 	sessionRepo                repository.SessionRepository
 	sequenceService            *cdm.SequenceService
 	vatsimCache                *vatsim.Cache
+	standAssignmentRepo        repository.StandAssignmentRepository
 	standAssignmentReadiness   appconfig.StandAssignmentReadiness
+	standAssignmentDiagnostics standstatus.WebAPIDiagnostics
+	standAssignmentFailures    *standdiagnostics.AllocationFailureLog
 	standAssignmentStaleAfter  time.Duration
 	requireLiveCIDVerification bool
 	enableHTTPTracing          bool
@@ -759,6 +792,13 @@ func buildHandler(cfg buildHandlerConfig) http.Handler {
 	}
 
 	apiMux := http.NewServeMux()
+	standstatus.NewWebAPI(standstatus.WebAPIConfig{
+		Auth: cfg.authService, Sessions: cfg.sessionRepo, Assignments: cfg.standAssignmentRepo,
+		Feed: cfg.vatsimCache, Enabled: cfg.standAssignmentReadiness.Enabled,
+		Ready: cfg.standAssignmentReadiness.Ready, Reason: cfg.standAssignmentReadiness.Reason,
+		StaleAfter: cfg.standAssignmentStaleAfter, Diagnostics: cfg.standAssignmentDiagnostics,
+		Failures: cfg.standAssignmentFailures,
+	}).RegisterRoutes(apiMux)
 	if cfg.enableCDMAPI {
 		cdm.NewWebAPI(cfg.authService, cfg.sessionRepo, cfg.sequenceService).RegisterRoutes(apiMux)
 	}
@@ -775,9 +815,7 @@ func buildHandler(cfg buildHandlerConfig) http.Handler {
 	if cfg.enablePDCAPI {
 		pdc.NewWebAPI(cfg.authService, cfg.pdcService, cfg.vatsimCache, cfg.requireLiveCIDVerification).RegisterRoutes(apiMux)
 	}
-	if cfg.enableCDMAPI || cfg.enableECFMPAPI || cfg.enablePilotAPI || cfg.enableEFBAPI || cfg.enablePDCAPI {
-		mux.Handle("/api/", server.APIMiddleware(http.StripPrefix("/api", apiMux)))
-	}
+	mux.Handle("/api/", server.APIMiddleware(http.StripPrefix("/api", apiMux)))
 
 	var handler http.Handler = mux
 	if cfg.enableHTTPTracing {

--- a/backend/internal/app/app_test.go
+++ b/backend/internal/app/app_test.go
@@ -118,6 +118,11 @@ func TestBuildDisablesStandAssignmentByDefault(t *testing.T) {
 	response := httptest.NewRecorder()
 	application.Handler().ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/api/pdc/status", nil))
 	require.Equal(t, http.StatusNotFound, response.Code)
+
+	statusRequest := httptest.NewRequest(http.MethodGet, "/api/stand/status", nil)
+	statusResponse := httptest.NewRecorder()
+	application.Handler().ServeHTTP(statusResponse, statusRequest)
+	require.Equal(t, http.StatusUnauthorized, statusResponse.Code)
 }
 
 func TestBuildAssemblesPDCOnlyWithInjectedRealClientBoundary(t *testing.T) {

--- a/backend/internal/services/departure_lifecycle.go
+++ b/backend/internal/services/departure_lifecycle.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -53,6 +54,8 @@ type DepartureLifecycleService struct {
 	blockExtension time.Duration
 	sweepInterval  time.Duration
 	messenger      wrongStandMessenger
+	warningMu      sync.Mutex
+	warnings       map[string]string
 }
 
 type wrongStandMessenger interface {
@@ -66,6 +69,7 @@ func (s *DepartureLifecycleService) SetWrongStandMessenger(messenger wrongStandM
 // CancelDeparture cancels transient wrong-stand state when a departure
 // disappears from the live feed.
 func (s *DepartureLifecycleService) CancelDeparture(ctx context.Context, session int32, callsign string) error {
+	s.clearUnassignedStandWarning(session, callsign)
 	return s.cancelWrongStandEpisode(ctx, session, callsign)
 }
 
@@ -134,6 +138,7 @@ func NewDepartureLifecycleService(
 		hold:           defaultDepartureHoldDuration,
 		blockExtension: defaultDepartureBlockExtension,
 		sweepInterval:  defaultDepartureSweepInterval,
+		warnings:       make(map[string]string),
 	}
 	for _, option := range options {
 		if option != nil {
@@ -196,6 +201,7 @@ func (s *DepartureLifecycleService) ObserveDeparturePosition(ctx context.Context
 func (s *DepartureLifecycleService) activateObservedBlock(ctx context.Context, session int32, strip *models.Strip, flight vatsim.DepartureFlightInfo) (bool, error) {
 	observed, found := s.stands.StandAtPosition(strings.TrimSpace(strip.Origin), flight.Latitude, flight.Longitude)
 	if !found {
+		s.clearUnassignedStandWarning(session, strip.Callsign)
 		slog.Warn("online departure is not inside a configured stand radius",
 			slog.String("callsign", strip.Callsign),
 			slog.Float64("latitude", flight.Latitude),
@@ -218,11 +224,22 @@ func (s *DepartureLifecycleService) activateObservedBlock(ctx context.Context, s
 	request := s.buildRequest(session, strip, flight, StageDepartureBlock, expiry)
 	request.Stand = observed.Name
 	if _, err := s.allocations.AssignManually(ctx, request); err == nil {
+		s.clearUnassignedStandWarning(session, strip.Callsign)
 		return true, nil
 	} else if existing == nil {
-		slog.Warn("observed departure stand requires task 19 handling",
-			slog.String("callsign", strip.Callsign), slog.String("observedStand", observed.Name), slog.Any("error", err))
-		return false, nil
+		automaticRequest := s.buildRequest(session, strip, flight, StageDepartureBlock, expiry)
+		result, allocationErr := s.allocations.Allocate(ctx, automaticRequest)
+		if allocationErr != nil {
+			s.deliverUnassignedOccupiedStandWarning(session, strip.Callsign, observed.Name)
+			slog.Warn("observed departure stand is occupied and no alternative stand could be assigned",
+				slog.String("callsign", strip.Callsign),
+				slog.String("observedStand", observed.Name),
+				slog.Any("observed_stand_error", err),
+				slog.Any("alternative_allocation_error", allocationErr))
+			return false, nil
+		}
+		s.clearUnassignedStandWarning(session, strip.Callsign)
+		existing = &result.Assignment
 	}
 
 	pendingReason := wrongStandPendingPrefix + observed.Name
@@ -250,6 +267,30 @@ func (s *DepartureLifecycleService) activateObservedBlock(ctx context.Context, s
 		return false, fmt.Errorf("publish observed stand mismatch for %s: %w", strip.Callsign, err)
 	}
 	return false, s.deliverWrongStandWarning(ctx, &updated)
+}
+
+func (s *DepartureLifecycleService) deliverUnassignedOccupiedStandWarning(session int32, callsign, observedStand string) {
+	if s.messenger == nil {
+		return
+	}
+	key := fmt.Sprintf("%d:%s", session, strings.ToUpper(strings.TrimSpace(callsign)))
+
+	s.warningMu.Lock()
+	defer s.warningMu.Unlock()
+	if warnedStand, ok := s.warnings[key]; ok && strings.EqualFold(warnedStand, observedStand) {
+		return
+	}
+	if s.messenger.SendPrivateMessageFromDelivery(session, callsign,
+		fmt.Sprintf("STAND ASSIGNMENT: STAND %s IS OCCUPIED. PLEASE RELOCATE", observedStand)) {
+		s.warnings[key] = observedStand
+	}
+}
+
+func (s *DepartureLifecycleService) clearUnassignedStandWarning(session int32, callsign string) {
+	key := fmt.Sprintf("%d:%s", session, strings.ToUpper(strings.TrimSpace(callsign)))
+	s.warningMu.Lock()
+	delete(s.warnings, key)
+	s.warningMu.Unlock()
 }
 
 func (s *DepartureLifecycleService) deliverWrongStandWarning(ctx context.Context, assignment *models.StandAssignment) error {

--- a/backend/internal/services/departure_lifecycle_test.go
+++ b/backend/internal/services/departure_lifecycle_test.go
@@ -248,6 +248,82 @@ func TestDepartureLifecycle(t *testing.T) {
 		assert.Len(t, published, 3, "an unchanged mismatch must not be republished")
 	})
 
+	t.Run("EuroScope spawn on occupied stand sends relocation message", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := departureLifecycleFixture(t, pool, queries, "", "", nil)
+		messenger := &wrongStandTestMessenger{available: true}
+		lifecycle.SetWrongStandMessenger(messenger)
+		testdata.SeedTestStrip(t, queries, session, "SAS607")
+		clock.set(time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC))
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS607"), offlineFlight("SAS607", 1)))
+		require.NoError(t, assignments.CreateBlock(ctx, &models.StandBlock{
+			SessionID: session, Stand: "A2", BlockType: "MANUAL", Source: "CONTROLLER", Manual: true,
+		}))
+
+		require.NoError(t, lifecycle.ObserveDeparturePosition(
+			ctx, session, loadStrip(t, strips, session, "SAS607"), 55.6285306, 12.6434583,
+		))
+
+		require.Equal(t, 1, messenger.calls)
+		require.Equal(t, "STAND ASSIGNMENT: PLEASE RELOCATE TO YOUR ASSIGNED STAND A1", messenger.message)
+		assignment, err := assignments.GetAssignment(ctx, session, "SAS607")
+		require.NoError(t, err)
+		assert.Equal(t, "A1", assignment.Stand, "the occupied observed stand must not replace the reserved stand")
+		require.NotNil(t, assignment.ConflictReason)
+		assert.Contains(t, *assignment.ConflictReason, wrongStandPendingPrefix)
+	})
+
+	t.Run("EuroScope-only spawn on occupied stand receives an alternative and relocation message", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, _ := departureLifecycleFixture(t, pool, queries, "", "", nil)
+		messenger := &wrongStandTestMessenger{available: true}
+		lifecycle.SetWrongStandMessenger(messenger)
+		testdata.SeedTestStrip(t, queries, session, "SAS608")
+		require.NoError(t, assignments.CreateBlock(ctx, &models.StandBlock{
+			SessionID: session, Stand: "A2", BlockType: "MANUAL", Source: "CONTROLLER", Manual: true,
+		}))
+
+		require.NoError(t, lifecycle.ObserveDeparturePosition(
+			ctx, session, loadStrip(t, strips, session, "SAS608"), 55.6285306, 12.6434583,
+		))
+
+		require.Equal(t, 1, messenger.calls)
+		require.Equal(t, "STAND ASSIGNMENT: PLEASE RELOCATE TO YOUR ASSIGNED STAND A1", messenger.message)
+		assignment, err := assignments.GetAssignment(ctx, session, "SAS608")
+		require.NoError(t, err)
+		assert.Equal(t, "A1", assignment.Stand)
+		assert.Equal(t, StageDepartureBlock, assignment.Stage)
+		require.NotNil(t, assignment.ConflictReason)
+		assert.Contains(t, *assignment.ConflictReason, wrongStandPendingPrefix)
+
+		require.NoError(t, lifecycle.ObserveDeparturePosition(
+			ctx, session, loadStrip(t, strips, session, "SAS608"), 55.6285306, 12.6434583,
+		))
+		require.Equal(t, 1, messenger.calls, "the same occupied-stand episode must not send another message")
+	})
+
+	t.Run("EuroScope-only spawn with no alternative receives one occupied message", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, _ := departureLifecycleFixture(t, pool, queries, "", "", nil)
+		messenger := &wrongStandTestMessenger{available: true}
+		lifecycle.SetWrongStandMessenger(messenger)
+		testdata.SeedTestStrip(t, queries, session, "SAS609")
+		for _, stand := range []string{"A1", "A2"} {
+			require.NoError(t, assignments.CreateBlock(ctx, &models.StandBlock{
+				SessionID: session, Stand: stand, BlockType: "MANUAL", Source: "CONTROLLER", Manual: true,
+			}))
+		}
+		strip := loadStrip(t, strips, session, "SAS609")
+
+		require.NoError(t, lifecycle.ObserveDeparturePosition(ctx, session, strip, 55.6285306, 12.6434583))
+		require.NoError(t, lifecycle.ObserveDeparturePosition(ctx, session, strip, 55.6285306, 12.6434583))
+
+		require.Equal(t, 1, messenger.calls)
+		require.Equal(t, "STAND ASSIGNMENT: STAND A2 IS OCCUPIED. PLEASE RELOCATE", messenger.message)
+		_, err := assignments.GetAssignment(ctx, session, "SAS609")
+		require.Error(t, err)
+
+		require.NoError(t, lifecycle.ObserveDeparturePosition(ctx, session, strip, 55.6285306, 12.6434583))
+		require.Equal(t, 1, messenger.calls, "the same occupied-stand episode must remain one-shot")
+	})
+
 	t.Run("wrong stand timeout forces an explicit override", func(t *testing.T) {
 		lifecycle, _, session, assignments, strips, clock := departureLifecycleFixture(t, pool, queries, "", "", nil)
 		testdata.SeedTestStrip(t, queries, session, "SAS604")

--- a/backend/internal/services/stand_actions.go
+++ b/backend/internal/services/stand_actions.go
@@ -41,6 +41,7 @@ func NewStandActionService(allocations *StandAllocationService, assignments repo
 func (s *StandActionService) Allocate(ctx context.Context, session int32, airport, position, callsign string, version int32) (*StandAllocationResult, error) {
 	req, err := s.request(ctx, session, airport, position, callsign, version)
 	if err != nil {
+		s.recordRequestFailure(AutomaticStandAllocation, session, airport, callsign, "", err)
 		return nil, err
 	}
 	return s.allocations.Allocate(ctx, req)
@@ -49,6 +50,7 @@ func (s *StandActionService) Allocate(ctx context.Context, session int32, airpor
 func (s *StandActionService) AssignManually(ctx context.Context, session int32, airport, position, callsign, stand string, version int32) (*StandAllocationResult, error) {
 	req, err := s.request(ctx, session, airport, position, callsign, version)
 	if err != nil {
+		s.recordRequestFailure(CompatibleManualStand, session, airport, callsign, stand, err)
 		return nil, err
 	}
 	req.Stand = stand
@@ -60,10 +62,12 @@ func (s *StandActionService) AssignManually(ctx context.Context, session int32, 
 // deliberately cannot invoke the incompatible override path.
 func (s *StandActionService) AssignForPilot(ctx context.Context, session int32, airport, cid, callsign, stand string, version int32) (*StandAllocationResult, error) {
 	if strings.TrimSpace(cid) == "" {
+		s.recordRequestFailure(CompatibleManualStand, session, airport, callsign, stand, ErrStandActionUnauthorized)
 		return nil, ErrStandActionUnauthorized
 	}
 	req, err := s.request(ctx, session, airport, "PILOT:"+strings.TrimSpace(cid), callsign, version)
 	if err != nil {
+		s.recordRequestFailure(CompatibleManualStand, session, airport, callsign, stand, err)
 		return nil, err
 	}
 	req.Stand = stand
@@ -73,13 +77,35 @@ func (s *StandActionService) AssignForPilot(ctx context.Context, session int32, 
 func (s *StandActionService) Override(ctx context.Context, session int32, airport, position, callsign, stand, reason string, version int32) (*StandAllocationResult, error) {
 	req, err := s.request(ctx, session, airport, position, callsign, version)
 	if err != nil {
+		s.recordRequestFailure(IncompatibleManualOverride, session, airport, callsign, stand, err)
 		return nil, err
 	}
 	req.Stand, req.ConflictReason = stand, strings.TrimSpace(reason)
 	if req.ConflictReason == "" {
-		return nil, errors.New("confirmed override requires a reason")
+		err := errors.New("confirmed override requires a reason")
+		s.allocations.recordAllocationFailure(IncompatibleManualOverride, req, "invalid_request", err, 0)
+		return nil, err
 	}
 	return s.allocations.OverrideManually(ctx, req)
+}
+
+func (s *StandActionService) recordRequestFailure(command StandAllocationCommand, session int32, airport, callsign, stand string, err error) {
+	if s == nil || s.allocations == nil {
+		return
+	}
+	outcome := "request_error"
+	switch {
+	case errors.Is(err, ErrStandActionUnauthorized):
+		outcome = "unauthorized"
+	case errors.Is(err, ErrStandActionStaleVersion):
+		outcome = "stale_version"
+	}
+	s.allocations.recordAllocationFailure(command, StandAllocationRequest{
+		SessionID: session,
+		Airport:   strings.ToUpper(strings.TrimSpace(airport)),
+		Callsign:  strings.ToUpper(strings.TrimSpace(callsign)),
+		Stand:     strings.ToUpper(strings.TrimSpace(stand)),
+	}, outcome, err, 0)
 }
 
 func (s *StandActionService) request(ctx context.Context, session int32, airport, position, callsign string, version int32) (StandAllocationRequest, error) {

--- a/backend/internal/services/stand_allocation.go
+++ b/backend/internal/services/stand_allocation.go
@@ -5,6 +5,7 @@ import (
 	"FlightStrips/internal/models"
 	"FlightStrips/internal/repository"
 	"FlightStrips/internal/sat"
+	"FlightStrips/internal/standdiagnostics"
 	"context"
 	"errors"
 	"fmt"
@@ -94,6 +95,7 @@ type StandAllocationService struct {
 	publish     StandAllocationPublisher
 	attempts    int
 	now         func() time.Time
+	failures    *standdiagnostics.AllocationFailureLog
 }
 
 type StandAllocationOption func(*StandAllocationService)
@@ -104,6 +106,10 @@ func WithStandAllocationRandom(random func() float64) StandAllocationOption {
 
 func WithStandAllocationPublisher(publisher StandAllocationPublisher) StandAllocationOption {
 	return func(service *StandAllocationService) { service.publish = publisher }
+}
+
+func WithStandAllocationFailureLog(failures *standdiagnostics.AllocationFailureLog) StandAllocationOption {
+	return func(service *StandAllocationService) { service.failures = failures }
 }
 
 func (s *StandAllocationService) SetPublisher(publisher StandAllocationPublisher) {
@@ -218,6 +224,7 @@ func NewStandAllocationService(pool *pgxpool.Pool, strips repository.StripReposi
 	service := &StandAllocationService{
 		pool: pool, strips: strips, assignments: assignments, stands: stands,
 		policy: policy, random: rand.Float64, attempts: 3, now: time.Now,
+		failures: standdiagnostics.NewAllocationFailureLog(100),
 	}
 	for _, option := range options {
 		if option != nil {
@@ -311,6 +318,7 @@ func (s *StandAllocationService) DeleteManualBlock(ctx context.Context, session 
 
 func (s *StandAllocationService) allocate(ctx context.Context, command StandAllocationCommand, request StandAllocationRequest) (*StandAllocationResult, error) {
 	if err := validateStandAllocationRequest(command, &request); err != nil {
+		s.recordAllocationFailure(command, request, "invalid_request", err, 0)
 		return nil, err
 	}
 	tried := map[string]struct{}{}
@@ -347,22 +355,65 @@ func (s *StandAllocationService) allocate(ctx context.Context, command StandAllo
 			tried[selected] = struct{}{}
 		}
 		if !retryableStandAllocationError(err) {
-			outcome := "error"
-			if errors.Is(err, ErrNoCompatibleStand) {
-				outcome = "no_compatible_stand"
-			}
-			if errors.Is(err, ErrNoAvailableStand) {
-				outcome = "no_available_stand"
-			}
+			outcome := standAllocationFailureOutcome(err)
 			metrics.RecordSATOutcome(ctx, outcome, string(request.Direction))
 			slog.WarnContext(ctx, "SAT stand allocation rejected", slog.String("callsign", request.Callsign), slog.String("command", string(command)), slog.String("outcome", outcome), slog.Any("error", err))
+			s.recordAllocationFailure(command, request, outcome, err, attempt)
 			return nil, err
 		}
 		metrics.RecordSATConflict(ctx, "database_contention")
 		slog.WarnContext(ctx, "SAT allocation contention; retrying", slog.String("callsign", request.Callsign), slog.Int("attempt", attempt), slog.Any("error", err))
 	}
 	metrics.RecordSATOutcome(ctx, "database_contention", string(request.Direction))
-	return nil, fmt.Errorf("%w after %d attempts", ErrAllocationRetriesExhausted, s.attempts)
+	err := fmt.Errorf("%w after %d attempts", ErrAllocationRetriesExhausted, s.attempts)
+	s.recordAllocationFailure(command, request, "database_contention", err, s.attempts)
+	return nil, err
+}
+
+func standAllocationFailureOutcome(err error) string {
+	switch {
+	case errors.Is(err, ErrNoCompatibleStand):
+		return "no_compatible_stand"
+	case errors.Is(err, ErrNoAvailableStand):
+		return "no_available_stand"
+	case errors.Is(err, ErrIncompatibleManualAssignment):
+		return "manual_stand_unavailable"
+	case errors.Is(err, ErrUnknownManualOverrideStand):
+		return "unknown_stand"
+	default:
+		return "error"
+	}
+}
+
+func (s *StandAllocationService) recordAllocationFailure(command StandAllocationCommand, request StandAllocationRequest, outcome string, err error, attempts int) {
+	if s.failures == nil {
+		return
+	}
+	now := time.Now
+	if s.now != nil {
+		now = s.now
+	}
+	reason := ""
+	if err != nil {
+		reason = err.Error()
+	}
+	s.failures.Record(standdiagnostics.AllocationFailure{
+		OccurredAt:     now().UTC(),
+		SessionID:      request.SessionID,
+		Airport:        request.Airport,
+		Callsign:       request.Callsign,
+		Command:        string(command),
+		Outcome:        outcome,
+		Reason:         reason,
+		Direction:      string(request.Direction),
+		Stage:          request.Stage,
+		AttemptedStand: request.Stand,
+		AircraftType:   request.AssignmentFacts.AircraftType,
+		EngineType:     string(request.FlightFacts.EngineType),
+		WTC:            request.FlightFacts.WTC,
+		BorderStatus:   string(request.FlightFacts.BorderStatus),
+		Attempts:       attempts,
+	})
 }
 
 func validateStandAllocationRequest(command StandAllocationCommand, request *StandAllocationRequest) error {

--- a/backend/internal/services/stand_allocation_failures_test.go
+++ b/backend/internal/services/stand_allocation_failures_test.go
@@ -1,0 +1,57 @@
+package services
+
+import (
+	"FlightStrips/internal/sat"
+	"FlightStrips/internal/standdiagnostics"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStandAllocationRecordsRejectedRequest(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.July, 17, 20, 0, 0, 0, time.UTC)
+	failures := standdiagnostics.NewAllocationFailureLog(10)
+	service := &StandAllocationService{now: func() time.Time { return now }, failures: failures}
+
+	_, err := service.Allocate(context.Background(), StandAllocationRequest{
+		SessionID: 7,
+		Callsign:  "sas123",
+		Airport:   "ekch",
+		FlightFacts: sat.FlightCompatibilityFacts{
+			EngineType: sat.EngineJet,
+			WTC:        "M",
+		},
+		AssignmentFacts: sat.AssignmentFlightFacts{AircraftType: "A320", BorderStatus: sat.BorderStatusSchengen},
+	})
+	require.Error(t, err)
+
+	recorded := failures.List()
+	require.Len(t, recorded, 1)
+	require.Equal(t, "SAS123", recorded[0].Callsign)
+	require.Equal(t, "EKCH", recorded[0].Airport)
+	require.Equal(t, "invalid_request", recorded[0].Outcome)
+	require.Equal(t, "A320", recorded[0].AircraftType)
+	require.Equal(t, now, recorded[0].OccurredAt)
+}
+
+func TestStandActionRecordsPreAllocationRejection(t *testing.T) {
+	t.Parallel()
+
+	failures := standdiagnostics.NewAllocationFailureLog(10)
+	actions := &StandActionService{
+		allocations: &StandAllocationService{now: time.Now, failures: failures},
+	}
+
+	_, err := actions.AssignManually(context.Background(), 7, "EKCH", "", "sas123", "A12", 0)
+	require.ErrorIs(t, err, ErrStandActionUnauthorized)
+
+	recorded := failures.List()
+	require.Len(t, recorded, 1)
+	require.Equal(t, "MANUAL_ASSIGNMENT", recorded[0].Command)
+	require.Equal(t, "unauthorized", recorded[0].Outcome)
+	require.Equal(t, "A12", recorded[0].AttemptedStand)
+}

--- a/backend/internal/services/strip_airborne_test.go
+++ b/backend/internal/services/strip_airborne_test.go
@@ -7,10 +7,26 @@ import (
 	"FlightStrips/pkg/events/euroscope"
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type departurePositionObserverSpy struct {
+	calls     int
+	callsign  string
+	latitude  float64
+	longitude float64
+}
+
+func (s *departurePositionObserverSpy) ObserveDeparturePosition(_ context.Context, _ int32, strip *models.Strip, latitude, longitude float64) error {
+	s.calls++
+	s.callsign = strip.Callsign
+	s.latitude = latitude
+	s.longitude = longitude
+	return nil
+}
 
 // TestResolveAirborneController_NilSID verifies that a strip without a SID returns nil.
 func TestResolveAirborneController_NilSID(t *testing.T) {
@@ -211,6 +227,35 @@ func TestUpdateAircraftPosition_ArrivalHiddenRemainsHidden(t *testing.T) {
 	assert.Equal(t, shared.BAY_HIDDEN, savedBay,
 		"already-hidden arrivals must stay HIDDEN so valid post-STAND auto-hide is preserved")
 	assert.False(t, moveCalled, "no bay move should be triggered when the arrival remains in HIDDEN")
+}
+
+func TestUpdateAircraftPosition_PrefileStillUsesEuroscopeForDepartureBlock(t *testing.T) {
+	ctx := context.Background()
+	const session = int32(1)
+	const callsign = "SAS123"
+	vatsimSeenAt := time.Date(2026, time.July, 17, 10, 0, 0, 0, time.UTC)
+	stripRepo := &testutil.MockStripRepository{
+		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
+			return &models.Strip{
+				Callsign: callsign, Origin: "EKCH", Destination: "EGLL",
+				Bay: shared.BAY_NOT_CLEARED, VatsimSeenAt: &vatsimSeenAt,
+			}, nil
+		},
+		UpdateAircraftPositionFn: func(_ context.Context, _ int32, _ string, _ *float64, _ *float64, _ *int32, _ string, _ *int32) (int64, error) {
+			return 1, nil
+		},
+	}
+	observer := &departurePositionObserverSpy{}
+	service := NewStripService(stripRepo)
+	service.SetDeparturePositionObserver(observer)
+
+	require.NoError(t, service.UpdateAircraftPosition(
+		ctx, session, callsign, shared.AirportLatitude, shared.AirportLongitude, 20, "EKCH",
+	))
+	require.Equal(t, 1, observer.calls)
+	require.Equal(t, callsign, observer.callsign)
+	require.Equal(t, shared.AirportLatitude, observer.latitude)
+	require.Equal(t, shared.AirportLongitude, observer.longitude)
 }
 
 // TestCreateCoordinationTransfer_EsHandoverSentWhenTargetHasNoEsConnection verifies that

--- a/backend/internal/services/strip_arrival.go
+++ b/backend/internal/services/strip_arrival.go
@@ -91,10 +91,11 @@ func (s *StripService) UpdateAircraftPosition(ctx context.Context, session int32
 		return err
 	}
 
-	// VATSIM-backed departures are observed by the feed reconciler. Locally
-	// spawned EuroScope aircraft never enter that path, so feed their live
-	// position into the same stand lifecycle here.
-	if s.departureObserver != nil && existingStrip.VatsimSeenAt == nil &&
+	// An EuroScope position is authoritative evidence that the operational
+	// departure strip exists. Feed it into the stand lifecycle even when VATSIM
+	// has only supplied a prefile; prefile provenance must not suppress the
+	// EuroScope-first transition to a departure block.
+	if s.departureObserver != nil &&
 		strings.EqualFold(strings.TrimSpace(existingStrip.Origin), strings.TrimSpace(airport)) {
 		if err := s.departureObserver.ObserveDeparturePosition(ctx, session, existingStrip, lat, lon); err != nil {
 			return err

--- a/backend/internal/standdiagnostics/failures.go
+++ b/backend/internal/standdiagnostics/failures.go
@@ -1,0 +1,73 @@
+package standdiagnostics
+
+import (
+	"slices"
+	"sync"
+	"time"
+)
+
+// AllocationFailure is one failed attempt to allocate or reallocate a stand.
+// It is operational diagnostic state, not part of the authoritative assignment
+// model, and is intentionally retained only in memory.
+type AllocationFailure struct {
+	ID             uint64    `json:"id"`
+	OccurredAt     time.Time `json:"occurred_at"`
+	SessionID      int32     `json:"session_id"`
+	Airport        string    `json:"airport"`
+	Callsign       string    `json:"callsign"`
+	Command        string    `json:"command"`
+	Outcome        string    `json:"outcome"`
+	Reason         string    `json:"reason"`
+	Direction      string    `json:"direction"`
+	Stage          string    `json:"stage"`
+	AttemptedStand string    `json:"attempted_stand,omitempty"`
+	AircraftType   string    `json:"aircraft_type,omitempty"`
+	EngineType     string    `json:"engine_type,omitempty"`
+	WTC            string    `json:"wtc,omitempty"`
+	BorderStatus   string    `json:"border_status,omitempty"`
+	Attempts       int       `json:"attempts"`
+}
+
+// AllocationFailureLog retains the newest failures up to a fixed capacity.
+type AllocationFailureLog struct {
+	mu      sync.RWMutex
+	limit   int
+	nextID  uint64
+	entries []AllocationFailure
+}
+
+func NewAllocationFailureLog(limit int) *AllocationFailureLog {
+	if limit <= 0 {
+		limit = 100
+	}
+	return &AllocationFailureLog{limit: limit}
+}
+
+func (l *AllocationFailureLog) Record(failure AllocationFailure) {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.nextID++
+	failure.ID = l.nextID
+	l.entries = append(l.entries, failure)
+	if overflow := len(l.entries) - l.limit; overflow > 0 {
+		copy(l.entries, l.entries[overflow:])
+		l.entries = l.entries[:l.limit]
+	}
+}
+
+// List returns a copy ordered newest first.
+func (l *AllocationFailureLog) List() []AllocationFailure {
+	if l == nil {
+		return []AllocationFailure{}
+	}
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	result := slices.Clone(l.entries)
+	slices.Reverse(result)
+	return result
+}

--- a/backend/internal/standdiagnostics/failures_test.go
+++ b/backend/internal/standdiagnostics/failures_test.go
@@ -1,0 +1,26 @@
+package standdiagnostics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllocationFailureLogRetainsNewestFailures(t *testing.T) {
+	t.Parallel()
+
+	log := NewAllocationFailureLog(2)
+	log.Record(AllocationFailure{Callsign: "ONE", OccurredAt: time.Unix(1, 0)})
+	log.Record(AllocationFailure{Callsign: "TWO", OccurredAt: time.Unix(2, 0)})
+	log.Record(AllocationFailure{Callsign: "THREE", OccurredAt: time.Unix(3, 0)})
+
+	failures := log.List()
+	require.Len(t, failures, 2)
+	require.Equal(t, "THREE", failures[0].Callsign)
+	require.Equal(t, uint64(3), failures[0].ID)
+	require.Equal(t, "TWO", failures[1].Callsign)
+
+	failures[0].Callsign = "CHANGED"
+	require.Equal(t, "THREE", log.List()[0].Callsign)
+}

--- a/backend/internal/standstatus/webapi.go
+++ b/backend/internal/standstatus/webapi.go
@@ -1,0 +1,346 @@
+package standstatus
+
+import (
+	"FlightStrips/internal/models"
+	"FlightStrips/internal/shared"
+	"FlightStrips/internal/standdiagnostics"
+	"FlightStrips/internal/vatsim"
+	"context"
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+type standStatusSessionRepository interface {
+	List(context.Context) ([]*models.Session, error)
+}
+
+type standStatusAssignmentRepository interface {
+	ListAssignments(context.Context, int32) ([]*models.StandAssignment, error)
+	ListBlocks(context.Context, int32) ([]*models.StandBlock, error)
+}
+
+type standStatusFeed interface {
+	Snapshot() vatsim.Snapshot
+}
+
+type standStatusFailureSource interface {
+	List() []standdiagnostics.AllocationFailure
+}
+
+// WebAPIDiagnostics describes the configuration that was loaded at startup.
+type WebAPIDiagnostics struct {
+	AircraftTypes int `json:"aircraft_types"`
+	Stands        int `json:"stands"`
+	StandVariants int `json:"stand_variants"`
+	AirlineRules  int `json:"airline_rules"`
+	StandGroups   int `json:"stand_groups"`
+	FallbackRules int `json:"fallback_rules"`
+}
+
+// WebAPIConfig contains the read-only dependencies for the SAT diagnostics page.
+type WebAPIConfig struct {
+	Auth        shared.AuthenticationService
+	Sessions    standStatusSessionRepository
+	Assignments standStatusAssignmentRepository
+	Feed        standStatusFeed
+	Enabled     bool
+	Ready       bool
+	Reason      string
+	StaleAfter  time.Duration
+	Diagnostics WebAPIDiagnostics
+	Failures    standStatusFailureSource
+}
+
+// WebAPI exposes an authenticated, read-only snapshot of SAT's internal state.
+type WebAPI struct {
+	config WebAPIConfig
+	now    func() time.Time
+}
+
+type standStatusResponse struct {
+	GeneratedAt   string                               `json:"generated_at"`
+	System        standStatusSystemResponse            `json:"system"`
+	Configuration WebAPIDiagnostics                    `json:"configuration"`
+	Feed          standStatusFeedResponse              `json:"feed"`
+	Failures      []standdiagnostics.AllocationFailure `json:"failures"`
+	Sessions      []standStatusSessionResponse         `json:"sessions"`
+}
+
+type standStatusSystemResponse struct {
+	Enabled bool   `json:"enabled"`
+	Ready   bool   `json:"ready"`
+	Status  string `json:"status"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+type standStatusFeedResponse struct {
+	Status             string   `json:"status"`
+	SnapshotAt         string   `json:"snapshot_at,omitempty"`
+	SnapshotAgeSeconds *float64 `json:"snapshot_age_seconds,omitempty"`
+	LastError          string   `json:"last_error,omitempty"`
+	Flights            int      `json:"flights"`
+	Online             int      `json:"online"`
+	Prefiles           int      `json:"prefiles"`
+}
+
+type standStatusSessionResponse struct {
+	SessionID   int32                           `json:"session_id"`
+	Name        string                          `json:"name"`
+	Airport     string                          `json:"airport"`
+	Assignments []standStatusAssignmentResponse `json:"assignments"`
+	Blocks      []standStatusBlockResponse      `json:"blocks"`
+}
+
+type standStatusAssignmentResponse struct {
+	ID             int64      `json:"id"`
+	Callsign       string     `json:"callsign"`
+	Stand          string     `json:"stand"`
+	Direction      string     `json:"direction"`
+	Stage          string     `json:"stage"`
+	Source         string     `json:"source"`
+	RuleID         *string    `json:"rule_id,omitempty"`
+	Tier           *int32     `json:"tier,omitempty"`
+	MatchedVariant *string    `json:"matched_variant,omitempty"`
+	ConflictReason *string    `json:"conflict_reason,omitempty"`
+	ETA            *time.Time `json:"eta,omitempty"`
+	ETASource      *string    `json:"eta_source,omitempty"`
+	AssignedAt     *time.Time `json:"assigned_at,omitempty"`
+	ExpiresAt      *time.Time `json:"expires_at,omitempty"`
+	Manual         bool       `json:"manual"`
+	Acknowledged   bool       `json:"acknowledged"`
+	AcknowledgedAt *time.Time `json:"acknowledged_at,omitempty"`
+	AcknowledgedBy *string    `json:"acknowledged_by,omitempty"`
+	VatsimCID      *int64     `json:"vatsim_cid,omitempty"`
+	VatsimRevision *int64     `json:"vatsim_revision,omitempty"`
+	Version        int32      `json:"version"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+}
+
+type standStatusBlockResponse struct {
+	ID        int64      `json:"id"`
+	Stand     string     `json:"stand"`
+	BlockType string     `json:"block_type"`
+	Source    string     `json:"source"`
+	Reason    *string    `json:"reason,omitempty"`
+	Callsign  *string    `json:"callsign,omitempty"`
+	CreatedBy *string    `json:"created_by,omitempty"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	Manual    bool       `json:"manual"`
+	Version   int32      `json:"version"`
+	CreatedAt time.Time  `json:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at"`
+}
+
+func NewWebAPI(config WebAPIConfig) *WebAPI {
+	return &WebAPI{config: config, now: time.Now}
+}
+
+func (a *WebAPI) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/stand/status", a.handleStatus)
+}
+
+func (a *WebAPI) handleStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	if !a.authenticate(w, r) {
+		return
+	}
+
+	now := a.now().UTC()
+	response := standStatusResponse{
+		GeneratedAt:   now.Format(time.RFC3339),
+		System:        a.systemStatus(),
+		Configuration: a.config.Diagnostics,
+		Feed:          a.feedStatus(),
+		Failures:      []standdiagnostics.AllocationFailure{},
+		Sessions:      []standStatusSessionResponse{},
+	}
+	if a.config.Failures != nil {
+		response.Failures = a.config.Failures.List()
+	}
+
+	if a.config.Sessions != nil && a.config.Assignments != nil {
+		sessions, err := a.config.Sessions.List(r.Context())
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, "failed to list sessions")
+			return
+		}
+		for _, session := range sessions {
+			if session == nil {
+				continue
+			}
+			assignments, err := a.config.Assignments.ListAssignments(r.Context(), session.ID)
+			if err != nil {
+				writeJSONError(w, http.StatusInternalServerError, "failed to list stand assignments")
+				return
+			}
+			blocks, err := a.config.Assignments.ListBlocks(r.Context(), session.ID)
+			if err != nil {
+				writeJSONError(w, http.StatusInternalServerError, "failed to list stand blocks")
+				return
+			}
+			response.Sessions = append(response.Sessions, mapStandStatusSession(session, assignments, blocks, now))
+		}
+	}
+
+	sort.SliceStable(response.Sessions, func(i, j int) bool {
+		left, right := response.Sessions[i], response.Sessions[j]
+		if left.Airport != right.Airport {
+			return left.Airport < right.Airport
+		}
+		if left.Name != right.Name {
+			return left.Name < right.Name
+		}
+		return left.SessionID < right.SessionID
+	})
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (a *WebAPI) systemStatus() standStatusSystemResponse {
+	result := standStatusSystemResponse{
+		Enabled: a.config.Enabled,
+		Ready:   a.config.Ready,
+		Status:  "disabled",
+	}
+	switch {
+	case !a.config.Enabled:
+	case !a.config.Ready:
+		result.Status = "invalid_config"
+		result.Reason = a.config.Reason
+	default:
+		result.Status = "ready"
+		feed := a.feedStatus()
+		if feed.Status != "ready" {
+			result.Ready = false
+			result.Status = feed.Status
+			result.Reason = feed.LastError
+			if result.Reason == "" {
+				result.Reason = "VATSIM feed is unavailable"
+			}
+		}
+	}
+	return result
+}
+
+func (a *WebAPI) feedStatus() standStatusFeedResponse {
+	if !a.config.Enabled {
+		return standStatusFeedResponse{Status: "disabled"}
+	}
+	if a.config.Feed == nil {
+		return standStatusFeedResponse{Status: "feed_unavailable", LastError: "VATSIM feed is unavailable"}
+	}
+
+	snapshot := a.config.Feed.Snapshot()
+	result := standStatusFeedResponse{Status: "ready"}
+	if !snapshot.Timestamp.IsZero() {
+		result.SnapshotAt = snapshot.Timestamp.UTC().Format(time.RFC3339)
+		age := snapshot.Age.Seconds()
+		result.SnapshotAgeSeconds = &age
+	}
+	for _, flight := range snapshot.Flights() {
+		result.Flights++
+		if flight.Prefile() {
+			result.Prefiles++
+		} else {
+			result.Online++
+		}
+	}
+
+	switch {
+	case snapshot.Timestamp.IsZero():
+		result.Status = "feed_unavailable"
+		result.LastError = "VATSIM feed has not produced a snapshot"
+	case snapshot.LastRefreshError != nil:
+		result.Status = "feed_failed"
+		result.LastError = snapshot.LastRefreshError.Error()
+	case a.config.StaleAfter > 0 && snapshot.Age > a.config.StaleAfter:
+		result.Status = "feed_stale"
+		result.LastError = "VATSIM snapshot is stale"
+	}
+	return result
+}
+
+func mapStandStatusSession(session *models.Session, assignments []*models.StandAssignment, blocks []*models.StandBlock, now time.Time) standStatusSessionResponse {
+	response := standStatusSessionResponse{
+		SessionID:   session.ID,
+		Name:        session.Name,
+		Airport:     session.Airport,
+		Assignments: make([]standStatusAssignmentResponse, 0, len(assignments)),
+		Blocks:      make([]standStatusBlockResponse, 0, len(blocks)),
+	}
+	for _, assignment := range assignments {
+		if assignment == nil {
+			continue
+		}
+		response.Assignments = append(response.Assignments, standStatusAssignmentResponse{
+			ID: assignment.ID, Callsign: assignment.Callsign, Stand: assignment.Stand,
+			Direction: assignment.Direction, Stage: assignment.Stage, Source: assignment.Source,
+			RuleID: assignment.RuleID, Tier: assignment.Tier, MatchedVariant: assignment.MatchedVariant,
+			ConflictReason: assignment.ConflictReason, ETA: assignment.ETA, ETASource: assignment.ETASource,
+			AssignedAt: assignment.AssignedAt, ExpiresAt: assignment.ExpiresAt, Manual: assignment.Manual,
+			Acknowledged: assignment.Acknowledged, AcknowledgedAt: assignment.AcknowledgedAt,
+			AcknowledgedBy: assignment.AcknowledgedBy, VatsimCID: assignment.VatsimCID,
+			VatsimRevision: assignment.VatsimRevision, Version: assignment.Version,
+			CreatedAt: assignment.CreatedAt, UpdatedAt: assignment.UpdatedAt,
+		})
+	}
+	for _, block := range blocks {
+		if block == nil || (block.ExpiresAt != nil && !block.ExpiresAt.After(now)) {
+			continue
+		}
+		response.Blocks = append(response.Blocks, standStatusBlockResponse{
+			ID: block.ID, Stand: block.Stand, BlockType: block.BlockType, Source: block.Source,
+			Reason: block.Reason, Callsign: block.Callsign, CreatedBy: block.CreatedBy,
+			ExpiresAt: block.ExpiresAt, Manual: block.Manual, Version: block.Version,
+			CreatedAt: block.CreatedAt, UpdatedAt: block.UpdatedAt,
+		})
+	}
+	sort.SliceStable(response.Assignments, func(i, j int) bool {
+		return response.Assignments[i].Callsign < response.Assignments[j].Callsign
+	})
+	sort.SliceStable(response.Blocks, func(i, j int) bool {
+		if response.Blocks[i].Stand != response.Blocks[j].Stand {
+			return response.Blocks[i].Stand < response.Blocks[j].Stand
+		}
+		return response.Blocks[i].ID < response.Blocks[j].ID
+	})
+	return response
+}
+
+func (a *WebAPI) authenticate(w http.ResponseWriter, r *http.Request) bool {
+	authHeader := strings.TrimSpace(r.Header.Get("Authorization"))
+	if authHeader == "" {
+		writeJSONError(w, http.StatusUnauthorized, "missing authorization header")
+		return false
+	}
+	token := strings.TrimSpace(strings.TrimPrefix(authHeader, "Bearer"))
+	if token == authHeader || token == "" {
+		writeJSONError(w, http.StatusUnauthorized, "invalid authorization header")
+		return false
+	}
+	if a.config.Auth == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "authentication unavailable")
+		return false
+	}
+	if _, err := a.config.Auth.Validate(token); err != nil {
+		writeJSONError(w, http.StatusUnauthorized, "invalid token")
+		return false
+	}
+	return true
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func writeJSONError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]string{"error": message})
+}

--- a/backend/internal/standstatus/webapi_test.go
+++ b/backend/internal/standstatus/webapi_test.go
@@ -1,0 +1,204 @@
+package standstatus
+
+import (
+	"FlightStrips/internal/models"
+	"FlightStrips/internal/shared"
+	"FlightStrips/internal/standdiagnostics"
+	"FlightStrips/internal/vatsim"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type standStatusAuthStub struct {
+	err error
+}
+
+func (s standStatusAuthStub) Validate(string) (shared.AuthenticatedUser, error) {
+	return shared.NewAuthenticatedUser("1234567", 0, nil), s.err
+}
+
+type standStatusSessionStub struct {
+	sessions []*models.Session
+	err      error
+}
+
+func (s standStatusSessionStub) List(context.Context) ([]*models.Session, error) {
+	return s.sessions, s.err
+}
+
+type standStatusAssignmentStub struct {
+	assignments map[int32][]*models.StandAssignment
+	blocks      map[int32][]*models.StandBlock
+}
+
+func (s standStatusAssignmentStub) ListAssignments(_ context.Context, session int32) ([]*models.StandAssignment, error) {
+	return s.assignments[session], nil
+}
+
+func (s standStatusAssignmentStub) ListBlocks(_ context.Context, session int32) ([]*models.StandBlock, error) {
+	return s.blocks[session], nil
+}
+
+type standStatusFeedStub struct {
+	snapshot vatsim.Snapshot
+}
+
+func (s standStatusFeedStub) Snapshot() vatsim.Snapshot {
+	return s.snapshot
+}
+
+func TestStandStatusRequiresAuthorization(t *testing.T) {
+	t.Parallel()
+
+	api := NewWebAPI(WebAPIConfig{Auth: standStatusAuthStub{}})
+	recorder := httptest.NewRecorder()
+	api.handleStatus(recorder, httptest.NewRequest(http.MethodGet, "/stand/status", nil))
+
+	require.Equal(t, http.StatusUnauthorized, recorder.Code)
+}
+
+func TestStandStatusReturnsOperationalSnapshot(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.July, 17, 12, 0, 0, 0, time.UTC)
+	eta := now.Add(20 * time.Minute)
+	expiry := now.Add(time.Hour)
+	rule := "sas-arrivals"
+	tier := int32(2)
+	variant := "NON-SCHENGEN/A320"
+	callsign := "SAS123"
+	reason := "maintenance"
+	expired := now.Add(-time.Minute)
+	failures := standdiagnostics.NewAllocationFailureLog(10)
+	failures.Record(standdiagnostics.AllocationFailure{
+		OccurredAt: now.Add(-time.Minute), SessionID: 7, Airport: "EKCH", Callsign: "SAS999",
+		Command: "AUTOMATIC_ALLOCATION", Outcome: "no_available_stand",
+		Reason: "no compatible stand is available", Direction: "ARRIVAL", Stage: "CONFIRMED", Attempts: 1,
+	})
+
+	api := NewWebAPI(WebAPIConfig{
+		Auth:     standStatusAuthStub{},
+		Sessions: standStatusSessionStub{sessions: []*models.Session{{ID: 7, Name: "LIVE", Airport: "EKCH"}}},
+		Assignments: standStatusAssignmentStub{
+			assignments: map[int32][]*models.StandAssignment{
+				7: {
+					{
+						ID: 11, SessionID: 7, Callsign: callsign, Stand: "A12", Direction: "ARRIVAL",
+						Stage: "CONFIRMED", Source: "AUTO", RuleID: &rule, Tier: &tier,
+						MatchedVariant: &variant, ETA: &eta, ExpiresAt: &expiry, Acknowledged: true,
+						Version: 3, CreatedAt: now.Add(-time.Hour), UpdatedAt: now,
+					},
+				},
+			},
+			blocks: map[int32][]*models.StandBlock{
+				7: {
+					{
+						ID: 21, SessionID: 7, Stand: "B2", BlockType: "OCCUPIED", Source: "CONTROLLER",
+						Reason: &reason, Callsign: &callsign, Manual: true, Version: 2,
+						CreatedAt: now.Add(-time.Minute), UpdatedAt: now,
+					},
+					{
+						ID: 22, SessionID: 7, Stand: "B3", BlockType: "CLOSURE", Source: "CONTROLLER",
+						ExpiresAt: &expired, Manual: true, Version: 1,
+						CreatedAt: now.Add(-time.Hour), UpdatedAt: now.Add(-time.Minute),
+					},
+				},
+			},
+		},
+		Feed:        standStatusFeedStub{snapshot: vatsim.Snapshot{Timestamp: now.Add(-10 * time.Second), Age: 10 * time.Second}},
+		Enabled:     true,
+		Ready:       true,
+		StaleAfter:  time.Minute,
+		Diagnostics: WebAPIDiagnostics{AircraftTypes: 812, Stands: 97, StandVariants: 121, AirlineRules: 18},
+		Failures:    failures,
+	})
+	api.now = func() time.Time { return now }
+
+	request := httptest.NewRequest(http.MethodGet, "/stand/status", nil)
+	request.Header.Set("Authorization", "Bearer token")
+	recorder := httptest.NewRecorder()
+	api.handleStatus(recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+	var payload standStatusResponse
+	require.NoError(t, json.NewDecoder(recorder.Body).Decode(&payload))
+	require.Equal(t, "ready", payload.System.Status)
+	require.True(t, payload.System.Ready)
+	require.Equal(t, 97, payload.Configuration.Stands)
+	require.Equal(t, "ready", payload.Feed.Status)
+	require.Len(t, payload.Failures, 1)
+	require.Equal(t, "SAS999", payload.Failures[0].Callsign)
+	require.Equal(t, "no_available_stand", payload.Failures[0].Outcome)
+	require.Len(t, payload.Sessions, 1)
+	require.Len(t, payload.Sessions[0].Assignments, 1)
+	require.Equal(t, "SAS123", payload.Sessions[0].Assignments[0].Callsign)
+	require.Equal(t, "sas-arrivals", *payload.Sessions[0].Assignments[0].RuleID)
+	require.Len(t, payload.Sessions[0].Blocks, 1)
+	require.Equal(t, int64(21), payload.Sessions[0].Blocks[0].ID)
+	require.Equal(t, "maintenance", *payload.Sessions[0].Blocks[0].Reason)
+}
+
+func TestStandStatusShowsConfigurationAndFeedFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		config     WebAPIConfig
+		wantStatus string
+		wantReason string
+	}{
+		{
+			name:       "invalid configuration",
+			config:     WebAPIConfig{Auth: standStatusAuthStub{}, Enabled: true, Reason: "load stand capabilities: bad row"},
+			wantStatus: "invalid_config",
+			wantReason: "load stand capabilities: bad row",
+		},
+		{
+			name: "failed feed",
+			config: WebAPIConfig{
+				Auth: standStatusAuthStub{}, Enabled: true, Ready: true, StaleAfter: time.Minute,
+				Feed: standStatusFeedStub{snapshot: vatsim.Snapshot{
+					Timestamp: time.Now().UTC(), Age: time.Second, LastRefreshError: errors.New("network down"),
+				}},
+			},
+			wantStatus: "feed_failed",
+			wantReason: "network down",
+		},
+		{
+			name: "stale feed",
+			config: WebAPIConfig{
+				Auth: standStatusAuthStub{}, Enabled: true, Ready: true, StaleAfter: time.Minute,
+				Feed: standStatusFeedStub{snapshot: vatsim.Snapshot{
+					Timestamp: time.Now().UTC().Add(-2 * time.Minute), Age: 2 * time.Minute,
+				}},
+			},
+			wantStatus: "feed_stale",
+			wantReason: "VATSIM snapshot is stale",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			api := NewWebAPI(test.config)
+			request := httptest.NewRequest(http.MethodGet, "/stand/status", nil)
+			request.Header.Set("Authorization", "Bearer token")
+			recorder := httptest.NewRecorder()
+			api.handleStatus(recorder, request)
+
+			require.Equal(t, http.StatusOK, recorder.Code)
+			var payload standStatusResponse
+			require.NoError(t, json.NewDecoder(recorder.Body).Decode(&payload))
+			require.Equal(t, test.wantStatus, payload.System.Status)
+			require.Equal(t, test.wantReason, payload.System.Reason)
+		})
+	}
+}

--- a/backend/internal/vatsim/reconciliation.go
+++ b/backend/internal/vatsim/reconciliation.go
@@ -258,9 +258,17 @@ func (r *Reconciler) reconcileSession(ctx context.Context, snapshot Snapshot, se
 			changedCount++
 			r.notify(session.ID, strip.Callsign)
 		}
-		if strings.EqualFold(strings.TrimSpace(flight.FlightPlan.Origin), airport) {
-			if err := r.lifecycle.ProcessDeparture(ctx, session.ID, strip, departureFlightInfo(flight)); err != nil {
-				return err
+		if r.lifecycle != nil && strings.EqualFold(strings.TrimSpace(flight.FlightPlan.Origin), airport) {
+			// Prefiles may reserve a stand before EuroScope sees the flight, but
+			// an online VATSIM record alone must not create a departure block.
+			// EuroScope supplies the operational strip that makes the block
+			// controller-visible and authoritative.
+			prefileBeforeEuroscope := !flight.Online() && strip.EuroscopeSeenAt == nil
+			onlineAfterEuroscope := flight.Online() && strip.EuroscopeSeenAt != nil
+			if prefileBeforeEuroscope || onlineAfterEuroscope {
+				if err := r.lifecycle.ProcessDeparture(ctx, session.ID, strip, departureFlightInfo(flight)); err != nil {
+					return err
+				}
 			}
 		}
 		if strings.EqualFold(strings.TrimSpace(flight.FlightPlan.Destination), airport) {
@@ -273,7 +281,7 @@ func (r *Reconciler) reconcileSession(ctx context.Context, snapshot Snapshot, se
 	slog.InfoContext(ctx, "SAT VATSIM reconciliation completed", slog.Int("session", int(session.ID)), slog.String("airport", airport), slog.Duration("snapshot_age", snapshot.Age), slog.Int("pilots", pilots), slog.Int("prefiles", prefiles), slog.Int("changed", changedCount))
 
 	for callsign, strip := range existing {
-		if relevant[callsign].Callsign == "" &&
+		if relevant[callsign].Callsign == "" && strip.EuroscopeSeenAt == nil && r.lifecycle != nil &&
 			strings.EqualFold(strings.TrimSpace(strip.Origin), airport) {
 			if err := r.lifecycle.CancelDeparture(ctx, session.ID, callsign); err != nil {
 				return err

--- a/backend/internal/vatsim/reconciliation_test.go
+++ b/backend/internal/vatsim/reconciliation_test.go
@@ -121,9 +121,11 @@ func (n *reconciliationTestNotifier) SendStripUpdate(_ int32, callsign string) {
 
 type reconciliationTestDepartureLifecycle struct {
 	cancelled []string
+	processed []string
 }
 
-func (*reconciliationTestDepartureLifecycle) ProcessDeparture(context.Context, int32, *models.Strip, DepartureFlightInfo) error {
+func (l *reconciliationTestDepartureLifecycle) ProcessDeparture(_ context.Context, _ int32, strip *models.Strip, _ DepartureFlightInfo) error {
+	l.processed = append(l.processed, strip.Callsign)
 	return nil
 }
 
@@ -179,6 +181,41 @@ func TestReconcileKeepsOnlineAPIDepartureHidden(t *testing.T) {
 
 	require.NoError(t, reconciler.Reconcile(context.Background()))
 	assert.Equal(t, hiddenDepartureBay, existing.Bay)
+}
+
+func TestReconcileRequiresEuroscopeStripBeforeOnlineDepartureBlock(t *testing.T) {
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	cache := newReconciliationTestCache(now,
+		Flight{CID: "1", Callsign: "SAS101", State: FlightStateOnline, LastUpdated: now, FlightPlan: FlightPlan{Origin: "EKCH", Destination: "EGLL", Revision: 4}},
+		Flight{CID: "2", Callsign: "SAS202", State: FlightStatePrefile, LastUpdated: now, FlightPlan: FlightPlan{Origin: "EKCH", Destination: "EDDF", Revision: 5}},
+	)
+	strips := &reconciliationTestStrips{bySession: map[int32][]*models.Strip{}}
+	lifecycle := &reconciliationTestDepartureLifecycle{}
+	reconciler := newTestReconciler(cache, reconciliationTestSessions{items: []*models.Session{{ID: 7, Airport: "EKCH"}}}, strips, reconciliationTestAssignments{}, nil, time.Second)
+	reconciler.lifecycle = lifecycle
+
+	require.NoError(t, reconciler.Reconcile(context.Background()))
+	assert.Equal(t, []string{"SAS202"}, lifecycle.processed,
+		"the offline prefile may reserve a stand, but an API-only online flight must not create a departure block")
+
+	var onlineStrip, prefileStrip *models.Strip
+	for _, strip := range strips.created {
+		switch strip.Callsign {
+		case "SAS101":
+			onlineStrip = strip
+		case "SAS202":
+			prefileStrip = strip
+		}
+	}
+	require.NotNil(t, onlineStrip)
+	require.NotNil(t, prefileStrip)
+	onlineStrip.EuroscopeSeenAt = &now
+	prefileStrip.EuroscopeSeenAt = &now
+	lifecycle.processed = nil
+
+	require.NoError(t, reconciler.Reconcile(context.Background()))
+	assert.Equal(t, []string{"SAS101"}, lifecycle.processed,
+		"the online departure may enter the block path after EuroScope has supplied the strip, while an ES-owned prefile must not reset that state")
 }
 
 func TestReconcileMovesExistingAPIPrefileOutOfCLX(t *testing.T) {
@@ -266,6 +303,22 @@ func TestReconcileCancelsDepartureLifecycleWhenFlightDisappears(t *testing.T) {
 
 	require.NoError(t, reconciler.Reconcile(context.Background()))
 	assert.Equal(t, []string{"SAS505"}, lifecycle.cancelled)
+}
+
+func TestReconcileDoesNotCancelEuroscopeOwnedDepartureLifecycleWhenFlightDisappears(t *testing.T) {
+	now := time.Date(2026, 7, 12, 10, 0, 0, 0, time.UTC)
+	cid := "5"
+	strip := &models.Strip{
+		Callsign: "SAS506", Session: 7, Origin: "EKCH",
+		VatsimCID: &cid, VatsimSeenAt: &now, EuroscopeSeenAt: &now,
+	}
+	strips := &reconciliationTestStrips{bySession: map[int32][]*models.Strip{7: {strip}}}
+	reconciler := newTestReconciler(newReconciliationTestCache(now), reconciliationTestSessions{items: []*models.Session{{ID: 7, Airport: "EKCH"}}}, strips, reconciliationTestAssignments{}, nil, time.Second)
+	lifecycle := &reconciliationTestDepartureLifecycle{}
+	reconciler.lifecycle = lifecycle
+
+	require.NoError(t, reconciler.Reconcile(context.Background()))
+	assert.Empty(t, lifecycle.cancelled, "EuroScope still owns the operational departure state")
 }
 
 func TestRetainsStripHonorsReservationExpiry(t *testing.T) {

--- a/frontend/src/components/navigation/AppSidebar.tsx
+++ b/frontend/src/components/navigation/AppSidebar.tsx
@@ -1,5 +1,6 @@
 import {
   Clock3,
+  Warehouse,
   User,
   Proportions,
 } from "lucide-react"
@@ -39,6 +40,11 @@ export function AppSidebar() {
       title: "CDM",
       url: "/cdm",
       icon: Clock3,
+    },
+    {
+      title: "Stand System",
+      url: "/stand",
+      icon: Warehouse,
     },
     docsNav,
   ]

--- a/frontend/src/components/public/ThemeSync.tsx
+++ b/frontend/src/components/public/ThemeSync.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/lib/public-theme";
 
 const SELECTABLE_PUBLIC_PATHS = new Set(["/", "/about", "/contact"]);
-const STANDALONE_SCROLL_PATHS = new Set(["/cdm"]);
+const STANDALONE_SCROLL_PATHS = new Set(["/cdm", "/stand"]);
 
 /**
  * Syncs document theme with stored public theme. On /app we always remove dark

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -15,6 +15,7 @@ import Dashboard from "@/pages/dashboard";
 import AppPage from "@/pages/app";
 import PluginAuthComplete from "@/pages/plugin-auth-complete";
 import CdmPage from "@/pages/cdm";
+import StandStatusPage from "@/pages/stand-status";
 import PilotLayout from "@/pages/pilot-layout";
 import PilotFlightPage from "@/pages/pilot-flight";
 import EfbLayout from "@/pages/efb-layout";
@@ -28,6 +29,7 @@ startAppUpdateMonitoring();
 
 const ProtectedLayout = withAuthenticationRequired(Layout);
 const ProtectedCdmPage = withAuthenticationRequired(CdmPage);
+const ProtectedStandStatusPage = withAuthenticationRequired(StandStatusPage);
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -55,6 +57,7 @@ createRoot(document.getElementById('root')!).render(
             <Route path="/dashboard/docs" element={<DocsRouter />}/>
           </Route>
           <Route path="/cdm" element={<ProtectedCdmPage />} />
+          <Route path="/stand" element={<ProtectedStandStatusPage />} />
           <Route path="*" element={<div>404 Not Found</div>}/>
         </Routes>
       </Auth0ProviderWithNavigate>

--- a/frontend/src/pages/stand-status.tsx
+++ b/frontend/src/pages/stand-status.tsx
@@ -1,0 +1,512 @@
+import { useAuth0 } from "@auth0/auth0-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { getApiUrl } from "@/lib/api-url";
+
+const POLL_INTERVAL_MS = 10_000;
+
+type StandSystem = {
+  enabled: boolean;
+  ready: boolean;
+  status: string;
+  reason?: string;
+};
+
+type StandConfiguration = {
+  aircraft_types: number;
+  stands: number;
+  stand_variants: number;
+  airline_rules: number;
+  stand_groups: number;
+  fallback_rules: number;
+};
+
+type StandFeed = {
+  status: string;
+  snapshot_at?: string;
+  snapshot_age_seconds?: number;
+  last_error?: string;
+  flights: number;
+  online: number;
+  prefiles: number;
+};
+
+type StandAssignment = {
+  id: number;
+  callsign: string;
+  stand: string;
+  direction: string;
+  stage: string;
+  source: string;
+  rule_id?: string;
+  tier?: number;
+  matched_variant?: string;
+  conflict_reason?: string;
+  eta?: string;
+  eta_source?: string;
+  assigned_at?: string;
+  expires_at?: string;
+  manual: boolean;
+  acknowledged: boolean;
+  acknowledged_at?: string;
+  acknowledged_by?: string;
+  vatsim_cid?: number;
+  vatsim_revision?: number;
+  version: number;
+  created_at: string;
+  updated_at: string;
+};
+
+type StandBlock = {
+  id: number;
+  stand: string;
+  block_type: string;
+  source: string;
+  reason?: string;
+  callsign?: string;
+  created_by?: string;
+  expires_at?: string;
+  manual: boolean;
+  version: number;
+  created_at: string;
+  updated_at: string;
+};
+
+type StandAllocationFailure = {
+  id: number;
+  occurred_at: string;
+  session_id: number;
+  airport: string;
+  callsign: string;
+  command: string;
+  outcome: string;
+  reason: string;
+  direction: string;
+  stage: string;
+  attempted_stand?: string;
+  aircraft_type?: string;
+  engine_type?: string;
+  wtc?: string;
+  border_status?: string;
+  attempts: number;
+};
+
+type StandSession = {
+  session_id: number;
+  name: string;
+  airport: string;
+  assignments: StandAssignment[];
+  blocks: StandBlock[];
+};
+
+type StandStatusResponse = {
+  generated_at: string;
+  system: StandSystem;
+  configuration: StandConfiguration;
+  feed: StandFeed;
+  failures: StandAllocationFailure[];
+  sessions: StandSession[];
+};
+
+function formatStatus(value: string): string {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (letter: string) => letter.toUpperCase());
+}
+
+function statusTone(status: string): string {
+  if (status === "ready") {
+    return "border-emerald-300 bg-emerald-50 text-emerald-950 dark:border-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-100";
+  }
+  if (status === "disabled") {
+    return "border-slate-300 bg-slate-50 text-slate-900 dark:border-slate-700 dark:bg-slate-900/50 dark:text-slate-100";
+  }
+  return "border-amber-300 bg-amber-50 text-amber-950 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-100";
+}
+
+function formatTimestamp(value?: string): string {
+  if (!value) {
+    return "—";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    day: "2-digit",
+    month: "short",
+  });
+}
+
+function formatAge(seconds?: number): string {
+  if (typeof seconds !== "number") {
+    return "—";
+  }
+  if (seconds < 60) {
+    return `${Math.round(seconds)} sec`;
+  }
+  return `${Math.floor(seconds / 60)} min ${Math.round(seconds % 60)} sec`;
+}
+
+function configurationEntries(configuration: StandConfiguration) {
+  return [
+    ["Aircraft types", configuration.aircraft_types],
+    ["Physical stands", configuration.stands],
+    ["Stand variants", configuration.stand_variants],
+    ["Airline rules", configuration.airline_rules],
+    ["Stand groups", configuration.stand_groups],
+    ["Fallback rules", configuration.fallback_rules],
+  ] as const;
+}
+
+export default function StandStatusPage() {
+  const { getAccessTokenSilently } = useAuth0();
+  const [data, setData] = useState<StandStatusResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const authorizedFetch = useCallback(async () => {
+    const token = await getAccessTokenSilently();
+    const response = await fetch(getApiUrl("/api/stand/status"), {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!response.ok) {
+      const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+      throw new Error(payload?.error ?? `Request failed (${response.status} ${response.statusText})`);
+    }
+    return (await response.json()) as StandStatusResponse;
+  }, [getAccessTokenSilently]);
+
+  useEffect(() => {
+    let active = true;
+    const poll = async () => {
+      try {
+        const payload = await authorizedFetch();
+        if (!active) {
+          return;
+        }
+        setData(payload);
+        setError(null);
+      } catch (fetchError) {
+        if (active) {
+          setError(fetchError instanceof Error ? fetchError.message : "Failed to load stand system status.");
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void poll();
+    const interval = window.setInterval(() => void poll(), POLL_INTERVAL_MS);
+    return () => {
+      active = false;
+      window.clearInterval(interval);
+    };
+  }, [authorizedFetch]);
+
+  const totals = useMemo(() => {
+    return (data?.sessions ?? []).reduce(
+      (total, session) => ({
+        assignments: total.assignments + session.assignments.length,
+        blocks: total.blocks + session.blocks.length,
+      }),
+      { assignments: 0, blocks: 0 },
+    );
+  }, [data]);
+
+  if (loading && !data) {
+    return (
+      <div className="p-6 md:p-8">
+        <div className="rounded-xl border bg-card p-6 text-sm text-muted-foreground">
+          Loading stand system status...
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen overflow-y-auto bg-background p-6 text-foreground md:p-8">
+      <div className="mx-auto max-w-[1800px] space-y-6">
+        <header className="space-y-2">
+          <h1 className="text-3xl font-semibold tracking-tight">Stand System Status</h1>
+          <p className="text-sm text-muted-foreground">
+            {totals.assignments} assignments and {totals.blocks} active blocks across{" "}
+            {data?.sessions.length ?? 0} sessions, with {data?.failures.length ?? 0} recent failures.
+            Last updated {formatTimestamp(data?.generated_at)}.
+          </p>
+        </header>
+
+        {error ? (
+          <div className="rounded-xl border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-900 dark:border-red-900 dark:bg-red-950/30 dark:text-red-100">
+            {error}
+          </div>
+        ) : null}
+
+        {data ? (
+          <>
+            <div className="grid gap-4 lg:grid-cols-3">
+              <section className={`rounded-xl border p-5 ${statusTone(data.system.status)}`}>
+                <div className="text-xs font-medium uppercase tracking-wide opacity-70">System</div>
+                <div className="mt-1 text-2xl font-semibold">{formatStatus(data.system.status)}</div>
+                <div className="mt-2 text-sm">
+                  Feature {data.system.enabled ? "enabled" : "disabled"} · Runtime{" "}
+                  {data.system.ready ? "ready" : "not ready"}
+                </div>
+                {data.system.reason ? <div className="mt-2 text-sm">{data.system.reason}</div> : null}
+              </section>
+
+              <section className={`rounded-xl border p-5 ${statusTone(data.feed.status)}`}>
+                <div className="text-xs font-medium uppercase tracking-wide opacity-70">VATSIM feed</div>
+                <div className="mt-1 text-2xl font-semibold">{formatStatus(data.feed.status)}</div>
+                <div className="mt-2 text-sm">
+                  {data.feed.online} online · {data.feed.prefiles} prefiles · {data.feed.flights} total
+                </div>
+                <div className="mt-1 text-sm">
+                  Snapshot {formatTimestamp(data.feed.snapshot_at)} ({formatAge(data.feed.snapshot_age_seconds)} old)
+                </div>
+                {data.feed.last_error ? <div className="mt-2 text-sm">{data.feed.last_error}</div> : null}
+              </section>
+
+              <section className="rounded-xl border bg-card p-5">
+                <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Runtime state</div>
+                <div className="mt-1 text-2xl font-semibold">{totals.assignments} assignments</div>
+                <div className="mt-2 text-sm text-muted-foreground">
+                  {totals.blocks} blocks · {data.failures.length} recent failures · {data.sessions.length} sessions
+                </div>
+              </section>
+            </div>
+
+            <section className="rounded-2xl border bg-card shadow-sm">
+              <div className="border-b px-6 py-4">
+                <h2 className="text-xl font-semibold">Loaded configuration</h2>
+                <p className="text-sm text-muted-foreground">Counts from the validated SAT startup configuration.</p>
+              </div>
+              <div className="grid grid-cols-2 gap-px bg-border sm:grid-cols-3 lg:grid-cols-6">
+                {configurationEntries(data.configuration).map(([label, value]) => (
+                  <div key={label} className="bg-card px-5 py-4">
+                    <div className="text-2xl font-semibold">{value.toLocaleString()}</div>
+                    <div className="text-xs text-muted-foreground">{label}</div>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            <section className="rounded-2xl border bg-card shadow-sm">
+              <div className="border-b px-6 py-4">
+                <div className="flex flex-col gap-2 md:flex-row md:items-baseline md:justify-between">
+                  <div>
+                    <h2 className="text-xl font-semibold">Recent assignment failures</h2>
+                    <p className="text-sm text-muted-foreground">
+                      The newest failed allocation and reallocation attempts retained by this server.
+                    </p>
+                  </div>
+                  <div className="text-sm text-muted-foreground">
+                    {data.failures.length} failures · maximum 100 since startup
+                  </div>
+                </div>
+              </div>
+              <div className="overflow-x-auto">
+                <table className="min-w-full text-sm">
+                  <thead className="bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+                    <tr>
+                      <th className="px-4 py-3 font-medium">Time</th>
+                      <th className="px-4 py-3 font-medium">Flight</th>
+                      <th className="px-4 py-3 font-medium">Request</th>
+                      <th className="px-4 py-3 font-medium">Failure</th>
+                      <th className="px-4 py-3 font-medium">Flight facts</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.failures.length === 0 ? (
+                      <tr className="border-t">
+                        <td colSpan={5} className="px-4 py-6 text-center text-muted-foreground">
+                          No stand assignment failures have been recorded since this server started.
+                        </td>
+                      </tr>
+                    ) : null}
+                    {data.failures.map((failure) => (
+                      <tr key={failure.id} className="border-t bg-amber-50/50 align-top dark:bg-amber-950/10">
+                        <td className="whitespace-nowrap px-4 py-3">{formatTimestamp(failure.occurred_at)}</td>
+                        <td className="px-4 py-3">
+                          <div className="font-semibold">{failure.callsign || "—"}</div>
+                          <div className="text-xs text-muted-foreground">
+                            {failure.airport || "—"} · session {failure.session_id || "—"}
+                          </div>
+                        </td>
+                        <td className="px-4 py-3">
+                          <div>{formatStatus(failure.command)}</div>
+                          <div className="text-xs text-muted-foreground">
+                            {failure.direction || "—"} · {failure.stage || "—"}
+                          </div>
+                          <div className="text-xs text-muted-foreground">
+                            Stand {failure.attempted_stand || "automatic"} · {failure.attempts} attempt
+                            {failure.attempts === 1 ? "" : "s"}
+                          </div>
+                        </td>
+                        <td className="px-4 py-3">
+                          <div className="font-medium text-amber-800 dark:text-amber-200">
+                            {formatStatus(failure.outcome)}
+                          </div>
+                          <div className="mt-1 max-w-xl text-xs">{failure.reason}</div>
+                        </td>
+                        <td className="px-4 py-3">
+                          <div>{failure.aircraft_type || "Unknown aircraft"}</div>
+                          <div className="text-xs text-muted-foreground">
+                            Engine {failure.engine_type || "—"} · WTC {failure.wtc || "—"} · Border{" "}
+                            {failure.border_status || "—"}
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            {data.sessions.length === 0 ? (
+              <div className="rounded-xl border bg-card p-6 text-sm text-muted-foreground">
+                No stand-system session state is currently available.
+              </div>
+            ) : null}
+
+            {data.sessions.map((session) => (
+              <section key={session.session_id} className="rounded-2xl border bg-card shadow-sm">
+                <div className="border-b px-6 py-4">
+                  <div className="flex flex-col gap-2 md:flex-row md:items-baseline md:justify-between">
+                    <div>
+                      <h2 className="text-xl font-semibold">{session.airport} - {session.name}</h2>
+                      <p className="text-sm text-muted-foreground">Session {session.session_id}</p>
+                    </div>
+                    <div className="text-sm text-muted-foreground">
+                      {session.assignments.length} assignments · {session.blocks.length} blocks
+                    </div>
+                  </div>
+                </div>
+
+                <div className="overflow-x-auto">
+                  <table className="min-w-full text-sm">
+                    <thead className="bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+                      <tr>
+                        <th className="px-4 py-3 font-medium">Flight</th>
+                        <th className="px-4 py-3 font-medium">Assignment</th>
+                        <th className="px-4 py-3 font-medium">Decision</th>
+                        <th className="px-4 py-3 font-medium">Timing</th>
+                        <th className="px-4 py-3 font-medium">Acknowledgement</th>
+                        <th className="px-4 py-3 font-medium">VATSIM / Version</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {session.assignments.length === 0 ? (
+                        <tr className="border-t">
+                          <td colSpan={6} className="px-4 py-6 text-center text-muted-foreground">
+                            No active stand assignments.
+                          </td>
+                        </tr>
+                      ) : null}
+                      {session.assignments.map((assignment) => (
+                        <tr key={assignment.id} className="border-t align-top">
+                          <td className="px-4 py-3">
+                            <div className="font-semibold">{assignment.callsign}</div>
+                            <div className="text-xs text-muted-foreground">{assignment.direction || "—"}</div>
+                          </td>
+                          <td className="px-4 py-3">
+                            <div className="font-semibold">{assignment.stand || "—"}</div>
+                            <div className="text-xs text-muted-foreground">
+                              {assignment.stage || "—"} · {assignment.source || "—"}
+                              {assignment.manual ? " · manual" : ""}
+                            </div>
+                          </td>
+                          <td className="px-4 py-3">
+                            <div>{assignment.rule_id || "No policy rule"}</div>
+                            <div className="text-xs text-muted-foreground">
+                              Tier {assignment.tier ?? "—"} · Variant {assignment.matched_variant || "—"}
+                            </div>
+                            {assignment.conflict_reason ? (
+                              <div className="mt-1 text-xs text-amber-700 dark:text-amber-300">
+                                Override: {assignment.conflict_reason}
+                              </div>
+                            ) : null}
+                          </td>
+                          <td className="px-4 py-3">
+                            <div>ETA {formatTimestamp(assignment.eta)}</div>
+                            <div className="text-xs text-muted-foreground">
+                              {assignment.eta_source || "No ETA source"} · expires {formatTimestamp(assignment.expires_at)}
+                            </div>
+                            <div className="text-xs text-muted-foreground">
+                              Assigned {formatTimestamp(assignment.assigned_at)}
+                            </div>
+                          </td>
+                          <td className="px-4 py-3">
+                            <div>{assignment.acknowledged ? "Acknowledged" : "Pending"}</div>
+                            <div className="text-xs text-muted-foreground">
+                              {assignment.acknowledged_by || "—"} · {formatTimestamp(assignment.acknowledged_at)}
+                            </div>
+                          </td>
+                          <td className="px-4 py-3">
+                            <div>CID {assignment.vatsim_cid ?? "—"}</div>
+                            <div className="text-xs text-muted-foreground">
+                              Revision {assignment.vatsim_revision ?? "—"} · record v{assignment.version}
+                            </div>
+                            <div className="text-xs text-muted-foreground">
+                              Updated {formatTimestamp(assignment.updated_at)}
+                            </div>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+
+                {session.blocks.length > 0 ? (
+                  <div className="border-t">
+                    <div className="px-6 py-3 text-sm font-semibold">Active stand blocks</div>
+                    <div className="overflow-x-auto">
+                      <table className="min-w-full text-sm">
+                        <thead className="bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+                          <tr>
+                            <th className="px-4 py-3 font-medium">Stand</th>
+                            <th className="px-4 py-3 font-medium">Type</th>
+                            <th className="px-4 py-3 font-medium">Source</th>
+                            <th className="px-4 py-3 font-medium">Reason / Flight</th>
+                            <th className="px-4 py-3 font-medium">Expiry</th>
+                            <th className="px-4 py-3 font-medium">Version</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {session.blocks.map((block) => (
+                            <tr key={block.id} className="border-t">
+                              <td className="px-4 py-3 font-semibold">{block.stand}</td>
+                              <td className="px-4 py-3">{block.block_type || "—"}</td>
+                              <td className="px-4 py-3">
+                                {block.source || "—"}{block.manual ? " · manual" : ""}
+                              </td>
+                              <td className="px-4 py-3">
+                                <div>{block.reason || "—"}</div>
+                                <div className="text-xs text-muted-foreground">
+                                  {block.callsign || "No callsign"} · {block.created_by || "system"}
+                                </div>
+                              </td>
+                              <td className="px-4 py-3">{formatTimestamp(block.expires_at)}</td>
+                              <td className="px-4 py-3">
+                                v{block.version}
+                                <div className="text-xs text-muted-foreground">
+                                  Updated {formatTimestamp(block.updated_at)}
+                                </div>
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                ) : null}
+              </section>
+            ))}
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What changed

- Add an authenticated stand-system status page and API showing readiness, loaded configuration, active assignments, and recent allocation failures.
- Record failed stand allocations, including aircraft appearing on an occupied stand, so controllers can inspect why an assignment failed.
- Require the EuroScope-sourced strip before an online departure creates its stand block, while still allowing prefiles to reserve a stand.
- Preserve EuroScope-owned departure state when a flight disappears from VATSIM and suppress repeated occupied-stand messages during recurring lifecycle sweeps.

## Why

The stand system needed the same operational visibility as CDM, and its departure lifecycle could otherwise let an ES/VATSIM-only record establish the wrong source ordering. Occupied-stand notifications were also being resent on every sweep instead of behaving as a single actionable message.

## Validation

- `go test ./...` (backend)
- `npm run build` (frontend)
- `git diff --check origin/main...HEAD`