### PR TITLE
fix(pdc): allow Web PDC without Hoppie

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -98,9 +98,6 @@ type App struct {
 
 func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	cfg = cfg.withDefaults()
-	if cfg.EnablePDC && deps.PDCClient == nil && strings.TrimSpace(cfg.HoppieLogon) == "" {
-		return nil, fmt.Errorf("PDC is enabled but no Hoppie client or HOPPIE_LOGON is configured")
-	}
 	standAssignmentReadiness := configureStandAssignment(cfg.EnableStandAssignment)
 
 	dbpool, closeDB, err := buildDBPool(ctx, cfg, deps.DBPool)
@@ -650,11 +647,11 @@ func buildPDCService(
 	transceiverProviders []pdc.TransceiverLookup,
 ) (*pdc.Service, error) {
 	if client == nil {
-		if cfg.HoppieLogon != "" {
-			client = pdc.NewClient(cfg.HoppieLogon)
+		if hoppieLogon := strings.TrimSpace(cfg.HoppieLogon); hoppieLogon != "" {
+			client = pdc.NewClient(hoppieLogon)
 			slog.Info("PDC Hoppie client initialized")
 		} else {
-			return nil, fmt.Errorf("PDC is enabled but no Hoppie client or HOPPIE_LOGON is configured")
+			slog.Info("PDC Hoppie integration disabled; Web PDC remains available")
 		}
 	}
 

--- a/backend/internal/app/app_test.go
+++ b/backend/internal/app/app_test.go
@@ -22,7 +22,7 @@ func (appTestHoppieClient) SendTelex(context.Context, string, string, string) er
 	return nil
 }
 
-func TestBuildFailsWhenPDCIsEnabledWithoutHoppieConfiguration(t *testing.T) {
+func TestBuildEnablesWebPDCWithoutHoppieConfiguration(t *testing.T) {
 	poolConfig, err := pgxpool.ParseConfig("postgres://user:password@127.0.0.1:1/test")
 	require.NoError(t, err)
 	dbPool, err := pgxpool.NewWithConfig(context.Background(), poolConfig)
@@ -40,9 +40,13 @@ func TestBuildFailsWhenPDCIsEnabledWithoutHoppieConfiguration(t *testing.T) {
 		AuthenticationService: services.NewTestAuthenticationService(),
 	})
 
-	require.Nil(t, application)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "PDC is enabled but no Hoppie client or HOPPIE_LOGON is configured")
+	require.NoError(t, err)
+	require.NotNil(t, application)
+	require.Len(t, application.workers, 5)
+
+	response := httptest.NewRecorder()
+	application.Handler().ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/api/pdc/status", nil))
+	require.NotEqual(t, http.StatusNotFound, response.Code)
 }
 
 func TestBuildKeepsUnrelatedApplicationAvailableWhenStandAssignmentIsUnavailable(t *testing.T) {

--- a/backend/internal/pdc/integration_test.go
+++ b/backend/internal/pdc/integration_test.go
@@ -187,6 +187,7 @@ func TestSubmitWebPDCRequest_AutoIssuesClearanceWithoutHoppie(t *testing.T) {
 	t.Parallel()
 	suite := &PDCIntegrationTestSuite{}
 	suite.SetupTest(t)
+	suite.service.client = nil
 
 	ctx := context.Background()
 	sessionID := int32(1)

--- a/backend/internal/pdc/service.go
+++ b/backend/internal/pdc/service.go
@@ -112,7 +112,6 @@ func NewPDCService(deps ServiceDependencies) (*Service, error) {
 		name  string
 		value any
 	}{
-		{"Hoppie client", deps.Client},
 		{"session repository", deps.Sessions},
 		{"strip store", deps.Strips},
 		{"sector repository", deps.Sectors},
@@ -146,6 +145,13 @@ func NewPDCService(deps ServiceDependencies) (*Service, error) {
 		timeoutConfig:      10 * time.Minute,
 		webLookupLiveOnly:  deps.WebLookupLiveOnly,
 	}, nil
+}
+
+func (s *Service) hoppieClient() (HoppieClientInterface, error) {
+	if dependencies.IsNil(s.client) {
+		return nil, errors.New("Hoppie is not configured; only Web PDC is available")
+	}
+	return s.client, nil
 }
 
 func normalizedStripAircraftType(strip *models.Strip) string {
@@ -187,13 +193,18 @@ func (s *Service) getNextSequence(ctx context.Context, sessionID int32) (int32, 
 
 // sendErrorAndReturn sends an error message to the pilot and returns the original error
 func (s *Service) sendErrorAndReturn(ctx context.Context, session sessionInformation, callsign string, originalErr error, messageBuilder func(int32) string) error {
+	client, err := s.hoppieClient()
+	if err != nil {
+		return errors.Join(originalErr, err)
+	}
+
 	seq, seqErr := s.getNextSequence(ctx, session.id)
 	if seqErr != nil {
 		return fmt.Errorf("%w; also failed to get message sequence: %w", originalErr, seqErr)
 	}
 
 	msg := messageBuilder(seq)
-	if sendErr := s.client.SendCPDLC(ctx, session.callsign, callsign, msg); sendErr != nil {
+	if sendErr := client.SendCPDLC(ctx, session.callsign, callsign, msg); sendErr != nil {
 		return fmt.Errorf("%w; also failed to send error message: %w", originalErr, sendErr)
 	}
 
@@ -462,6 +473,11 @@ func (s *Service) Start(ctx context.Context) {
 		slog.InfoContext(ctx, "PDC Service: Restored pending confirmation timeouts", slog.Int("count", restored))
 	}
 
+	if _, err := s.hoppieClient(); err != nil {
+		slog.InfoContext(ctx, "PDC Service: Hoppie polling disabled; Web PDC remains available")
+		return
+	}
+
 	slog.InfoContext(ctx, "PDC Service: Starting Hoppie polling loop")
 
 	for {
@@ -545,8 +561,13 @@ func (s *Service) pollAndProcess(ctx context.Context) error {
 }
 
 func (s *Service) pollAndProcessForSession(ctx context.Context, session sessionInformation) error {
+	client, err := s.hoppieClient()
+	if err != nil {
+		return err
+	}
+
 	slog.DebugContext(ctx, "PDC Service: Polling for messages", slog.String("callsign", session.callsign), slog.Int("session", int(session.id)))
-	messages, err := s.client.Poll(ctx, session.callsign)
+	messages, err := client.Poll(ctx, session.callsign)
 	if err != nil {
 		return fmt.Errorf("failed to poll: %w", err)
 	}
@@ -686,13 +707,18 @@ func (s *Service) ProcessPDCRequest(ctx context.Context, msg *IncomingMessage, s
 
 // SendStatusAck sends the "request received" message
 func (s *Service) SendStatusAck(ctx context.Context, session sessionInformation, callsign, origin string) error {
+	client, err := s.hoppieClient()
+	if err != nil {
+		return err
+	}
+
 	seq, err := s.getNextSequence(ctx, session.id)
 	if err != nil {
 		return err
 	}
 
 	msg := buildRequestAck(seq, origin, callsign)
-	return s.client.SendCPDLC(ctx, session.callsign, callsign, msg)
+	return client.SendCPDLC(ctx, session.callsign, callsign, msg)
 }
 
 // IssueClearance sends a PDC clearance to a pilot
@@ -830,7 +856,11 @@ func (s *Service) deliverPdcClearance(ctx context.Context, sessionInfo sessionIn
 		return nil
 	}
 
-	if err := s.client.SendCPDLC(ctx, sessionInfo.callsign, callsign, buildPDCClearance(options)); err != nil {
+	client, err := s.hoppieClient()
+	if err != nil {
+		return err
+	}
+	if err := client.SendCPDLC(ctx, sessionInfo.callsign, callsign, buildPDCClearance(options)); err != nil {
 		return fmt.Errorf("failed to send clearance: %w", err)
 	}
 
@@ -890,15 +920,18 @@ func (s *Service) RevertToVoice(ctx context.Context, callsign string, sessionId 
 		return fmt.Errorf("cannot revert to voice, PDC state is %s", strip.PdcState)
 	}
 
-	nextSeq, err := s.getNextSequence(ctx, sessionInfo.id)
-	if err != nil {
-		return err
-	}
-
-	pdcMessage := buildRevertToVoice(nextSeq)
-	err = s.client.SendCPDLC(ctx, sessionInfo.callsign, callsign, pdcMessage)
-	if err != nil {
-		return fmt.Errorf("failed to send revert to voice: %w", err)
+	if !isWebPDCRequest(strip) {
+		client, clientErr := s.hoppieClient()
+		if clientErr != nil {
+			return clientErr
+		}
+		nextSeq, sequenceErr := s.getNextSequence(ctx, sessionInfo.id)
+		if sequenceErr != nil {
+			return sequenceErr
+		}
+		if sendErr := client.SendCPDLC(ctx, sessionInfo.callsign, callsign, buildRevertToVoice(nextSeq)); sendErr != nil {
+			return fmt.Errorf("failed to send revert to voice: %w", sendErr)
+		}
 	}
 
 	s.CancelTimeout(callsign, sessionId)
@@ -1237,12 +1270,17 @@ func (s *Service) ManualStateChange(ctx context.Context, callsign string, sessio
 
 // SendErrorMessage sends error message to pilot for invalid PDC requests
 func (s *Service) SendErrorMessage(ctx context.Context, session sessionInformation, callsign string) error {
+	client, err := s.hoppieClient()
+	if err != nil {
+		return err
+	}
+
 	seq, err := s.getNextSequence(ctx, session.id)
 	if err != nil {
 		return err
 	}
 	msg := fmt.Sprintf("/data2/%d//NE/BAD PDC MESSAGE. @RESEND OR REVERT TO VOICE", seq)
-	return s.client.SendCPDLC(ctx, session.callsign, callsign, msg)
+	return client.SendCPDLC(ctx, session.callsign, callsign, msg)
 }
 
 // StartClearanceTimeout starts a timeout that reverts cleared flag if pilot doesn't respond
@@ -1332,14 +1370,19 @@ func (s *Service) handleTimeout(ctx context.Context, delay time.Duration, callsi
 		}
 
 		if !tracker.web {
-			seq, err := s.getNextSequence(ctx, session.id)
-			if err != nil {
-				slog.ErrorContext(ctx, "PDC Service: Failed to get next message sequence", slog.Any("error", err))
+			client, clientErr := s.hoppieClient()
+			if clientErr != nil {
+				slog.ErrorContext(ctx, "PDC Service: Failed to send no response message", slog.Any("error", clientErr))
 			} else {
-				msg := buildNoResponseMessage(seq, messageId, session.airport, callsign)
-				err = s.client.SendCPDLC(ctx, session.callsign, callsign, msg)
+				seq, err := s.getNextSequence(ctx, session.id)
 				if err != nil {
-					slog.ErrorContext(ctx, "PDC Service: Failed to send no response message", slog.Any("error", err))
+					slog.ErrorContext(ctx, "PDC Service: Failed to get next message sequence", slog.Any("error", err))
+				} else {
+					msg := buildNoResponseMessage(seq, messageId, session.airport, callsign)
+					err = client.SendCPDLC(ctx, session.callsign, callsign, msg)
+					if err != nil {
+						slog.ErrorContext(ctx, "PDC Service: Failed to send no response message", slog.Any("error", err))
+					}
 				}
 			}
 		}

--- a/backend/internal/pdc/service_constructor_test.go
+++ b/backend/internal/pdc/service_constructor_test.go
@@ -37,7 +37,6 @@ func TestNewPDCServiceRejectsMissingRequiredDependencies(t *testing.T) {
 		remove func(*ServiceDependencies)
 		want   string
 	}{
-		{"client", func(d *ServiceDependencies) { d.Client = nil }, "pdc service requires Hoppie client"},
 		{"sessions", func(d *ServiceDependencies) { d.Sessions = nil }, "pdc service requires session repository"},
 		{"strips", func(d *ServiceDependencies) { d.Strips = nil }, "pdc service requires strip store"},
 		{"sectors", func(d *ServiceDependencies) { d.Sectors = nil }, "pdc service requires sector repository"},
@@ -55,6 +54,16 @@ func TestNewPDCServiceRejectsMissingRequiredDependencies(t *testing.T) {
 			require.EqualError(t, err, test.want)
 		})
 	}
+}
+
+func TestNewPDCServiceAllowsWebPDCWithoutHoppieClient(t *testing.T) {
+	deps := validPdcServiceDependencies()
+	deps.Client = nil
+
+	service, err := NewPDCService(deps)
+
+	require.NoError(t, err)
+	require.NotNil(t, service)
 }
 
 func TestNewPDCServiceRejectsNilTransceiverProvider(t *testing.T) {


### PR DESCRIPTION
## Summary

- allow the application to assemble the PDC service without a Hoppie client or `HOPPIE_LOGON`
- keep WebPDC routes, clearance generation, state updates, and timeout handling available in WebPDC-only deployments
- disable Hoppie polling cleanly and return explicit errors from CPDLC-only operations when Hoppie is unavailable
- avoid sending Hoppie messages when reverting a WebPDC clearance to voice

## Root cause

Application assembly treated Hoppie as a required dependency whenever PDC was enabled. That prevented startup before the WebPDC API could be registered, even though WebPDC clearance delivery is persisted through the web channel and does not call Hoppie.

## Impact

Deployments can now run WebPDC without configuring Hoppie. Existing Hoppie-backed PDC behavior is unchanged when a client or logon is configured.

## Validation

- `go test ./internal/app ./internal/pdc`
- `go test ./...`
- `git diff --check`
