### PR TITLE
feat(sat): add local test console

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -38,13 +38,20 @@ func main() {
 		slog.Error("Failed to initialize config", slog.Any("error", err))
 		os.Exit(1)
 	}
+	environment := getEnv("ENVIRONMENT", "development")
+	enableTestTools := envBool("ENABLE_TEST_TOOLS", false)
+	if enableTestTools && isLiveEnvironment(environment) {
+		slog.Error("ENABLE_TEST_TOOLS cannot be enabled in a live environment")
+		os.Exit(1)
+	}
+	standAssignmentAircraftJSON := standAssignmentAircraftFile(enableTestTools, os.Getenv("GRPLUGIN_ICAO_AIRCRAFT_JSON"))
 
 	otlpEndpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
 	if otlpEndpoint != "" {
 		tel, err := telemetry.Initialize(ctx, telemetry.Config{
 			ServiceName:    "flightstrips-backend",
 			ServiceVersion: "1.0.0",
-			Environment:    getEnv("ENVIRONMENT", "development"),
+			Environment:    environment,
 		})
 		if err != nil {
 			slog.Error("Failed to initialize telemetry", slog.Any("error", err))
@@ -61,31 +68,33 @@ func main() {
 	}
 
 	application, err := app.Build(ctx, app.Config{
-		DatabaseConnectionString: os.Getenv("DATABASE_CONNECTIONSTRING"),
-		OIDCSigningAlgorithm:     os.Getenv("OIDC_SIGNING_ALGO"),
-		OIDCAuthority:            os.Getenv("OIDC_AUTHORITY"),
-		OIDCAudience:             getEnv("OIDC_AUDIENCE", "backend-dev"),
-		Environment:              getEnv("ENVIRONMENT", "development"),
-		EnablePostgresTracing:    otlpEndpoint != "",
-		EnableHTTPTracing:        otlpEndpoint != "",
-		CDMKey:                   os.Getenv("CDM_KEY"),
-		CDMConfigRefreshInterval: envDuration("CDM_CONFIG_REFRESH_INTERVAL", 15*time.Minute),
-		EnableCDMConfigStore:     true,
-		HoppieLogon:              os.Getenv("HOPPIE_LOGON"),
-		PDCWebLookupLiveOnly:     envBool("PDC_WEB_LOOKUP_LIVE_ONLY", isLiveEnvironment(getEnv("ENVIRONMENT", "development"))),
-		EnablePDC:                true,
-		ECFMPBaseURL:             getEnv("ECFMP_BASE_URL", ""),
-		EnableECFMP:              true,
-		EnableECFMPAPI:           !isLiveEnvironment(getEnv("ENVIRONMENT", "development")),
-		EnablePilotAPI:           true,
-		EnableEFB:                envBool("ENABLE_EFB", false),
-		EnableALB:                true,
-		EnableMetar:              true,
-		EnableVATSIM:             true,
-		EnableTransceivers:       true,
-		EnableTraffic:            true,
-		EnableStandAssignment:    envBool("ENABLE_STAND_ASSIGNMENT", false),
-		EnableDBSeed:             true,
+		DatabaseConnectionString:    os.Getenv("DATABASE_CONNECTIONSTRING"),
+		OIDCSigningAlgorithm:        os.Getenv("OIDC_SIGNING_ALGO"),
+		OIDCAuthority:               os.Getenv("OIDC_AUTHORITY"),
+		OIDCAudience:                getEnv("OIDC_AUDIENCE", "backend-dev"),
+		Environment:                 environment,
+		EnablePostgresTracing:       otlpEndpoint != "",
+		EnableHTTPTracing:           otlpEndpoint != "",
+		CDMKey:                      os.Getenv("CDM_KEY"),
+		CDMConfigRefreshInterval:    envDuration("CDM_CONFIG_REFRESH_INTERVAL", 15*time.Minute),
+		EnableCDMConfigStore:        true,
+		HoppieLogon:                 os.Getenv("HOPPIE_LOGON"),
+		PDCWebLookupLiveOnly:        envBool("PDC_WEB_LOOKUP_LIVE_ONLY", isLiveEnvironment(environment)),
+		EnablePDC:                   true,
+		ECFMPBaseURL:                getEnv("ECFMP_BASE_URL", ""),
+		EnableECFMP:                 true,
+		EnableECFMPAPI:              !isLiveEnvironment(environment),
+		EnablePilotAPI:              true,
+		EnableEFB:                   envBool("ENABLE_EFB", false),
+		EnableALB:                   true,
+		EnableMetar:                 true,
+		EnableVATSIM:                true,
+		EnableTransceivers:          true,
+		EnableTraffic:               true,
+		EnableStandAssignment:       envBool("ENABLE_STAND_ASSIGNMENT", false),
+		EnableTestTools:             enableTestTools,
+		EnableDBSeed:                true,
+		StandAssignmentAircraftJSON: standAssignmentAircraftJSON,
 	}, app.Dependencies{
 		VATSIMStatusURL:      getEnv("VATSIM_STATUS_URL", ""),
 		VATSIMPollInterval:   envDuration("VATSIM_POLL_INTERVAL", 15*time.Second),
@@ -132,6 +141,14 @@ func main() {
 	}
 
 	slog.Info("Server shutdown complete")
+}
+
+func standAssignmentAircraftFile(testTools bool, configured string) string {
+	configured = strings.TrimSpace(configured)
+	if testTools && configured == "" {
+		return "config/test/ICAO_Aircraft.json"
+	}
+	return configured
 }
 
 func configureLogging() {

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -48,3 +48,15 @@ func TestEFBFlagDefaultsFalseRegardlessOfEnvironment(t *testing.T) {
 		t.Fatal("ENABLE_EFB should remain false in production unless explicitly enabled")
 	}
 }
+
+func TestTestToolsAircraftFixtureDoesNotOverrideExplicitConfiguration(t *testing.T) {
+	if got := standAssignmentAircraftFile(true, " C:/sector/ICAO_Aircraft.json "); got != "C:/sector/ICAO_Aircraft.json" {
+		t.Fatalf("explicit aircraft file = %q", got)
+	}
+	if got := standAssignmentAircraftFile(true, ""); got != "config/test/ICAO_Aircraft.json" {
+		t.Fatalf("test-tools fixture = %q", got)
+	}
+	if got := standAssignmentAircraftFile(false, ""); got != "" {
+		t.Fatalf("production default changed to %q", got)
+	}
+}

--- a/backend/config/test/ICAO_Aircraft.json
+++ b/backend/config/test/ICAO_Aircraft.json
@@ -1,0 +1,20 @@
+[
+  {
+    "ICAO": "A320",
+    "Description": "L2J",
+    "WTC": "M",
+    "IATA": "320"
+  },
+  {
+    "ICAO": "B738",
+    "Description": "L2J",
+    "WTC": "M",
+    "IATA": "738"
+  },
+  {
+    "ICAO": "C172",
+    "Description": "L1P",
+    "WTC": "L",
+    "IATA": "172"
+  }
+]

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -20,12 +20,14 @@ import (
 	"FlightStrips/internal/shared"
 	"FlightStrips/internal/standdiagnostics"
 	"FlightStrips/internal/standstatus"
+	"FlightStrips/internal/testtools"
 	"FlightStrips/internal/vatsim"
 	"FlightStrips/internal/websocket"
 	pkgEuroscope "FlightStrips/pkg/events/euroscope"
 	pkgFrontend "FlightStrips/pkg/events/frontend"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -69,8 +71,11 @@ type Config struct {
 	EnableTransceivers    bool
 	EnableTraffic         bool
 	EnableStandAssignment bool
+	EnableTestTools       bool
 	EnableDBSeed          bool
 	CloseDBOnClose        bool
+
+	StandAssignmentAircraftJSON string
 
 	StandAssignmentHoldDuration   time.Duration
 	StandAssignmentBlockExtension time.Duration
@@ -98,7 +103,16 @@ type App struct {
 
 func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	cfg = cfg.withDefaults()
-	standAssignmentReadiness := configureStandAssignment(cfg.EnableStandAssignment)
+	if cfg.EnableTestTools && isLiveEnvironment(cfg.Environment) {
+		return nil, errors.New("ENABLE_TEST_TOOLS cannot be enabled in a live environment")
+	}
+	standAssignmentReadiness := configureStandAssignment(cfg.EnableStandAssignment, cfg.StandAssignmentAircraftJSON)
+	var testClock *testtools.Clock
+	satNow := time.Now
+	if cfg.EnableTestTools {
+		testClock = testtools.NewClock()
+		satNow = testClock.Now
+	}
 
 	dbpool, closeDB, err := buildDBPool(ctx, cfg, deps.DBPool)
 	if err != nil {
@@ -121,7 +135,7 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	coordRepo := core.coordinations
 	tacticalStripRepo := core.tacticalStrips
 
-	satGraph, err := assembleSAT(cfg, standAssignmentReadiness, dbpool, core)
+	satGraph, err := assembleSAT(cfg, standAssignmentReadiness, dbpool, core, satNow)
 	if err != nil {
 		if closeDB {
 			dbpool.Close()
@@ -150,7 +164,7 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	cdmClient := cdm.NewClient(cdm.WithAPIKey(cfg.CDMKey))
 
 	requireLiveCIDVerification := isLiveEnvironment(cfg.Environment)
-	vatsimCache := buildVATSIMCache(cfg, deps, requireLiveCIDVerification, standAssignmentReadiness.Ready)
+	vatsimGraph := assembleVATSIMSource(cfg, deps, requireLiveCIDVerification, standAssignmentReadiness.Ready)
 
 	var fsServer *server.Server
 	transports := assembleTransports(cfg, deps, func(ctx context.Context) error {
@@ -198,21 +212,18 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 		return nil, fmt.Errorf("initialize CDM service: %w", err)
 	}
 	stripService.SetCdmService(cdmService)
-	if departureLifecycle != nil {
-		departureLifecycle.SetWrongStandMessenger(euroscopeHub)
-	}
 	var vatsimReconciler *vatsim.Reconciler
-	if standAssignmentReadiness.Ready && vatsimCache != nil && standAssignmentRepo != nil {
+	if standAssignmentReadiness.Ready && vatsimGraph.source != nil && standAssignmentRepo != nil {
 		latitude, longitude := appconfig.GetAirportCoordinates()
 		vatsimReconciler, err = vatsim.NewReconciler(vatsim.ReconcilerDependencies{
-			Cache:              vatsimCache,
+			Cache:              vatsimGraph.source,
 			Sessions:           sessionRepo,
 			Strips:             stripRepo,
 			Assignments:        standAssignmentRepo,
 			DepartureLifecycle: departureLifecycle,
 			ArrivalLifecycle:   arrivalLifecycle,
 			Notifier:           frontendHub,
-		}, deps.VATSIMPollInterval, vatsim.WithAirportCoordinates(latitude, longitude))
+		}, deps.VATSIMPollInterval, vatsim.WithAirportCoordinates(latitude, longitude), vatsim.WithClock(satNow))
 		if err != nil {
 			if closeDB {
 				dbpool.Close()
@@ -221,6 +232,12 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 		}
 		euroscopeHub.SetAircraftDisconnectRetainer(vatsimReconciler.RetainsStrip)
 	}
+	testToolsGraph := assembleTestTools(cfg.EnableTestTools, testToolsAssemblyDependencies{
+		auth: authService, readiness: standAssignmentReadiness,
+		source: vatsimGraph.synthetic, reconciler: vatsimReconciler,
+		sat: satGraph, core: core, stripDeleter: stripService,
+		clock: testClock, euroscope: euroscopeHub,
+	})
 	var albHub *alb.Hub
 	if cfg.EnableALB {
 		albHub = alb.NewHub()
@@ -336,13 +353,13 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 			albHub:       albHub,
 			pdcService:   pdcService,
 			efbAPI: efb.NewWebAPI(efb.WebAPIConfig{
-				Auth: authService, Callsigns: vatsimCache, Flights: efbFlightFinder, Sessions: sessionRepo,
+				Auth: authService, Callsigns: vatsimGraph.source, Flights: efbFlightFinder, Sessions: sessionRepo,
 				Assignments: standAssignmentRepo, CDM: cdmService, CDMReady: sequenceService != nil,
 				Stands: standActionService, ATIS: metarPoller, Routes: fsServer, PDCReady: pdcService != nil, Live: requireLiveCIDVerification,
 			}),
 			sessionRepo:                sessionRepo,
 			sequenceService:            sequenceService,
-			vatsimCache:                vatsimCache,
+			vatsimSource:               vatsimGraph.source,
 			standAssignmentRepo:        standAssignmentRepo,
 			standAssignmentReadiness:   standAssignmentReadiness,
 			standAssignmentDiagnostics: standAssignmentDiagnostics(),
@@ -356,7 +373,9 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 			enablePilotAPI:             cfg.EnablePilotAPI,
 			enableEFBAPI:               cfg.EnableEFB,
 			enablePDCAPI:               pdcService != nil,
+			enableTestTools:            cfg.EnableTestTools,
 			ecfmpService:               ecfmpService,
+			testToolsAPI:               testToolsGraph.api,
 		}),
 	}
 
@@ -370,10 +389,10 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	if cfg.EnablePDC && pdcService != nil {
 		app.addWorker(pdcService.Start)
 	}
-	if cfg.EnableVATSIM && vatsimCache != nil {
-		app.addWorker(vatsimCache.Start)
+	if cfg.EnableVATSIM && vatsimGraph.cache != nil {
+		app.addWorker(vatsimGraph.cache.Start)
 	}
-	if vatsimReconciler != nil {
+	if vatsimReconciler != nil && !cfg.EnableTestTools {
 		app.addWorker(vatsimReconciler.Start)
 	}
 	if departureLifecycle != nil {
@@ -431,7 +450,7 @@ type satAssembly struct {
 	failures    *standdiagnostics.AllocationFailureLog
 }
 
-func assembleSAT(cfg Config, readiness appconfig.StandAssignmentReadiness, dbpool *pgxpool.Pool, core coreRepositories) (satAssembly, error) {
+func assembleSAT(cfg Config, readiness appconfig.StandAssignmentReadiness, dbpool *pgxpool.Pool, core coreRepositories, now func() time.Time) (satAssembly, error) {
 	graph := satAssembly{
 		failures: standdiagnostics.NewAllocationFailureLog(100),
 	}
@@ -447,6 +466,7 @@ func assembleSAT(cfg Config, readiness appconfig.StandAssignmentReadiness, dbpoo
 	allocations, err := services.NewStandAllocationService(
 		dbpool, core.strips, assignments, stands, appconfig.GetAirlineAssignment(),
 		services.WithStandAllocationFailureLog(graph.failures),
+		services.WithStandAllocationClock(now),
 	)
 	if err != nil {
 		return satAssembly{}, fmt.Errorf("initialize stand allocation service: %w", err)
@@ -456,6 +476,7 @@ func assembleSAT(cfg Config, readiness appconfig.StandAssignmentReadiness, dbpoo
 		services.WithDepartureHoldDuration(cfg.StandAssignmentHoldDuration),
 		services.WithDepartureBlockExtension(cfg.StandAssignmentBlockExtension),
 		services.WithDepartureSweepInterval(cfg.StandAssignmentSweepInterval),
+		services.WithDepartureLifecycleClock(now),
 	)
 	if err != nil {
 		return satAssembly{}, fmt.Errorf("initialize departure lifecycle service: %w", err)
@@ -463,6 +484,7 @@ func assembleSAT(cfg Config, readiness appconfig.StandAssignmentReadiness, dbpoo
 	arrivals, err := services.NewArrivalLifecycleService(
 		allocations, assignments, core.strips, core.sessions, stands, aircraft, engines, borders,
 		services.WithArrivalSweepInterval(cfg.StandAssignmentSweepInterval),
+		services.WithArrivalLifecycleClock(now),
 	)
 	if err != nil {
 		return satAssembly{}, fmt.Errorf("initialize arrival lifecycle service: %w", err)
@@ -483,7 +505,7 @@ type transportAssembly struct {
 }
 
 func assembleTransports(cfg Config, deps Dependencies, refreshSectors func(context.Context) error) transportAssembly {
-	if !cfg.EnableTransceivers {
+	if !cfg.EnableTransceivers || cfg.EnableTestTools {
 		return transportAssembly{}
 	}
 
@@ -529,8 +551,8 @@ func (a *App) StandAssignmentReadiness() appconfig.StandAssignmentReadiness {
 	return a.standAssignmentReadiness
 }
 
-func configureStandAssignment(enabled bool) appconfig.StandAssignmentReadiness {
-	readiness := appconfig.InitializeStandAssignment(enabled)
+func configureStandAssignment(enabled bool, aircraftFile string) appconfig.StandAssignmentReadiness {
+	readiness := appconfig.InitializeStandAssignmentWithAircraftFile(enabled, aircraftFile)
 	switch {
 	case !readiness.Enabled:
 		slog.Info("Stand Assignment Tool disabled")
@@ -759,7 +781,7 @@ type buildHandlerConfig struct {
 	efbAPI                     *efb.WebAPI
 	sessionRepo                repository.SessionRepository
 	sequenceService            *cdm.SequenceService
-	vatsimCache                *vatsim.Cache
+	vatsimSource               vatsim.FlightSource
 	standAssignmentRepo        repository.StandAssignmentRepository
 	standAssignmentReadiness   appconfig.StandAssignmentReadiness
 	standAssignmentDiagnostics standstatus.WebAPIDiagnostics
@@ -773,7 +795,9 @@ type buildHandlerConfig struct {
 	enablePilotAPI             bool
 	enableEFBAPI               bool
 	enablePDCAPI               bool
+	enableTestTools            bool
 	ecfmpService               *ecfmp.Service
+	testToolsAPI               *testtools.WebAPI
 }
 
 func buildHandler(cfg buildHandlerConfig) http.Handler {
@@ -781,7 +805,7 @@ func buildHandler(cfg buildHandlerConfig) http.Handler {
 	frontendUpgrader := websocket.NewConnectionUpgrader[pkgFrontend.EventType, *frontend.Client](cfg.frontendHub, cfg.authService)
 	euroscopeUpgrader := websocket.NewConnectionUpgrader[pkgEuroscope.EventType, *euroscope.Client](cfg.euroscopeHub, cfg.authService)
 
-	mux.HandleFunc("/healthz", satHealthz(cfg.standAssignmentReadiness, cfg.vatsimCache, cfg.standAssignmentStaleAfter))
+	mux.HandleFunc("/healthz", satHealthz(cfg.standAssignmentReadiness, cfg.vatsimSource, cfg.standAssignmentStaleAfter))
 	mux.HandleFunc("/euroscopeEvents", euroscopeUpgrader.Upgrade)
 	mux.HandleFunc("/frontEndEvents", frontendUpgrader.Upgrade)
 	if cfg.enableALB {
@@ -791,7 +815,7 @@ func buildHandler(cfg buildHandlerConfig) http.Handler {
 	apiMux := http.NewServeMux()
 	standstatus.NewWebAPI(standstatus.WebAPIConfig{
 		Auth: cfg.authService, Sessions: cfg.sessionRepo, Assignments: cfg.standAssignmentRepo,
-		Feed: cfg.vatsimCache, Enabled: cfg.standAssignmentReadiness.Enabled,
+		Feed: cfg.vatsimSource, Enabled: cfg.standAssignmentReadiness.Enabled,
 		Ready: cfg.standAssignmentReadiness.Ready, Reason: cfg.standAssignmentReadiness.Reason,
 		StaleAfter: cfg.standAssignmentStaleAfter, Diagnostics: cfg.standAssignmentDiagnostics,
 		Failures: cfg.standAssignmentFailures,
@@ -804,13 +828,16 @@ func buildHandler(cfg buildHandlerConfig) http.Handler {
 	}
 	if cfg.enablePilotAPI {
 		flightLookup := pdc.NewFlightLookupAdapter(cfg.pdcService, cfg.sessionRepo)
-		pilot.NewWebAPI(cfg.authService, cfg.vatsimCache, flightLookup, cfg.requireLiveCIDVerification).RegisterRoutes(apiMux)
+		pilot.NewWebAPI(cfg.authService, cfg.vatsimSource, flightLookup, cfg.requireLiveCIDVerification).RegisterRoutes(apiMux)
 	}
 	if cfg.enableEFBAPI && cfg.efbAPI != nil {
 		cfg.efbAPI.RegisterRoutes(apiMux)
 	}
 	if cfg.enablePDCAPI {
-		pdc.NewWebAPI(cfg.authService, cfg.pdcService, cfg.vatsimCache, cfg.requireLiveCIDVerification).RegisterRoutes(apiMux)
+		pdc.NewWebAPI(cfg.authService, cfg.pdcService, cfg.vatsimSource, cfg.requireLiveCIDVerification).RegisterRoutes(apiMux)
+	}
+	if cfg.enableTestTools && cfg.testToolsAPI != nil {
+		cfg.testToolsAPI.RegisterRoutes(apiMux)
 	}
 	mux.Handle("/api/", server.APIMiddleware(http.StripPrefix("/api", apiMux)))
 
@@ -834,7 +861,7 @@ type satHealth struct {
 	SnapshotAgeSeconds *float64 `json:"snapshot_age_seconds,omitempty"`
 }
 
-func satHealthz(readiness appconfig.StandAssignmentReadiness, cache *vatsim.Cache, staleAfter time.Duration) http.HandlerFunc {
+func satHealthz(readiness appconfig.StandAssignmentReadiness, cache vatsim.SnapshotSource, staleAfter time.Duration) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
 		result := healthResponse{Status: "ok", StandAssignment: satHealth{Enabled: readiness.Enabled, Ready: readiness.Ready, Status: "disabled"}}
 		sat := &result.StandAssignment

--- a/backend/internal/app/app_test.go
+++ b/backend/internal/app/app_test.go
@@ -195,3 +195,50 @@ func TestBuildGatesEFBAPIBehindFeatureFlag(t *testing.T) {
 	build(true).Handler().ServeHTTP(enabled, httptest.NewRequest(http.MethodGet, "/api/efb/me", nil))
 	require.Equal(t, http.StatusUnauthorized, enabled.Code)
 }
+
+func TestBuildRejectsTestToolsInLiveEnvironmentBeforeOpeningDatabase(t *testing.T) {
+	_, err := Build(context.Background(), Config{
+		Environment:     "production",
+		EnableTestTools: true,
+	}, Dependencies{})
+	require.EqualError(t, err, "ENABLE_TEST_TOOLS cannot be enabled in a live environment")
+}
+
+func TestBuildGatesTestToolsAPIBehindExplicitFlag(t *testing.T) {
+	poolConfig, err := pgxpool.ParseConfig("postgres://user:password@127.0.0.1:1/test")
+	require.NoError(t, err)
+	dbPool, err := pgxpool.NewWithConfig(context.Background(), poolConfig)
+	require.NoError(t, err)
+	t.Cleanup(dbPool.Close)
+
+	build := func(enabled bool) *App {
+		application, buildErr := Build(context.Background(), Config{
+			Environment:          "test",
+			EnableTestTools:      enabled,
+			EnableTransceivers:   true,
+			EnableCDMConfigStore: false,
+			EnablePDC:            false,
+			EnableECFMP:          false,
+			EnableECFMPAPI:       false,
+			EnablePilotAPI:       false,
+			EnableALB:            false,
+			EnableMetar:          false,
+			EnableVATSIM:         false,
+			EnableTraffic:        false,
+			EnableDBSeed:         false,
+		}, Dependencies{DBPool: dbPool, AuthenticationService: services.NewTestAuthenticationService()})
+		require.NoError(t, buildErr)
+		return application
+	}
+
+	disabled := httptest.NewRecorder()
+	disabledApp := build(false)
+	disabledApp.Handler().ServeHTTP(disabled, httptest.NewRequest(http.MethodGet, "/api/test/status", nil))
+	require.Equal(t, http.StatusNotFound, disabled.Code)
+
+	enabled := httptest.NewRecorder()
+	enabledApp := build(true)
+	enabledApp.Handler().ServeHTTP(enabled, httptest.NewRequest(http.MethodGet, "/api/test/status", nil))
+	require.Equal(t, http.StatusUnauthorized, enabled.Code)
+	require.Len(t, disabledApp.workers, len(enabledApp.workers)+1, "normal mode should have the configured VATSIM transceiver worker")
+}

--- a/backend/internal/app/test_tools_assembly.go
+++ b/backend/internal/app/test_tools_assembly.go
@@ -1,0 +1,46 @@
+package app
+
+import (
+	appconfig "FlightStrips/internal/config"
+	"FlightStrips/internal/euroscope"
+	"FlightStrips/internal/shared"
+	"FlightStrips/internal/testtools"
+	"FlightStrips/internal/vatsim"
+)
+
+type testToolsAssembly struct {
+	api *testtools.WebAPI
+}
+
+type testToolsAssemblyDependencies struct {
+	auth         shared.AuthenticationService
+	readiness    appconfig.StandAssignmentReadiness
+	source       *vatsim.SyntheticSource
+	reconciler   *vatsim.Reconciler
+	sat          satAssembly
+	core         coreRepositories
+	stripDeleter testtools.StripDeleter
+	clock        *testtools.Clock
+	euroscope    *euroscope.Hub
+}
+
+func assembleTestTools(enabled bool, deps testToolsAssemblyDependencies) testToolsAssembly {
+	if !enabled {
+		if deps.sat.departures != nil {
+			deps.sat.departures.SetWrongStandMessenger(deps.euroscope)
+		}
+		return testToolsAssembly{}
+	}
+
+	service := testtools.NewService(testtools.ServiceConfig{
+		Source: deps.source, Reconciler: deps.reconciler,
+		Departures: deps.sat.departures, Arrivals: deps.sat.arrivals,
+		Allocations: deps.sat.allocations, Sessions: deps.core.sessions, Strips: deps.core.strips,
+		StripDeleter: deps.stripDeleter,
+		Assignments:  deps.sat.assignments, Stands: appconfig.GetStandCapabilities(), Clock: deps.clock,
+	})
+	if deps.sat.departures != nil {
+		deps.sat.departures.SetWrongStandMessenger(testtools.NewFallbackMessenger(deps.euroscope, service))
+	}
+	return testToolsAssembly{api: testtools.NewWebAPI(service, deps.auth, deps.readiness)}
+}

--- a/backend/internal/app/vatsim_source_assembly.go
+++ b/backend/internal/app/vatsim_source_assembly.go
@@ -1,0 +1,27 @@
+package app
+
+import (
+	"FlightStrips/internal/vatsim"
+	"log/slog"
+)
+
+type vatsimSourceAssembly struct {
+	cache     *vatsim.Cache
+	synthetic *vatsim.SyntheticSource
+	source    vatsim.FlightSource
+}
+
+func assembleVATSIMSource(cfg Config, deps Dependencies, requireLiveCIDVerification bool, enableReconciliation bool) vatsimSourceAssembly {
+	if cfg.EnableTestTools {
+		source := vatsim.NewSyntheticSource()
+		slog.Warn("Local test tools enabled; external VATSIM feed disabled")
+		return vatsimSourceAssembly{synthetic: source, source: source}
+	}
+
+	cache := buildVATSIMCache(cfg, deps, requireLiveCIDVerification, enableReconciliation)
+	assembly := vatsimSourceAssembly{cache: cache}
+	if cache != nil {
+		assembly.source = cache
+	}
+	return assembly
+}

--- a/backend/internal/cdm/service_sync_test.go
+++ b/backend/internal/cdm/service_sync_test.go
@@ -2,6 +2,7 @@ package cdm
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -13,6 +14,30 @@ import (
 	"FlightStrips/internal/testutil"
 	euroscopeEvents "FlightStrips/pkg/events/euroscope"
 )
+
+type masterSyncTestTimes struct {
+	Eobt        string
+	Tobt        string
+	ReqTobt     string
+	Tsat        string
+	Ttot        string
+	Ctot        string
+	TobtSeconds string
+}
+
+func futureMasterSyncTestTimes() masterSyncTestTimes {
+	eobt := time.Now().UTC().Truncate(time.Minute).Add(15 * time.Minute)
+	tobt := eobt.Add(10 * time.Minute)
+	return masterSyncTestTimes{
+		Eobt:        eobt.Format("1504"),
+		Tobt:        tobt.Format("1504"),
+		ReqTobt:     eobt.Add(5 * time.Minute).Format("1504"),
+		Tsat:        eobt.Add(15 * time.Minute).Format("150405"),
+		Ttot:        eobt.Add(25 * time.Minute).Format("150405"),
+		Ctot:        eobt.Add(40 * time.Minute).Format("1504"),
+		TobtSeconds: tobt.Format("150405"),
+	}
+}
 
 func TestSyncCdmData_PersistsFlowMessageAndReqTobtSource(t *testing.T) {
 	const sessionID = int32(77)
@@ -900,17 +925,18 @@ func TestSyncCdmData_SlaveSession_ReplacesPersistedCalculationSnapshotWithStored
 func TestSyncCdmData_MasterSession_DoesNotSyncTsatFromAPI(t *testing.T) {
 	const sessionID = int32(80)
 	const callsign = "SAS130"
+	times := futureMasterSyncTestTimes()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`[{
+		_, _ = fmt.Fprintf(w, `[{
 			"callsign":"SAS130",
 			"departure":"EKCH",
-			"eobt":"1000",
-			"tobt":"1010",
+			"eobt":%q,
+			"tobt":%q,
 			"ctot":"",
 			"cdmSts":"STUP",
-			"cdmData":{"tsat":"101500","ttot":"102500"}
-		}]`))
+			"cdmData":{"tsat":%q,"ttot":%q}
+		}]`, times.Eobt, times.Tobt, times.Tsat, times.Ttot)
 	}))
 	defer server.Close()
 
@@ -922,7 +948,7 @@ func TestSyncCdmData_MasterSession_DoesNotSyncTsatFromAPI(t *testing.T) {
 				return []*models.CdmDataRow{{
 					Callsign: callsign,
 					Data: (&models.CdmData{
-						Eobt: testStringPtr("1000"),
+						Eobt: testStringPtr(times.Eobt),
 					}).Normalize(),
 				}}, nil
 			},
@@ -1020,20 +1046,21 @@ func TestSyncCdmData_MasterSession_MarksRecalculationForReqTobtAndCtotChanges(t 
 func TestSyncCdmData_MasterSession_DoesNotExportStaleLocalTimesWhileRecalcPending(t *testing.T) {
 	const sessionID = int32(83)
 	const callsign = "SAS133"
+	times := futureMasterSyncTestTimes()
 
 	setCdmCh := make(chan struct{}, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/ifps/depAirport":
-			_, _ = w.Write([]byte(`[{
+			_, _ = fmt.Fprintf(w, `[{
 				"callsign":"SAS133",
 				"departure":"EKCH",
-				"eobt":"1000",
-				"tobt":"1010",
-				"ctot":"1040",
+				"eobt":%q,
+				"tobt":%q,
+				"ctot":%q,
 				"cdmSts":"REA",
-				"cdmData":{"reqTobt":"1005","reason":"REGUL"}
-			}]`))
+				"cdmData":{"reqTobt":%q,"reason":"REGUL"}
+			}]`, times.Eobt, times.Tobt, times.Ctot, times.ReqTobt)
 		case "/ifps/setCdmData":
 			setCdmCh <- struct{}{}
 			w.WriteHeader(http.StatusOK)
@@ -1051,10 +1078,10 @@ func TestSyncCdmData_MasterSession_DoesNotExportStaleLocalTimesWhileRecalcPendin
 				return []*models.CdmDataRow{{
 					Callsign: callsign,
 					Data: (&models.CdmData{
-						Eobt: testStringPtr("1000"),
-						Tobt: testStringPtr("1010"),
-						Tsat: testStringPtr("1015"),
-						Ttot: testStringPtr("1025"),
+						Eobt: testStringPtr(times.Eobt),
+						Tobt: testStringPtr(times.Tobt),
+						Tsat: testStringPtr(times.Tsat),
+						Ttot: testStringPtr(times.Ttot),
 					}).Normalize(),
 				}}, nil
 			},
@@ -1092,20 +1119,21 @@ func TestSyncCdmData_MasterSession_DoesNotExportStaleLocalTimesWhileRecalcPendin
 func TestSyncCdmData_MasterSession_PushesLocalTimesToViffWhenApiDiffers(t *testing.T) {
 	const sessionID = int32(81)
 	const callsign = "SAS131"
+	times := futureMasterSyncTestTimes()
 
 	setCdmCh := make(chan url.Values, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/ifps/depAirport":
-			_, _ = w.Write([]byte(`[{
+			_, _ = fmt.Fprintf(w, `[{
 				"callsign":"SAS131",
 				"departure":"EKCH",
-				"eobt":"1000",
-				"tobt":"1010",
+				"eobt":%q,
+				"tobt":%q,
 				"ctot":"",
 				"cdmSts":"STUP",
 				"cdmData":{"tsat":"","ttot":"","reason":""}
-			}]`))
+			}]`, times.Eobt, times.Tobt)
 		case "/ifps/setCdmData":
 			setCdmCh <- r.URL.Query()
 			w.WriteHeader(http.StatusOK)
@@ -1116,10 +1144,10 @@ func TestSyncCdmData_MasterSession_PushesLocalTimesToViffWhenApiDiffers(t *testi
 	defer server.Close()
 
 	local := (&models.CdmData{
-		Eobt: testStringPtr("1000"),
-		Tobt: testStringPtr("1010"),
-		Tsat: testStringPtr("101500"),
-		Ttot: testStringPtr("102500"),
+		Eobt: testStringPtr(times.Eobt),
+		Tobt: testStringPtr(times.Tobt),
+		Tsat: testStringPtr(times.Tsat),
+		Ttot: testStringPtr(times.Ttot),
 	}).Normalize()
 
 	service := newTestCdmService(
@@ -1144,7 +1172,7 @@ func TestSyncCdmData_MasterSession_PushesLocalTimesToViffWhenApiDiffers(t *testi
 
 	select {
 	case q := <-setCdmCh:
-		if q.Get("callsign") != callsign || q.Get("tobt") != "101000" || q.Get("tsat") != "101500" || q.Get("ttot") != "102500" || q.Get("depInfo") != "22R" {
+		if q.Get("callsign") != callsign || q.Get("tobt") != times.TobtSeconds || q.Get("tsat") != times.Tsat || q.Get("ttot") != times.Ttot || q.Get("depInfo") != "22R" {
 			t.Fatalf("unexpected setCdmData payload: %v", q)
 		}
 	case <-time.After(time.Second):

--- a/backend/internal/config/stand_assignment.go
+++ b/backend/internal/config/stand_assignment.go
@@ -38,6 +38,13 @@ func defaultStandAssignmentICAOFile() string {
 // enabled. A failed load leaves the rest of FlightStrips usable and records the
 // actionable reason that prevents SAT from becoming ready.
 func InitializeStandAssignment(enabled bool) StandAssignmentReadiness {
+	return InitializeStandAssignmentWithAircraftFile(enabled, "")
+}
+
+// InitializeStandAssignmentWithAircraftFile allows the explicitly enabled
+// local test console to supply a small aircraft fixture without changing the
+// production default or overriding an operator-provided path.
+func InitializeStandAssignmentWithAircraftFile(enabled bool, aircraftFile string) StandAssignmentReadiness {
 	if !enabled {
 		standAssignmentReadiness = StandAssignmentReadiness{}
 		aircraftReference = nil
@@ -62,7 +69,10 @@ func InitializeStandAssignment(enabled bool) StandAssignmentReadiness {
 		return standAssignmentReadiness
 	}
 
-	engineReference, err := sat.LoadAircraftEngineReferenceFile(standAssignmentICAOFile(), registry)
+	if strings.TrimSpace(aircraftFile) == "" {
+		aircraftFile = standAssignmentICAOFile()
+	}
+	engineReference, err := sat.LoadAircraftEngineReferenceFile(aircraftFile, registry)
 	if err != nil {
 		standAssignmentReadiness = StandAssignmentReadiness{
 			Enabled: true,

--- a/backend/internal/server/api.go
+++ b/backend/internal/server/api.go
@@ -28,7 +28,7 @@ func setAPIHeaders(w http.ResponseWriter, r *http.Request) {
 	addVaryHeader(headers, "Access-Control-Request-Method")
 	addVaryHeader(headers, "Access-Control-Request-Headers")
 	headers.Set("Access-Control-Allow-Origin", origin)
-	headers.Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+	headers.Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 	headers.Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
 	headers.Set("Access-Control-Max-Age", "600")
 }

--- a/backend/internal/server/api_test.go
+++ b/backend/internal/server/api_test.go
@@ -28,6 +28,28 @@ func TestAPIMiddlewareHandlesPreflight(t *testing.T) {
 	}
 }
 
+func TestAPIMiddlewareAllowsDeletePreflight(t *testing.T) {
+	handler := APIMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("preflight request should not reach downstream handler")
+	}))
+
+	req := httptest.NewRequest(http.MethodOptions, "/api/test/sat/scenarios", nil)
+	req.Header.Set("Origin", "http://localhost:5173")
+	req.Header.Set("Access-Control-Request-Method", http.MethodDelete)
+	req.Header.Set("Access-Control-Request-Headers", "authorization,content-type")
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+
+	response := recorder.Result()
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected status %d, got %d", http.StatusNoContent, response.StatusCode)
+	}
+	if got := response.Header.Get("Access-Control-Allow-Methods"); got != "GET, POST, PUT, DELETE, OPTIONS" {
+		t.Fatalf("DELETE preflight is not allowed, got methods %q", got)
+	}
+}
+
 func TestAPIMiddlewareAddsCORSHeadersToNormalRequests(t *testing.T) {
 	handler := APIMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
@@ -43,7 +65,7 @@ func TestAPIMiddlewareAddsCORSHeadersToNormalRequests(t *testing.T) {
 	if response.StatusCode != http.StatusAccepted {
 		t.Fatalf("expected status %d, got %d", http.StatusAccepted, response.StatusCode)
 	}
-	if got := response.Header.Get("Access-Control-Allow-Methods"); got != "GET, POST, OPTIONS" {
+	if got := response.Header.Get("Access-Control-Allow-Methods"); got != "GET, POST, PUT, DELETE, OPTIONS" {
 		t.Fatalf("unexpected Access-Control-Allow-Methods header %q", got)
 	}
 	if got := response.Header.Get("Access-Control-Allow-Headers"); got != "Authorization, Content-Type" {

--- a/backend/internal/testtools/clock.go
+++ b/backend/internal/testtools/clock.go
@@ -1,0 +1,35 @@
+package testtools
+
+import (
+	"sync"
+	"time"
+)
+
+type Clock struct {
+	mu  sync.RWMutex
+	now time.Time
+}
+
+func NewClock() *Clock {
+	return &Clock{now: time.Now().UTC()}
+}
+
+func (c *Clock) Now() time.Time {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.now
+}
+
+func (c *Clock) Advance(duration time.Duration) time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(duration)
+	return c.now
+}
+
+func (c *Clock) Reset() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = time.Now().UTC()
+	return c.now
+}

--- a/backend/internal/testtools/service.go
+++ b/backend/internal/testtools/service.go
@@ -1,0 +1,894 @@
+package testtools
+
+import (
+	"FlightStrips/internal/models"
+	"FlightStrips/internal/repository"
+	"FlightStrips/internal/sat"
+	"FlightStrips/internal/services"
+	"FlightStrips/internal/vatsim"
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+const (
+	testSource  = "TEST_TOOLS"
+	testCIDBase = int64(990000000)
+)
+
+var (
+	ErrUnavailable = errors.New("SAT test tools are unavailable")
+	ErrNotFound    = errors.New("test scenario not found")
+	ErrConflict    = errors.New("test scenario conflicts with existing data")
+	ErrInvalid     = errors.New("invalid test scenario request")
+)
+
+type ScenarioPreset string
+
+const (
+	PresetDeparture  ScenarioPreset = "departure"
+	PresetArrival    ScenarioPreset = "arrival"
+	PresetWrongStand ScenarioPreset = "wrong_stand"
+)
+
+type CreateScenarioRequest struct {
+	SessionID     int32          `json:"session_id"`
+	Preset        ScenarioPreset `json:"preset"`
+	Callsign      string         `json:"callsign"`
+	AircraftType  string         `json:"aircraft_type"`
+	Origin        string         `json:"origin"`
+	Destination   string         `json:"destination"`
+	Route         string         `json:"route"`
+	InitialState  string         `json:"initial_state"`
+	EOBT          string         `json:"eobt"`
+	EnrouteTime   string         `json:"enroute_time"`
+	Altitude      int            `json:"altitude"`
+	Groundspeed   int            `json:"groundspeed"`
+	ObservedStand string         `json:"observed_stand"`
+}
+
+type ScenarioCommand struct {
+	Command string `json:"command"`
+	Minutes int    `json:"minutes,omitempty"`
+	Stand   string `json:"stand,omitempty"`
+}
+
+type Scenario struct {
+	ID               string          `json:"id"`
+	SessionID        int32           `json:"session_id"`
+	Preset           ScenarioPreset  `json:"preset"`
+	Step             int             `json:"step"`
+	Callsign         string          `json:"callsign"`
+	CID              string          `json:"cid"`
+	AircraftType     string          `json:"aircraft_type"`
+	Origin           string          `json:"origin"`
+	Destination      string          `json:"destination"`
+	Route            string          `json:"route"`
+	EOBT             string          `json:"eobt"`
+	EnrouteTime      string          `json:"enroute_time"`
+	FeedState        string          `json:"feed_state"`
+	Altitude         int             `json:"altitude"`
+	Groundspeed      int             `json:"groundspeed"`
+	ObservedStand    string          `json:"observed_stand,omitempty"`
+	StripBay         string          `json:"strip_bay,omitempty"`
+	Assignment       *AssignmentView `json:"assignment,omitempty"`
+	LastAction       string          `json:"last_action,omitempty"`
+	GeneratedMessage string          `json:"generated_message,omitempty"`
+	Error            string          `json:"error,omitempty"`
+}
+
+type AssignmentView struct {
+	Stand          string     `json:"stand"`
+	Direction      string     `json:"direction"`
+	Stage          string     `json:"stage"`
+	Source         string     `json:"source"`
+	Version        int32      `json:"version"`
+	ETA            *time.Time `json:"eta,omitempty"`
+	ExpiresAt      *time.Time `json:"expires_at,omitempty"`
+	ConflictReason *string    `json:"conflict_reason,omitempty"`
+}
+
+type SessionView struct {
+	ID      int32  `json:"id"`
+	Name    string `json:"name"`
+	Airport string `json:"airport"`
+}
+
+type BlockView struct {
+	ID        int64   `json:"id"`
+	SessionID int32   `json:"session_id"`
+	Stand     string  `json:"stand"`
+	Reason    *string `json:"reason,omitempty"`
+	Version   int32   `json:"version"`
+}
+
+type StripDeleter interface {
+	DeleteStrip(context.Context, int32, string) error
+}
+
+type Service struct {
+	source       *vatsim.SyntheticSource
+	reconciler   *vatsim.Reconciler
+	departures   *services.DepartureLifecycleService
+	arrivals     *services.ArrivalLifecycleService
+	allocations  *services.StandAllocationService
+	sessions     repository.SessionRepository
+	strips       repository.StripRepository
+	stripDeleter StripDeleter
+	assignments  repository.StandAssignmentRepository
+	stands       *sat.StandCapabilityRegistry
+	clock        *Clock
+
+	operations sync.Mutex
+	mu         sync.RWMutex
+	scenarios  map[string]*Scenario
+	nextCID    int64
+}
+
+type ServiceConfig struct {
+	Source       *vatsim.SyntheticSource
+	Reconciler   *vatsim.Reconciler
+	Departures   *services.DepartureLifecycleService
+	Arrivals     *services.ArrivalLifecycleService
+	Allocations  *services.StandAllocationService
+	Sessions     repository.SessionRepository
+	Strips       repository.StripRepository
+	StripDeleter StripDeleter
+	Assignments  repository.StandAssignmentRepository
+	Stands       *sat.StandCapabilityRegistry
+	Clock        *Clock
+}
+
+func NewService(cfg ServiceConfig) *Service {
+	return &Service{
+		source: cfg.Source, reconciler: cfg.Reconciler, departures: cfg.Departures,
+		arrivals: cfg.Arrivals, allocations: cfg.Allocations, sessions: cfg.Sessions,
+		strips: cfg.Strips, stripDeleter: cfg.StripDeleter,
+		assignments: cfg.Assignments, stands: cfg.Stands,
+		clock: cfg.Clock, scenarios: make(map[string]*Scenario), nextCID: testCIDBase,
+	}
+}
+
+func (s *Service) Available() bool {
+	return s != nil && s.source != nil && s.reconciler != nil && s.departures != nil &&
+		s.arrivals != nil && s.allocations != nil && s.sessions != nil &&
+		s.strips != nil && s.stripDeleter != nil && s.assignments != nil &&
+		s.stands != nil && s.clock != nil
+}
+
+func (s *Service) Now() time.Time {
+	if s == nil || s.clock == nil {
+		return time.Now().UTC()
+	}
+	return s.clock.Now()
+}
+
+func (s *Service) Sessions(ctx context.Context) ([]SessionView, error) {
+	if s == nil || s.sessions == nil {
+		return nil, ErrUnavailable
+	}
+	rows, err := s.sessions.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]SessionView, 0, len(rows))
+	for _, session := range rows {
+		if session != nil && strings.EqualFold(session.Airport, "EKCH") {
+			result = append(result, SessionView{ID: session.ID, Name: session.Name, Airport: session.Airport})
+		}
+	}
+	return result, nil
+}
+
+func (s *Service) CreateScenario(ctx context.Context, request CreateScenarioRequest) (*Scenario, error) {
+	if !s.Available() {
+		return nil, ErrUnavailable
+	}
+	s.operations.Lock()
+	defer s.operations.Unlock()
+
+	request = normalizeCreateRequest(request, s.Now())
+	if err := validateCreateRequest(request); err != nil {
+		return nil, err
+	}
+	session, err := s.sessions.GetByID(ctx, request.SessionID)
+	if err != nil || session == nil || !strings.EqualFold(session.Airport, "EKCH") {
+		return nil, fmt.Errorf("%w: select an existing EKCH session", ErrInvalid)
+	}
+	exists, err := s.callsignExists(ctx, request.Callsign)
+	if err != nil {
+		return nil, err
+	}
+	if exists {
+		return nil, fmt.Errorf("%w: callsign %s already exists", ErrConflict, request.Callsign)
+	}
+
+	s.mu.Lock()
+	for _, current := range s.scenarios {
+		if current.Callsign == request.Callsign {
+			s.mu.Unlock()
+			return nil, fmt.Errorf("%w: callsign %s already has a scenario", ErrConflict, request.Callsign)
+		}
+	}
+	s.nextCID++
+	scenario := &Scenario{
+		ID: uuid.NewString(), SessionID: request.SessionID, Preset: request.Preset,
+		Callsign: request.Callsign, CID: strconv.FormatInt(s.nextCID, 10),
+		AircraftType: request.AircraftType, Origin: request.Origin,
+		Destination: request.Destination, Route: request.Route,
+		EOBT: request.EOBT, EnrouteTime: request.EnrouteTime,
+		FeedState: request.InitialState, Altitude: request.Altitude,
+		Groundspeed: request.Groundspeed, ObservedStand: request.ObservedStand,
+		LastAction: "scenario created",
+	}
+	s.scenarios[scenario.ID] = scenario
+	s.mu.Unlock()
+
+	flight := s.flightForScenario(scenario)
+	s.source.Upsert(flight)
+	if err := s.reconcileScenario(ctx, scenario); err != nil {
+		s.source.Remove(scenario.Callsign)
+		s.mu.Lock()
+		delete(s.scenarios, scenario.ID)
+		s.mu.Unlock()
+		return nil, err
+	}
+	if err := s.markAssignmentOwned(ctx, scenario); err != nil {
+		_ = s.cleanupScenario(ctx, scenario)
+		s.mu.Lock()
+		delete(s.scenarios, scenario.ID)
+		s.mu.Unlock()
+		return nil, err
+	}
+	return s.refreshScenario(ctx, scenario), nil
+}
+
+func (s *Service) callsignExists(ctx context.Context, callsign string) (bool, error) {
+	if _, ok := s.source.Snapshot().FlightByCallsign(callsign); ok {
+		return true, nil
+	}
+	sessions, err := s.sessions.List(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, session := range sessions {
+		if session == nil {
+			continue
+		}
+		strip, err := s.strips.GetByCallsign(ctx, session.ID, callsign)
+		switch {
+		case err == nil && strip != nil:
+			return true, nil
+		case err != nil && !errors.Is(err, pgx.ErrNoRows):
+			return false, err
+		}
+	}
+	return false, nil
+}
+
+func normalizeCreateRequest(request CreateScenarioRequest, now time.Time) CreateScenarioRequest {
+	request.Preset = ScenarioPreset(strings.ToLower(strings.TrimSpace(string(request.Preset))))
+	request.Callsign = strings.ToUpper(strings.TrimSpace(request.Callsign))
+	request.AircraftType = strings.ToUpper(strings.TrimSpace(request.AircraftType))
+	request.Origin = strings.ToUpper(strings.TrimSpace(request.Origin))
+	request.Destination = strings.ToUpper(strings.TrimSpace(request.Destination))
+	request.Route = strings.ToUpper(strings.TrimSpace(request.Route))
+	request.InitialState = strings.ToLower(strings.TrimSpace(request.InitialState))
+	request.ObservedStand = strings.ToUpper(strings.TrimSpace(request.ObservedStand))
+	if request.Preset == "" {
+		request.Preset = PresetDeparture
+	}
+	if request.Callsign == "" {
+		request.Callsign = "TST" + now.Format("150405")
+	}
+	if request.AircraftType == "" {
+		request.AircraftType = "A320"
+	}
+	if request.Route == "" {
+		request.Route = "DCT"
+	}
+	if request.InitialState == "" {
+		request.InitialState = "prefile"
+	}
+	if request.EOBT == "" {
+		request.EOBT = now.UTC().Format("1504")
+	}
+	if request.EnrouteTime == "" {
+		request.EnrouteTime = "0045"
+	}
+	if request.Preset == PresetArrival {
+		if request.Origin == "" {
+			request.Origin = "EGLL"
+		}
+		if request.Destination == "" {
+			request.Destination = "EKCH"
+		}
+	} else {
+		if request.Origin == "" {
+			request.Origin = "EKCH"
+		}
+		if request.Destination == "" {
+			request.Destination = "EGLL"
+		}
+	}
+	return request
+}
+
+func validateCreateRequest(request CreateScenarioRequest) error {
+	switch request.Preset {
+	case PresetDeparture, PresetArrival, PresetWrongStand:
+	default:
+		return fmt.Errorf("%w: unsupported preset %q", ErrInvalid, request.Preset)
+	}
+	if request.SessionID <= 0 || request.Callsign == "" || request.AircraftType == "" ||
+		request.Origin == "" || request.Destination == "" {
+		return fmt.Errorf("%w: session, callsign, aircraft, origin, and destination are required", ErrInvalid)
+	}
+	if request.InitialState != "prefile" && request.InitialState != "online" {
+		return fmt.Errorf("%w: initial_state must be prefile or online", ErrInvalid)
+	}
+	if _, err := time.Parse("1504", request.EOBT); err != nil {
+		return fmt.Errorf("%w: eobt must use HHMM", ErrInvalid)
+	}
+	if len(request.EnrouteTime) != 4 {
+		return fmt.Errorf("%w: enroute_time must use HHMM", ErrInvalid)
+	}
+	hours, hoursErr := strconv.Atoi(request.EnrouteTime[:2])
+	minutes, minutesErr := strconv.Atoi(request.EnrouteTime[2:])
+	if hoursErr != nil || minutesErr != nil || hours < 0 || minutes < 0 || minutes >= 60 {
+		return fmt.Errorf("%w: enroute_time must use HHMM", ErrInvalid)
+	}
+	if request.Altitude < 0 || request.Groundspeed < 0 {
+		return fmt.Errorf("%w: altitude and groundspeed cannot be negative", ErrInvalid)
+	}
+	return nil
+}
+
+func (s *Service) flightForScenario(scenario *Scenario) vatsim.Flight {
+	snapshot := s.snapshotScenario(scenario)
+	state := vatsim.FlightStatePrefile
+	if snapshot.FeedState == "online" {
+		state = vatsim.FlightStateOnline
+	}
+	return vatsim.Flight{
+		CID: snapshot.CID, Callsign: snapshot.Callsign, State: state,
+		Altitude: snapshot.Altitude, Groundspeed: snapshot.Groundspeed,
+		LastUpdated: s.Now(),
+		FlightPlan: vatsim.FlightPlan{
+			FlightRules: "I", Aircraft: snapshot.AircraftType,
+			AircraftShort: snapshot.AircraftType, Origin: snapshot.Origin,
+			Destination: snapshot.Destination, Route: snapshot.Route,
+			EOBT: snapshot.EOBT, EnrouteDuration: snapshot.EnrouteTime, Revision: int64(snapshot.Step + 1),
+		},
+	}
+}
+
+func (s *Service) snapshotScenario(scenario *Scenario) Scenario {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return *scenario
+}
+
+func (s *Service) updateScenario(scenario *Scenario, update func(*Scenario)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	update(scenario)
+}
+
+func (s *Service) ListScenarios(ctx context.Context, sessionID int32) ([]*Scenario, error) {
+	if !s.Available() {
+		return nil, ErrUnavailable
+	}
+	s.mu.RLock()
+	selected := make([]*Scenario, 0, len(s.scenarios))
+	for _, scenario := range s.scenarios {
+		if sessionID == 0 || scenario.SessionID == sessionID {
+			selected = append(selected, scenario)
+		}
+	}
+	s.mu.RUnlock()
+	result := make([]*Scenario, 0, len(selected))
+	for _, scenario := range selected {
+		result = append(result, s.refreshScenario(ctx, scenario))
+	}
+	return result, nil
+}
+
+func (s *Service) Command(ctx context.Context, id string, command ScenarioCommand) (*Scenario, error) {
+	if !s.Available() {
+		return nil, ErrUnavailable
+	}
+	s.operations.Lock()
+	defer s.operations.Unlock()
+
+	s.mu.RLock()
+	scenario := s.scenarios[id]
+	s.mu.RUnlock()
+	if scenario == nil {
+		return nil, ErrNotFound
+	}
+
+	var err error
+	switch strings.ToLower(strings.TrimSpace(command.Command)) {
+	case "advance":
+		err = s.advance(ctx, scenario)
+	case "advance_time":
+		if command.Minutes <= 0 || command.Minutes > 24*60 {
+			return nil, fmt.Errorf("%w: minutes must be between 1 and 1440", ErrInvalid)
+		}
+		s.clock.Advance(time.Duration(command.Minutes) * time.Minute)
+		err = s.runSweeps(ctx)
+		s.updateScenario(scenario, func(state *Scenario) {
+			state.LastAction = fmt.Sprintf("advanced simulated time by %d minutes", command.Minutes)
+		})
+	case "move_to_stand":
+		err = s.moveToStand(ctx, scenario, command.Stand)
+	case "remove":
+		snapshot := s.snapshotScenario(scenario)
+		s.source.Remove(snapshot.Callsign)
+		s.updateScenario(scenario, func(state *Scenario) {
+			state.FeedState = "removed"
+			state.LastAction = "removed from synthetic feed"
+		})
+		err = s.reconcileScenario(ctx, scenario)
+	default:
+		return nil, fmt.Errorf("%w: unsupported command %q", ErrInvalid, command.Command)
+	}
+	if err != nil {
+		s.updateScenario(scenario, func(state *Scenario) { state.Error = err.Error() })
+		return s.refreshScenario(ctx, scenario), err
+	}
+	if err := s.markAssignmentOwned(ctx, scenario); err != nil {
+		s.updateScenario(scenario, func(state *Scenario) { state.Error = err.Error() })
+		return s.refreshScenario(ctx, scenario), err
+	}
+	s.updateScenario(scenario, func(state *Scenario) { state.Error = "" })
+	return s.refreshScenario(ctx, scenario), nil
+}
+
+func (s *Service) markAssignmentOwned(ctx context.Context, scenario *Scenario) error {
+	assignment, err := s.assignments.GetAssignment(ctx, scenario.SessionID, scenario.Callsign)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil || assignment == nil {
+		return err
+	}
+	if assignment.Source == testSource {
+		return nil
+	}
+	assignment.Source = testSource
+	updated, err := s.assignments.UpdateAssignment(ctx, assignment)
+	if err != nil {
+		return err
+	}
+	if updated != 1 {
+		return errors.New("test-tools assignment changed concurrently")
+	}
+	assignment.Version++
+	return s.allocations.PublishAssignment(ctx, *assignment)
+}
+
+func (s *Service) advance(ctx context.Context, scenario *Scenario) error {
+	snapshot := s.snapshotScenario(scenario)
+	switch snapshot.Preset {
+	case PresetDeparture:
+		switch snapshot.Step {
+		case 0:
+			assignment, err := s.assignments.GetAssignment(ctx, snapshot.SessionID, snapshot.Callsign)
+			if err != nil {
+				return err
+			}
+			if err := s.moveToStand(ctx, scenario, assignment.Stand); err != nil {
+				return err
+			}
+		case 1:
+			s.source.Remove(snapshot.Callsign)
+			s.updateScenario(scenario, func(state *Scenario) {
+				state.FeedState = "removed"
+				state.LastAction = "departure removed from feed"
+			})
+			if err := s.reconcileScenario(ctx, scenario); err != nil {
+				return err
+			}
+		default:
+			if strip, err := s.strips.GetByCallsign(ctx, snapshot.SessionID, snapshot.Callsign); err == nil && strip != nil && strip.VatsimCID != nil && isTestCID(*strip.VatsimCID) {
+				if err := s.stripDeleter.DeleteStrip(ctx, snapshot.SessionID, snapshot.Callsign); err != nil {
+					return err
+				}
+			}
+			s.clock.Advance(20 * time.Minute)
+			s.updateScenario(scenario, func(state *Scenario) { state.LastAction = "departure expiry swept" })
+			if err := s.runSweeps(ctx); err != nil {
+				return err
+			}
+			if err := s.reconcileScenario(ctx, scenario); err != nil {
+				return err
+			}
+		}
+	case PresetArrival:
+		switch snapshot.Step {
+		case 0:
+			if err := s.advanceToETAWindow(ctx, snapshot, 9*time.Minute); err != nil {
+				return err
+			}
+			s.updateScenario(scenario, func(state *Scenario) {
+				state.FeedState, state.Altitude, state.Groundspeed = "online", 9000, 250
+				state.LastAction = "arrival advanced to ASSIGNED threshold"
+			})
+			s.source.Upsert(s.flightForScenario(scenario))
+			if err := s.reconcileScenario(ctx, scenario); err != nil {
+				return err
+			}
+		case 1:
+			if err := s.advanceToETAWindow(ctx, snapshot, time.Minute); err != nil {
+				return err
+			}
+			s.updateScenario(scenario, func(state *Scenario) {
+				state.Altitude = 2000
+				state.LastAction = "arrival advanced to CONFIRMED threshold"
+			})
+			s.source.Upsert(s.flightForScenario(scenario))
+			if err := s.reconcileScenario(ctx, scenario); err != nil {
+				return err
+			}
+		default:
+			s.source.Remove(snapshot.Callsign)
+			s.clock.Advance(32 * time.Minute)
+			s.updateScenario(scenario, func(state *Scenario) {
+				state.FeedState = "removed"
+				state.LastAction = "arrival timeout swept"
+			})
+			if err := s.runSweeps(ctx); err != nil {
+				return err
+			}
+			if err := s.reconcileScenario(ctx, scenario); err != nil {
+				return err
+			}
+		}
+	case PresetWrongStand:
+		switch snapshot.Step {
+		case 0:
+			assignment, err := s.assignments.GetAssignment(ctx, snapshot.SessionID, snapshot.Callsign)
+			if err != nil {
+				return err
+			}
+			stand, err := s.pickWrongStand(assignment.Stand, snapshot.ObservedStand)
+			if err != nil {
+				return err
+			}
+			reason := "test-tools wrong-stand scenario"
+			callsign := snapshot.Callsign
+			block := &models.StandBlock{SessionID: snapshot.SessionID, Stand: stand.Name, BlockType: "CLOSURE", Source: testSource, Reason: &reason, Callsign: &callsign, Manual: true}
+			if err := s.allocations.CreateManualBlock(ctx, "EKCH", block); err != nil {
+				return err
+			}
+			s.updateScenario(scenario, func(state *Scenario) { state.ObservedStand = stand.Name })
+			if err := s.moveToStand(ctx, scenario, stand.Name); err != nil {
+				return err
+			}
+		case 1:
+			s.clock.Advance(6 * time.Minute)
+			s.updateScenario(scenario, func(state *Scenario) { state.LastAction = "wrong-stand deadline swept" })
+			if err := s.departures.ReleaseExpired(ctx); err != nil {
+				return err
+			}
+		default:
+			s.source.Remove(snapshot.Callsign)
+			s.updateScenario(scenario, func(state *Scenario) {
+				state.FeedState = "removed"
+				state.LastAction = "wrong-stand flight removed"
+			})
+			if err := s.reconcileScenario(ctx, scenario); err != nil {
+				return err
+			}
+		}
+	}
+	s.updateScenario(scenario, func(state *Scenario) { state.Step++ })
+	return nil
+}
+
+func (s *Service) advanceToETAWindow(ctx context.Context, scenario Scenario, window time.Duration) error {
+	assignment, err := s.assignments.GetAssignment(ctx, scenario.SessionID, scenario.Callsign)
+	if err != nil {
+		return err
+	}
+	if assignment.ETA == nil {
+		return fmt.Errorf("%w: scenario has no arrival ETA", ErrInvalid)
+	}
+	if advance := assignment.ETA.Add(-window).Sub(s.Now()); advance > 0 {
+		s.clock.Advance(advance)
+	}
+	return nil
+}
+
+func (s *Service) pickWrongStand(assigned, preferred string) (sat.Stand, error) {
+	if preferred != "" && !strings.EqualFold(preferred, assigned) {
+		if stand, ok := s.stands.Lookup("EKCH", preferred); ok {
+			return stand, nil
+		}
+	}
+	for _, stand := range s.stands.Stands("EKCH") {
+		if !strings.EqualFold(stand.Name, assigned) && !stand.Variants[0].Manual {
+			return stand, nil
+		}
+	}
+	return sat.Stand{}, fmt.Errorf("%w: no alternate stand available", ErrInvalid)
+}
+
+func (s *Service) moveToStand(ctx context.Context, scenario *Scenario, name string) error {
+	stand, ok := s.stands.Lookup("EKCH", strings.ToUpper(strings.TrimSpace(name)))
+	if !ok {
+		return fmt.Errorf("%w: unknown stand %q", ErrInvalid, name)
+	}
+	flight := s.flightForScenario(scenario)
+	flight.State = vatsim.FlightStateOnline
+	flight.Latitude, flight.Longitude = stand.Latitude, stand.Longitude
+	snapshot := s.snapshotScenario(scenario)
+	if flight.Altitude == 0 && snapshot.Preset == PresetArrival {
+		flight.Altitude = 9000
+	}
+	s.updateScenario(scenario, func(state *Scenario) {
+		state.FeedState = "online"
+		state.ObservedStand = stand.Name
+		state.LastAction = "moved online flight to stand " + stand.Name
+		if state.Altitude == 0 && state.Preset == PresetArrival {
+			state.Altitude = 9000
+		}
+	})
+	s.source.Upsert(flight)
+	if err := s.reconcileScenario(ctx, scenario); err != nil {
+		return err
+	}
+	if !strings.EqualFold(snapshot.Origin, "EKCH") {
+		return nil
+	}
+	strip, err := s.strips.GetByCallsign(ctx, snapshot.SessionID, snapshot.Callsign)
+	if err != nil {
+		return err
+	}
+	return s.departures.ObserveDeparturePosition(ctx, snapshot.SessionID, strip, stand.Latitude, stand.Longitude)
+}
+
+func (s *Service) reconcileScenario(ctx context.Context, scenario *Scenario) error {
+	return s.reconciler.ReconcileSession(ctx, s.snapshotScenario(scenario).SessionID)
+}
+
+func (s *Service) runSweeps(ctx context.Context) error {
+	if err := s.departures.ReleaseExpired(ctx); err != nil {
+		return err
+	}
+	return s.arrivals.ReleaseExpired(ctx)
+}
+
+func (s *Service) refreshScenario(ctx context.Context, scenario *Scenario) *Scenario {
+	copy := s.snapshotScenario(scenario)
+	strip, err := s.strips.GetByCallsign(ctx, copy.SessionID, copy.Callsign)
+	if err == nil && strip != nil {
+		copy.StripBay = strip.Bay
+	}
+	assignment, err := s.assignments.GetAssignment(ctx, copy.SessionID, copy.Callsign)
+	if err == nil && assignment != nil {
+		copy.Assignment = &AssignmentView{
+			Stand: assignment.Stand, Direction: assignment.Direction, Stage: assignment.Stage,
+			Source: assignment.Source, Version: assignment.Version, ETA: assignment.ETA,
+			ExpiresAt: assignment.ExpiresAt, ConflictReason: assignment.ConflictReason,
+		}
+	}
+	return &copy
+}
+
+func (s *Service) DeleteScenario(ctx context.Context, id string) error {
+	s.operations.Lock()
+	defer s.operations.Unlock()
+
+	s.mu.RLock()
+	scenario := s.scenarios[id]
+	s.mu.RUnlock()
+	if scenario == nil {
+		return ErrNotFound
+	}
+	if err := s.cleanupScenario(ctx, scenario); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	delete(s.scenarios, id)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *Service) cleanupScenario(ctx context.Context, scenario *Scenario) error {
+	s.source.Remove(scenario.Callsign)
+	if assignment, err := s.assignments.GetAssignment(ctx, scenario.SessionID, scenario.Callsign); err == nil && assignment != nil {
+		if err := s.allocations.ReleaseAssignment(ctx, assignment); err != nil {
+			return err
+		}
+	}
+	blocks, err := s.assignments.ListBlocks(ctx, scenario.SessionID)
+	if err != nil {
+		return err
+	}
+	for _, block := range blocks {
+		if block != nil && block.Source == testSource && block.Callsign != nil && strings.EqualFold(*block.Callsign, scenario.Callsign) {
+			if _, err := s.allocations.DeleteManualBlock(ctx, scenario.SessionID, block.ID, block.Version); err != nil {
+				return err
+			}
+		}
+	}
+	if strip, err := s.strips.GetByCallsign(ctx, scenario.SessionID, scenario.Callsign); err == nil && strip != nil {
+		if strip.VatsimCID != nil && isTestCID(*strip.VatsimCID) {
+			if err := s.stripDeleter.DeleteStrip(ctx, scenario.SessionID, scenario.Callsign); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (s *Service) Reset(ctx context.Context) error {
+	if !s.Available() {
+		return ErrUnavailable
+	}
+	s.operations.Lock()
+	defer s.operations.Unlock()
+
+	s.mu.RLock()
+	scenarios := make([]*Scenario, 0, len(s.scenarios))
+	for _, scenario := range s.scenarios {
+		scenarios = append(scenarios, scenario)
+	}
+	s.mu.RUnlock()
+	for _, scenario := range scenarios {
+		if err := s.cleanupScenario(ctx, scenario); err != nil {
+			return err
+		}
+	}
+	s.source.Reset()
+	s.clock.Reset()
+	s.mu.Lock()
+	s.scenarios = make(map[string]*Scenario)
+	s.mu.Unlock()
+	return s.cleanupOrphans(ctx)
+}
+
+func (s *Service) cleanupOrphans(ctx context.Context) error {
+	sessions, err := s.sessions.List(ctx)
+	if err != nil {
+		return err
+	}
+	for _, session := range sessions {
+		if session == nil {
+			continue
+		}
+		strips, err := s.strips.List(ctx, session.ID)
+		if err != nil {
+			return err
+		}
+		for _, strip := range strips {
+			if strip == nil || strip.VatsimCID == nil || !isTestCID(*strip.VatsimCID) {
+				continue
+			}
+			if assignment, err := s.assignments.GetAssignment(ctx, session.ID, strip.Callsign); err == nil && assignment != nil {
+				if err := s.allocations.ReleaseAssignment(ctx, assignment); err != nil {
+					return err
+				}
+			}
+			if err := s.stripDeleter.DeleteStrip(ctx, session.ID, strip.Callsign); err != nil {
+				return err
+			}
+		}
+		blocks, err := s.assignments.ListBlocks(ctx, session.ID)
+		if err != nil {
+			return err
+		}
+		for _, block := range blocks {
+			if block != nil && block.Source == testSource {
+				if _, err := s.allocations.DeleteManualBlock(ctx, session.ID, block.ID, block.Version); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func isTestCID(value string) bool {
+	cid, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+	return err == nil && cid > testCIDBase && cid < testCIDBase+1000000
+}
+
+func (s *Service) CreateBlock(ctx context.Context, sessionID int32, stand, reason string) (*BlockView, error) {
+	if !s.Available() {
+		return nil, ErrUnavailable
+	}
+	session, err := s.sessions.GetByID(ctx, sessionID)
+	if err != nil || session == nil || !strings.EqualFold(session.Airport, "EKCH") {
+		return nil, fmt.Errorf("%w: select an existing EKCH session", ErrInvalid)
+	}
+	stand = strings.ToUpper(strings.TrimSpace(stand))
+	if _, ok := s.stands.Lookup("EKCH", stand); !ok {
+		return nil, fmt.Errorf("%w: unknown stand %q", ErrInvalid, stand)
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "Local test console"
+	}
+	block := &models.StandBlock{SessionID: sessionID, Stand: stand, BlockType: "CLOSURE", Source: testSource, Reason: &reason, Manual: true}
+	if err := s.allocations.CreateManualBlock(ctx, "EKCH", block); err != nil {
+		return nil, err
+	}
+	return &BlockView{ID: block.ID, SessionID: sessionID, Stand: block.Stand, Reason: block.Reason, Version: block.Version}, nil
+}
+
+func (s *Service) DeleteBlock(ctx context.Context, sessionID int32, id int64, version int32) error {
+	if !s.Available() {
+		return ErrUnavailable
+	}
+	block, err := s.assignments.GetBlock(ctx, sessionID, id)
+	if err != nil {
+		return err
+	}
+	if block.Source != testSource {
+		return fmt.Errorf("%w: only test-tools blocks can be removed here", ErrConflict)
+	}
+	_, err = s.allocations.DeleteManualBlock(ctx, sessionID, id, version)
+	return err
+}
+
+func (s *Service) Blocks(ctx context.Context, sessionID int32) ([]BlockView, error) {
+	if !s.Available() {
+		return nil, ErrUnavailable
+	}
+	rows, err := s.assignments.ListBlocks(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]BlockView, 0)
+	for _, block := range rows {
+		if block != nil && block.Source == testSource {
+			result = append(result, BlockView{ID: block.ID, SessionID: block.SessionID, Stand: block.Stand, Reason: block.Reason, Version: block.Version})
+		}
+	}
+	return result, nil
+}
+
+// RecordGeneratedMessage lets the wrong-stand fallback messenger expose the
+// message on the scenario card.
+func (s *Service) RecordGeneratedMessage(callsign, message string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, scenario := range s.scenarios {
+		if strings.EqualFold(scenario.Callsign, callsign) {
+			scenario.GeneratedMessage = message
+		}
+	}
+}
+
+type privateMessenger interface {
+	SendPrivateMessageFromDelivery(session int32, callsign, message string) bool
+}
+
+type FallbackMessenger struct {
+	primary  privateMessenger
+	recorder *Service
+}
+
+func NewFallbackMessenger(primary privateMessenger, recorder *Service) *FallbackMessenger {
+	return &FallbackMessenger{primary: primary, recorder: recorder}
+}
+
+func (m *FallbackMessenger) SendPrivateMessageFromDelivery(session int32, callsign, message string) bool {
+	delivered := m.primary != nil && m.primary.SendPrivateMessageFromDelivery(session, callsign, message)
+	if m.recorder != nil {
+		m.recorder.RecordGeneratedMessage(callsign, message)
+		return true
+	}
+	return delivered
+}

--- a/backend/internal/testtools/service_test.go
+++ b/backend/internal/testtools/service_test.go
@@ -1,0 +1,166 @@
+package testtools
+
+import (
+	"FlightStrips/internal/models"
+	"FlightStrips/internal/pdc/testdata"
+	"FlightStrips/internal/repository"
+	"FlightStrips/internal/repository/postgres"
+	"FlightStrips/internal/sat"
+	"FlightStrips/internal/services"
+	"FlightStrips/internal/vatsim"
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type scenarioNotifier struct{}
+
+func (scenarioNotifier) SendStripUpdate(int32, string) {}
+
+type repositoryStripDeleter struct {
+	repository.StripRepository
+	deleted []string
+}
+
+func (d *repositoryStripDeleter) DeleteStrip(ctx context.Context, session int32, callsign string) error {
+	d.deleted = append(d.deleted, callsign)
+	return d.Delete(ctx, session, callsign)
+}
+
+func TestScenariosUseRealReconciliationAndLifecycle(t *testing.T) {
+	pool, queries := testdata.SetupTestDB(t)
+	ctx := context.Background()
+	require.NoError(t, queries.InsertAirport(ctx, "EKCH"))
+
+	sessionRepo := postgres.NewSessionRepository(pool)
+	stripRepo := postgres.NewStripRepository(pool)
+	assignmentRepo := postgres.NewStandAssignmentRepository(pool)
+	sessionID, err := sessionRepo.Create(ctx, &models.Session{Name: "SAT-TEST", Airport: "EKCH", CdmMaster: true})
+	require.NoError(t, err)
+	otherSessionID, err := sessionRepo.Create(ctx, &models.Session{Name: "SAT-OTHER", Airport: "EKCH"})
+	require.NoError(t, err)
+
+	configDir := filepath.Join("..", "..", "config", "ekch")
+	aircraft, err := sat.LoadAircraftReferenceFile(filepath.Join(configDir, "GRpluginAircraftInfo.txt"))
+	require.NoError(t, err)
+	engines, err := sat.LoadAircraftEngineReferenceFile(filepath.Join("..", "..", "config", "test", "ICAO_Aircraft.json"), aircraft)
+	require.NoError(t, err)
+	stands, err := sat.LoadStandCapabilityFile(filepath.Join(configDir, "GRpluginStands.txt"))
+	require.NoError(t, err)
+	policy, err := sat.LoadAirlineAssignmentFile(filepath.Join(configDir, "airline_assignment.json"), stands)
+	require.NoError(t, err)
+	borders := sat.NewAirportCountryRegistry()
+
+	clock := NewClock()
+	allocations, err := services.NewStandAllocationService(pool, stripRepo, assignmentRepo, stands, policy, services.WithStandAllocationClock(clock.Now))
+	require.NoError(t, err)
+	departures, err := services.NewDepartureLifecycleService(
+		allocations, assignmentRepo, stripRepo, sessionRepo, stands, aircraft, engines, borders,
+		services.WithDepartureLifecycleClock(clock.Now),
+	)
+	require.NoError(t, err)
+	arrivals, err := services.NewArrivalLifecycleService(
+		allocations, assignmentRepo, stripRepo, sessionRepo, stands, aircraft, engines, borders,
+		services.WithArrivalLifecycleClock(clock.Now),
+	)
+	require.NoError(t, err)
+	source := vatsim.NewSyntheticSource()
+	reconciler, err := vatsim.NewReconciler(vatsim.ReconcilerDependencies{
+		Cache: source, Sessions: sessionRepo, Strips: stripRepo, Assignments: assignmentRepo,
+		DepartureLifecycle: departures, ArrivalLifecycle: arrivals, Notifier: scenarioNotifier{},
+	}, time.Second, vatsim.WithClock(clock.Now))
+	require.NoError(t, err)
+	deleter := &repositoryStripDeleter{StripRepository: stripRepo}
+	service := NewService(ServiceConfig{
+		Source: source, Reconciler: reconciler, Departures: departures, Arrivals: arrivals,
+		Allocations: allocations, Sessions: sessionRepo, Strips: stripRepo,
+		StripDeleter: deleter, Assignments: assignmentRepo, Stands: stands, Clock: clock,
+	})
+	departures.SetWrongStandMessenger(NewFallbackMessenger(nil, service))
+
+	scenario, err := service.CreateScenario(ctx, CreateScenarioRequest{
+		SessionID: sessionID, Preset: PresetDeparture, Callsign: "TST101", AircraftType: "A320",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, scenario.Assignment)
+	assert.Equal(t, services.StageReserved, scenario.Assignment.Stage)
+	assert.Equal(t, testSource, scenario.Assignment.Source)
+	_, err = stripRepo.GetByCallsign(ctx, otherSessionID, "TST101")
+	assert.ErrorIs(t, err, pgx.ErrNoRows)
+	_, err = service.CreateScenario(ctx, CreateScenarioRequest{
+		SessionID: otherSessionID, Preset: PresetDeparture, Callsign: "TST101", AircraftType: "A320",
+	})
+	assert.ErrorIs(t, err, ErrConflict)
+
+	listDone := make(chan error, 1)
+	go func() {
+		for range 20 {
+			if _, listErr := service.ListScenarios(ctx, sessionID); listErr != nil {
+				listDone <- listErr
+				return
+			}
+		}
+		listDone <- nil
+	}()
+	scenario, err = service.Command(ctx, scenario.ID, ScenarioCommand{Command: "advance"})
+	require.NoError(t, err)
+	require.NoError(t, <-listDone)
+	require.NotNil(t, scenario.Assignment)
+	assert.Equal(t, services.StageDepartureBlock, scenario.Assignment.Stage)
+	assert.Equal(t, testSource, scenario.Assignment.Source)
+	assert.Equal(t, "online", scenario.FeedState)
+
+	require.NoError(t, service.Reset(ctx))
+	_, err = stripRepo.GetByCallsign(ctx, sessionID, "TST101")
+	assert.ErrorIs(t, err, pgx.ErrNoRows)
+	_, err = assignmentRepo.GetAssignment(ctx, sessionID, "TST101")
+	assert.ErrorIs(t, err, pgx.ErrNoRows)
+	assert.Contains(t, deleter.deleted, "TST101")
+
+	customEOBT := clock.Now().Add(5 * time.Minute).Format("1504")
+	arrival, err := service.CreateScenario(ctx, CreateScenarioRequest{
+		SessionID: sessionID, Preset: PresetArrival, Callsign: "TST201", AircraftType: "A320",
+		EOBT: customEOBT, EnrouteTime: "0030",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, arrival.Assignment)
+	assert.Equal(t, services.StageEstimated, arrival.Assignment.Stage)
+	assert.Equal(t, testSource, arrival.Assignment.Source)
+
+	arrival, err = service.Command(ctx, arrival.ID, ScenarioCommand{Command: "advance"})
+	require.NoError(t, err)
+	require.NotNil(t, arrival.Assignment)
+	assert.Equal(t, services.StageAssigned, arrival.Assignment.Stage)
+	arrival, err = service.Command(ctx, arrival.ID, ScenarioCommand{Command: "advance"})
+	require.NoError(t, err)
+	require.NotNil(t, arrival.Assignment)
+	assert.Equal(t, services.StageConfirmed, arrival.Assignment.Stage)
+	flight, ok := source.Snapshot().FlightByCallsign("TST201")
+	require.True(t, ok)
+	assert.Equal(t, customEOBT, flight.FlightPlan.EOBT)
+	assert.Equal(t, "0030", flight.FlightPlan.EnrouteDuration)
+	require.NoError(t, service.Reset(ctx))
+
+	wrongStand, err := service.CreateScenario(ctx, CreateScenarioRequest{
+		SessionID: sessionID, Preset: PresetWrongStand, Callsign: "TST301", AircraftType: "A320",
+	})
+	require.NoError(t, err)
+	wrongStand, err = service.Command(ctx, wrongStand.ID, ScenarioCommand{Command: "advance"})
+	require.NoError(t, err)
+	require.NotNil(t, wrongStand.Assignment)
+	require.NotNil(t, wrongStand.Assignment.ConflictReason)
+	assert.Contains(t, *wrongStand.Assignment.ConflictReason, "WRONG_STAND_PENDING")
+	assert.Contains(t, wrongStand.GeneratedMessage, "PLEASE RELOCATE")
+
+	wrongStand, err = service.Command(ctx, wrongStand.ID, ScenarioCommand{Command: "advance"})
+	require.NoError(t, err)
+	require.NotNil(t, wrongStand.Assignment)
+	assert.Equal(t, testSource, wrongStand.Assignment.Source)
+	require.NotNil(t, wrongStand.Assignment.ConflictReason)
+	assert.Contains(t, *wrongStand.Assignment.ConflictReason, "WRONG_STAND_FORCED")
+}

--- a/backend/internal/testtools/webapi.go
+++ b/backend/internal/testtools/webapi.go
@@ -1,0 +1,195 @@
+package testtools
+
+import (
+	appconfig "FlightStrips/internal/config"
+	"FlightStrips/internal/shared"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+type WebAPI struct {
+	service   *Service
+	auth      shared.AuthenticationService
+	readiness appconfig.StandAssignmentReadiness
+}
+
+func NewWebAPI(service *Service, auth shared.AuthenticationService, readiness appconfig.StandAssignmentReadiness) *WebAPI {
+	return &WebAPI{service: service, auth: auth, readiness: readiness}
+}
+
+func (a *WebAPI) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/test/status", a.authenticated(a.handleStatus))
+	mux.HandleFunc("/test/sat/scenarios", a.authenticated(a.handleScenarios))
+	mux.HandleFunc("/test/sat/scenarios/", a.authenticated(a.handleScenario))
+	mux.HandleFunc("/test/sat/blocks", a.authenticated(a.handleBlocks))
+}
+
+func (a *WebAPI) authenticated(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		header := strings.TrimSpace(r.Header.Get("Authorization"))
+		token := strings.TrimSpace(strings.TrimPrefix(header, "Bearer"))
+		if header == "" || token == "" || token == header {
+			writeError(w, http.StatusUnauthorized, "invalid authorization header")
+			return
+		}
+		if _, err := a.auth.Validate(token); err != nil {
+			writeError(w, http.StatusUnauthorized, "invalid token")
+			return
+		}
+		next(w, r)
+	}
+}
+
+func (a *WebAPI) handleStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	sessions, err := a.service.Sessions(r.Context())
+	if err != nil {
+		writeServiceError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"enabled":        true,
+		"simulated_time": a.service.Now(),
+		"sessions":       sessions,
+		"sat":            map[string]any{"enabled": a.readiness.Enabled, "ready": a.readiness.Ready, "reason": a.readiness.Reason},
+	})
+}
+
+func (a *WebAPI) handleScenarios(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		sessionID, _ := strconv.ParseInt(r.URL.Query().Get("session_id"), 10, 32)
+		scenarios, err := a.service.ListScenarios(r.Context(), int32(sessionID))
+		if err != nil {
+			writeServiceError(w, err)
+			return
+		}
+		blocks, err := a.service.Blocks(r.Context(), int32(sessionID))
+		if err != nil && sessionID != 0 {
+			writeServiceError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"scenarios": scenarios, "blocks": blocks, "simulated_time": a.service.Now()})
+	case http.MethodPost:
+		var request CreateScenarioRequest
+		if err := decodeJSON(r, &request); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		scenario, err := a.service.CreateScenario(r.Context(), request)
+		if err != nil {
+			writeServiceError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusCreated, scenario)
+	case http.MethodDelete:
+		if err := a.service.Reset(r.Context()); err != nil {
+			writeServiceError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"reset": true, "simulated_time": a.service.Now()})
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func (a *WebAPI) handleScenario(w http.ResponseWriter, r *http.Request) {
+	path := strings.Trim(strings.TrimPrefix(r.URL.Path, "/test/sat/scenarios/"), "/")
+	parts := strings.Split(path, "/")
+	if len(parts) == 1 && r.Method == http.MethodDelete {
+		if err := a.service.DeleteScenario(r.Context(), parts[0]); err != nil {
+			writeServiceError(w, err)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if len(parts) == 2 && parts[1] == "commands" && r.Method == http.MethodPost {
+		var command ScenarioCommand
+		if err := decodeJSON(r, &command); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		scenario, err := a.service.Command(r.Context(), parts[0], command)
+		if err != nil {
+			writeServiceError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, scenario)
+		return
+	}
+	http.NotFound(w, r)
+}
+
+func (a *WebAPI) handleBlocks(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		var request struct {
+			SessionID int32  `json:"session_id"`
+			Stand     string `json:"stand"`
+			Reason    string `json:"reason"`
+		}
+		if err := decodeJSON(r, &request); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		block, err := a.service.CreateBlock(r.Context(), request.SessionID, request.Stand, request.Reason)
+		if err != nil {
+			writeServiceError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusCreated, block)
+	case http.MethodDelete:
+		sessionID, sessionErr := strconv.ParseInt(r.URL.Query().Get("session_id"), 10, 32)
+		id, idErr := strconv.ParseInt(r.URL.Query().Get("id"), 10, 64)
+		version, versionErr := strconv.ParseInt(r.URL.Query().Get("version"), 10, 32)
+		if sessionErr != nil || idErr != nil || versionErr != nil {
+			writeError(w, http.StatusBadRequest, "session_id, id, and version are required")
+			return
+		}
+		if err := a.service.DeleteBlock(r.Context(), int32(sessionID), id, int32(version)); err != nil {
+			writeServiceError(w, err)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func decodeJSON(r *http.Request, destination any) error {
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	return decoder.Decode(destination)
+}
+
+func writeServiceError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrInvalid):
+		writeError(w, http.StatusBadRequest, err.Error())
+	case errors.Is(err, ErrConflict):
+		writeError(w, http.StatusConflict, err.Error())
+	case errors.Is(err, ErrNotFound):
+		writeError(w, http.StatusNotFound, err.Error())
+	case errors.Is(err, ErrUnavailable):
+		writeError(w, http.StatusServiceUnavailable, err.Error())
+	default:
+		writeError(w, http.StatusInternalServerError, err.Error())
+	}
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]string{"error": message})
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}

--- a/backend/internal/testtools/webapi_test.go
+++ b/backend/internal/testtools/webapi_test.go
@@ -1,0 +1,32 @@
+package testtools
+
+import (
+	appconfig "FlightStrips/internal/config"
+	"FlightStrips/internal/shared"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type acceptingAuth struct{}
+
+func (acceptingAuth) Validate(string) (shared.AuthenticatedUser, error) {
+	return shared.AuthenticatedUser{}, nil
+}
+
+func TestWebAPIRequiresAuthenticationBeforeExposingStatus(t *testing.T) {
+	mux := http.NewServeMux()
+	NewWebAPI(&Service{}, acceptingAuth{}, appconfig.StandAssignmentReadiness{}).RegisterRoutes(mux)
+
+	unauthorized := httptest.NewRecorder()
+	mux.ServeHTTP(unauthorized, httptest.NewRequest(http.MethodGet, "/test/status", nil))
+	require.Equal(t, http.StatusUnauthorized, unauthorized.Code)
+
+	authorized := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/test/status", nil)
+	request.Header.Set("Authorization", "Bearer local-token")
+	mux.ServeHTTP(authorized, request)
+	require.Equal(t, http.StatusServiceUnavailable, authorized.Code)
+}

--- a/backend/internal/vatsim/cache.go
+++ b/backend/internal/vatsim/cache.go
@@ -81,6 +81,18 @@ type Snapshot struct {
 	flightsByCID      map[string]Flight
 }
 
+// SnapshotSource supplies the latest immutable network-data generation.
+type SnapshotSource interface {
+	Snapshot() Snapshot
+}
+
+// FlightSource is the complete VATSIM lookup surface consumed by the app.
+type FlightSource interface {
+	SnapshotSource
+	VerifyPilotOwnsCallsign(context.Context, string, string) (bool, error)
+	GetCallsignByCID(context.Context, string) (string, bool, error)
+}
+
 // FlightByCallsign retrieves either an online pilot or prefile by normalized
 // callsign.
 func (s Snapshot) FlightByCallsign(callsign string) (Flight, bool) {
@@ -281,10 +293,16 @@ func (c *Cache) refresh(ctx context.Context) error {
 	c.lastRefreshError = nil
 	c.mu.Unlock()
 	age := time.Since(snapshot.timestamp)
-	if age < 0 { age = 0 }
+	if age < 0 {
+		age = 0
+	}
 	pilots, prefiles := 0, 0
 	for _, flight := range snapshot.flightsByCallsign {
-		if flight.Prefile() { prefiles++ } else { pilots++ }
+		if flight.Prefile() {
+			prefiles++
+		} else {
+			pilots++
+		}
 	}
 	metrics.RecordSATFeedSnapshot(ctx, age, pilots, prefiles)
 	slog.InfoContext(ctx, "SAT VATSIM feed refreshed", slog.Time("snapshot_at", snapshot.timestamp), slog.Duration("snapshot_age", age), slog.Int("pilots", pilots), slog.Int("prefiles", prefiles))

--- a/backend/internal/vatsim/reconciliation.go
+++ b/backend/internal/vatsim/reconciliation.go
@@ -86,7 +86,7 @@ type reconciliationNotifier interface {
 // session. It deliberately owns only feed fields; operational state remains
 // controller/EuroScope owned.
 type Reconciler struct {
-	cache              *Cache
+	cache              SnapshotSource
 	sessions           reconciliationSessionStore
 	strips             reconciliationStripStore
 	assignments        reconciliationAssignmentStore
@@ -99,7 +99,7 @@ type Reconciler struct {
 }
 
 type ReconcilerDependencies struct {
-	Cache              *Cache
+	Cache              SnapshotSource
 	Sessions           reconciliationSessionStore
 	Strips             reconciliationStripStore
 	Assignments        reconciliationAssignmentStore
@@ -140,7 +140,7 @@ func NewReconciler(deps ReconcilerDependencies, interval time.Duration, options 
 	), nil
 }
 
-func newReconciler(cache *Cache, sessions reconciliationSessionStore, strips reconciliationStripStore, assignments reconciliationAssignmentStore, departureLifecycle DepartureLifecycle, arrivalLifecycle ArrivalLifecycle, notifier reconciliationNotifier, interval time.Duration, options ...ArrivalETAOption) *Reconciler {
+func newReconciler(cache SnapshotSource, sessions reconciliationSessionStore, strips reconciliationStripStore, assignments reconciliationAssignmentStore, departureLifecycle DepartureLifecycle, arrivalLifecycle ArrivalLifecycle, notifier reconciliationNotifier, interval time.Duration, options ...ArrivalETAOption) *Reconciler {
 	if interval <= 0 {
 		interval = defaultRefreshInterval
 	}
@@ -190,6 +190,29 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+// ReconcileSession applies the current source snapshot to one explicitly
+// selected session. Test tools use this to avoid leaking synthetic flights
+// into other sessions that happen to serve the same airport.
+func (r *Reconciler) ReconcileSession(ctx context.Context, sessionID int32) error {
+	snapshot := r.cache.Snapshot()
+	if snapshot.Timestamp.IsZero() {
+		return nil
+	}
+	sessions, err := r.sessions.List(ctx)
+	if err != nil {
+		return err
+	}
+	for _, session := range sessions {
+		if session != nil && session.ID == sessionID {
+			if strings.TrimSpace(session.Airport) == "" {
+				return fmt.Errorf("session %d has no airport", sessionID)
+			}
+			return r.reconcileSession(ctx, snapshot, session)
+		}
+	}
+	return fmt.Errorf("session %d not found", sessionID)
 }
 
 func (r *Reconciler) reconcileSession(ctx context.Context, snapshot Snapshot, session *models.Session) error {

--- a/backend/internal/vatsim/synthetic_source.go
+++ b/backend/internal/vatsim/synthetic_source.go
@@ -1,0 +1,95 @@
+package vatsim
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+)
+
+// SyntheticSource is an in-memory VATSIM source for explicitly enabled local
+// test tools. It never performs network I/O.
+type SyntheticSource struct {
+	mu       sync.RWMutex
+	flights  map[string]Flight
+	received time.Time
+}
+
+func NewSyntheticSource() *SyntheticSource {
+	return &SyntheticSource{flights: make(map[string]Flight), received: time.Now().UTC()}
+}
+
+func (s *SyntheticSource) Upsert(flight Flight) {
+	if s == nil {
+		return
+	}
+	flight.Callsign = normalizeCallsign(flight.Callsign)
+	flight.CID = strings.TrimSpace(flight.CID)
+	if flight.Callsign == "" || flight.CID == "" {
+		return
+	}
+	s.mu.Lock()
+	s.flights[flight.Callsign] = flight
+	s.received = time.Now().UTC()
+	s.mu.Unlock()
+}
+
+func (s *SyntheticSource) Remove(callsign string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	delete(s.flights, normalizeCallsign(callsign))
+	s.received = time.Now().UTC()
+	s.mu.Unlock()
+}
+
+func (s *SyntheticSource) Reset() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.flights = make(map[string]Flight)
+	s.received = time.Now().UTC()
+	s.mu.Unlock()
+}
+
+func (s *SyntheticSource) Snapshot() Snapshot {
+	if s == nil {
+		return Snapshot{}
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	byCallsign := make(map[string]Flight, len(s.flights))
+	byCID := make(map[string]Flight, len(s.flights))
+	for callsign, flight := range s.flights {
+		byCallsign[callsign] = flight
+		if current, ok := byCID[flight.CID]; !ok || preferFlight(flight, current) {
+			byCID[flight.CID] = flight
+		}
+	}
+	age := time.Since(s.received)
+	if age < 0 {
+		age = 0
+	}
+	return Snapshot{
+		Timestamp:         s.received,
+		Age:               age,
+		flightsByCallsign: byCallsign,
+		flightsByCID:      byCID,
+	}
+}
+
+func (s *SyntheticSource) VerifyPilotOwnsCallsign(_ context.Context, cid, callsign string) (bool, error) {
+	flight, ok := s.Snapshot().FlightByCallsign(callsign)
+	return ok && flight.Online() && flight.CID == strings.TrimSpace(cid), nil
+}
+
+func (s *SyntheticSource) GetCallsignByCID(_ context.Context, cid string) (string, bool, error) {
+	flight, ok := s.Snapshot().FlightByCID(cid)
+	if !ok || !flight.Online() {
+		return "", false, nil
+	}
+	return flight.Callsign, true, nil
+}

--- a/backend/internal/vatsim/synthetic_source_test.go
+++ b/backend/internal/vatsim/synthetic_source_test.go
@@ -1,0 +1,38 @@
+package vatsim
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyntheticSourceSupportsOfflineScenarioControl(t *testing.T) {
+	source := NewSyntheticSource()
+	source.Upsert(Flight{
+		CID: "990000001", Callsign: " tst101 ", State: FlightStatePrefile,
+		FlightPlan: FlightPlan{Origin: "EKCH", Destination: "EGLL", Revision: 1},
+	})
+
+	flight, ok := source.Snapshot().FlightByCallsign("TST101")
+	require.True(t, ok)
+	assert.True(t, flight.Prefile())
+	owned, err := source.VerifyPilotOwnsCallsign(context.Background(), "990000001", "TST101")
+	require.NoError(t, err)
+	assert.False(t, owned, "prefiles must not satisfy live CID verification")
+
+	flight.State = FlightStateOnline
+	source.Upsert(flight)
+	owned, err = source.VerifyPilotOwnsCallsign(context.Background(), "990000001", "TST101")
+	require.NoError(t, err)
+	assert.True(t, owned)
+	callsign, found, err := source.GetCallsignByCID(context.Background(), "990000001")
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, "TST101", callsign)
+
+	source.Remove("TST101")
+	assert.Empty(t, source.Snapshot().Flights())
+	assert.False(t, source.Snapshot().Timestamp.IsZero())
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -40,6 +40,9 @@ services:
       # Keep SAT release-safe. Enable only after /healthz reports
       # stand_assignment.status=ready; rollback by restoring false and restarting.
       ENABLE_STAND_ASSIGNMENT: ${ENABLE_STAND_ASSIGNMENT:-false}
+      # Local-only synthetic data console. The backend also refuses to start
+      # if this is enabled while ENVIRONMENT is production.
+      ENABLE_TEST_TOOLS: "false"
       # Release EFB code disabled until the authenticated pilot surface is ready.
       ENABLE_EFB: ${ENABLE_EFB:-false}
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}

--- a/docs/src/content/docs/dev/local-dev.md
+++ b/docs/src/content/docs/dev/local-dev.md
@@ -104,3 +104,31 @@ Dev server runs at `localhost:4321` by default.
 ## Wiring checks
 
 With the backend on **8090**: the frontend shows live strips once auth and WebSockets succeed; the plugin negotiates the `euroscopeEvents` WebSocket independently of the frontend origin.
+
+## Local SAT test console
+
+The protected `/test` page can create and advance synthetic stand-assignment
+scenarios without contacting the VATSIM data feed. Start the backend from
+`backend/` with:
+
+```powershell
+$env:ENABLE_STAND_ASSIGNMENT = "true"
+$env:ENABLE_TEST_TOOLS = "true"
+go run ./cmd/server
+```
+
+When test tools are enabled, the backend uses its committed small aircraft
+fixture unless `GRPLUGIN_ICAO_AIRCRAFT_JSON` explicitly points to a full
+installed reference. The production VATSIM HTTP cache is replaced by an
+in-memory source, and the VATSIM transceiver cache is disabled, so no VATSIM
+network data is requested.
+
+Sign in normally, connect the local EuroScope plugin to create an EKCH session,
+then open `http://localhost:8080/test`. Select the session and use a departure,
+arrival, or wrong-stand preset. `Next` drives the real reconciliation and SAT
+lifecycle; manual time, position, block, remove, and reset controls are also
+available.
+
+`ENABLE_TEST_TOOLS` defaults to false. The backend refuses to start when it is
+true in a `live`, `prod`, or `production` environment, and `/api/test/*` is not
+registered while it is false.

--- a/frontend/src/components/navigation/AppSidebar.tsx
+++ b/frontend/src/components/navigation/AppSidebar.tsx
@@ -1,5 +1,6 @@
 import {
   Clock3,
+  FlaskConical,
   Warehouse,
   User,
   Proportions,
@@ -20,10 +21,12 @@ import { Button } from "@/components/ui/button"
 import { useAuth0 } from "@auth0/auth0-react"
 import { useDocsNav } from "@/hooks/useDocsNav"
 import type { NavItem } from "@/types/nav"
+import { useTestToolsAvailability } from "@/hooks/useTestToolsAvailability"
 
 export function AppSidebar() {
   const { logout } = useAuth0()
   const docsNav = useDocsNav()
+  const testToolsAvailable = useTestToolsAvailability()
 
   const items: NavItem[] = [
     {
@@ -47,6 +50,11 @@ export function AppSidebar() {
       icon: Warehouse,
     },
     docsNav,
+    ...(testToolsAvailable ? [{
+      title: "Test Console",
+      url: "/test",
+      icon: FlaskConical,
+    }] : []),
   ]
 
   return (

--- a/frontend/src/hooks/useTestToolsAvailability.ts
+++ b/frontend/src/hooks/useTestToolsAvailability.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+import { useAuth0 } from "@auth0/auth0-react";
+import { getApiUrl } from "@/lib/api-url";
+
+export function useTestToolsAvailability() {
+  const { getAccessTokenSilently, isAuthenticated } = useAuth0();
+  const [available, setAvailable] = useState(false);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const token = await getAccessTokenSilently();
+        const response = await fetch(getApiUrl("/api/test/status"), {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!cancelled) {
+          setAvailable(response.ok);
+        }
+      } catch {
+        if (!cancelled) {
+          setAvailable(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [getAccessTokenSilently, isAuthenticated]);
+
+  return isAuthenticated && available;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -22,6 +22,7 @@ import EfbLayout from "@/pages/efb-layout";
 import EfbPage from "@/pages/efb";
 import { withAuthenticationRequired } from '@auth0/auth0-react';
 import DocsRouter from "@/pages/docs/DocsRouter";
+import TestToolsPage from "@/pages/test-tools";
 import { ThemeSync } from "@/components/public/ThemeSync";
 import { startAppUpdateMonitoring } from "@/lib/app-update";
 
@@ -30,6 +31,7 @@ startAppUpdateMonitoring();
 const ProtectedLayout = withAuthenticationRequired(Layout);
 const ProtectedCdmPage = withAuthenticationRequired(CdmPage);
 const ProtectedStandStatusPage = withAuthenticationRequired(StandStatusPage);
+const ProtectedTestToolsPage = withAuthenticationRequired(TestToolsPage);
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -58,6 +60,7 @@ createRoot(document.getElementById('root')!).render(
           </Route>
           <Route path="/cdm" element={<ProtectedCdmPage />} />
           <Route path="/stand" element={<ProtectedStandStatusPage />} />
+          <Route path="/test" element={<ProtectedTestToolsPage />} />
           <Route path="*" element={<div>404 Not Found</div>}/>
         </Routes>
       </Auth0ProviderWithNavigate>

--- a/frontend/src/pages/test-tools.test.tsx
+++ b/frontend/src/pages/test-tools.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import TestToolsPage from "./test-tools";
+
+vi.mock("@auth0/auth0-react", () => ({
+  useAuth0: () => ({ getAccessTokenSilently: vi.fn().mockResolvedValue("token") }),
+}));
+
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve(new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  }));
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("local test console", () => {
+  it("renders a backend-enabled SAT console and creates an editable preset", async () => {
+    const fetchMock = vi.fn().mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/test/status")) {
+        return jsonResponse({
+          enabled: true,
+          simulated_time: "2026-07-17T12:00:00Z",
+          sessions: [{ id: 7, name: "LOCAL", airport: "EKCH" }],
+          sat: { enabled: true, ready: true },
+        });
+      }
+      if (url.includes("/api/test/sat/scenarios") && init?.method === "POST") {
+        return jsonResponse({ id: "one", callsign: "TST101" }, 201);
+      }
+      return jsonResponse({ scenarios: [], blocks: [], simulated_time: "2026-07-17T12:00:00Z" });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<TestToolsPage />);
+    expect(await screen.findByText("Local Test Console")).toBeInTheDocument();
+    expect(await screen.findByText("Changes publish to LOCAL.")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Callsign"), { target: { value: "tst101" } });
+    fireEvent.change(screen.getByLabelText("Preset"), { target: { value: "arrival" } });
+    fireEvent.click(screen.getByRole("button", { name: /create scenario/i }));
+
+    await waitFor(() => {
+      const createCall = fetchMock.mock.calls.find(([, init]) => init?.method === "POST");
+      expect(createCall).toBeDefined();
+      const body = JSON.parse(String(createCall?.[1]?.body));
+      expect(body).toMatchObject({
+        session_id: 7,
+        preset: "arrival",
+        callsign: "TST101",
+        origin: "EGLL",
+        destination: "EKCH",
+      });
+    });
+    expect(screen.getByLabelText("Preset")).toHaveValue("arrival");
+    expect(screen.getByLabelText("Origin")).toHaveValue("EGLL");
+    expect(screen.getByLabelText("Destination")).toHaveValue("EKCH");
+  });
+
+  it("renders the normal not-found state when the backend route is disabled", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockImplementation(() => jsonResponse({ error: "Not Found" }, 404)));
+    render(<TestToolsPage />);
+    expect(await screen.findByText("404 Not Found")).toBeInTheDocument();
+  });
+
+  it("shows API failures instead of masking them as a disabled route", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockImplementation(() => jsonResponse({ error: "database unavailable" }, 500)));
+    render(<TestToolsPage />);
+    expect(await screen.findByText("Unable to load test console")).toBeInTheDocument();
+    expect(screen.getByText("database unavailable")).toBeInTheDocument();
+    expect(screen.queryByText("404 Not Found")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/test-tools.tsx
+++ b/frontend/src/pages/test-tools.tsx
@@ -1,0 +1,414 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useAuth0 } from "@auth0/auth0-react";
+import { AlertTriangle, Clock3, FlaskConical, Plane, RefreshCw, Trash2 } from "lucide-react";
+import { Toaster, toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { getApiUrl } from "@/lib/api-url";
+
+type Session = { id: number; name: string; airport: string };
+type Assignment = {
+  stand: string;
+  direction: string;
+  stage: string;
+  source: string;
+  version: number;
+  eta?: string;
+  expires_at?: string;
+  conflict_reason?: string;
+};
+type Scenario = {
+  id: string;
+  session_id: number;
+  preset: "departure" | "arrival" | "wrong_stand";
+  step: number;
+  callsign: string;
+  cid: string;
+  aircraft_type: string;
+  origin: string;
+  destination: string;
+  route: string;
+  feed_state: string;
+  altitude: number;
+  groundspeed: number;
+  observed_stand?: string;
+  strip_bay?: string;
+  assignment?: Assignment;
+  last_action?: string;
+  generated_message?: string;
+  error?: string;
+};
+type StandBlock = { id: number; session_id: number; stand: string; reason?: string; version: number };
+type Status = {
+  enabled: boolean;
+  simulated_time: string;
+  sessions: Session[];
+  sat: { enabled: boolean; ready: boolean; reason?: string };
+};
+type ScenarioState = { scenarios: Scenario[]; blocks: StandBlock[]; simulated_time: string };
+
+const emptyForm = {
+  preset: "departure" as Scenario["preset"],
+  callsign: "",
+  aircraft_type: "A320",
+  origin: "EKCH",
+  destination: "EGLL",
+  route: "DCT",
+  initial_state: "prefile",
+  eobt: "",
+  enroute_time: "0045",
+  altitude: 0,
+  groundspeed: 0,
+  observed_stand: "",
+};
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="grid gap-1 text-sm text-slate-300">
+      <span>{label}</span>
+      {children}
+    </label>
+  );
+}
+
+const inputClass = "h-10 rounded-md border border-slate-700 bg-slate-950 px-3 text-white outline-none focus:border-cyan-500";
+
+class ApiError extends Error {
+  constructor(readonly status: number, message: string) {
+    super(message);
+  }
+}
+
+function emptyFormForPreset(preset: Scenario["preset"]) {
+  return {
+    ...emptyForm,
+    preset,
+    origin: preset === "arrival" ? "EGLL" : "EKCH",
+    destination: preset === "arrival" ? "EKCH" : "EGLL",
+  };
+}
+
+export default function TestToolsPage() {
+  const { getAccessTokenSilently } = useAuth0();
+  const [status, setStatus] = useState<Status | null>(null);
+  const [notAvailable, setNotAvailable] = useState(false);
+  const [statusError, setStatusError] = useState("");
+  const [sessionID, setSessionID] = useState(0);
+  const [state, setState] = useState<ScenarioState>({ scenarios: [], blocks: [], simulated_time: "" });
+  const [form, setForm] = useState(emptyForm);
+  const [blockStand, setBlockStand] = useState("");
+  const [blockReason, setBlockReason] = useState("Local test console");
+  const [manualStands, setManualStands] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState(false);
+
+  const authorizedFetch = useCallback(async (path: string, init?: RequestInit) => {
+    const token = await getAccessTokenSilently();
+    const response = await fetch(getApiUrl(path), {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        ...init?.headers,
+      },
+    });
+    if (!response.ok) {
+      const payload = await response.json().catch(() => ({ error: response.statusText }));
+      throw new ApiError(response.status, payload.error || response.statusText);
+    }
+    if (response.status === 204) return null;
+    return response.json();
+  }, [getAccessTokenSilently]);
+
+  const loadStatus = useCallback(async () => {
+    try {
+      const value = await authorizedFetch("/api/test/status") as Status;
+      setStatus(value);
+      setNotAvailable(false);
+      setStatusError("");
+      setSessionID(current => current || value.sessions[0]?.id || 0);
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 404) {
+        setNotAvailable(true);
+        setStatusError("");
+      } else {
+        setNotAvailable(false);
+        setStatusError(error instanceof Error ? error.message : "Unable to load test-console status");
+      }
+    }
+  }, [authorizedFetch]);
+
+  const loadState = useCallback(async () => {
+    if (!sessionID || !status?.sat.ready) return;
+    try {
+      const value = await authorizedFetch(`/api/test/sat/scenarios?session_id=${sessionID}`) as ScenarioState;
+      setState(value);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Unable to load test scenarios");
+    }
+  }, [authorizedFetch, sessionID, status?.sat.ready]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => void loadStatus(), 0);
+    return () => window.clearTimeout(timer);
+  }, [loadStatus]);
+
+  useEffect(() => {
+    if (!sessionID || !status?.sat.ready) return;
+    const initial = window.setTimeout(() => void loadState(), 0);
+    const timer = window.setInterval(() => void loadState(), 2000);
+    return () => {
+      window.clearTimeout(initial);
+      window.clearInterval(timer);
+    };
+  }, [loadState, sessionID, status?.sat.ready]);
+
+  const run = useCallback(async (action: () => Promise<unknown>, success: string) => {
+    setBusy(true);
+    try {
+      await action();
+      toast.success(success);
+      await Promise.all([loadStatus(), loadState()]);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Test action failed");
+    } finally {
+      setBusy(false);
+    }
+  }, [loadState, loadStatus]);
+
+  const setPreset = (preset: Scenario["preset"]) => {
+    setForm(current => ({
+      ...current,
+      preset,
+      origin: preset === "arrival" ? "EGLL" : "EKCH",
+      destination: preset === "arrival" ? "EKCH" : "EGLL",
+      altitude: 0,
+      groundspeed: 0,
+    }));
+  };
+
+  const createScenario = () => run(async () => {
+    await authorizedFetch("/api/test/sat/scenarios", {
+      method: "POST",
+      body: JSON.stringify({ ...form, session_id: sessionID }),
+    });
+    setForm(current => emptyFormForPreset(current.preset));
+  }, "Scenario created");
+
+  const command = (scenario: Scenario, commandName: string, extra: Record<string, unknown> = {}) =>
+    run(
+      () => authorizedFetch(`/api/test/sat/scenarios/${scenario.id}/commands`, {
+        method: "POST",
+        body: JSON.stringify({ command: commandName, ...extra }),
+      }),
+      `Updated ${scenario.callsign}`,
+    );
+
+  const simulatedTime = state.simulated_time || status?.simulated_time;
+  const selectedSession = useMemo(() => status?.sessions.find(session => session.id === sessionID), [sessionID, status?.sessions]);
+
+  if (notAvailable) {
+    return <div className="p-8 text-xl">404 Not Found</div>;
+  }
+  if (statusError) {
+    return (
+      <div className="grid gap-3 p-8">
+        <h1 className="text-xl font-semibold">Unable to load test console</h1>
+        <p className="text-red-500">{statusError}</p>
+        <Button className="w-fit" variant="outline" onClick={() => void loadStatus()}>Retry</Button>
+      </div>
+    );
+  }
+  if (!status) {
+    return <div className="p-8 text-slate-500">Checking local test-tools availability…</div>;
+  }
+
+  return (
+    <>
+      <Toaster richColors position="top-right" />
+      <div className="h-full w-full overflow-y-auto bg-slate-950 text-white">
+        <div className="mx-auto grid min-h-full w-full max-w-7xl gap-6 p-6 md:p-8">
+        <header className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <div className="flex items-center gap-3">
+              <FlaskConical className="size-8 text-cyan-400" />
+              <h1 className="text-3xl font-semibold">Local Test Console</h1>
+            </div>
+            <p className="mt-1 text-slate-400">Synthetic SAT scenarios using the real reconciliation and allocation paths.</p>
+          </div>
+          <div className="flex items-center gap-3 rounded-lg border border-slate-800 bg-slate-900 px-4 py-3">
+            <Clock3 className="size-5 text-cyan-400" />
+            <div>
+              <div className="text-xs uppercase tracking-wide text-slate-500">Simulated UTC</div>
+              <div className="font-mono">{simulatedTime ? new Date(simulatedTime).toISOString().replace(".000Z", "Z") : "—"}</div>
+            </div>
+            <Button variant="outline" size="icon" disabled={busy} onClick={() => void loadState()} aria-label="Refresh scenarios">
+              <RefreshCw className="size-4" />
+            </Button>
+          </div>
+        </header>
+
+        {!status.sat.ready && (
+          <div className="flex gap-3 rounded-lg border border-amber-700 bg-amber-950/50 p-4 text-amber-100">
+            <AlertTriangle className="mt-0.5 size-5 shrink-0" />
+            <div>
+              <div className="font-semibold">Stand assignment is unavailable</div>
+              <div className="text-sm">{status.sat.enabled ? status.sat.reason || "SAT configuration did not become ready." : "Set ENABLE_STAND_ASSIGNMENT=true and restart the backend."}</div>
+            </div>
+          </div>
+        )}
+
+        <section className="grid gap-4 rounded-xl border border-slate-800 bg-slate-900 p-5">
+          <div className="flex flex-wrap items-end justify-between gap-4">
+            <Field label="Target EKCH session">
+              <select className={inputClass} value={sessionID} onChange={event => setSessionID(Number(event.target.value))}>
+                <option value={0}>Select a connected session</option>
+                {status.sessions.map(session => <option key={session.id} value={session.id}>{session.name} · {session.airport}</option>)}
+              </select>
+            </Field>
+            <div className="text-sm text-slate-400">
+              {selectedSession ? `Changes publish to ${selectedSession.name}.` : "Connect the local EuroScope plugin first to create a session."}
+            </div>
+          </div>
+        </section>
+
+        <section className="grid gap-5 rounded-xl border border-slate-800 bg-slate-900 p-5">
+          <div>
+            <h2 className="text-xl font-semibold">Create SAT scenario</h2>
+            <p className="text-sm text-slate-400">Presets supply lifecycle transitions; every feed field remains editable.</p>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <Field label="Preset">
+              <select className={inputClass} value={form.preset} onChange={event => setPreset(event.target.value as Scenario["preset"])}>
+                <option value="departure">Departure lifecycle</option>
+                <option value="arrival">Arrival lifecycle</option>
+                <option value="wrong_stand">Wrong stand</option>
+              </select>
+            </Field>
+            <Field label="Callsign"><input className={inputClass} value={form.callsign} onChange={event => setForm({ ...form, callsign: event.target.value.toUpperCase() })} placeholder="TST101" /></Field>
+            <Field label="Aircraft"><input className={inputClass} value={form.aircraft_type} onChange={event => setForm({ ...form, aircraft_type: event.target.value.toUpperCase() })} /></Field>
+            <Field label="Initial state">
+              <select className={inputClass} value={form.initial_state} onChange={event => setForm({ ...form, initial_state: event.target.value })}>
+                <option value="prefile">Prefile</option>
+                <option value="online">Online</option>
+              </select>
+            </Field>
+            <Field label="Origin"><input className={inputClass} value={form.origin} onChange={event => setForm({ ...form, origin: event.target.value.toUpperCase() })} /></Field>
+            <Field label="Destination"><input className={inputClass} value={form.destination} onChange={event => setForm({ ...form, destination: event.target.value.toUpperCase() })} /></Field>
+            <Field label="Route"><input className={inputClass} value={form.route} onChange={event => setForm({ ...form, route: event.target.value.toUpperCase() })} /></Field>
+            <Field label="Observed stand"><input className={inputClass} value={form.observed_stand} onChange={event => setForm({ ...form, observed_stand: event.target.value.toUpperCase() })} placeholder="Optional" /></Field>
+            <Field label="EOBT"><input className={inputClass} value={form.eobt} onChange={event => setForm({ ...form, eobt: event.target.value })} placeholder="Current UTC" /></Field>
+            <Field label="Enroute time"><input className={inputClass} value={form.enroute_time} onChange={event => setForm({ ...form, enroute_time: event.target.value })} /></Field>
+            <Field label="Altitude"><input className={inputClass} type="number" value={form.altitude} onChange={event => setForm({ ...form, altitude: Number(event.target.value) })} /></Field>
+            <Field label="Groundspeed"><input className={inputClass} type="number" value={form.groundspeed} onChange={event => setForm({ ...form, groundspeed: Number(event.target.value) })} /></Field>
+          </div>
+          <Button className="w-fit" disabled={busy || !sessionID || !status.sat.ready} onClick={() => void createScenario()}>
+            <Plane className="mr-2 size-4" /> Create scenario
+          </Button>
+        </section>
+
+        <section className="grid gap-4 rounded-xl border border-slate-800 bg-slate-900 p-5">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h2 className="text-xl font-semibold">Test-owned stand blocks</h2>
+              <p className="text-sm text-slate-400">Blocks created here are tagged and removed by console reset.</p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <input className={`${inputClass} w-28`} value={blockStand} onChange={event => setBlockStand(event.target.value.toUpperCase())} placeholder="Stand" />
+              <input className={`${inputClass} w-64`} value={blockReason} onChange={event => setBlockReason(event.target.value)} placeholder="Reason" />
+              <Button variant="outline" disabled={busy || !sessionID || !blockStand} onClick={() => void run(
+                () => authorizedFetch("/api/test/sat/blocks", { method: "POST", body: JSON.stringify({ session_id: sessionID, stand: blockStand, reason: blockReason }) }),
+                `Blocked ${blockStand}`,
+              )}>Block stand</Button>
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {state.blocks.length === 0 && <span className="text-sm text-slate-500">No test-owned blocks.</span>}
+            {state.blocks.map(block => (
+              <div key={block.id} className="flex items-center gap-2 rounded-full border border-amber-700 bg-amber-950/40 px-3 py-1 text-sm">
+                <span>{block.stand} · {block.reason}</span>
+                <button aria-label={`Remove block ${block.stand}`} onClick={() => void run(
+                  () => authorizedFetch(`/api/test/sat/blocks?session_id=${block.session_id}&id=${block.id}&version=${block.version}`, { method: "DELETE" }),
+                  `Unblocked ${block.stand}`,
+                )}><Trash2 className="size-3.5" /></button>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="grid gap-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-xl font-semibold">Active scenarios</h2>
+              <p className="text-sm text-slate-400">Next follows the selected preset; manual controls remain available.</p>
+            </div>
+            <Button variant="destructive" disabled={busy || (state.scenarios.length === 0 && state.blocks.length === 0)} onClick={() => {
+              if (window.confirm("Reset all test-console SAT data?")) {
+                void run(() => authorizedFetch("/api/test/sat/scenarios", { method: "DELETE" }), "Test data reset");
+              }
+            }}><Trash2 className="mr-2 size-4" /> Reset all</Button>
+          </div>
+          {state.scenarios.length === 0 && <div className="rounded-xl border border-dashed border-slate-800 p-10 text-center text-slate-500">No active scenarios.</div>}
+          <div className="grid gap-4 lg:grid-cols-2">
+            {state.scenarios.map(scenario => (
+              <article key={scenario.id} className="grid gap-4 rounded-xl border border-slate-800 bg-slate-900 p-5">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <span className="text-xl font-semibold">{scenario.callsign}</span>
+                      <span className="rounded bg-cyan-950 px-2 py-0.5 text-xs uppercase text-cyan-300">{scenario.preset.replace("_", " ")}</span>
+                    </div>
+                    <div className="text-sm text-slate-400">{scenario.aircraft_type} · {scenario.origin} → {scenario.destination} · CID {scenario.cid}</div>
+                  </div>
+                  <button aria-label={`Delete ${scenario.callsign}`} onClick={() => void run(
+                    () => authorizedFetch(`/api/test/sat/scenarios/${scenario.id}`, { method: "DELETE" }),
+                    `Deleted ${scenario.callsign}`,
+                  )}><Trash2 className="size-4 text-slate-400 hover:text-red-400" /></button>
+                </div>
+                <div className="grid grid-cols-2 gap-3 text-sm md:grid-cols-4">
+                  <div><div className="text-slate-500">Feed</div><div>{scenario.feed_state}</div></div>
+                  <div><div className="text-slate-500">Strip bay</div><div>{scenario.strip_bay || "—"}</div></div>
+                  <div><div className="text-slate-500">Stage</div><div>{scenario.assignment?.stage || "—"}</div></div>
+                  <div><div className="text-slate-500">Stand</div><div>{scenario.assignment?.stand || "—"}</div></div>
+                  <div><div className="text-slate-500">Source</div><div>{scenario.assignment?.source || "—"}</div></div>
+                  <div><div className="text-slate-500">Version</div><div>{scenario.assignment?.version ?? "—"}</div></div>
+                  <div><div className="text-slate-500">ETA</div><div>{scenario.assignment?.eta ? new Date(scenario.assignment.eta).toISOString().slice(11, 16) : "—"}</div></div>
+                  <div><div className="text-slate-500">Expires</div><div>{scenario.assignment?.expires_at ? new Date(scenario.assignment.expires_at).toISOString().slice(11, 16) : "—"}</div></div>
+                </div>
+                {(scenario.last_action || scenario.generated_message || scenario.assignment?.conflict_reason || scenario.error) && (
+                  <div className="grid gap-1 rounded-md bg-slate-950 p-3 text-sm">
+                    {scenario.last_action && <div><span className="text-slate-500">Last action:</span> {scenario.last_action}</div>}
+                    {scenario.generated_message && <div><span className="text-slate-500">Message:</span> {scenario.generated_message}</div>}
+                    {scenario.assignment?.conflict_reason && <div className="text-amber-300">{scenario.assignment.conflict_reason}</div>}
+                    {scenario.error && <div className="text-red-400">{scenario.error}</div>}
+                  </div>
+                )}
+                <div className="flex flex-wrap gap-2">
+                  <Button disabled={busy} onClick={() => void command(scenario, "advance")}>Next</Button>
+                  {[5, 15, 30].map(minutes => <Button key={minutes} variant="outline" disabled={busy} onClick={() => void command(scenario, "advance_time", { minutes })}>+{minutes} min</Button>)}
+                  <input
+                    aria-label={`Move ${scenario.callsign} to stand`}
+                    className={`${inputClass} w-24`}
+                    value={manualStands[scenario.id] ?? scenario.observed_stand ?? ""}
+                    onChange={event => setManualStands(current => ({ ...current, [scenario.id]: event.target.value.toUpperCase() }))}
+                    onKeyDown={event => {
+                      if (event.key === "Enter") void command(scenario, "move_to_stand", { stand: event.currentTarget.value });
+                    }}
+                    placeholder="Stand"
+                  />
+                  <Button
+                    variant="outline"
+                    disabled={busy || !(manualStands[scenario.id] ?? scenario.observed_stand)}
+                    onClick={() => void command(scenario, "move_to_stand", { stand: manualStands[scenario.id] ?? scenario.observed_stand })}
+                  >
+                    Move
+                  </Button>
+                  <Button variant="outline" disabled={busy || scenario.feed_state === "removed"} onClick={() => void command(scenario, "remove")}>Remove feed</Button>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

- add an authenticated `/test` console gated by `ENABLE_TEST_TOOLS=true`, with startup protection that prevents enabling it in live or production environments
- introduce a VATSIM flight-source abstraction, an in-memory synthetic source, a controllable SAT clock, and a small committed aircraft fixture for deterministic local scenarios without external VATSIM requests
- add departure, arrival, and wrong-stand scenario workflows, stand-block controls, time advancement, targeted cleanup, real reconciliation/lifecycle execution, and websocket publication
- add the standalone centered and scrollable test-console UI with conditional dashboard navigation and polling
- allow `PUT` and `DELETE` CORS preflights so cross-origin local API operations work
- document local setup and keep the feature disabled in production compose configuration

## Why

SAT behavior previously depended on the live VATSIM feed, real timing, and manual controller state, which made local end-to-end testing slow and unreliable. This console provides deterministic test data while continuing to exercise the production allocation, persistence, lifecycle, messaging, and publication paths.

## Safety and impact

- test tools default to disabled and their API routes are not registered while disabled
- the backend refuses to start with test tools enabled in `live`, `prod`, or `production`
- test mode replaces external VATSIM/transceiver polling with in-memory data
- generated records use reserved synthetic CIDs and `TEST_TOOLS` ownership; cleanup removes only console-owned data
- normal production SAT aircraft configuration remains unchanged

## Validation

- `go test ./...`
- `go test -race ./internal/testtools`
- `npm test` (100 tests)
- ESLint for changed frontend files
- `npm run build`
- staged diff whitespace check
