### PR TITLE
feat(aman): define shared domain contracts

### DIFF
--- a/backend/internal/aman/doc.go
+++ b/backend/internal/aman/doc.go
@@ -1,4 +1,6 @@
 // Package aman contains the provider-neutral core domain contract for the
 // Arrival Manager. It deliberately has no dependency on persistence, source
-// adapters, transport, presentation, or navigation implementations.
+// adapters, transport, presentation, or navigation implementations. Owning
+// wire packages use its serialization helpers; its domain structs are not wire
+// DTOs.
 package aman

--- a/backend/internal/aman/doc.go
+++ b/backend/internal/aman/doc.go
@@ -1,0 +1,4 @@
+// Package aman contains the provider-neutral core domain contract for the
+// Arrival Manager. It deliberately has no dependency on persistence, source
+// adapters, transport, presentation, or navigation implementations.
+package aman

--- a/backend/internal/aman/package_direction_test.go
+++ b/backend/internal/aman/package_direction_test.go
@@ -1,0 +1,20 @@
+package aman
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestCorePackageDependsOnlyOnStandardLibrary(t *testing.T) {
+	command := exec.Command("go", "list", "-f", "{{join .Imports \"\\n\"}}", ".")
+	output, err := command.Output()
+	if err != nil {
+		t.Fatalf("list direct package imports: %v", err)
+	}
+	for _, importPath := range strings.Fields(string(output)) {
+		if strings.Contains(importPath, "/") || strings.Contains(importPath, ".") {
+			t.Errorf("core AMAN package must not import %q; adapters and owning packages depend inward", importPath)
+		}
+	}
+}

--- a/backend/internal/aman/serialization.go
+++ b/backend/internal/aman/serialization.go
@@ -1,0 +1,30 @@
+package aman
+
+import (
+	"time"
+)
+
+// RFC3339Millis is the canonical JSON timestamp layout for AMAN owning wire
+// packages. Domain fields remain time.Time; adapters call FormatTime before
+// putting them in a transport DTO.
+const RFC3339Millis = "2006-01-02T15:04:05.000Z07:00"
+
+// FormatTime returns the required UTC RFC3339 value with exactly millisecond
+// precision. It rejects non-UTC values so an adapter cannot silently emit a
+// local-zone timestamp.
+func FormatTime(value time.Time) (string, error) {
+	if err := requireUTCTime("timestamp", value); err != nil {
+		return "", err
+	}
+	return value.Format(RFC3339Millis), nil
+}
+
+// WholeSeconds returns a duration for an AMAN wire age/duration field. The
+// domain keeps time.Duration, while wire packages must not silently discard
+// sub-second precision.
+func WholeSeconds(value time.Duration) (int64, error) {
+	if value%time.Second != 0 {
+		return 0, invalid("wire duration must be a whole number of seconds")
+	}
+	return int64(value / time.Second), nil
+}

--- a/backend/internal/aman/types.go
+++ b/backend/internal/aman/types.go
@@ -1,0 +1,477 @@
+package aman
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// FlightID identifies one active AMAN flight. It is generated once and is not
+// derived from a mutable callsign.
+type FlightID string
+
+// RunwayGroupID identifies an airport-specific AMAN runway group.
+type RunwayGroupID string
+
+// SequenceRevision is the monotonically increasing committed revision for an
+// airport AMAN state.
+type SequenceRevision uint64
+
+type FlightState string
+
+const (
+	StatePlanned  FlightState = "planned"
+	StateAirborne FlightState = "airborne"
+	StateUnstable FlightState = "unstable"
+	StateStable   FlightState = "stable"
+	StateLanded   FlightState = "landed"
+	StateGoAround FlightState = "go_around"
+	StateRemoved  FlightState = "removed"
+)
+
+func (s FlightState) Valid() bool {
+	switch s {
+	case StatePlanned, StateAirborne, StateUnstable, StateStable, StateLanded, StateGoAround, StateRemoved:
+		return true
+	default:
+		return false
+	}
+}
+
+type DataStatus string
+
+const (
+	DataFresh        DataStatus = "fresh"
+	DataStale        DataStatus = "stale"
+	DataDisconnected DataStatus = "disconnected"
+)
+
+func (s DataStatus) Valid() bool {
+	return s == DataFresh || s == DataStale || s == DataDisconnected
+}
+
+type RolloutMode string
+
+const (
+	ModeDisabled      RolloutMode = "disabled"
+	ModeShadow        RolloutMode = "shadow"
+	ModeReadOnly      RolloutMode = "read_only"
+	ModeAuthoritative RolloutMode = "authoritative"
+)
+
+func (m RolloutMode) Valid() bool {
+	switch m {
+	case ModeDisabled, ModeShadow, ModeReadOnly, ModeAuthoritative:
+		return true
+	default:
+		return false
+	}
+}
+
+type Confidence string
+
+const (
+	ConfidenceUnknown Confidence = "unknown"
+	ConfidenceLow     Confidence = "low"
+	ConfidenceMedium  Confidence = "medium"
+	ConfidenceHigh    Confidence = "high"
+)
+
+func (c Confidence) Valid() bool {
+	switch c {
+	case ConfidenceUnknown, ConfidenceLow, ConfidenceMedium, ConfidenceHigh:
+		return true
+	default:
+		return false
+	}
+}
+
+// FreezeReason is the only representation of an operational TETA/slot freeze.
+// A flight must not add a parallel state or locked boolean.
+type FreezeReason string
+
+const (
+	FreezeNone        FreezeReason = "none"
+	FreezeSuperstable FreezeReason = "superstable"
+	FreezeManual      FreezeReason = "manual"
+)
+
+func (r FreezeReason) Valid() bool {
+	switch r {
+	case FreezeNone, FreezeSuperstable, FreezeManual:
+		return true
+	default:
+		return false
+	}
+}
+
+// FlightObservation is the provider-neutral reconciliation input. Adapters
+// map their vendor data to this value before it reaches AMAN.
+type FlightObservation struct {
+	FlightID        FlightID          `json:"flight_id"`
+	VATSIMCID       string            `json:"vatsim_cid"`
+	Callsign        string            `json:"callsign"`
+	Origin          string            `json:"origin"`
+	Destination     string            `json:"destination"`
+	AircraftType    *string           `json:"aircraft_type"`
+	WakeCategory    *string           `json:"wake_category"`
+	FiledRoute      *string           `json:"filed_route"`
+	RequestedLevel  *int              `json:"requested_level_ft"`
+	PlannedTiming   *PlannedTiming    `json:"planned_timing"`
+	FlightPlan      FlightPlanFact    `json:"flight_plan"`
+	Surveillance    *SurveillanceFact `json:"surveillance"`
+	TakeoffDetected *time.Time        `json:"takeoff_detected_at"`
+	ReconciledAt    time.Time         `json:"reconciled_at"`
+	SourceStatus    DataStatus        `json:"source_status"`
+}
+
+// PlannedTiming contains provider-neutral planned times. Durations are domain
+// time.Duration values; owning wire packages serialize them as whole seconds.
+type PlannedTiming struct {
+	EstimatedOffBlockTime *time.Time     `json:"estimated_off_block_time"`
+	EstimatedEnrouteTime  *time.Duration `json:"estimated_enroute_time"`
+}
+
+// FlightPlanFact records the source ordering facts for a flight plan.
+type FlightPlanFact struct {
+	Revision   *uint64    `json:"revision"`
+	ObservedAt *time.Time `json:"observed_at"`
+}
+
+// SurveillanceFact is an optional positional observation. Coordinates are
+// WGS84 degrees, altitude is feet, ground speed is knots, and track is true
+// degrees in [0,360).
+type SurveillanceFact struct {
+	LatitudeDegrees  float64    `json:"latitude_degrees"`
+	LongitudeDegrees float64    `json:"longitude_degrees"`
+	AltitudeFeet     *int       `json:"altitude_feet"`
+	GroundspeedKnots *float64   `json:"groundspeed_knots"`
+	TrackTrueDegrees *float64   `json:"track_true_degrees"`
+	Sequence         *uint64    `json:"sequence"`
+	ObservedAt       *time.Time `json:"observed_at"`
+}
+
+// Prediction separates a physical/model result from the backend-owned value
+// used for lifecycle and sequencing. RawTETA continues to move during a
+// freeze; OperationalTETA is the only value consumers sequence.
+type Prediction struct {
+	RawTETA           time.Time `json:"raw_teta"`
+	OperationalTETA   time.Time `json:"operational_teta"`
+	OperationalReason string    `json:"operational_reason"`
+
+	GeneratedAt       time.Time  `json:"generated_at"`
+	InputObservedAt   time.Time  `json:"input_observed_at"`
+	Confidence        Confidence `json:"confidence"`
+	Publishable       bool       `json:"publishable"`
+	DegradationReason *string    `json:"degradation_reason"`
+
+	DatasetVersion string     `json:"dataset_version"`
+	GeometryDigest string     `json:"geometry_digest"`
+	DistanceToGoNM *float64   `json:"distance_to_go_nm"`
+	HoldingFixETA  *time.Time `json:"holding_fix_eta"`
+
+	ModelVersion         string   `json:"model_version"`
+	ConfigVersion        string   `json:"config_version"`
+	PerformanceProfileID *string  `json:"performance_profile_id"`
+	WeatherSource        *string  `json:"weather_source"`
+	Sources              []string `json:"sources"`
+}
+
+// Slot is a committed sequencing result. It intentionally has no locked
+// field: freezes are represented exclusively by AMANFlight.FreezeReason.
+type Slot struct {
+	Time          time.Time        `json:"time"`
+	RunwayGroupID RunwayGroupID    `json:"runway_group_id"`
+	Sequence      int              `json:"sequence"`
+	Revision      SequenceRevision `json:"revision"`
+	Reason        string           `json:"reason"`
+}
+
+// RouteFact is the currently active operational route fact. Transport and
+// tracking-authority details belong to the route-fact owner, not this core
+// contract.
+type RouteFact struct {
+	ID         string    `json:"id"`
+	Fix        string    `json:"fix"`
+	ObservedAt time.Time `json:"observed_at"`
+}
+
+// ETAReview and GoAroundDetectionState reserve the aggregate's owned state
+// without defining command, persistence, or detector implementation details.
+// Their full workflows are owned by their respective components.
+type ETAReview struct {
+	Status string `json:"status"`
+}
+
+type GoAroundDetectionState struct {
+	EpisodeID *string `json:"episode_id"`
+}
+
+// RunwayGroupPolicy is the airport-state identity for a runway group. The
+// sequence component owns the policy's rate and spacing declarations.
+type RunwayGroupPolicy struct {
+	ID RunwayGroupID `json:"id"`
+}
+
+// AMANFlight is the persisted aggregate shape. All operational TETA, state,
+// freeze, slot, and order changes are backend-owned.
+type AMANFlight struct {
+	ID                    FlightID                `json:"id"`
+	State                 FlightState             `json:"state"`
+	DataStatus            DataStatus              `json:"data_status"`
+	Prediction            *Prediction             `json:"prediction"`
+	SelectedRunwayGroup   *RunwayGroupID          `json:"selected_runway_group"`
+	SelectedFeeder        *string                 `json:"selected_feeder"`
+	SelectedHolding       *string                 `json:"selected_holding"`
+	ActiveRouteFact       *RouteFact              `json:"active_route_fact"`
+	FreezeReason          FreezeReason            `json:"freeze_reason"`
+	FrozenAt              *time.Time              `json:"frozen_at"`
+	FrozenOperationalTETA *time.Time              `json:"frozen_operational_teta"`
+	Slot                  *Slot                   `json:"slot"`
+	Order                 *int                    `json:"order"`
+	ETAReview             *ETAReview              `json:"eta_review"`
+	GoAroundDetection     *GoAroundDetectionState `json:"go_around_detection"`
+	UpdatedAt             time.Time               `json:"updated_at"`
+}
+
+// AirportState is the sole source for one coherent AMAN replacement state.
+// Revisions are allocated only when a committed domain result changes it.
+type AirportState struct {
+	Airport       string              `json:"airport"`
+	Revision      SequenceRevision    `json:"revision"`
+	GeneratedAt   time.Time           `json:"generated_at"`
+	PolicyVersion string              `json:"policy_version"`
+	Mode          RolloutMode         `json:"mode"`
+	Authoritative bool                `json:"authoritative"`
+	Flights       []AMANFlight        `json:"flights"`
+	RunwayGroups  []RunwayGroupPolicy `json:"runway_groups"`
+}
+
+// CommandMetadata is shared by typed command values. It deliberately does not
+// use a kind plus nullable fields; each command owner defines a separate type.
+type CommandMetadata struct {
+	CommandID        string           `json:"command_id"`
+	ExpectedRevision SequenceRevision `json:"expected_revision"`
+}
+
+type ErrorClass string
+
+const (
+	ErrorInvalidArgument              ErrorClass = "invalid_argument"
+	ErrorNotFound                     ErrorClass = "not_found"
+	ErrorRevisionConflict             ErrorClass = "revision_conflict"
+	ErrorUnauthorized                 ErrorClass = "unauthorized"
+	ErrorInvalidTransition            ErrorClass = "invalid_transition"
+	ErrorDependencyUnavailable        ErrorClass = "dependency_unavailable"
+	ErrorDegradedOrIncompleteGeometry ErrorClass = "degraded_or_incomplete_geometry"
+	ErrorUnsupportedLeg               ErrorClass = "unsupported_leg"
+	ErrorDatasetMismatch              ErrorClass = "dataset_mismatch"
+	ErrorCorruptData                  ErrorClass = "corrupt_data"
+	ErrorActiveFlightConflict         ErrorClass = "active_flight_conflict"
+)
+
+func (c ErrorClass) Valid() bool {
+	switch c {
+	case ErrorInvalidArgument, ErrorNotFound, ErrorRevisionConflict, ErrorUnauthorized,
+		ErrorInvalidTransition, ErrorDependencyUnavailable, ErrorDegradedOrIncompleteGeometry,
+		ErrorUnsupportedLeg, ErrorDatasetMismatch, ErrorCorruptData, ErrorActiveFlightConflict:
+		return true
+	default:
+		return false
+	}
+}
+
+// DomainError provides a stable, provider-independent error class for a
+// transport adapter to map once at its boundary.
+type DomainError struct {
+	Class   ErrorClass
+	Message string
+}
+
+func (e *DomainError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Message == "" {
+		return string(e.Class)
+	}
+	return fmt.Sprintf("%s: %s", e.Class, e.Message)
+}
+
+// Validate checks the unit and nullability rules that can be established at
+// the neutral observation boundary without imposing a source implementation.
+func (o FlightObservation) Validate() error {
+	if strings.TrimSpace(string(o.FlightID)) == "" || strings.TrimSpace(o.VATSIMCID) == "" ||
+		strings.TrimSpace(o.Callsign) == "" || strings.TrimSpace(o.Origin) == "" || strings.TrimSpace(o.Destination) == "" {
+		return invalid("flight observation identity is incomplete")
+	}
+	if !o.SourceStatus.Valid() {
+		return invalid("source status is invalid")
+	}
+	if err := requireUTCTime("reconciled at", o.ReconciledAt); err != nil {
+		return err
+	}
+	if o.FlightPlan.ObservedAt != nil {
+		if err := requireUTCTime("flight plan observed at", *o.FlightPlan.ObservedAt); err != nil {
+			return err
+		}
+	}
+	if o.TakeoffDetected != nil {
+		if err := requireUTCTime("takeoff detected at", *o.TakeoffDetected); err != nil {
+			return err
+		}
+	}
+	if o.Surveillance != nil {
+		return o.Surveillance.validate()
+	}
+	return nil
+}
+
+func (s SurveillanceFact) validate() error {
+	if s.LatitudeDegrees < -90 || s.LatitudeDegrees > 90 || s.LongitudeDegrees < -180 || s.LongitudeDegrees > 180 {
+		return invalid("surveillance coordinates are invalid")
+	}
+	if s.GroundspeedKnots != nil && *s.GroundspeedKnots < 0 {
+		return invalid("ground speed cannot be negative")
+	}
+	if s.TrackTrueDegrees != nil && (*s.TrackTrueDegrees < 0 || *s.TrackTrueDegrees >= 360) {
+		return invalid("track must be true degrees in [0,360)")
+	}
+	if s.ObservedAt == nil {
+		return invalid("surveillance observed at is required")
+	}
+	return requireUTCTime("surveillance observed at", *s.ObservedAt)
+}
+
+func (p Prediction) Validate() error {
+	if err := requireUTCTime("raw TETA", p.RawTETA); err != nil {
+		return err
+	}
+	if err := requireUTCTime("operational TETA", p.OperationalTETA); err != nil {
+		return err
+	}
+	if strings.TrimSpace(p.OperationalReason) == "" {
+		return invalid("operational reason is required")
+	}
+	if err := requireUTCTime("generated at", p.GeneratedAt); err != nil {
+		return err
+	}
+	if err := requireUTCTime("input observed at", p.InputObservedAt); err != nil {
+		return err
+	}
+	if !p.Confidence.Valid() {
+		return invalid("confidence is invalid")
+	}
+	if strings.TrimSpace(p.DatasetVersion) == "" || strings.TrimSpace(p.GeometryDigest) == "" ||
+		strings.TrimSpace(p.ModelVersion) == "" || strings.TrimSpace(p.ConfigVersion) == "" {
+		return invalid("prediction provenance is incomplete")
+	}
+	if p.DistanceToGoNM != nil && *p.DistanceToGoNM < 0 {
+		return invalid("distance to go cannot be negative")
+	}
+	if p.HoldingFixETA != nil {
+		if err := requireUTCTime("holding fix ETA", *p.HoldingFixETA); err != nil {
+			return err
+		}
+	}
+	if p.Sources == nil {
+		return invalid("prediction sources must be explicit")
+	}
+	return nil
+}
+
+func (f AMANFlight) Validate() error {
+	if strings.TrimSpace(string(f.ID)) == "" {
+		return invalid("flight ID is required")
+	}
+	if !f.State.Valid() || !f.DataStatus.Valid() || !f.FreezeReason.Valid() {
+		return invalid("flight has an invalid state")
+	}
+	if f.Prediction != nil {
+		if err := f.Prediction.Validate(); err != nil {
+			return err
+		}
+	}
+	if err := f.validateFreeze(); err != nil {
+		return err
+	}
+	if f.Slot != nil {
+		if err := f.Slot.validate(); err != nil {
+			return err
+		}
+	}
+	return requireUTCTime("updated at", f.UpdatedAt)
+}
+
+func (f AMANFlight) validateFreeze() error {
+	if f.FreezeReason == FreezeNone {
+		if f.FrozenAt != nil || f.FrozenOperationalTETA != nil {
+			return invalid("unfrozen flight cannot retain freeze values")
+		}
+		return nil
+	}
+	if f.FrozenAt == nil || f.FrozenOperationalTETA == nil {
+		return invalid("frozen flight requires timestamp and operational TETA")
+	}
+	if err := requireUTCTime("frozen at", *f.FrozenAt); err != nil {
+		return err
+	}
+	return requireUTCTime("frozen operational TETA", *f.FrozenOperationalTETA)
+}
+
+func (s Slot) validate() error {
+	if err := requireUTCTime("slot time", s.Time); err != nil {
+		return err
+	}
+	if strings.TrimSpace(string(s.RunwayGroupID)) == "" || s.Sequence < 1 || strings.TrimSpace(s.Reason) == "" {
+		return invalid("slot is incomplete")
+	}
+	return nil
+}
+
+func (s AirportState) Validate() error {
+	if strings.TrimSpace(s.Airport) == "" || strings.TrimSpace(s.PolicyVersion) == "" || !s.Mode.Valid() {
+		return invalid("airport state is incomplete")
+	}
+	if err := requireUTCTime("generated at", s.GeneratedAt); err != nil {
+		return err
+	}
+	flightIDs := make(map[FlightID]struct{}, len(s.Flights))
+	for _, flight := range s.Flights {
+		if err := flight.Validate(); err != nil {
+			return err
+		}
+		if _, exists := flightIDs[flight.ID]; exists {
+			return invalid("airport state contains duplicate flight ID")
+		}
+		flightIDs[flight.ID] = struct{}{}
+		if flight.Slot != nil && flight.Slot.Revision != s.Revision {
+			return invalid("slot revision must match airport state revision")
+		}
+	}
+	groupIDs := make(map[RunwayGroupID]struct{}, len(s.RunwayGroups))
+	for _, group := range s.RunwayGroups {
+		if strings.TrimSpace(string(group.ID)) == "" {
+			return invalid("runway group ID is required")
+		}
+		if _, exists := groupIDs[group.ID]; exists {
+			return invalid("airport state contains duplicate runway group")
+		}
+		groupIDs[group.ID] = struct{}{}
+	}
+	return nil
+}
+
+func requireUTCTime(name string, value time.Time) error {
+	if value.IsZero() {
+		return invalid(name + " is required")
+	}
+	if value.Location() != time.UTC {
+		return invalid(name + " must be UTC")
+	}
+	return nil
+}
+
+func invalid(message string) error {
+	return &DomainError{Class: ErrorInvalidArgument, Message: message}
+}

--- a/backend/internal/aman/types.go
+++ b/backend/internal/aman/types.go
@@ -216,7 +216,11 @@ type RunwayGroupPolicy struct {
 // AMANFlight is the persisted aggregate shape. All operational TETA, state,
 // freeze, slot, and order changes are backend-owned.
 type AMANFlight struct {
-	ID                    FlightID
+	ID FlightID
+	// VATSIMCID remains bound to the aggregate while CurrentCallsign may be
+	// corrected without rekeying FlightID.
+	VATSIMCID             string
+	CurrentCallsign       string
 	State                 FlightState
 	DataStatus            DataStatus
 	Prediction            *Prediction
@@ -387,6 +391,9 @@ func (f AMANFlight) Validate() error {
 	if !f.State.Valid() || !f.DataStatus.Valid() || !f.FreezeReason.Valid() {
 		return invalid("flight has an invalid state")
 	}
+	if f.State != StateRemoved && (!isTrimmedNonEmpty(f.VATSIMCID) || !isTrimmedNonEmpty(f.CurrentCallsign)) {
+		return invalid("active flight requires VATSIM CID and current callsign")
+	}
 	if f.Prediction != nil {
 		if err := f.Prediction.Validate(); err != nil {
 			return err
@@ -474,4 +481,8 @@ func requireUTCTime(name string, value time.Time) error {
 
 func invalid(message string) error {
 	return &DomainError{Class: ErrorInvalidArgument, Message: message}
+}
+
+func isTrimmedNonEmpty(value string) bool {
+	return value != "" && strings.TrimSpace(value) == value
 }

--- a/backend/internal/aman/types.go
+++ b/backend/internal/aman/types.go
@@ -108,150 +108,150 @@ func (r FreezeReason) Valid() bool {
 // FlightObservation is the provider-neutral reconciliation input. Adapters
 // map their vendor data to this value before it reaches AMAN.
 type FlightObservation struct {
-	FlightID        FlightID          `json:"flight_id"`
-	VATSIMCID       string            `json:"vatsim_cid"`
-	Callsign        string            `json:"callsign"`
-	Origin          string            `json:"origin"`
-	Destination     string            `json:"destination"`
-	AircraftType    *string           `json:"aircraft_type"`
-	WakeCategory    *string           `json:"wake_category"`
-	FiledRoute      *string           `json:"filed_route"`
-	RequestedLevel  *int              `json:"requested_level_ft"`
-	PlannedTiming   *PlannedTiming    `json:"planned_timing"`
-	FlightPlan      FlightPlanFact    `json:"flight_plan"`
-	Surveillance    *SurveillanceFact `json:"surveillance"`
-	TakeoffDetected *time.Time        `json:"takeoff_detected_at"`
-	ReconciledAt    time.Time         `json:"reconciled_at"`
-	SourceStatus    DataStatus        `json:"source_status"`
+	FlightID        FlightID
+	VATSIMCID       string
+	Callsign        string
+	Origin          string
+	Destination     string
+	AircraftType    *string
+	WakeCategory    *string
+	FiledRoute      *string
+	RequestedLevel  *int
+	PlannedTiming   *PlannedTiming
+	FlightPlan      FlightPlanFact
+	Surveillance    *SurveillanceFact
+	TakeoffDetected *time.Time
+	ReconciledAt    time.Time
+	SourceStatus    DataStatus
 }
 
 // PlannedTiming contains provider-neutral planned times. Durations are domain
 // time.Duration values; owning wire packages serialize them as whole seconds.
 type PlannedTiming struct {
-	EstimatedOffBlockTime *time.Time     `json:"estimated_off_block_time"`
-	EstimatedEnrouteTime  *time.Duration `json:"estimated_enroute_time"`
+	EstimatedOffBlockTime *time.Time
+	EstimatedEnrouteTime  *time.Duration
 }
 
 // FlightPlanFact records the source ordering facts for a flight plan.
 type FlightPlanFact struct {
-	Revision   *uint64    `json:"revision"`
-	ObservedAt *time.Time `json:"observed_at"`
+	Revision   *uint64
+	ObservedAt *time.Time
 }
 
 // SurveillanceFact is an optional positional observation. Coordinates are
 // WGS84 degrees, altitude is feet, ground speed is knots, and track is true
 // degrees in [0,360).
 type SurveillanceFact struct {
-	LatitudeDegrees  float64    `json:"latitude_degrees"`
-	LongitudeDegrees float64    `json:"longitude_degrees"`
-	AltitudeFeet     *int       `json:"altitude_feet"`
-	GroundspeedKnots *float64   `json:"groundspeed_knots"`
-	TrackTrueDegrees *float64   `json:"track_true_degrees"`
-	Sequence         *uint64    `json:"sequence"`
-	ObservedAt       *time.Time `json:"observed_at"`
+	LatitudeDegrees  float64
+	LongitudeDegrees float64
+	AltitudeFeet     *int
+	GroundspeedKnots *float64
+	TrackTrueDegrees *float64
+	Sequence         *uint64
+	ObservedAt       *time.Time
 }
 
 // Prediction separates a physical/model result from the backend-owned value
 // used for lifecycle and sequencing. RawTETA continues to move during a
 // freeze; OperationalTETA is the only value consumers sequence.
 type Prediction struct {
-	RawTETA           time.Time `json:"raw_teta"`
-	OperationalTETA   time.Time `json:"operational_teta"`
-	OperationalReason string    `json:"operational_reason"`
+	RawTETA           time.Time
+	OperationalTETA   time.Time
+	OperationalReason string
 
-	GeneratedAt       time.Time  `json:"generated_at"`
-	InputObservedAt   time.Time  `json:"input_observed_at"`
-	Confidence        Confidence `json:"confidence"`
-	Publishable       bool       `json:"publishable"`
-	DegradationReason *string    `json:"degradation_reason"`
+	GeneratedAt       time.Time
+	InputObservedAt   time.Time
+	Confidence        Confidence
+	Publishable       bool
+	DegradationReason *string
 
-	DatasetVersion string     `json:"dataset_version"`
-	GeometryDigest string     `json:"geometry_digest"`
-	DistanceToGoNM *float64   `json:"distance_to_go_nm"`
-	HoldingFixETA  *time.Time `json:"holding_fix_eta"`
+	DatasetVersion string
+	GeometryDigest string
+	DistanceToGoNM *float64
+	HoldingFixETA  *time.Time
 
-	ModelVersion         string   `json:"model_version"`
-	ConfigVersion        string   `json:"config_version"`
-	PerformanceProfileID *string  `json:"performance_profile_id"`
-	WeatherSource        *string  `json:"weather_source"`
-	Sources              []string `json:"sources"`
+	ModelVersion         string
+	ConfigVersion        string
+	PerformanceProfileID *string
+	WeatherSource        *string
+	Sources              []string
 }
 
 // Slot is a committed sequencing result. It intentionally has no locked
 // field: freezes are represented exclusively by AMANFlight.FreezeReason.
 type Slot struct {
-	Time          time.Time        `json:"time"`
-	RunwayGroupID RunwayGroupID    `json:"runway_group_id"`
-	Sequence      int              `json:"sequence"`
-	Revision      SequenceRevision `json:"revision"`
-	Reason        string           `json:"reason"`
+	Time          time.Time
+	RunwayGroupID RunwayGroupID
+	Sequence      int
+	Revision      SequenceRevision
+	Reason        string
 }
 
 // RouteFact is the currently active operational route fact. Transport and
 // tracking-authority details belong to the route-fact owner, not this core
 // contract.
 type RouteFact struct {
-	ID         string    `json:"id"`
-	Fix        string    `json:"fix"`
-	ObservedAt time.Time `json:"observed_at"`
+	ID         string
+	Fix        string
+	ObservedAt time.Time
 }
 
 // ETAReview and GoAroundDetectionState reserve the aggregate's owned state
 // without defining command, persistence, or detector implementation details.
 // Their full workflows are owned by their respective components.
 type ETAReview struct {
-	Status string `json:"status"`
+	Status string
 }
 
 type GoAroundDetectionState struct {
-	EpisodeID *string `json:"episode_id"`
+	EpisodeID *string
 }
 
 // RunwayGroupPolicy is the airport-state identity for a runway group. The
 // sequence component owns the policy's rate and spacing declarations.
 type RunwayGroupPolicy struct {
-	ID RunwayGroupID `json:"id"`
+	ID RunwayGroupID
 }
 
 // AMANFlight is the persisted aggregate shape. All operational TETA, state,
 // freeze, slot, and order changes are backend-owned.
 type AMANFlight struct {
-	ID                    FlightID                `json:"id"`
-	State                 FlightState             `json:"state"`
-	DataStatus            DataStatus              `json:"data_status"`
-	Prediction            *Prediction             `json:"prediction"`
-	SelectedRunwayGroup   *RunwayGroupID          `json:"selected_runway_group"`
-	SelectedFeeder        *string                 `json:"selected_feeder"`
-	SelectedHolding       *string                 `json:"selected_holding"`
-	ActiveRouteFact       *RouteFact              `json:"active_route_fact"`
-	FreezeReason          FreezeReason            `json:"freeze_reason"`
-	FrozenAt              *time.Time              `json:"frozen_at"`
-	FrozenOperationalTETA *time.Time              `json:"frozen_operational_teta"`
-	Slot                  *Slot                   `json:"slot"`
-	Order                 *int                    `json:"order"`
-	ETAReview             *ETAReview              `json:"eta_review"`
-	GoAroundDetection     *GoAroundDetectionState `json:"go_around_detection"`
-	UpdatedAt             time.Time               `json:"updated_at"`
+	ID                    FlightID
+	State                 FlightState
+	DataStatus            DataStatus
+	Prediction            *Prediction
+	SelectedRunwayGroup   *RunwayGroupID
+	SelectedFeeder        *string
+	SelectedHolding       *string
+	ActiveRouteFact       *RouteFact
+	FreezeReason          FreezeReason
+	FrozenAt              *time.Time
+	FrozenOperationalTETA *time.Time
+	Slot                  *Slot
+	Order                 *int
+	ETAReview             *ETAReview
+	GoAroundDetection     *GoAroundDetectionState
+	UpdatedAt             time.Time
 }
 
 // AirportState is the sole source for one coherent AMAN replacement state.
 // Revisions are allocated only when a committed domain result changes it.
 type AirportState struct {
-	Airport       string              `json:"airport"`
-	Revision      SequenceRevision    `json:"revision"`
-	GeneratedAt   time.Time           `json:"generated_at"`
-	PolicyVersion string              `json:"policy_version"`
-	Mode          RolloutMode         `json:"mode"`
-	Authoritative bool                `json:"authoritative"`
-	Flights       []AMANFlight        `json:"flights"`
-	RunwayGroups  []RunwayGroupPolicy `json:"runway_groups"`
+	Airport       string
+	Revision      SequenceRevision
+	GeneratedAt   time.Time
+	PolicyVersion string
+	Mode          RolloutMode
+	Authoritative bool
+	Flights       []AMANFlight
+	RunwayGroups  []RunwayGroupPolicy
 }
 
 // CommandMetadata is shared by typed command values. It deliberately does not
 // use a kind plus nullable fields; each command owner defines a separate type.
 type CommandMetadata struct {
-	CommandID        string           `json:"command_id"`
-	ExpectedRevision SequenceRevision `json:"expected_revision"`
+	CommandID        string
+	ExpectedRevision SequenceRevision
 }
 
 type ErrorClass string

--- a/backend/internal/aman/types_test.go
+++ b/backend/internal/aman/types_test.go
@@ -1,44 +1,67 @@
 package aman
 
 import (
-	"encoding/json"
 	"errors"
-	"strings"
+	"reflect"
 	"testing"
 	"time"
 )
 
-func TestPredictionJSONUsesUTCInstantsAndExplicitNulls(t *testing.T) {
+func TestFormatTimeUsesRFC3339MillisecondsIncludingExactSeconds(t *testing.T) {
 	instant := time.Date(2026, time.July, 18, 12, 34, 56, 123000000, time.UTC)
-	prediction := Prediction{
-		RawTETA:           instant,
-		OperationalTETA:   instant,
-		OperationalReason: "smoothed",
-		GeneratedAt:       instant,
-		InputObservedAt:   instant,
-		Confidence:        ConfidenceHigh,
-		DatasetVersion:    "2026-07",
-		GeometryDigest:    "abc123",
-		ModelVersion:      "model-v1",
-		ConfigVersion:     "config-v1",
-		Sources:           []string{"vatsim", "nav-cache"},
+	encoded, err := FormatTime(instant)
+	if err != nil {
+		t.Fatalf("format millisecond timestamp: %v", err)
+	}
+	if encoded != "2026-07-18T12:34:56.123Z" {
+		t.Errorf("formatted timestamp = %q", encoded)
 	}
 
-	encoded, err := json.Marshal(prediction)
+	exactSecond, err := FormatTime(instant.Truncate(time.Second))
 	if err != nil {
-		t.Fatalf("marshal prediction: %v", err)
+		t.Fatalf("format exact-second timestamp: %v", err)
 	}
-	jsonText := string(encoded)
-	for _, want := range []string{
-		`"raw_teta":"2026-07-18T12:34:56.123Z"`,
-		`"operational_teta":"2026-07-18T12:34:56.123Z"`,
-		`"degradation_reason":null`,
-		`"distance_to_go_nm":null`,
-		`"holding_fix_eta":null`,
-		`"sources":["vatsim","nav-cache"]`,
-	} {
-		if !strings.Contains(jsonText, want) {
-			t.Errorf("prediction JSON %s does not contain %s", jsonText, want)
+	if exactSecond != "2026-07-18T12:34:56.000Z" {
+		t.Errorf("formatted exact-second timestamp = %q", exactSecond)
+	}
+}
+
+func TestWholeSecondsPreservesDurationWithoutNanosecondSerialization(t *testing.T) {
+	seconds, err := WholeSeconds(90 * time.Second)
+	if err != nil {
+		t.Fatalf("whole seconds: %v", err)
+	}
+	if seconds != 90 {
+		t.Errorf("whole seconds = %d", seconds)
+	}
+
+	if _, err := WholeSeconds(1500 * time.Millisecond); err == nil {
+		t.Error("expected non-whole duration to be rejected")
+	}
+}
+
+func TestDomainTypesDoNotDeclareWireJSONTags(t *testing.T) {
+	types := []reflect.Type{
+		reflect.TypeFor[FlightObservation](),
+		reflect.TypeFor[PlannedTiming](),
+		reflect.TypeFor[FlightPlanFact](),
+		reflect.TypeFor[SurveillanceFact](),
+		reflect.TypeFor[Prediction](),
+		reflect.TypeFor[Slot](),
+		reflect.TypeFor[RouteFact](),
+		reflect.TypeFor[ETAReview](),
+		reflect.TypeFor[GoAroundDetectionState](),
+		reflect.TypeFor[RunwayGroupPolicy](),
+		reflect.TypeFor[AMANFlight](),
+		reflect.TypeFor[AirportState](),
+		reflect.TypeFor[CommandMetadata](),
+	}
+	for _, domainType := range types {
+		for index := range domainType.NumField() {
+			field := domainType.Field(index)
+			if tag := field.Tag.Get("json"); tag != "" {
+				t.Errorf("%s.%s declares wire JSON tag %q", domainType.Name(), field.Name, tag)
+			}
 		}
 	}
 }

--- a/backend/internal/aman/types_test.go
+++ b/backend/internal/aman/types_test.go
@@ -1,0 +1,191 @@
+package aman
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPredictionJSONUsesUTCInstantsAndExplicitNulls(t *testing.T) {
+	instant := time.Date(2026, time.July, 18, 12, 34, 56, 123000000, time.UTC)
+	prediction := Prediction{
+		RawTETA:           instant,
+		OperationalTETA:   instant,
+		OperationalReason: "smoothed",
+		GeneratedAt:       instant,
+		InputObservedAt:   instant,
+		Confidence:        ConfidenceHigh,
+		DatasetVersion:    "2026-07",
+		GeometryDigest:    "abc123",
+		ModelVersion:      "model-v1",
+		ConfigVersion:     "config-v1",
+		Sources:           []string{"vatsim", "nav-cache"},
+	}
+
+	encoded, err := json.Marshal(prediction)
+	if err != nil {
+		t.Fatalf("marshal prediction: %v", err)
+	}
+	jsonText := string(encoded)
+	for _, want := range []string{
+		`"raw_teta":"2026-07-18T12:34:56.123Z"`,
+		`"operational_teta":"2026-07-18T12:34:56.123Z"`,
+		`"degradation_reason":null`,
+		`"distance_to_go_nm":null`,
+		`"holding_fix_eta":null`,
+		`"sources":["vatsim","nav-cache"]`,
+	} {
+		if !strings.Contains(jsonText, want) {
+			t.Errorf("prediction JSON %s does not contain %s", jsonText, want)
+		}
+	}
+}
+
+func TestPredictionRejectsUnknownAsZeroAndNonUTC(t *testing.T) {
+	base := validPrediction()
+	base.DistanceToGoNM = float64Ptr(-1)
+	assertInvalidArgument(t, base.Validate())
+
+	base = validPrediction()
+	base.GeneratedAt = base.GeneratedAt.In(time.FixedZone("CEST", 2*60*60))
+	assertInvalidArgument(t, base.Validate())
+
+	base = validPrediction()
+	base.Sources = nil
+	assertInvalidArgument(t, base.Validate())
+}
+
+func TestFlightFreezeHasOneCanonicalRepresentation(t *testing.T) {
+	now := time.Date(2026, time.July, 18, 12, 0, 0, 0, time.UTC)
+	flight := validFlight(now)
+	flight.FrozenAt = &now
+	assertInvalidArgument(t, flight.Validate())
+
+	flight = validFlight(now)
+	flight.FreezeReason = FreezeSuperstable
+	assertInvalidArgument(t, flight.Validate())
+
+	flight.FrozenAt = &now
+	freezeTETA := now.Add(10 * time.Minute)
+	flight.FrozenOperationalTETA = &freezeTETA
+	if err := flight.Validate(); err != nil {
+		t.Fatalf("validate frozen flight: %v", err)
+	}
+}
+
+func TestAirportStateRejectsMismatchedSlotRevisionAndDuplicateFlight(t *testing.T) {
+	now := time.Date(2026, time.July, 18, 12, 0, 0, 0, time.UTC)
+	flight := validFlight(now)
+	flight.Slot = &Slot{
+		Time:          now.Add(10 * time.Minute),
+		RunwayGroupID: "22L",
+		Sequence:      1,
+		Revision:      4,
+		Reason:        "rate",
+	}
+	state := AirportState{
+		Airport:       "EKCH",
+		Revision:      5,
+		GeneratedAt:   now,
+		PolicyVersion: "v1",
+		Mode:          ModeReadOnly,
+		Flights:       []AMANFlight{flight},
+		RunwayGroups:  []RunwayGroupPolicy{{ID: "22L"}},
+	}
+	assertInvalidArgument(t, state.Validate())
+
+	flight.Slot.Revision = state.Revision
+	state.Flights = append(state.Flights, flight)
+	assertInvalidArgument(t, state.Validate())
+}
+
+func TestFlightObservationUsesNeutralUnitsAndOptionalFacts(t *testing.T) {
+	now := time.Date(2026, time.July, 18, 12, 0, 0, 0, time.UTC)
+	track := 359.9
+	observation := FlightObservation{
+		FlightID:     "flight-1",
+		VATSIMCID:    "1234567",
+		Callsign:     "SAS123",
+		Origin:       "ESSA",
+		Destination:  "EKCH",
+		ReconciledAt: now,
+		SourceStatus: DataFresh,
+		Surveillance: &SurveillanceFact{
+			LatitudeDegrees:  55.6,
+			LongitudeDegrees: 12.6,
+			TrackTrueDegrees: &track,
+			ObservedAt:       &now,
+		},
+	}
+	if err := observation.Validate(); err != nil {
+		t.Fatalf("validate observation: %v", err)
+	}
+
+	track = 360
+	assertInvalidArgument(t, observation.Validate())
+}
+
+func TestStableErrorClasses(t *testing.T) {
+	classes := []ErrorClass{
+		ErrorInvalidArgument,
+		ErrorNotFound,
+		ErrorRevisionConflict,
+		ErrorUnauthorized,
+		ErrorInvalidTransition,
+		ErrorDependencyUnavailable,
+		ErrorDegradedOrIncompleteGeometry,
+		ErrorUnsupportedLeg,
+		ErrorDatasetMismatch,
+		ErrorCorruptData,
+		ErrorActiveFlightConflict,
+	}
+	for _, class := range classes {
+		if !class.Valid() {
+			t.Errorf("error class %q is not valid", class)
+		}
+	}
+}
+
+func validPrediction() Prediction {
+	now := time.Date(2026, time.July, 18, 12, 0, 0, 0, time.UTC)
+	return Prediction{
+		RawTETA:           now.Add(15 * time.Minute),
+		OperationalTETA:   now.Add(15 * time.Minute),
+		OperationalReason: "raw",
+		GeneratedAt:       now,
+		InputObservedAt:   now,
+		Confidence:        ConfidenceMedium,
+		DatasetVersion:    "2026-07",
+		GeometryDigest:    "abc123",
+		ModelVersion:      "model-v1",
+		ConfigVersion:     "config-v1",
+		Sources:           []string{},
+	}
+}
+
+func validFlight(now time.Time) AMANFlight {
+	return AMANFlight{
+		ID:           "flight-1",
+		State:        StateStable,
+		DataStatus:   DataFresh,
+		FreezeReason: FreezeNone,
+		UpdatedAt:    now,
+	}
+}
+
+func float64Ptr(value float64) *float64 {
+	return &value
+}
+
+func assertInvalidArgument(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected invalid argument error")
+	}
+	var domainError *DomainError
+	if !errors.As(err, &domainError) || domainError.Class != ErrorInvalidArgument {
+		t.Fatalf("expected invalid argument domain error, got %v", err)
+	}
+}

--- a/backend/internal/aman/types_test.go
+++ b/backend/internal/aman/types_test.go
@@ -98,6 +98,32 @@ func TestFlightFreezeHasOneCanonicalRepresentation(t *testing.T) {
 	}
 }
 
+func TestFlightCallsignCorrectionKeepsFlightIDAndVATSIMCID(t *testing.T) {
+	now := time.Date(2026, time.July, 18, 12, 0, 0, 0, time.UTC)
+	flight := validFlight(now)
+	originalID := flight.ID
+	originalCID := flight.VATSIMCID
+
+	flight.CurrentCallsign = "SAS124"
+	if err := flight.Validate(); err != nil {
+		t.Fatalf("validate corrected callsign: %v", err)
+	}
+	if flight.ID != originalID || flight.VATSIMCID != originalCID {
+		t.Fatalf("callsign correction changed stable identity: ID=%q CID=%q", flight.ID, flight.VATSIMCID)
+	}
+}
+
+func TestActiveFlightRejectsEmptyOrUntrimmedProviderIdentity(t *testing.T) {
+	now := time.Date(2026, time.July, 18, 12, 0, 0, 0, time.UTC)
+	flight := validFlight(now)
+	flight.VATSIMCID = ""
+	assertInvalidArgument(t, flight.Validate())
+
+	flight = validFlight(now)
+	flight.CurrentCallsign = " SAS123"
+	assertInvalidArgument(t, flight.Validate())
+}
+
 func TestAirportStateRejectsMismatchedSlotRevisionAndDuplicateFlight(t *testing.T) {
 	now := time.Date(2026, time.July, 18, 12, 0, 0, 0, time.UTC)
 	flight := validFlight(now)
@@ -190,11 +216,13 @@ func validPrediction() Prediction {
 
 func validFlight(now time.Time) AMANFlight {
 	return AMANFlight{
-		ID:           "flight-1",
-		State:        StateStable,
-		DataStatus:   DataFresh,
-		FreezeReason: FreezeNone,
-		UpdatedAt:    now,
+		ID:              "flight-1",
+		VATSIMCID:       "1234567",
+		CurrentCallsign: "SAS123",
+		State:           StateStable,
+		DataStatus:      DataFresh,
+		FreezeReason:    FreezeNone,
+		UpdatedAt:       now,
 	}
 }
 


### PR DESCRIPTION
## What changed

- Add the dependency-free `internal/aman` core domain contract: stable FlightID/VATSIM CID/current-callsign identity, exact lifecycle/data/rollout/confidence/freeze enums, neutral observations, prediction provenance, airport state, slot, and shared command metadata/error classes.
- Enforce raw-versus-operational TETA ownership, canonical freeze fields, UTC/null/unit validation, coherent airport revisions, and no duplicate slots or flights.
- Add focused serialization-boundary, invariant, stable-error, and direct dependency-direction tests.

## Why

This freezes the lean shared foundation AMAN consumers need without pre-empting repository schemas, navigation adapters, command payloads, or frontend/EuroScope wire contracts.

## Impact

Future AMAN work can depend on one provider-neutral core package. Domain structs intentionally have no JSON tags; owning wire packages use the shared UTC millisecond timestamp and whole-second duration helpers. The package imports only the Go standard library and deliberately excludes ALB, SAT, transport, persistence, source-adapter, authority-epoch, outbox, and resnapshot contracts.

## Checks

- `go test ./internal/aman`
- `go test ./...`

Closes #337
