### PR TITLE
feat(aman): configure runtime modes

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"FlightStrips/internal/aman"
 	"FlightStrips/internal/app"
 	"FlightStrips/internal/config"
 	"FlightStrips/internal/telemetry"
 	"context"
 	"flag"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -45,6 +47,11 @@ func main() {
 		os.Exit(1)
 	}
 	standAssignmentAircraftJSON := standAssignmentAircraftFile(os.Getenv("GRPLUGIN_ICAO_AIRCRAFT_JSON"))
+	amanConfig, err := amanConfigFromEnv()
+	if err != nil {
+		slog.Error("Failed to configure AMAN", slog.Any("error", err))
+		os.Exit(1)
+	}
 
 	otlpEndpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
 	if otlpEndpoint != "" {
@@ -96,6 +103,7 @@ func main() {
 		EnableTestTools:                 enableTestTools,
 		EnableDBSeed:                    true,
 		StandAssignmentAircraftJSON:     standAssignmentAircraftJSON,
+		AMAN:                            amanConfig,
 	}, app.Dependencies{
 		VATSIMStatusURL:      getEnv("VATSIM_STATUS_URL", ""),
 		VATSIMPollInterval:   envDuration("VATSIM_POLL_INTERVAL", 15*time.Second),
@@ -206,6 +214,45 @@ func envDuration(key string, fallback time.Duration) time.Duration {
 		return fallback
 	}
 	return parsed
+}
+
+func amanConfigFromEnv() (aman.RuntimeConfig, error) {
+	config := aman.DefaultRuntimeConfig()
+	if value := strings.TrimSpace(os.Getenv("AMAN_MODE")); value != "" {
+		config.Mode = aman.RolloutMode(strings.ToLower(value))
+	}
+	config.EnabledAirports = splitEnvList(os.Getenv("AMAN_ENABLED_AIRPORTS"))
+	config.TerminalGeometryPath = strings.TrimSpace(os.Getenv("AMAN_TERMINAL_GEOMETRY_PATH"))
+	config.NavigationSourceAdapter = strings.TrimSpace(os.Getenv("AMAN_NAVIGATION_SOURCE"))
+	config.EnableEuroScopeGainLoseTags = envBool("ENABLE_AMAN_EUROSCOPE_GAIN_LOSE_TAGS", false)
+
+	var err error
+	if config.ReconciliationInterval, err = requiredEnvDuration("AMAN_RECONCILIATION_INTERVAL", config.ReconciliationInterval); err != nil {
+		return aman.RuntimeConfig{}, err
+	}
+	if config.SurveillanceInterval, err = requiredEnvDuration("AMAN_SURVEILLANCE_INTERVAL", config.SurveillanceInterval); err != nil {
+		return aman.RuntimeConfig{}, err
+	}
+	if err := config.Validate(); err != nil {
+		return aman.RuntimeConfig{}, err
+	}
+	return config, nil
+}
+
+func requiredEnvDuration(key string, fallback time.Duration) (time.Duration, error) {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback, nil
+	}
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be a duration: %w", key, err)
+	}
+	return duration, nil
+}
+
+func splitEnvList(value string) []string {
+	return strings.FieldsFunc(value, func(r rune) bool { return r == ',' })
 }
 
 func isLiveEnvironment(environment string) bool {

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "testing"
+import (
+	"FlightStrips/internal/aman"
+	"os"
+	"testing"
+	"time"
+)
 
 func TestEnvBool(t *testing.T) {
 	tests := []struct {
@@ -67,5 +72,50 @@ func TestStandAssignmentAircraftFilePreservesExplicitConfiguration(t *testing.T)
 	}
 	if got := standAssignmentAircraftFile(""); got != "" {
 		t.Fatalf("empty aircraft file = %q, want empty so config selects its default", got)
+	}
+}
+
+func TestAMANConfigFromEnvDefaultsDisabled(t *testing.T) {
+	for _, key := range []string{"AMAN_MODE", "AMAN_ENABLED_AIRPORTS", "AMAN_TERMINAL_GEOMETRY_PATH", "AMAN_NAVIGATION_SOURCE", "AMAN_RECONCILIATION_INTERVAL", "AMAN_SURVEILLANCE_INTERVAL", "ENABLE_AMAN_EUROSCOPE_GAIN_LOSE_TAGS"} {
+		t.Setenv(key, "")
+	}
+	config, err := amanConfigFromEnv()
+	if err != nil {
+		t.Fatalf("amanConfigFromEnv() error = %v", err)
+	}
+	if config.Mode != aman.ModeDisabled {
+		t.Fatalf("AMAN mode = %q, want disabled", config.Mode)
+	}
+}
+
+func TestAMANConfigFromEnvParsesConfiguredRuntime(t *testing.T) {
+	geometry, err := os.CreateTemp(t.TempDir(), "terminal-*.geojson")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := geometry.Close(); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AMAN_MODE", "authoritative")
+	t.Setenv("AMAN_ENABLED_AIRPORTS", "EKCH,EKRN")
+	t.Setenv("AMAN_TERMINAL_GEOMETRY_PATH", geometry.Name())
+	t.Setenv("AMAN_NAVIGATION_SOURCE", "airacnet")
+	t.Setenv("AMAN_RECONCILIATION_INTERVAL", "21s")
+	t.Setenv("AMAN_SURVEILLANCE_INTERVAL", "34s")
+	t.Setenv("ENABLE_AMAN_EUROSCOPE_GAIN_LOSE_TAGS", "true")
+
+	config, err := amanConfigFromEnv()
+	if err != nil {
+		t.Fatalf("amanConfigFromEnv() error = %v", err)
+	}
+	if config.Mode != aman.ModeAuthoritative || len(config.EnabledAirports) != 2 || config.ReconciliationInterval != 21*time.Second || config.SurveillanceInterval != 34*time.Second || !config.EnableEuroScopeGainLoseTags {
+		t.Fatalf("unexpected AMAN config: %#v", config)
+	}
+}
+
+func TestAMANConfigFromEnvRejectsInvalidTiming(t *testing.T) {
+	t.Setenv("AMAN_RECONCILIATION_INTERVAL", "later")
+	if _, err := amanConfigFromEnv(); err == nil {
+		t.Fatal("amanConfigFromEnv() succeeded with invalid timing")
 	}
 }

--- a/backend/internal/aman/runtime.go
+++ b/backend/internal/aman/runtime.go
@@ -56,10 +56,20 @@ func (c RuntimeConfig) withDefaults() RuntimeConfig {
 	return c
 }
 
+func (c RuntimeConfig) normalize() RuntimeConfig {
+	c = c.withDefaults()
+	c.Mode = RolloutMode(strings.ToLower(strings.TrimSpace(string(c.Mode))))
+	c.EnabledAirports = normalizeAirports(c.EnabledAirports)
+	c.TerminalGeometryPath = strings.TrimSpace(c.TerminalGeometryPath)
+	c.NavigationSourceAdapter = strings.ToLower(strings.TrimSpace(c.NavigationSourceAdapter))
+	return c
+}
+
 // Validate rejects configuration that would make an enabled AMAN runtime
 // ambiguous or unusable. Disabled AMAN accepts its zero-value configuration.
 func (c RuntimeConfig) Validate() error {
-	c = c.withDefaults()
+	original := c.withDefaults()
+	c = original.normalize()
 	if !c.Mode.Valid() {
 		return fmt.Errorf("AMAN mode %q is invalid", c.Mode)
 	}
@@ -70,12 +80,11 @@ func (c RuntimeConfig) Validate() error {
 		return fmt.Errorf("AMAN surveillance interval must be greater than 0")
 	}
 
-	airports := normalizeAirports(c.EnabledAirports)
-	if len(airports) != len(nonEmpty(c.EnabledAirports)) {
+	if len(c.EnabledAirports) != len(nonEmpty(original.EnabledAirports)) {
 		return fmt.Errorf("AMAN enabled airports must be unique ICAO identifiers")
 	}
-	seenAirports := make(map[string]struct{}, len(airports))
-	for _, airport := range airports {
+	seenAirports := make(map[string]struct{}, len(c.EnabledAirports))
+	for _, airport := range c.EnabledAirports {
 		if !airportIdentifier.MatchString(airport) {
 			return fmt.Errorf("AMAN airport %q must be a four-letter ICAO identifier", airport)
 		}
@@ -90,7 +99,7 @@ func (c RuntimeConfig) Validate() error {
 	if c.Mode == ModeDisabled {
 		return nil
 	}
-	if len(airports) == 0 {
+	if len(c.EnabledAirports) == 0 {
 		return fmt.Errorf("AMAN enabled airports are required when mode is %q", c.Mode)
 	}
 	if !isSupportedNavigationAdapter(c.NavigationSourceAdapter) {
@@ -135,7 +144,7 @@ type Component interface {
 }
 
 // Worker is a cancellation-aware AMAN loop. The runtime owns its lifecycle;
-// concrete source and reconciliation implementations stay outside this task.
+// concrete surveillance and reconciliation implementations stay outside this task.
 type Worker interface {
 	Run(context.Context, time.Duration)
 }
@@ -144,17 +153,17 @@ type Worker interface {
 // explicit lets later AMAN tasks add concrete implementations without changing
 // startup ownership or adding a service locator.
 type Dependencies struct {
-	Repositories            Component
-	NavigationMaterializer  Component
-	NavigationReader        Component
-	Predictor               Component
-	StateEngine             Component
-	SequenceService         Component
-	Publisher               Component
-	ValidationService       Component
-	HealthService           Component
-	NavigationRefreshWorker Worker
-	ReconciliationWorker    Worker
+	Repositories           Component
+	NavigationMaterializer Component
+	NavigationReader       Component
+	Predictor              Component
+	StateEngine            Component
+	SequenceService        Component
+	Publisher              Component
+	ValidationService      Component
+	HealthService          Component
+	SurveillanceWorker     Worker
+	ReconciliationWorker   Worker
 }
 
 // Ownership describes the runtime authority selected by rollout mode.
@@ -177,7 +186,7 @@ type Runtime struct {
 // NewRuntime validates the rollout configuration and all required explicit
 // dependencies before workers can start.
 func NewRuntime(config RuntimeConfig, deps Dependencies) (*Runtime, error) {
-	config = config.withDefaults()
+	config = config.normalize()
 	if err := config.Validate(); err != nil {
 		return nil, err
 	}
@@ -203,8 +212,8 @@ func NewRuntime(config RuntimeConfig, deps Dependencies) (*Runtime, error) {
 			return nil, fmt.Errorf("AMAN runtime requires %s", dependency.name)
 		}
 	}
-	if deps.NavigationRefreshWorker == nil {
-		return nil, fmt.Errorf("AMAN runtime requires navigation refresh worker")
+	if deps.SurveillanceWorker == nil {
+		return nil, fmt.Errorf("AMAN runtime requires surveillance worker")
 	}
 	if deps.ReconciliationWorker == nil {
 		return nil, fmt.Errorf("AMAN runtime requires reconciliation worker")
@@ -250,10 +259,12 @@ func (r *Runtime) Enabled() bool {
 
 // Start runs only the configured AMAN loops. Both workers receive the same
 // application context, so normal application cancellation shuts them down.
+// Surveillance is the source-observation loop; navigation materializer refresh
+// policy is deliberately outside this runtime.
 func (r *Runtime) Start(ctx context.Context) {
 	if !r.Enabled() {
 		return
 	}
-	go r.deps.NavigationRefreshWorker.Run(ctx, r.config.SurveillanceInterval)
+	go r.deps.SurveillanceWorker.Run(ctx, r.config.SurveillanceInterval)
 	go r.deps.ReconciliationWorker.Run(ctx, r.config.ReconciliationInterval)
 }

--- a/backend/internal/aman/runtime.go
+++ b/backend/internal/aman/runtime.go
@@ -1,0 +1,259 @@
+package aman
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+)
+
+const (
+	defaultReconciliationInterval = 15 * time.Second
+	defaultSurveillanceInterval   = 15 * time.Second
+
+	// NavigationAdapterAIRACNet is the approved navigation-data adapter. Its
+	// implementation belongs to the navigation task; this package only names
+	// the configured boundary.
+	NavigationAdapterAIRACNet = "airacnet"
+)
+
+var airportIdentifier = regexp.MustCompile(`^[A-Z]{4}$`)
+
+// RuntimeConfig is the application configuration for one AMAN runtime. The
+// zero value is intentionally release-safe: AMAN remains disabled.
+type RuntimeConfig struct {
+	EnabledAirports             []string
+	Mode                        RolloutMode
+	ReconciliationInterval      time.Duration
+	SurveillanceInterval        time.Duration
+	TerminalGeometryPath        string
+	NavigationSourceAdapter     string
+	EnableEuroScopeGainLoseTags bool
+}
+
+// DefaultRuntimeConfig returns the release-safe runtime configuration.
+func DefaultRuntimeConfig() RuntimeConfig {
+	return RuntimeConfig{
+		Mode:                   ModeDisabled,
+		ReconciliationInterval: defaultReconciliationInterval,
+		SurveillanceInterval:   defaultSurveillanceInterval,
+	}
+}
+
+func (c RuntimeConfig) withDefaults() RuntimeConfig {
+	defaults := DefaultRuntimeConfig()
+	if c.Mode == "" {
+		c.Mode = defaults.Mode
+	}
+	if c.ReconciliationInterval == 0 {
+		c.ReconciliationInterval = defaults.ReconciliationInterval
+	}
+	if c.SurveillanceInterval == 0 {
+		c.SurveillanceInterval = defaults.SurveillanceInterval
+	}
+	return c
+}
+
+// Validate rejects configuration that would make an enabled AMAN runtime
+// ambiguous or unusable. Disabled AMAN accepts its zero-value configuration.
+func (c RuntimeConfig) Validate() error {
+	c = c.withDefaults()
+	if !c.Mode.Valid() {
+		return fmt.Errorf("AMAN mode %q is invalid", c.Mode)
+	}
+	if c.ReconciliationInterval <= 0 {
+		return fmt.Errorf("AMAN reconciliation interval must be greater than 0")
+	}
+	if c.SurveillanceInterval <= 0 {
+		return fmt.Errorf("AMAN surveillance interval must be greater than 0")
+	}
+
+	airports := normalizeAirports(c.EnabledAirports)
+	if len(airports) != len(nonEmpty(c.EnabledAirports)) {
+		return fmt.Errorf("AMAN enabled airports must be unique ICAO identifiers")
+	}
+	seenAirports := make(map[string]struct{}, len(airports))
+	for _, airport := range airports {
+		if !airportIdentifier.MatchString(airport) {
+			return fmt.Errorf("AMAN airport %q must be a four-letter ICAO identifier", airport)
+		}
+		if _, exists := seenAirports[airport]; exists {
+			return fmt.Errorf("AMAN enabled airports must be unique ICAO identifiers")
+		}
+		seenAirports[airport] = struct{}{}
+	}
+	if c.NavigationSourceAdapter != "" && !isSupportedNavigationAdapter(c.NavigationSourceAdapter) {
+		return fmt.Errorf("AMAN navigation source adapter %q is unsupported", c.NavigationSourceAdapter)
+	}
+	if c.Mode == ModeDisabled {
+		return nil
+	}
+	if len(airports) == 0 {
+		return fmt.Errorf("AMAN enabled airports are required when mode is %q", c.Mode)
+	}
+	if !isSupportedNavigationAdapter(c.NavigationSourceAdapter) {
+		return fmt.Errorf("AMAN navigation source adapter %q is unsupported", c.NavigationSourceAdapter)
+	}
+	if strings.TrimSpace(c.TerminalGeometryPath) == "" {
+		return fmt.Errorf("AMAN terminal geometry path is required when enabled")
+	}
+	return nil
+}
+
+func normalizeAirports(values []string) []string {
+	airports := make([]string, 0, len(values))
+	for _, value := range values {
+		airport := strings.ToUpper(strings.TrimSpace(value))
+		if airport != "" {
+			airports = append(airports, airport)
+		}
+	}
+	return airports
+}
+
+func nonEmpty(values []string) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func isSupportedNavigationAdapter(value string) bool {
+	return strings.EqualFold(strings.TrimSpace(value), NavigationAdapterAIRACNet)
+}
+
+// Component is a narrow constructor-time seam. The owning persistence,
+// navigation, prediction, state, sequence, publishing, validation, and health
+// tasks provide concrete components without a package-level registry.
+type Component interface {
+	Name() string
+}
+
+// Worker is a cancellation-aware AMAN loop. The runtime owns its lifecycle;
+// concrete source and reconciliation implementations stay outside this task.
+type Worker interface {
+	Run(context.Context, time.Duration)
+}
+
+// Dependencies are injected by application assembly. Keeping these boundaries
+// explicit lets later AMAN tasks add concrete implementations without changing
+// startup ownership or adding a service locator.
+type Dependencies struct {
+	Repositories            Component
+	NavigationMaterializer  Component
+	NavigationReader        Component
+	Predictor               Component
+	StateEngine             Component
+	SequenceService         Component
+	Publisher               Component
+	ValidationService       Component
+	HealthService           Component
+	NavigationRefreshWorker Worker
+	ReconciliationWorker    Worker
+}
+
+// Ownership describes the runtime authority selected by rollout mode.
+type Ownership struct {
+	LegacyArrivalETAWriter       bool
+	AMANArrivalETAWriter         bool
+	SequenceAuthoritative        bool
+	ControllerMutationAuthorized bool
+	EuroScopeGainLoseTagsEnabled bool
+}
+
+// Runtime owns AMAN mode and worker lifecycle. It deliberately does not
+// implement navigation, prediction, persistence, or sequencing policy.
+type Runtime struct {
+	config    RuntimeConfig
+	deps      Dependencies
+	ownership Ownership
+}
+
+// NewRuntime validates the rollout configuration and all required explicit
+// dependencies before workers can start.
+func NewRuntime(config RuntimeConfig, deps Dependencies) (*Runtime, error) {
+	config = config.withDefaults()
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+	runtime := &Runtime{config: config, deps: deps, ownership: ownershipFor(config)}
+	if config.Mode == ModeDisabled {
+		return runtime, nil
+	}
+	for _, dependency := range []struct {
+		name  string
+		value Component
+	}{
+		{"repositories", deps.Repositories},
+		{"navigation materializer", deps.NavigationMaterializer},
+		{"navigation reader", deps.NavigationReader},
+		{"predictor", deps.Predictor},
+		{"state engine", deps.StateEngine},
+		{"sequence service", deps.SequenceService},
+		{"publisher", deps.Publisher},
+		{"validation service", deps.ValidationService},
+		{"health service", deps.HealthService},
+	} {
+		if dependency.value == nil || strings.TrimSpace(dependency.value.Name()) == "" {
+			return nil, fmt.Errorf("AMAN runtime requires %s", dependency.name)
+		}
+	}
+	if deps.NavigationRefreshWorker == nil {
+		return nil, fmt.Errorf("AMAN runtime requires navigation refresh worker")
+	}
+	if deps.ReconciliationWorker == nil {
+		return nil, fmt.Errorf("AMAN runtime requires reconciliation worker")
+	}
+	return runtime, nil
+}
+
+func ownershipFor(config RuntimeConfig) Ownership {
+	ownership := Ownership{EuroScopeGainLoseTagsEnabled: config.EnableEuroScopeGainLoseTags}
+	switch config.Mode {
+	case ModeDisabled, ModeShadow:
+		ownership.LegacyArrivalETAWriter = true
+	case ModeReadOnly:
+		ownership.AMANArrivalETAWriter = true
+	case ModeAuthoritative:
+		ownership.AMANArrivalETAWriter = true
+		ownership.SequenceAuthoritative = true
+		ownership.ControllerMutationAuthorized = true
+	}
+	return ownership
+}
+
+// Config returns a copy of the normalized configuration.
+func (r *Runtime) Config() RuntimeConfig {
+	if r == nil {
+		return DefaultRuntimeConfig()
+	}
+	config := r.config
+	config.EnabledAirports = slices.Clone(config.EnabledAirports)
+	return config
+}
+
+func (r *Runtime) Ownership() Ownership {
+	if r == nil {
+		return ownershipFor(DefaultRuntimeConfig())
+	}
+	return r.ownership
+}
+
+func (r *Runtime) Enabled() bool {
+	return r != nil && r.config.Mode != ModeDisabled
+}
+
+// Start runs only the configured AMAN loops. Both workers receive the same
+// application context, so normal application cancellation shuts them down.
+func (r *Runtime) Start(ctx context.Context) {
+	if !r.Enabled() {
+		return
+	}
+	go r.deps.NavigationRefreshWorker.Run(ctx, r.config.SurveillanceInterval)
+	go r.deps.ReconciliationWorker.Run(ctx, r.config.ReconciliationInterval)
+}

--- a/backend/internal/aman/runtime_test.go
+++ b/backend/internal/aman/runtime_test.go
@@ -43,17 +43,17 @@ func validRuntimeConfig(mode RolloutMode) RuntimeConfig {
 func runtimeTestDependencies() Dependencies {
 	component := runtimeTestComponent("test component")
 	return Dependencies{
-		Repositories:            component,
-		NavigationMaterializer:  component,
-		NavigationReader:        component,
-		Predictor:               component,
-		StateEngine:             component,
-		SequenceService:         component,
-		Publisher:               component,
-		ValidationService:       component,
-		HealthService:           component,
-		NavigationRefreshWorker: newRuntimeTestWorker(),
-		ReconciliationWorker:    newRuntimeTestWorker(),
+		Repositories:           component,
+		NavigationMaterializer: component,
+		NavigationReader:       component,
+		Predictor:              component,
+		StateEngine:            component,
+		SequenceService:        component,
+		Publisher:              component,
+		ValidationService:      component,
+		HealthService:          component,
+		SurveillanceWorker:     newRuntimeTestWorker(),
+		ReconciliationWorker:   newRuntimeTestWorker(),
 	}
 }
 
@@ -85,7 +85,7 @@ func TestRuntimeRejectsInvalidConfiguration(t *testing.T) {
 		want   string
 	}{
 		{"airport", func(c *RuntimeConfig) { c.EnabledAirports = []string{"bad"} }, "ICAO"},
-		{"duplicate airport", func(c *RuntimeConfig) { c.EnabledAirports = []string{"EKCH", "ekch"} }, "unique"},
+		{"duplicate airport", func(c *RuntimeConfig) { c.EnabledAirports = []string{" EKCH ", "ekch"} }, "unique"},
 		{"reconciliation timing", func(c *RuntimeConfig) { c.ReconciliationInterval = -time.Second }, "reconciliation interval"},
 		{"surveillance timing", func(c *RuntimeConfig) { c.SurveillanceInterval = -time.Second }, "surveillance interval"},
 		{"source adapter", func(c *RuntimeConfig) { c.NavigationSourceAdapter = "other" }, "source adapter"},
@@ -117,12 +117,12 @@ func TestRuntimeWorkersUseApplicationContextAndConfiguredIntervals(t *testing.T)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	runtime.Start(ctx)
-	require.Equal(t, 4*time.Second, <-deps.NavigationRefreshWorker.(*runtimeTestWorker).started)
+	require.Equal(t, 4*time.Second, <-deps.SurveillanceWorker.(*runtimeTestWorker).started)
 	require.Equal(t, 3*time.Second, <-deps.ReconciliationWorker.(*runtimeTestWorker).started)
 	cancel()
 	require.Eventually(t, func() bool {
 		select {
-		case <-deps.NavigationRefreshWorker.(*runtimeTestWorker).stopped:
+		case <-deps.SurveillanceWorker.(*runtimeTestWorker).stopped:
 			return true
 		default:
 			return false
@@ -136,6 +136,25 @@ func TestRuntimeWorkersUseApplicationContextAndConfiguredIntervals(t *testing.T)
 			return false
 		}
 	}, time.Second, 10*time.Millisecond)
+}
+
+func TestRuntimeStoresNormalizedConfiguration(t *testing.T) {
+	config := validRuntimeConfig(ModeShadow)
+	config.Mode = " SHADOW "
+	config.EnabledAirports = []string{" ekch ", "ekrn"}
+	config.NavigationSourceAdapter = " AIRACNET "
+	config.TerminalGeometryPath = " testdata/terminal.geojson "
+
+	runtime, err := NewRuntime(config, runtimeTestDependencies())
+	require.NoError(t, err)
+	require.Equal(t, RuntimeConfig{
+		Mode:                    ModeShadow,
+		EnabledAirports:         []string{"EKCH", "EKRN"},
+		ReconciliationInterval:  3 * time.Second,
+		SurveillanceInterval:    4 * time.Second,
+		TerminalGeometryPath:    "testdata/terminal.geojson",
+		NavigationSourceAdapter: NavigationAdapterAIRACNet,
+	}, runtime.Config())
 }
 
 func TestRuntimeOwnershipFollowsRolloutMode(t *testing.T) {

--- a/backend/internal/aman/runtime_test.go
+++ b/backend/internal/aman/runtime_test.go
@@ -1,0 +1,167 @@
+package aman
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type runtimeTestComponent string
+
+func (c runtimeTestComponent) Name() string { return string(c) }
+
+type runtimeTestWorker struct {
+	started chan time.Duration
+	stopped chan struct{}
+	once    sync.Once
+}
+
+func newRuntimeTestWorker() *runtimeTestWorker {
+	return &runtimeTestWorker{started: make(chan time.Duration, 1), stopped: make(chan struct{})}
+}
+
+func (w *runtimeTestWorker) Run(ctx context.Context, interval time.Duration) {
+	w.started <- interval
+	<-ctx.Done()
+	w.once.Do(func() { close(w.stopped) })
+}
+
+func validRuntimeConfig(mode RolloutMode) RuntimeConfig {
+	return RuntimeConfig{
+		Mode:                    mode,
+		EnabledAirports:         []string{"EKCH"},
+		TerminalGeometryPath:    "testdata/terminal.geojson",
+		NavigationSourceAdapter: NavigationAdapterAIRACNet,
+		ReconciliationInterval:  3 * time.Second,
+		SurveillanceInterval:    4 * time.Second,
+	}
+}
+
+func runtimeTestDependencies() Dependencies {
+	component := runtimeTestComponent("test component")
+	return Dependencies{
+		Repositories:            component,
+		NavigationMaterializer:  component,
+		NavigationReader:        component,
+		Predictor:               component,
+		StateEngine:             component,
+		SequenceService:         component,
+		Publisher:               component,
+		ValidationService:       component,
+		HealthService:           component,
+		NavigationRefreshWorker: newRuntimeTestWorker(),
+		ReconciliationWorker:    newRuntimeTestWorker(),
+	}
+}
+
+func TestDefaultRuntimeConfigIsDisabledAndReleaseSafe(t *testing.T) {
+	config := DefaultRuntimeConfig()
+	require.Equal(t, ModeDisabled, config.Mode)
+	require.NoError(t, config.Validate())
+
+	runtime, err := NewRuntime(RuntimeConfig{}, Dependencies{})
+	require.NoError(t, err)
+	require.False(t, runtime.Enabled())
+	require.True(t, runtime.Ownership().LegacyArrivalETAWriter)
+}
+
+func TestRuntimeAcceptsAllConfiguredModes(t *testing.T) {
+	for _, mode := range []RolloutMode{ModeShadow, ModeReadOnly, ModeAuthoritative} {
+		t.Run(string(mode), func(t *testing.T) {
+			runtime, err := NewRuntime(validRuntimeConfig(mode), runtimeTestDependencies())
+			require.NoError(t, err)
+			require.True(t, runtime.Enabled())
+		})
+	}
+}
+
+func TestRuntimeRejectsInvalidConfiguration(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*RuntimeConfig)
+		want   string
+	}{
+		{"airport", func(c *RuntimeConfig) { c.EnabledAirports = []string{"bad"} }, "ICAO"},
+		{"duplicate airport", func(c *RuntimeConfig) { c.EnabledAirports = []string{"EKCH", "ekch"} }, "unique"},
+		{"reconciliation timing", func(c *RuntimeConfig) { c.ReconciliationInterval = -time.Second }, "reconciliation interval"},
+		{"surveillance timing", func(c *RuntimeConfig) { c.SurveillanceInterval = -time.Second }, "surveillance interval"},
+		{"source adapter", func(c *RuntimeConfig) { c.NavigationSourceAdapter = "other" }, "source adapter"},
+		{"geometry", func(c *RuntimeConfig) { c.TerminalGeometryPath = "" }, "geometry path"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := validRuntimeConfig(ModeShadow)
+			test.mutate(&config)
+			require.ErrorContains(t, config.Validate(), test.want)
+		})
+	}
+}
+
+func TestDisabledRuntimeRejectsAnExplicitInvalidSourceAdapter(t *testing.T) {
+	err := (RuntimeConfig{NavigationSourceAdapter: "other"}).Validate()
+	require.ErrorContains(t, err, "source adapter")
+}
+
+func TestRuntimeRequiresExplicitDependenciesWhenEnabled(t *testing.T) {
+	_, err := NewRuntime(validRuntimeConfig(ModeShadow), Dependencies{})
+	require.EqualError(t, err, "AMAN runtime requires repositories")
+}
+
+func TestRuntimeWorkersUseApplicationContextAndConfiguredIntervals(t *testing.T) {
+	deps := runtimeTestDependencies()
+	runtime, err := NewRuntime(validRuntimeConfig(ModeShadow), deps)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runtime.Start(ctx)
+	require.Equal(t, 4*time.Second, <-deps.NavigationRefreshWorker.(*runtimeTestWorker).started)
+	require.Equal(t, 3*time.Second, <-deps.ReconciliationWorker.(*runtimeTestWorker).started)
+	cancel()
+	require.Eventually(t, func() bool {
+		select {
+		case <-deps.NavigationRefreshWorker.(*runtimeTestWorker).stopped:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool {
+		select {
+		case <-deps.ReconciliationWorker.(*runtimeTestWorker).stopped:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestRuntimeOwnershipFollowsRolloutMode(t *testing.T) {
+	tests := []struct {
+		mode             RolloutMode
+		legacy, amanETA  bool
+		sequence, mutate bool
+	}{
+		{mode: ModeDisabled, legacy: true},
+		{mode: ModeShadow, legacy: true},
+		{mode: ModeReadOnly, amanETA: true},
+		{mode: ModeAuthoritative, amanETA: true, sequence: true, mutate: true},
+	}
+	for _, test := range tests {
+		t.Run(string(test.mode), func(t *testing.T) {
+			config := validRuntimeConfig(test.mode)
+			if test.mode == ModeDisabled {
+				config = RuntimeConfig{}
+			}
+			runtime, err := NewRuntime(config, runtimeTestDependencies())
+			require.NoError(t, err)
+			ownership := runtime.Ownership()
+			require.Equal(t, test.legacy, ownership.LegacyArrivalETAWriter)
+			require.Equal(t, test.amanETA, ownership.AMANArrivalETAWriter)
+			require.Equal(t, test.sequence, ownership.SequenceAuthoritative)
+			require.Equal(t, test.mutate, ownership.ControllerMutationAuthorized)
+		})
+	}
+}

--- a/backend/internal/app/aman_runtime_test.go
+++ b/backend/internal/app/aman_runtime_test.go
@@ -36,17 +36,17 @@ func (w *amanAppTestWorker) Run(ctx context.Context, _ time.Duration) {
 func amanAppTestDependencies() aman.Dependencies {
 	component := amanAppTestComponent("injected test component")
 	return aman.Dependencies{
-		Repositories:            component,
-		NavigationMaterializer:  component,
-		NavigationReader:        component,
-		Predictor:               component,
-		StateEngine:             component,
-		SequenceService:         component,
-		Publisher:               component,
-		ValidationService:       component,
-		HealthService:           component,
-		NavigationRefreshWorker: newAMANAppTestWorker(),
-		ReconciliationWorker:    newAMANAppTestWorker(),
+		Repositories:           component,
+		NavigationMaterializer: component,
+		NavigationReader:       component,
+		Predictor:              component,
+		StateEngine:            component,
+		SequenceService:        component,
+		Publisher:              component,
+		ValidationService:      component,
+		HealthService:          component,
+		SurveillanceWorker:     newAMANAppTestWorker(),
+		ReconciliationWorker:   newAMANAppTestWorker(),
 	}
 }
 
@@ -108,13 +108,13 @@ func TestBuildAddsAMANWorkersOnlyWhenEnabled(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	application.StartWorkers(ctx)
-	refresh := amanDeps.NavigationRefreshWorker.(*amanAppTestWorker)
+	surveillance := amanDeps.SurveillanceWorker.(*amanAppTestWorker)
 	reconcile := amanDeps.ReconciliationWorker.(*amanAppTestWorker)
-	require.Eventually(t, func() bool { return len(refresh.started) == 1 && len(reconcile.started) == 1 }, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool { return len(surveillance.started) == 1 && len(reconcile.started) == 1 }, time.Second, 10*time.Millisecond)
 	cancel()
 	require.Eventually(t, func() bool {
 		select {
-		case <-refresh.stopped:
+		case <-surveillance.stopped:
 			return true
 		default:
 			return false

--- a/backend/internal/app/aman_runtime_test.go
+++ b/backend/internal/app/aman_runtime_test.go
@@ -1,0 +1,123 @@
+package app
+
+import (
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/services"
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+type amanAppTestComponent string
+
+func (c amanAppTestComponent) Name() string { return string(c) }
+
+type amanAppTestWorker struct {
+	started chan struct{}
+	stopped chan struct{}
+	once    sync.Once
+}
+
+func newAMANAppTestWorker() *amanAppTestWorker {
+	return &amanAppTestWorker{started: make(chan struct{}, 1), stopped: make(chan struct{})}
+}
+
+func (w *amanAppTestWorker) Run(ctx context.Context, _ time.Duration) {
+	w.started <- struct{}{}
+	<-ctx.Done()
+	w.once.Do(func() { close(w.stopped) })
+}
+
+func amanAppTestDependencies() aman.Dependencies {
+	component := amanAppTestComponent("injected test component")
+	return aman.Dependencies{
+		Repositories:            component,
+		NavigationMaterializer:  component,
+		NavigationReader:        component,
+		Predictor:               component,
+		StateEngine:             component,
+		SequenceService:         component,
+		Publisher:               component,
+		ValidationService:       component,
+		HealthService:           component,
+		NavigationRefreshWorker: newAMANAppTestWorker(),
+		ReconciliationWorker:    newAMANAppTestWorker(),
+	}
+}
+
+func TestValidateAMANTerminalGeometry(t *testing.T) {
+	tempFile, err := os.CreateTemp(t.TempDir(), "terminal-*.geojson")
+	require.NoError(t, err)
+	require.NoError(t, tempFile.Close())
+
+	require.NoError(t, validateAMANTerminalGeometry(aman.RuntimeConfig{}))
+	require.NoError(t, validateAMANTerminalGeometry(aman.RuntimeConfig{Mode: aman.ModeShadow, TerminalGeometryPath: tempFile.Name()}))
+	require.ErrorContains(t, validateAMANTerminalGeometry(aman.RuntimeConfig{Mode: aman.ModeShadow, TerminalGeometryPath: t.TempDir()}), "must name a file")
+	require.ErrorContains(t, validateAMANTerminalGeometry(aman.RuntimeConfig{Mode: aman.ModeShadow, TerminalGeometryPath: "missing.geojson"}), "terminal geometry path")
+	require.ErrorContains(t, validateAMANTerminalGeometry(aman.RuntimeConfig{TerminalGeometryPath: "missing.geojson"}), "terminal geometry path")
+}
+
+func TestApplicationConfigDefaultsAMANToDisabled(t *testing.T) {
+	config := (Config{}).withDefaults()
+	require.Equal(t, aman.ModeDisabled, config.AMAN.Mode)
+}
+
+func TestBuildAddsAMANWorkersOnlyWhenEnabled(t *testing.T) {
+	poolConfig, err := pgxpool.ParseConfig("postgres://user:password@127.0.0.1:1/test")
+	require.NoError(t, err)
+	dbPool, err := pgxpool.NewWithConfig(context.Background(), poolConfig)
+	require.NoError(t, err)
+	t.Cleanup(dbPool.Close)
+	geometry, err := os.CreateTemp(t.TempDir(), "terminal-*.geojson")
+	require.NoError(t, err)
+	require.NoError(t, geometry.Close())
+	amanDeps := amanAppTestDependencies()
+
+	application, err := Build(context.Background(), Config{
+		Environment:          "test",
+		EnableCDMConfigStore: false,
+		EnablePDC:            false,
+		EnableECFMP:          false,
+		EnableECFMPAPI:       false,
+		EnablePilotAPI:       false,
+		EnableALB:            false,
+		EnableMetar:          false,
+		EnableVATSIM:         false,
+		EnableTraffic:        false,
+		EnableDBSeed:         false,
+		AMAN: aman.RuntimeConfig{
+			Mode:                    aman.ModeShadow,
+			EnabledAirports:         []string{"EKCH"},
+			TerminalGeometryPath:    geometry.Name(),
+			NavigationSourceAdapter: aman.NavigationAdapterAIRACNet,
+		},
+	}, Dependencies{
+		DBPool:                dbPool,
+		AuthenticationService: services.NewTestAuthenticationService(),
+		AMAN:                  amanDeps,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, application.AMANRuntime())
+	require.True(t, application.AMANRuntime().Ownership().LegacyArrivalETAWriter)
+	require.Len(t, application.workers, 5)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	application.StartWorkers(ctx)
+	refresh := amanDeps.NavigationRefreshWorker.(*amanAppTestWorker)
+	reconcile := amanDeps.ReconciliationWorker.(*amanAppTestWorker)
+	require.Eventually(t, func() bool { return len(refresh.started) == 1 && len(reconcile.started) == 1 }, time.Second, 10*time.Millisecond)
+	cancel()
+	require.Eventually(t, func() bool {
+		select {
+		case <-refresh.stopped:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+}

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"FlightStrips/internal/alb"
+	"FlightStrips/internal/aman"
 	"FlightStrips/internal/cdm"
 	appconfig "FlightStrips/internal/config"
 	"FlightStrips/internal/database"
@@ -31,6 +32,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -81,6 +83,8 @@ type Config struct {
 	StandAssignmentHoldDuration   time.Duration
 	StandAssignmentBlockExtension time.Duration
 	StandAssignmentSweepInterval  time.Duration
+
+	AMAN aman.RuntimeConfig
 }
 
 type Dependencies struct {
@@ -91,6 +95,7 @@ type Dependencies struct {
 	VATSIMPollInterval    time.Duration
 	TransceiversURL       string
 	TransceiversInterval  time.Duration
+	AMAN                  aman.Dependencies
 }
 
 type App struct {
@@ -100,12 +105,20 @@ type App struct {
 	workers                  []func(context.Context)
 	startWorkers             sync.Once
 	standAssignmentReadiness appconfig.StandAssignmentReadiness
+	amanRuntime              *aman.Runtime
 }
 
 func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	cfg = cfg.withDefaults()
 	if cfg.EnableTestTools && isLiveEnvironment(cfg.Environment) {
 		return nil, errors.New("ENABLE_TEST_TOOLS cannot be enabled in a live environment")
+	}
+	if err := validateAMANTerminalGeometry(cfg.AMAN); err != nil {
+		return nil, err
+	}
+	amanRuntime, err := aman.NewRuntime(cfg.AMAN, deps.AMAN)
+	if err != nil {
+		return nil, fmt.Errorf("initialize AMAN runtime: %w", err)
 	}
 	standAssignmentReadiness := configureStandAssignment(cfg.EnableStandAssignment, cfg.StandAssignmentAircraftJSON)
 	var testClock *testtools.Clock
@@ -224,7 +237,7 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 			DepartureLifecycle: departureLifecycle,
 			ArrivalLifecycle:   arrivalLifecycle,
 			Notifier:           frontendHub,
-		}, deps.VATSIMPollInterval, vatsim.WithAirportCoordinates(latitude, longitude), vatsim.WithClock(satNow))
+		}, deps.VATSIMPollInterval, vatsim.WithAirportCoordinates(latitude, longitude), vatsim.WithClock(satNow), vatsim.WithLegacyArrivalETAWriter(amanRuntime.Ownership().LegacyArrivalETAWriter))
 		if err != nil {
 			if closeDB {
 				dbpool.Close()
@@ -347,6 +360,7 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 		dbpool:                   dbpool,
 		closeDB:                  closeDB,
 		standAssignmentReadiness: standAssignmentReadiness,
+		amanRuntime:              amanRuntime,
 		handler: buildHandler(buildHandlerConfig{
 			authService:  authService,
 			frontendHub:  frontendHub,
@@ -417,6 +431,9 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	if cfg.EnableTraffic {
 		trafficMetrics := services.NewTrafficMetricsService(sessionRepo, stripRepo)
 		app.addWorker(trafficMetrics.Start)
+	}
+	if amanRuntime.Enabled() {
+		app.addWorker(amanRuntime.Start)
 	}
 
 	return app, nil
@@ -550,6 +567,32 @@ func assembleRealtime(stripService shared.StripService, controllerService shared
 // state instead of independently reading environment configuration.
 func (a *App) StandAssignmentReadiness() appconfig.StandAssignmentReadiness {
 	return a.standAssignmentReadiness
+}
+
+// AMANRuntime returns the application's AMAN lifecycle and ownership state.
+func (a *App) AMANRuntime() *aman.Runtime {
+	if a == nil {
+		return nil
+	}
+	return a.amanRuntime
+}
+
+func validateAMANTerminalGeometry(config aman.RuntimeConfig) error {
+	path := strings.TrimSpace(config.TerminalGeometryPath)
+	if (config.Mode == "" || config.Mode == aman.ModeDisabled) && path == "" {
+		return nil
+	}
+	if path == "" {
+		return fmt.Errorf("AMAN terminal geometry path is required when enabled")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("AMAN terminal geometry path %q: %w", path, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("AMAN terminal geometry path %q must name a file", path)
+	}
+	return nil
 }
 
 func configureStandAssignment(enabled bool, aircraftFile string) appconfig.StandAssignmentReadiness {
@@ -915,6 +958,9 @@ func satStaleAfter(poll time.Duration) time.Duration {
 }
 
 func (cfg Config) withDefaults() Config {
+	if cfg.AMAN.Mode == "" {
+		cfg.AMAN.Mode = aman.ModeDisabled
+	}
 	if cfg.OIDCAudience == "" {
 		cfg.OIDCAudience = "backend-dev"
 	}

--- a/backend/internal/vatsim/arrival_eta.go
+++ b/backend/internal/vatsim/arrival_eta.go
@@ -31,6 +31,15 @@ type AirportCoordinates struct {
 // not need a live calculation or a controlled clock.
 type ArrivalETAOption func(*Reconciler)
 
+// WithLegacyArrivalETAWriter controls whether VATSIM reconciliation owns the
+// accepted ArrivalETA field. AMAN read-only and authoritative modes disable
+// this legacy writer before reconciliation begins.
+func WithLegacyArrivalETAWriter(enabled bool) ArrivalETAOption {
+	return func(r *Reconciler) {
+		r.legacyArrivalETAWriter = enabled
+	}
+}
+
 // WithAirportCoordinates enables live ETA calculation against the configured
 // airport location.
 func WithAirportCoordinates(latitude, longitude float64) ArrivalETAOption {

--- a/backend/internal/vatsim/arrival_eta_ownership_test.go
+++ b/backend/internal/vatsim/arrival_eta_ownership_test.go
@@ -1,0 +1,16 @@
+package vatsim
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLegacyArrivalETAWriterDefaultsOnAndCanBeDisabled(t *testing.T) {
+	base := newReconciler(nil, nil, nil, nil, nil, nil, nil, time.Second)
+	require.True(t, base.legacyArrivalETAWriter)
+
+	disabled := newReconciler(nil, nil, nil, nil, nil, nil, nil, time.Second, WithLegacyArrivalETAWriter(false))
+	require.False(t, disabled.legacyArrivalETAWriter)
+}

--- a/backend/internal/vatsim/reconciliation.go
+++ b/backend/internal/vatsim/reconciliation.go
@@ -86,16 +86,17 @@ type reconciliationNotifier interface {
 // session. It deliberately owns only feed fields; operational state remains
 // controller/EuroScope owned.
 type Reconciler struct {
-	cache              SnapshotSource
-	sessions           reconciliationSessionStore
-	strips             reconciliationStripStore
-	assignments        reconciliationAssignmentStore
-	lifecycle          DepartureLifecycle
-	arrivalLifecycle   ArrivalLifecycle
-	notifier           reconciliationNotifier
-	interval           time.Duration
-	airportCoordinates AirportCoordinates
-	now                func() time.Time
+	cache                  SnapshotSource
+	sessions               reconciliationSessionStore
+	strips                 reconciliationStripStore
+	assignments            reconciliationAssignmentStore
+	lifecycle              DepartureLifecycle
+	arrivalLifecycle       ArrivalLifecycle
+	notifier               reconciliationNotifier
+	interval               time.Duration
+	airportCoordinates     AirportCoordinates
+	legacyArrivalETAWriter bool
+	now                    func() time.Time
 }
 
 type ReconcilerDependencies struct {
@@ -148,6 +149,7 @@ func newReconciler(cache SnapshotSource, sessions reconciliationSessionStore, st
 		cache: cache, sessions: sessions, strips: strips, assignments: assignments,
 		lifecycle: departureLifecycle, arrivalLifecycle: arrivalLifecycle,
 		notifier: notifier, interval: interval, now: time.Now,
+		legacyArrivalETAWriter: true,
 	}
 	for _, option := range options {
 		option(reconciler)
@@ -271,11 +273,13 @@ func (r *Reconciler) reconcileSession(ctx context.Context, snapshot Snapshot, se
 			}
 		}
 		if strings.EqualFold(strings.TrimSpace(flight.FlightPlan.Destination), airport) {
-			etaChanged, err := r.updateArrivalETA(ctx, session.ID, strip, flight)
-			if err != nil {
-				return err
+			if r.legacyArrivalETAWriter {
+				etaChanged, err := r.updateArrivalETA(ctx, session.ID, strip, flight)
+				if err != nil {
+					return err
+				}
+				changed = etaChanged || changed
 			}
-			changed = etaChanged || changed
 		}
 		if changed {
 			changedCount++


### PR DESCRIPTION
## What

- Adds typed AMAN runtime configuration with release-safe disabled defaults and startup validation.
- Wires explicit AMAN component and worker dependencies into application startup.
- Applies disabled, shadow, read-only, and authoritative ETA/sequence ownership and cancellation-driven worker lifecycle.

## Why

Establishes the runtime foundation for AMAN without introducing navigation, prediction, persistence, or transport implementations owned by later tasks.

## Impact

Disabled remains the default and preserves the legacy ArrivalETA writer. Shadow computes only through injected AMAN workers; read-only and authoritative reserve ArrivalETA ownership for AMAN.

## Checks

- `go test ./internal/aman ./internal/vatsim ./internal/app ./cmd/server`
- `go test ./...` (from `backend`)

Closes #305