### PR TITLE
feat(aman): publish VATSIM observations

### DIFF
--- a/backend/internal/aman/persistence.go
+++ b/backend/internal/aman/persistence.go
@@ -85,6 +85,43 @@ type ValidationEvidenceReader interface {
 	ListValidationEvidence(context.Context, string) ([]ValidationEvidence, error)
 }
 
+// ObservationSink receives normalized provider-neutral facts before prediction
+// or sequencing. Source adapters own their delivery scheduling; AMAN owners
+// decide how an accepted observation changes the aggregate.
+type ObservationSink interface {
+	Observe(context.Context, FlightObservation) error
+}
+
+// VATSIMFlightIdentityBinder is the narrow durable identity capability needed
+// by a VATSIM observation adapter. It finds the active binding for a stable
+// VATSIM CID, so a corrected callsign never rekeys an active AMAN flight.
+//
+// It deliberately does not offer aliases, merges, tombstones, or a general
+// identity lookup API.
+type VATSIMFlightIdentityBinder interface {
+	BindVATSIMFlight(context.Context, VATSIMFlightIdentity) (FlightID, error)
+}
+
+// VATSIMFlightIdentityRetirer releases an active CID binding once the AMAN
+// lifecycle removes that flight. Lifecycle policy owns when to invoke this;
+// this narrow repository seam only makes a later flight from the same CID able
+// to receive a new generated FlightID.
+type VATSIMFlightIdentityRetirer interface {
+	RetireVATSIMFlight(context.Context, FlightID) error
+}
+
+type VATSIMFlightIdentity struct {
+	VATSIMCID       string
+	CurrentCallsign string
+}
+
+func (i VATSIMFlightIdentity) Validate() error {
+	if !isTrimmedNonEmpty(i.VATSIMCID) || !isTrimmedNonEmpty(i.CurrentCallsign) {
+		return invalid("VATSIM flight identity is incomplete")
+	}
+	return nil
+}
+
 func (c StateCommit) Validate() error {
 	if err := c.State.Validate(); err != nil {
 		return err

--- a/backend/internal/aman/runtime.go
+++ b/backend/internal/aman/runtime.go
@@ -162,6 +162,7 @@ type Dependencies struct {
 	Publisher              Component
 	ValidationService      Component
 	HealthService          Component
+	ObservationSink        ObservationSink
 	SurveillanceWorker     Worker
 	ReconciliationWorker   Worker
 }
@@ -217,6 +218,9 @@ func NewRuntime(config RuntimeConfig, deps Dependencies) (*Runtime, error) {
 	}
 	if deps.ReconciliationWorker == nil {
 		return nil, fmt.Errorf("AMAN runtime requires reconciliation worker")
+	}
+	if deps.ObservationSink == nil {
+		return nil, fmt.Errorf("AMAN runtime requires observation sink")
 	}
 	return runtime, nil
 }

--- a/backend/internal/aman/runtime.go
+++ b/backend/internal/aman/runtime.go
@@ -143,8 +143,8 @@ type Component interface {
 	Name() string
 }
 
-// Worker is a cancellation-aware AMAN loop. The runtime owns its lifecycle;
-// concrete surveillance and reconciliation implementations stay outside this task.
+// Worker is a cancellation-aware AMAN reconciliation loop. The concrete source
+// observation worker is assembled independently by the application.
 type Worker interface {
 	Run(context.Context, time.Duration)
 }
@@ -163,7 +163,6 @@ type Dependencies struct {
 	ValidationService      Component
 	HealthService          Component
 	ObservationSink        ObservationSink
-	SurveillanceWorker     Worker
 	ReconciliationWorker   Worker
 }
 
@@ -213,9 +212,6 @@ func NewRuntime(config RuntimeConfig, deps Dependencies) (*Runtime, error) {
 			return nil, fmt.Errorf("AMAN runtime requires %s", dependency.name)
 		}
 	}
-	if deps.SurveillanceWorker == nil {
-		return nil, fmt.Errorf("AMAN runtime requires surveillance worker")
-	}
 	if deps.ReconciliationWorker == nil {
 		return nil, fmt.Errorf("AMAN runtime requires reconciliation worker")
 	}
@@ -261,14 +257,12 @@ func (r *Runtime) Enabled() bool {
 	return r != nil && r.config.Mode != ModeDisabled
 }
 
-// Start runs only the configured AMAN loops. Both workers receive the same
-// application context, so normal application cancellation shuts them down.
-// Surveillance is the source-observation loop; navigation materializer refresh
-// policy is deliberately outside this runtime.
+// Start runs the configured future AMAN reconciliation loop. The application
+// owns the concrete VATSIM source-observation worker so it cannot be started a
+// second time through this runtime.
 func (r *Runtime) Start(ctx context.Context) {
 	if !r.Enabled() {
 		return
 	}
-	go r.deps.SurveillanceWorker.Run(ctx, r.config.SurveillanceInterval)
 	go r.deps.ReconciliationWorker.Run(ctx, r.config.ReconciliationInterval)
 }

--- a/backend/internal/aman/runtime_test.go
+++ b/backend/internal/aman/runtime_test.go
@@ -13,6 +13,10 @@ type runtimeTestComponent string
 
 func (c runtimeTestComponent) Name() string { return string(c) }
 
+type runtimeTestObservationSink struct{}
+
+func (runtimeTestObservationSink) Observe(context.Context, FlightObservation) error { return nil }
+
 type runtimeTestWorker struct {
 	started chan time.Duration
 	stopped chan struct{}
@@ -52,6 +56,7 @@ func runtimeTestDependencies() Dependencies {
 		Publisher:              component,
 		ValidationService:      component,
 		HealthService:          component,
+		ObservationSink:        runtimeTestObservationSink{},
 		SurveillanceWorker:     newRuntimeTestWorker(),
 		ReconciliationWorker:   newRuntimeTestWorker(),
 	}

--- a/backend/internal/aman/runtime_test.go
+++ b/backend/internal/aman/runtime_test.go
@@ -57,7 +57,6 @@ func runtimeTestDependencies() Dependencies {
 		ValidationService:      component,
 		HealthService:          component,
 		ObservationSink:        runtimeTestObservationSink{},
-		SurveillanceWorker:     newRuntimeTestWorker(),
 		ReconciliationWorker:   newRuntimeTestWorker(),
 	}
 }
@@ -122,17 +121,8 @@ func TestRuntimeWorkersUseApplicationContextAndConfiguredIntervals(t *testing.T)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	runtime.Start(ctx)
-	require.Equal(t, 4*time.Second, <-deps.SurveillanceWorker.(*runtimeTestWorker).started)
 	require.Equal(t, 3*time.Second, <-deps.ReconciliationWorker.(*runtimeTestWorker).started)
 	cancel()
-	require.Eventually(t, func() bool {
-		select {
-		case <-deps.SurveillanceWorker.(*runtimeTestWorker).stopped:
-			return true
-		default:
-			return false
-		}
-	}, time.Second, 10*time.Millisecond)
 	require.Eventually(t, func() bool {
 		select {
 		case <-deps.ReconciliationWorker.(*runtimeTestWorker).stopped:

--- a/backend/internal/app/aman_runtime_test.go
+++ b/backend/internal/app/aman_runtime_test.go
@@ -17,6 +17,10 @@ type amanAppTestComponent string
 
 func (c amanAppTestComponent) Name() string { return string(c) }
 
+type amanAppTestObservationSink struct{}
+
+func (amanAppTestObservationSink) Observe(context.Context, aman.FlightObservation) error { return nil }
+
 type amanAppTestWorker struct {
 	started chan struct{}
 	stopped chan struct{}
@@ -45,6 +49,7 @@ func amanAppTestDependencies() aman.Dependencies {
 		Publisher:              component,
 		ValidationService:      component,
 		HealthService:          component,
+		ObservationSink:        amanAppTestObservationSink{},
 		SurveillanceWorker:     newAMANAppTestWorker(),
 		ReconciliationWorker:   newAMANAppTestWorker(),
 	}
@@ -87,7 +92,7 @@ func TestBuildAddsAMANWorkersOnlyWhenEnabled(t *testing.T) {
 		EnablePilotAPI:       false,
 		EnableALB:            false,
 		EnableMetar:          false,
-		EnableVATSIM:         false,
+		EnableVATSIM:         true,
 		EnableTraffic:        false,
 		EnableDBSeed:         false,
 		AMAN: aman.RuntimeConfig{
@@ -104,7 +109,7 @@ func TestBuildAddsAMANWorkersOnlyWhenEnabled(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, application.AMANRuntime())
 	require.True(t, application.AMANRuntime().Ownership().LegacyArrivalETAWriter)
-	require.Len(t, application.workers, 5)
+	require.Len(t, application.workers, 7)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	application.StartWorkers(ctx)

--- a/backend/internal/app/aman_runtime_test.go
+++ b/backend/internal/app/aman_runtime_test.go
@@ -50,7 +50,6 @@ func amanAppTestDependencies() aman.Dependencies {
 		ValidationService:      component,
 		HealthService:          component,
 		ObservationSink:        amanAppTestObservationSink{},
-		SurveillanceWorker:     newAMANAppTestWorker(),
 		ReconciliationWorker:   newAMANAppTestWorker(),
 	}
 }
@@ -113,13 +112,12 @@ func TestBuildAddsAMANWorkersOnlyWhenEnabled(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	application.StartWorkers(ctx)
-	surveillance := amanDeps.SurveillanceWorker.(*amanAppTestWorker)
 	reconcile := amanDeps.ReconciliationWorker.(*amanAppTestWorker)
-	require.Eventually(t, func() bool { return len(surveillance.started) == 1 && len(reconcile.started) == 1 }, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool { return len(reconcile.started) == 1 }, time.Second, 10*time.Millisecond)
 	cancel()
 	require.Eventually(t, func() bool {
 		select {
-		case <-surveillance.stopped:
+		case <-reconcile.stopped:
 			return true
 		default:
 			return false

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -178,7 +178,7 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	cdmClient := cdm.NewClient(cdm.WithAPIKey(cfg.CDMKey))
 
 	requireLiveCIDVerification := isLiveEnvironment(cfg.Environment)
-	vatsimGraph := assembleVATSIMSource(cfg, deps, requireLiveCIDVerification, standAssignmentReadiness.Ready)
+	vatsimGraph := assembleVATSIMSource(cfg, deps, requireLiveCIDVerification, standAssignmentReadiness.Ready || amanRuntime.Enabled())
 
 	var fsServer *server.Server
 	transports := assembleTransports(cfg, deps, func(ctx context.Context) error {
@@ -245,6 +245,25 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 			return nil, fmt.Errorf("initialize VATSIM reconciler: %w", err)
 		}
 		euroscopeHub.SetAircraftDisconnectRetainer(vatsimReconciler.RetainsStrip)
+	}
+	var amanObservationWorker *vatsim.ObservationWorker
+	if amanRuntime.Enabled() {
+		if vatsimGraph.source == nil {
+			if closeDB {
+				dbpool.Close()
+			}
+			return nil, errors.New("initialize AMAN VATSIM observations: VATSIM source is unavailable")
+		}
+		amanObservationWorker, err = vatsim.NewObservationWorker(vatsim.ObservationWorkerDependencies{
+			Cache: vatsimGraph.source, Identities: postgres.NewAMANRepository(dbpool), Sink: deps.AMAN.ObservationSink,
+			EnabledAirports: cfg.AMAN.EnabledAirports, StaleAfter: satStaleAfter(deps.VATSIMPollInterval), Now: satNow,
+		})
+		if err != nil {
+			if closeDB {
+				dbpool.Close()
+			}
+			return nil, fmt.Errorf("initialize AMAN VATSIM observations: %w", err)
+		}
 	}
 	testToolsGraph := assembleTestTools(cfg.EnableTestTools, testToolsAssemblyDependencies{
 		auth: authService, readiness: standAssignmentReadiness,
@@ -409,6 +428,9 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	}
 	if vatsimReconciler != nil && !cfg.EnableTestTools {
 		app.addWorker(vatsimReconciler.Start)
+	}
+	if amanObservationWorker != nil {
+		app.addWorker(func(ctx context.Context) { amanObservationWorker.Run(ctx, cfg.AMAN.ReconciliationInterval) })
 	}
 	if departureLifecycle != nil {
 		app.addWorker(departureLifecycle.StartSweep)
@@ -745,7 +767,7 @@ func buildVATSIMCache(cfg Config, deps Dependencies, requireLiveCIDVerification 
 	}
 
 	cache := vatsim.NewCache(deps.VATSIMStatusURL, deps.VATSIMPollInterval, nil)
-	slog.Info("VATSIM cache enabled", slog.Bool("livePdcVerification", requireLiveCIDVerification), slog.Bool("standAssignmentReconciliation", enableReconciliation))
+	slog.Info("VATSIM cache enabled", slog.Bool("livePdcVerification", requireLiveCIDVerification), slog.Bool("reconciliationRequired", enableReconciliation))
 	return cache
 }
 

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -430,7 +430,7 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 		app.addWorker(vatsimReconciler.Start)
 	}
 	if amanObservationWorker != nil {
-		app.addWorker(func(ctx context.Context) { amanObservationWorker.Run(ctx, cfg.AMAN.ReconciliationInterval) })
+		app.addWorker(func(ctx context.Context) { amanObservationWorker.Run(ctx, cfg.AMAN.SurveillanceInterval) })
 	}
 	if departureLifecycle != nil {
 		app.addWorker(departureLifecycle.StartSweep)

--- a/backend/internal/database/aman.sql.go
+++ b/backend/internal/database/aman.sql.go
@@ -59,6 +59,34 @@ func (q *Queries) CreateAMANCommandOutcome(ctx context.Context, arg CreateAMANCo
 	return err
 }
 
+const createAMANVATSIMObservationIdentity = `-- name: CreateAMANVATSIMObservationIdentity :one
+INSERT INTO aman_vatsim_observation_identities (
+    flight_id, vatsim_cid, current_callsign
+)
+VALUES ($1, $2, $3)
+RETURNING flight_id, vatsim_cid, current_callsign, retired_at, created_at, updated_at
+`
+
+type CreateAMANVATSIMObservationIdentityParams struct {
+	FlightID        string
+	VatsimCid       string
+	CurrentCallsign string
+}
+
+func (q *Queries) CreateAMANVATSIMObservationIdentity(ctx context.Context, arg CreateAMANVATSIMObservationIdentityParams) (AmanVatsimObservationIdentity, error) {
+	row := q.db.QueryRow(ctx, createAMANVATSIMObservationIdentity, arg.FlightID, arg.VatsimCid, arg.CurrentCallsign)
+	var i AmanVatsimObservationIdentity
+	err := row.Scan(
+		&i.FlightID,
+		&i.VatsimCid,
+		&i.CurrentCallsign,
+		&i.RetiredAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const createAMANValidationEvidence = `-- name: CreateAMANValidationEvidence :exec
 INSERT INTO aman_validation_evidence (evidence_id, airport, kind, payload, recorded_at)
 VALUES ($1, $2, $3, $4, $5)
@@ -130,6 +158,27 @@ func (q *Queries) GetAMANCommandOutcome(ctx context.Context, commandID string) (
 		&i.Revision,
 		&i.Payload,
 		&i.RecordedAt,
+	)
+	return i, err
+}
+
+const getActiveAMANVATSIMObservationIdentity = `-- name: GetActiveAMANVATSIMObservationIdentity :one
+SELECT flight_id, vatsim_cid, current_callsign, retired_at, created_at, updated_at
+FROM aman_vatsim_observation_identities
+WHERE vatsim_cid = $1
+  AND retired_at IS NULL
+`
+
+func (q *Queries) GetActiveAMANVATSIMObservationIdentity(ctx context.Context, vatsimCid string) (AmanVatsimObservationIdentity, error) {
+	row := q.db.QueryRow(ctx, getActiveAMANVATSIMObservationIdentity, vatsimCid)
+	var i AmanVatsimObservationIdentity
+	err := row.Scan(
+		&i.FlightID,
+		&i.VatsimCid,
+		&i.CurrentCallsign,
+		&i.RetiredAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
 	)
 	return i, err
 }
@@ -244,6 +293,59 @@ SELECT pg_advisory_xact_lock(hashtextextended($1, 0))
 func (q *Queries) LockAMANCommand(ctx context.Context, hashtextextended string) error {
 	_, err := q.db.Exec(ctx, lockAMANCommand, hashtextextended)
 	return err
+}
+
+const lockAMANVATSIMObservationIdentity = `-- name: LockAMANVATSIMObservationIdentity :exec
+SELECT pg_advisory_xact_lock(hashtextextended($1, 0))
+`
+
+func (q *Queries) LockAMANVATSIMObservationIdentity(ctx context.Context, hashtextextended string) error {
+	_, err := q.db.Exec(ctx, lockAMANVATSIMObservationIdentity, hashtextextended)
+	return err
+}
+
+const retireAMANVATSIMObservationIdentity = `-- name: RetireAMANVATSIMObservationIdentity :execrows
+UPDATE aman_vatsim_observation_identities
+SET retired_at = NOW(),
+    updated_at = NOW()
+WHERE flight_id = $1
+  AND retired_at IS NULL
+`
+
+func (q *Queries) RetireAMANVATSIMObservationIdentity(ctx context.Context, flightID string) (int64, error) {
+	result, err := q.db.Exec(ctx, retireAMANVATSIMObservationIdentity, flightID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateAMANVATSIMObservationIdentityCallsign = `-- name: UpdateAMANVATSIMObservationIdentityCallsign :one
+UPDATE aman_vatsim_observation_identities
+SET current_callsign = $2,
+    updated_at = NOW()
+WHERE flight_id = $1
+  AND retired_at IS NULL
+RETURNING flight_id, vatsim_cid, current_callsign, retired_at, created_at, updated_at
+`
+
+type UpdateAMANVATSIMObservationIdentityCallsignParams struct {
+	FlightID        string
+	CurrentCallsign string
+}
+
+func (q *Queries) UpdateAMANVATSIMObservationIdentityCallsign(ctx context.Context, arg UpdateAMANVATSIMObservationIdentityCallsignParams) (AmanVatsimObservationIdentity, error) {
+	row := q.db.QueryRow(ctx, updateAMANVATSIMObservationIdentityCallsign, arg.FlightID, arg.CurrentCallsign)
+	var i AmanVatsimObservationIdentity
+	err := row.Scan(
+		&i.FlightID,
+		&i.VatsimCid,
+		&i.CurrentCallsign,
+		&i.RetiredAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
 }
 
 const upsertAMANAirportState = `-- name: UpsertAMANAirportState :one

--- a/backend/internal/database/models.go
+++ b/backend/internal/database/models.go
@@ -67,6 +67,15 @@ type AmanValidationEvidence struct {
 	RecordedAt pgtype.Timestamptz
 }
 
+type AmanVatsimObservationIdentity struct {
+	FlightID        string
+	VatsimCid       string
+	CurrentCallsign string
+	RetiredAt       pgtype.Timestamptz
+	CreatedAt       pgtype.Timestamptz
+	UpdatedAt       pgtype.Timestamptz
+}
+
 type Controller struct {
 	ID                int32
 	Session           int32

--- a/backend/internal/repository/postgres/aman.go
+++ b/backend/internal/repository/postgres/aman.go
@@ -7,8 +7,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -78,6 +80,58 @@ func (r *amanRepository) ListValidationEvidence(ctx context.Context, airport str
 		})
 	}
 	return evidence, nil
+}
+
+// BindVATSIMFlight creates an opaque FlightID once for an active VATSIM flight
+// and keeps the current callsign current across repository reconstruction. The
+// CID lock makes concurrent first observations converge without making the
+// caller choose or derive an identifier. A retired flight releases the CID for
+// a subsequent flight to receive a different generated FlightID.
+func (r *amanRepository) BindVATSIMFlight(ctx context.Context, identity aman.VATSIMFlightIdentity) (aman.FlightID, error) {
+	if err := identity.Validate(); err != nil {
+		return "", err
+	}
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	queries := r.queries.WithTx(tx)
+	if err := queries.LockAMANVATSIMObservationIdentity(ctx, identity.VATSIMCID); err != nil {
+		return "", err
+	}
+	row, err := queries.GetActiveAMANVATSIMObservationIdentity(ctx, identity.VATSIMCID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		row, err = queries.CreateAMANVATSIMObservationIdentity(ctx, database.CreateAMANVATSIMObservationIdentityParams{
+			FlightID: uuid.NewString(), VatsimCid: identity.VATSIMCID, CurrentCallsign: identity.CurrentCallsign,
+		})
+	}
+	if err != nil {
+		return "", err
+	}
+	if row.CurrentCallsign != identity.CurrentCallsign {
+		row, err = queries.UpdateAMANVATSIMObservationIdentityCallsign(ctx, database.UpdateAMANVATSIMObservationIdentityCallsignParams{
+			FlightID: row.FlightID, CurrentCallsign: identity.CurrentCallsign,
+		})
+		if err != nil {
+			return "", err
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return "", err
+	}
+	return aman.FlightID(row.FlightID), nil
+}
+
+// RetireVATSIMFlight releases one active identity after its owning AMAN
+// lifecycle has removed the flight. It intentionally has no callsign or CID
+// alias behavior.
+func (r *amanRepository) RetireVATSIMFlight(ctx context.Context, flightID aman.FlightID) error {
+	if strings.TrimSpace(string(flightID)) == "" {
+		return &aman.DomainError{Class: aman.ErrorInvalidArgument, Message: "flight ID is required"}
+	}
+	_, err := r.queries.RetireAMANVATSIMObservationIdentity(ctx, string(flightID))
+	return err
 }
 
 // Commit provides the repository's one atomic transition. A returned result
@@ -298,10 +352,12 @@ func mapAMANWriteError(err error) error {
 }
 
 var (
-	_ aman.AirportStateReader       = (*amanRepository)(nil)
-	_ aman.CommandOutcomeReader     = (*amanRepository)(nil)
-	_ aman.StateCommitter           = (*amanRepository)(nil)
-	_ aman.AuditReader              = (*amanRepository)(nil)
-	_ aman.ValidationEvidenceReader = (*amanRepository)(nil)
-	_ aman.Component                = (*amanRepository)(nil)
+	_ aman.AirportStateReader          = (*amanRepository)(nil)
+	_ aman.CommandOutcomeReader        = (*amanRepository)(nil)
+	_ aman.StateCommitter              = (*amanRepository)(nil)
+	_ aman.AuditReader                 = (*amanRepository)(nil)
+	_ aman.ValidationEvidenceReader    = (*amanRepository)(nil)
+	_ aman.VATSIMFlightIdentityBinder  = (*amanRepository)(nil)
+	_ aman.VATSIMFlightIdentityRetirer = (*amanRepository)(nil)
+	_ aman.Component                   = (*amanRepository)(nil)
 )

--- a/backend/internal/repository/postgres/aman.go
+++ b/backend/internal/repository/postgres/aman.go
@@ -130,8 +130,14 @@ func (r *amanRepository) RetireVATSIMFlight(ctx context.Context, flightID aman.F
 	if strings.TrimSpace(string(flightID)) == "" {
 		return &aman.DomainError{Class: aman.ErrorInvalidArgument, Message: "flight ID is required"}
 	}
-	_, err := r.queries.RetireAMANVATSIMObservationIdentity(ctx, string(flightID))
-	return err
+	retired, err := r.queries.RetireAMANVATSIMObservationIdentity(ctx, string(flightID))
+	if err != nil {
+		return err
+	}
+	if retired == 0 {
+		return &aman.DomainError{Class: aman.ErrorNotFound, Message: "active VATSIM flight identity was not found"}
+	}
+	return nil
 }
 
 // Commit provides the repository's one atomic transition. A returned result

--- a/backend/internal/repository/postgres/aman_test.go
+++ b/backend/internal/repository/postgres/aman_test.go
@@ -121,6 +121,65 @@ func TestAMANRepositoryCompareAndSwapAllocatesOneRevision(t *testing.T) {
 	require.Equal(t, aman.SequenceRevision(1), state.Revision)
 }
 
+func TestAMANVATSIMObservationIdentitySurvivesRestartCorrectsCallsignAndRetires(t *testing.T) {
+	pool, _ := testdata.SetupTestDB(t)
+	ctx := context.Background()
+	firstRepository := NewAMANRepository(pool)
+	first, err := firstRepository.BindVATSIMFlight(ctx, aman.VATSIMFlightIdentity{VATSIMCID: "123456", CurrentCallsign: "SAS123"})
+	require.NoError(t, err)
+	require.NotEmpty(t, first)
+
+	// A reconstructed repository must find the same active flight and update
+	// only its mutable callsign.
+	secondRepository := NewAMANRepository(pool)
+	corrected, err := secondRepository.BindVATSIMFlight(ctx, aman.VATSIMFlightIdentity{VATSIMCID: "123456", CurrentCallsign: "SAS456"})
+	require.NoError(t, err)
+	require.Equal(t, first, corrected)
+	var callsign string
+	require.NoError(t, pool.QueryRow(ctx, "SELECT current_callsign FROM aman_vatsim_observation_identities WHERE flight_id = $1", string(first)).Scan(&callsign))
+	require.Equal(t, "SAS456", callsign)
+
+	require.NoError(t, secondRepository.RetireVATSIMFlight(ctx, first))
+	next, err := NewAMANRepository(pool).BindVATSIMFlight(ctx, aman.VATSIMFlightIdentity{VATSIMCID: "123456", CurrentCallsign: "SAS789"})
+	require.NoError(t, err)
+	require.NotEqual(t, first, next, "a later flight from the same VATSIM user receives a new FlightID")
+}
+
+func TestAMANVATSIMObservationIdentityAllowsOnlyOneConcurrentActiveCID(t *testing.T) {
+	pool, _ := testdata.SetupTestDB(t)
+	ctx := context.Background()
+	start := make(chan struct{})
+	ids := make(chan aman.FlightID, 2)
+	errs := make(chan error, 2)
+	var wait sync.WaitGroup
+	for _, callsign := range []string{"SAS123", "SAS456"} {
+		wait.Add(1)
+		go func(callsign string) {
+			defer wait.Done()
+			<-start
+			id, err := NewAMANRepository(pool).BindVATSIMFlight(ctx, aman.VATSIMFlightIdentity{VATSIMCID: "123456", CurrentCallsign: callsign})
+			ids <- id
+			errs <- err
+		}(callsign)
+	}
+	close(start)
+	wait.Wait()
+	close(ids)
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	var observed []aman.FlightID
+	for id := range ids {
+		observed = append(observed, id)
+	}
+	require.Len(t, observed, 2)
+	require.Equal(t, observed[0], observed[1])
+	var activeCount int
+	require.NoError(t, pool.QueryRow(ctx, "SELECT count(*) FROM aman_vatsim_observation_identities WHERE vatsim_cid = $1 AND retired_at IS NULL", "123456").Scan(&activeCount))
+	require.Equal(t, 1, activeCount)
+}
+
 func TestAMANPersistenceDoesNotDependOnTransportOrCreateOutbox(t *testing.T) {
 	_, sourceFile, _, ok := runtime.Caller(0)
 	require.True(t, ok)

--- a/backend/internal/repository/postgres/aman_test.go
+++ b/backend/internal/repository/postgres/aman_test.go
@@ -143,6 +143,7 @@ func TestAMANVATSIMObservationIdentitySurvivesRestartCorrectsCallsignAndRetires(
 	next, err := NewAMANRepository(pool).BindVATSIMFlight(ctx, aman.VATSIMFlightIdentity{VATSIMCID: "123456", CurrentCallsign: "SAS789"})
 	require.NoError(t, err)
 	require.NotEqual(t, first, next, "a later flight from the same VATSIM user receives a new FlightID")
+	requireDomainErrorClass(t, secondRepository.RetireVATSIMFlight(ctx, first), aman.ErrorNotFound)
 }
 
 func TestAMANVATSIMObservationIdentityAllowsOnlyOneConcurrentActiveCID(t *testing.T) {

--- a/backend/internal/vatsim/aman_observations.go
+++ b/backend/internal/vatsim/aman_observations.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -102,16 +103,21 @@ func (w *ObservationWorker) Publish(ctx context.Context) error {
 	now := w.now().UTC()
 	status := observationSourceStatus(snapshot, now, w.staleAfter)
 	current := make(map[string]aman.FlightObservation)
+	failed := make(map[string]struct{})
+	var publishErrors []error
 	if status != aman.DataDisconnected && !snapshot.Timestamp.IsZero() {
 		for _, flight := range snapshot.Flights() {
 			if _, enabled := w.airports[strings.ToUpper(strings.TrimSpace(flight.FlightPlan.Destination))]; !enabled {
 				continue
 			}
-			observation, err := w.mapFlight(ctx, flight, snapshot.Timestamp, status, now)
+			previous, known := w.known[flight.CID]
+			observation, err := w.mapFlight(ctx, flight, snapshot.Timestamp, status, now, optionalObservation(previous, known))
 			if err != nil {
-				return err
+				failed[flight.CID] = struct{}{}
+				publishErrors = append(publishErrors, fmt.Errorf("map VATSIM observation for CID %s: %w", flight.CID, err))
+				continue
 			}
-			if previous, exists := w.known[flight.CID]; exists {
+			if known {
 				observation = preserveNewerObservationFacts(previous, observation)
 			}
 			current[flight.CID] = observation
@@ -125,7 +131,6 @@ func (w *ObservationWorker) Publish(ctx context.Context) error {
 		}
 	}
 
-	var publishErrors []error
 	for cid, observation := range current {
 		if previous, exists := w.known[cid]; exists && sameObservation(previous, observation) {
 			continue
@@ -138,6 +143,9 @@ func (w *ObservationWorker) Publish(ctx context.Context) error {
 	}
 	if status != aman.DataDisconnected {
 		for cid := range w.known {
+			if _, mappingFailed := failed[cid]; mappingFailed {
+				continue
+			}
 			if _, present := current[cid]; !present {
 				delete(w.known, cid)
 			}
@@ -146,11 +154,17 @@ func (w *ObservationWorker) Publish(ctx context.Context) error {
 	return errors.Join(publishErrors...)
 }
 
-func (w *ObservationWorker) mapFlight(ctx context.Context, flight Flight, snapshotAt time.Time, status aman.DataStatus, reconciledAt time.Time) (aman.FlightObservation, error) {
+func (w *ObservationWorker) mapFlight(ctx context.Context, flight Flight, snapshotAt time.Time, status aman.DataStatus, reconciledAt time.Time, previous *aman.FlightObservation) (aman.FlightObservation, error) {
 	identity := aman.VATSIMFlightIdentity{VATSIMCID: strings.TrimSpace(flight.CID), CurrentCallsign: strings.TrimSpace(flight.Callsign)}
-	flightID, err := w.identities.BindVATSIMFlight(ctx, identity)
-	if err != nil {
-		return aman.FlightObservation{}, fmt.Errorf("bind VATSIM flight identity: %w", err)
+	flightID := aman.FlightID("")
+	if previous != nil && previous.Callsign == identity.CurrentCallsign {
+		flightID = previous.FlightID
+	} else {
+		var err error
+		flightID, err = w.identities.BindVATSIMFlight(ctx, identity)
+		if err != nil {
+			return aman.FlightObservation{}, fmt.Errorf("bind VATSIM flight identity: %w", err)
+		}
 	}
 	observedAt := flight.LastUpdated.UTC()
 	if observedAt.IsZero() {
@@ -159,8 +173,9 @@ func (w *ObservationWorker) mapFlight(ctx context.Context, flight Flight, snapsh
 	observation := aman.FlightObservation{
 		FlightID: flightID, VATSIMCID: identity.VATSIMCID, Callsign: identity.CurrentCallsign,
 		Origin: strings.ToUpper(strings.TrimSpace(flight.FlightPlan.Origin)), Destination: strings.ToUpper(strings.TrimSpace(flight.FlightPlan.Destination)),
-		AircraftType: optionalString(flight.FlightPlan.AircraftShort), FiledRoute: optionalString(flight.FlightPlan.Route),
-		PlannedTiming: plannedTiming(reconciledAt, flight.FlightPlan), FlightPlan: flightPlanFact(flight.FlightPlan.Revision, observedAt),
+		AircraftType: optionalString(flight.FlightPlan.AircraftShort), WakeCategory: wakeCategory(flight.FlightPlan.Aircraft),
+		FiledRoute: optionalString(flight.FlightPlan.Route), RequestedLevel: requestedLevelFeet(flight.FlightPlan.RequestedLevel),
+		PlannedTiming: plannedTiming(observedAt, flight.FlightPlan), FlightPlan: flightPlanFact(flight.FlightPlan.Revision, observedAt),
 		Surveillance: surveillanceFact(flight, observedAt), TakeoffDetected: takeoffDetected(flight, observedAt),
 		ReconciledAt: reconciledAt, SourceStatus: status,
 	}
@@ -241,6 +256,40 @@ func plannedOffBlockTime(now time.Time, eobt string) (time.Time, bool) {
 	return best, true
 }
 
+func wakeCategory(aircraft string) *string {
+	_, equipment, found := strings.Cut(strings.ToUpper(strings.TrimSpace(aircraft)), "/")
+	if !found || equipment == "" {
+		return nil
+	}
+	value := equipment[:1]
+	switch value {
+	case "L", "M", "H", "J":
+		return &value
+	default:
+		return nil
+	}
+}
+
+func requestedLevelFeet(value string) *int {
+	value = strings.ToUpper(strings.TrimSpace(value))
+	multiplier := 1
+	switch {
+	case strings.HasPrefix(value, "FL"):
+		value, multiplier = strings.TrimPrefix(value, "FL"), 100
+	case strings.HasPrefix(value, "F"):
+		value, multiplier = strings.TrimPrefix(value, "F"), 100
+	}
+	level, err := strconv.Atoi(value)
+	if err != nil || level <= 0 {
+		return nil
+	}
+	feet := level * multiplier
+	if feet < 1000 || feet > 60000 {
+		return nil
+	}
+	return &feet
+}
+
 func preserveNewerObservationFacts(previous, next aman.FlightObservation) aman.FlightObservation {
 	if flightPlanIsOlder(previous.FlightPlan, next.FlightPlan) {
 		next.Origin, next.Destination = previous.Origin, previous.Destination
@@ -281,6 +330,13 @@ func sameObservation(previous, next aman.FlightObservation) bool {
 func optionalString(value string) *string {
 	value = strings.TrimSpace(value)
 	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func optionalObservation(value aman.FlightObservation, ok bool) *aman.FlightObservation {
+	if !ok {
 		return nil
 	}
 	return &value

--- a/backend/internal/vatsim/aman_observations.go
+++ b/backend/internal/vatsim/aman_observations.go
@@ -1,0 +1,287 @@
+package vatsim
+
+import (
+	"FlightStrips/internal/aman"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"reflect"
+	"strings"
+	"time"
+)
+
+const defaultObservationStaleAfter = time.Minute
+
+// ObservationWorkerDependencies are deliberately separate from Reconciler.
+// AMAN consumes source facts before a strip, Stand Assignment, session, or
+// EuroScope controller exists.
+type ObservationWorkerDependencies struct {
+	Cache           SnapshotSource
+	Identities      aman.VATSIMFlightIdentityBinder
+	Sink            aman.ObservationSink
+	EnabledAirports []string
+	StaleAfter      time.Duration
+	Now             func() time.Time
+}
+
+// ObservationWorker maps immutable VATSIM cache snapshots into the neutral
+// AMAN observation contract. It owns no prediction, sequencing, strip, or SAT
+// policy.
+type ObservationWorker struct {
+	cache      SnapshotSource
+	identities aman.VATSIMFlightIdentityBinder
+	sink       aman.ObservationSink
+	airports   map[string]struct{}
+	staleAfter time.Duration
+	now        func() time.Time
+	known      map[string]aman.FlightObservation
+}
+
+func NewObservationWorker(deps ObservationWorkerDependencies) (*ObservationWorker, error) {
+	if deps.Cache == nil {
+		return nil, fmt.Errorf("AMAN observation worker requires VATSIM cache")
+	}
+	if deps.Identities == nil {
+		return nil, fmt.Errorf("AMAN observation worker requires flight identity binder")
+	}
+	if deps.Sink == nil {
+		return nil, fmt.Errorf("AMAN observation worker requires observation sink")
+	}
+	airports := make(map[string]struct{}, len(deps.EnabledAirports))
+	for _, value := range deps.EnabledAirports {
+		airport := strings.ToUpper(strings.TrimSpace(value))
+		if airport != "" {
+			airports[airport] = struct{}{}
+		}
+	}
+	if len(airports) == 0 {
+		return nil, fmt.Errorf("AMAN observation worker requires enabled airports")
+	}
+	if deps.StaleAfter <= 0 {
+		deps.StaleAfter = defaultObservationStaleAfter
+	}
+	if deps.Now == nil {
+		deps.Now = time.Now
+	}
+	return &ObservationWorker{
+		cache: deps.Cache, identities: deps.Identities, sink: deps.Sink, airports: airports,
+		staleAfter: deps.StaleAfter, now: deps.Now, known: make(map[string]aman.FlightObservation),
+	}, nil
+}
+
+// Run is intentionally independent of the strip reconciler loop. Delivery
+// errors are logged and retried on the next source interval; they cannot stop
+// Stand Assignment or strip reconciliation.
+func (w *ObservationWorker) Run(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = defaultRefreshInterval
+	}
+	if err := w.Publish(ctx); err != nil {
+		slog.WarnContext(ctx, "AMAN VATSIM observation publication failed", slog.Any("error", err))
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := w.Publish(ctx); err != nil {
+				slog.WarnContext(ctx, "AMAN VATSIM observation publication failed", slog.Any("error", err))
+			}
+		}
+	}
+}
+
+// Publish sends changes from one cache generation. Repeated unchanged source
+// health states are not re-emitted, while fresh, stale, disconnected, and
+// restored transitions are all delivered with their latest source facts.
+func (w *ObservationWorker) Publish(ctx context.Context) error {
+	snapshot := w.cache.Snapshot()
+	now := w.now().UTC()
+	status := observationSourceStatus(snapshot, now, w.staleAfter)
+	current := make(map[string]aman.FlightObservation)
+	if status != aman.DataDisconnected && !snapshot.Timestamp.IsZero() {
+		for _, flight := range snapshot.Flights() {
+			if _, enabled := w.airports[strings.ToUpper(strings.TrimSpace(flight.FlightPlan.Destination))]; !enabled {
+				continue
+			}
+			observation, err := w.mapFlight(ctx, flight, snapshot.Timestamp, status, now)
+			if err != nil {
+				return err
+			}
+			if previous, exists := w.known[flight.CID]; exists {
+				observation = preserveNewerObservationFacts(previous, observation)
+			}
+			current[flight.CID] = observation
+		}
+	}
+	if status == aman.DataDisconnected {
+		for cid, observation := range w.known {
+			observation.SourceStatus = status
+			observation.ReconciledAt = now
+			current[cid] = observation
+		}
+	}
+
+	var publishErrors []error
+	for cid, observation := range current {
+		if previous, exists := w.known[cid]; exists && sameObservation(previous, observation) {
+			continue
+		}
+		if err := w.sink.Observe(ctx, observation); err != nil {
+			publishErrors = append(publishErrors, fmt.Errorf("publish VATSIM observation for CID %s: %w", cid, err))
+			continue
+		}
+		w.known[cid] = observation
+	}
+	if status != aman.DataDisconnected {
+		for cid := range w.known {
+			if _, present := current[cid]; !present {
+				delete(w.known, cid)
+			}
+		}
+	}
+	return errors.Join(publishErrors...)
+}
+
+func (w *ObservationWorker) mapFlight(ctx context.Context, flight Flight, snapshotAt time.Time, status aman.DataStatus, reconciledAt time.Time) (aman.FlightObservation, error) {
+	identity := aman.VATSIMFlightIdentity{VATSIMCID: strings.TrimSpace(flight.CID), CurrentCallsign: strings.TrimSpace(flight.Callsign)}
+	flightID, err := w.identities.BindVATSIMFlight(ctx, identity)
+	if err != nil {
+		return aman.FlightObservation{}, fmt.Errorf("bind VATSIM flight identity: %w", err)
+	}
+	observedAt := flight.LastUpdated.UTC()
+	if observedAt.IsZero() {
+		observedAt = snapshotAt.UTC()
+	}
+	observation := aman.FlightObservation{
+		FlightID: flightID, VATSIMCID: identity.VATSIMCID, Callsign: identity.CurrentCallsign,
+		Origin: strings.ToUpper(strings.TrimSpace(flight.FlightPlan.Origin)), Destination: strings.ToUpper(strings.TrimSpace(flight.FlightPlan.Destination)),
+		AircraftType: optionalString(flight.FlightPlan.AircraftShort), FiledRoute: optionalString(flight.FlightPlan.Route),
+		PlannedTiming: plannedTiming(reconciledAt, flight.FlightPlan), FlightPlan: flightPlanFact(flight.FlightPlan.Revision, observedAt),
+		Surveillance: surveillanceFact(flight, observedAt), TakeoffDetected: takeoffDetected(flight, observedAt),
+		ReconciledAt: reconciledAt, SourceStatus: status,
+	}
+	if err := observation.Validate(); err != nil {
+		return aman.FlightObservation{}, fmt.Errorf("map VATSIM observation: %w", err)
+	}
+	return observation, nil
+}
+
+func observationSourceStatus(snapshot Snapshot, now time.Time, staleAfter time.Duration) aman.DataStatus {
+	if snapshot.Timestamp.IsZero() || snapshot.LastRefreshError != nil {
+		return aman.DataDisconnected
+	}
+	if now.Sub(snapshot.Timestamp) > staleAfter {
+		return aman.DataStale
+	}
+	return aman.DataFresh
+}
+
+func flightPlanFact(revision int64, observedAt time.Time) aman.FlightPlanFact {
+	var sourceRevision *uint64
+	if revision >= 0 {
+		value := uint64(revision)
+		sourceRevision = &value
+	}
+	return aman.FlightPlanFact{Revision: sourceRevision, ObservedAt: &observedAt}
+}
+
+func surveillanceFact(flight Flight, observedAt time.Time) *aman.SurveillanceFact {
+	if !flight.Online() || !validCoordinates(flight.Latitude, flight.Longitude) {
+		return nil
+	}
+	altitude := flight.Altitude
+	groundspeed := float64(flight.Groundspeed)
+	sequence := uint64(observedAt.UnixMilli())
+	return &aman.SurveillanceFact{
+		LatitudeDegrees: flight.Latitude, LongitudeDegrees: flight.Longitude, AltitudeFeet: &altitude,
+		GroundspeedKnots: &groundspeed, Sequence: &sequence, ObservedAt: &observedAt,
+	}
+}
+
+func takeoffDetected(flight Flight, observedAt time.Time) *time.Time {
+	if flight.Online() && flight.Altitude >= minimumLiveAltitude && flight.Groundspeed >= minimumLiveGroundspeed {
+		return &observedAt
+	}
+	return nil
+}
+
+func plannedTiming(now time.Time, plan FlightPlan) *aman.PlannedTiming {
+	departure, ok := plannedOffBlockTime(now, plan.EOBT)
+	if !ok {
+		return nil
+	}
+	duration, err := parseDuration(plan.EnrouteDuration)
+	if err != nil {
+		return &aman.PlannedTiming{EstimatedOffBlockTime: &departure}
+	}
+	return &aman.PlannedTiming{EstimatedOffBlockTime: &departure, EstimatedEnrouteTime: &duration}
+}
+
+func plannedOffBlockTime(now time.Time, eobt string) (time.Time, bool) {
+	hour, minute, err := parseClock(eobt)
+	if err != nil {
+		return time.Time{}, false
+	}
+	now = now.UTC()
+	candidates := []time.Time{
+		time.Date(now.Year(), now.Month(), now.Day()-1, hour, minute, 0, 0, time.UTC),
+		time.Date(now.Year(), now.Month(), now.Day(), hour, minute, 0, 0, time.UTC),
+		time.Date(now.Year(), now.Month(), now.Day()+1, hour, minute, 0, 0, time.UTC),
+	}
+	best := candidates[0]
+	for _, candidate := range candidates[1:] {
+		if absoluteDuration(candidate.Sub(now)) < absoluteDuration(best.Sub(now)) {
+			best = candidate
+		}
+	}
+	return best, true
+}
+
+func preserveNewerObservationFacts(previous, next aman.FlightObservation) aman.FlightObservation {
+	if flightPlanIsOlder(previous.FlightPlan, next.FlightPlan) {
+		next.Origin, next.Destination = previous.Origin, previous.Destination
+		next.AircraftType, next.WakeCategory, next.FiledRoute = previous.AircraftType, previous.WakeCategory, previous.FiledRoute
+		next.RequestedLevel, next.PlannedTiming, next.FlightPlan = previous.RequestedLevel, previous.PlannedTiming, previous.FlightPlan
+	}
+	if surveillanceIsOlder(previous.Surveillance, next.Surveillance) {
+		next.Surveillance, next.TakeoffDetected = previous.Surveillance, previous.TakeoffDetected
+	}
+	return next
+}
+
+func flightPlanIsOlder(previous, next aman.FlightPlanFact) bool {
+	if previous.Revision != nil && next.Revision != nil {
+		if *next.Revision != *previous.Revision {
+			return *next.Revision < *previous.Revision
+		}
+	}
+	return previous.ObservedAt != nil && next.ObservedAt != nil && next.ObservedAt.Before(*previous.ObservedAt)
+}
+
+func surveillanceIsOlder(previous, next *aman.SurveillanceFact) bool {
+	if previous == nil || next == nil {
+		return false
+	}
+	if previous.Sequence != nil && next.Sequence != nil && *next.Sequence < *previous.Sequence {
+		return true
+	}
+	return previous.ObservedAt != nil && next.ObservedAt != nil && next.ObservedAt.Before(*previous.ObservedAt)
+}
+
+func sameObservation(previous, next aman.FlightObservation) bool {
+	previous.ReconciledAt = time.Time{}
+	next.ReconciledAt = time.Time{}
+	return reflect.DeepEqual(previous, next)
+}
+
+func optionalString(value string) *string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return &value
+}

--- a/backend/internal/vatsim/aman_observations_test.go
+++ b/backend/internal/vatsim/aman_observations_test.go
@@ -1,0 +1,195 @@
+package vatsim
+
+import (
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/models"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type observationTestBinder struct {
+	mu       sync.Mutex
+	next     int
+	byCID    map[string]aman.FlightID
+	bindings []aman.VATSIMFlightIdentity
+}
+
+func (b *observationTestBinder) BindVATSIMFlight(_ context.Context, identity aman.VATSIMFlightIdentity) (aman.FlightID, error) {
+	if err := identity.Validate(); err != nil {
+		return "", err
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.byCID == nil {
+		b.byCID = make(map[string]aman.FlightID)
+	}
+	if id, ok := b.byCID[identity.VATSIMCID]; ok {
+		b.bindings = append(b.bindings, identity)
+		return id, nil
+	}
+	b.next++
+	id := aman.FlightID("flight-" + string(rune('0'+b.next)))
+	b.byCID[identity.VATSIMCID] = id
+	b.bindings = append(b.bindings, identity)
+	return id, nil
+}
+
+type observationTestSink struct {
+	observations []aman.FlightObservation
+	err          error
+}
+
+func (s *observationTestSink) Observe(_ context.Context, observation aman.FlightObservation) error {
+	if s.err != nil {
+		return s.err
+	}
+	s.observations = append(s.observations, observation)
+	return nil
+}
+
+func newObservationTestWorker(t *testing.T, cache *Cache, now *time.Time, sink *observationTestSink) (*ObservationWorker, *observationTestBinder) {
+	t.Helper()
+	binder := &observationTestBinder{}
+	worker, err := NewObservationWorker(ObservationWorkerDependencies{
+		Cache: cache, Identities: binder, Sink: sink, EnabledAirports: []string{"EKCH"}, StaleAfter: time.Minute,
+		Now: func() time.Time { return *now },
+	})
+	require.NoError(t, err)
+	return worker, binder
+}
+
+func TestObservationWorkerMapsPrefileAndOnlineFlightsWithoutSession(t *testing.T) {
+	now := time.Date(2026, time.July, 18, 12, 0, 0, 0, time.UTC)
+	cache := newReconciliationTestCache(now,
+		Flight{CID: "101", Callsign: "SAS101", State: FlightStatePrefile, LastUpdated: now.Add(-time.Minute), FlightPlan: FlightPlan{Origin: "ENGM", Destination: "EKCH", AircraftShort: "A20N", Route: "NEXIL M725", EOBT: "1130", EnrouteDuration: "0145", Revision: 4}},
+		Flight{CID: "202", Callsign: "SAS202", State: FlightStateOnline, Latitude: 55.1, Longitude: 12.1, Altitude: 18000, Groundspeed: 420, LastUpdated: now, FlightPlan: FlightPlan{Origin: "EGLL", Destination: "EKCH", AircraftShort: "B738", Route: "L620", EOBT: "0930", EnrouteDuration: "0200", Revision: 7}},
+	)
+	sink := &observationTestSink{}
+	worker, _ := newObservationTestWorker(t, cache, &now, sink)
+
+	require.NoError(t, worker.Publish(context.Background()))
+	require.Len(t, sink.observations, 2, "no session or EuroScope client is needed")
+	sort.Slice(sink.observations, func(i, j int) bool { return sink.observations[i].VATSIMCID < sink.observations[j].VATSIMCID })
+	prefile, online := sink.observations[0], sink.observations[1]
+	require.Equal(t, aman.DataFresh, prefile.SourceStatus)
+	require.Equal(t, "SAS101", prefile.Callsign)
+	require.Equal(t, "ENGM", prefile.Origin)
+	require.Equal(t, "EKCH", prefile.Destination)
+	require.Equal(t, "A20N", *prefile.AircraftType)
+	require.Equal(t, "NEXIL M725", *prefile.FiledRoute)
+	require.Equal(t, uint64(4), *prefile.FlightPlan.Revision)
+	require.Equal(t, now.Add(-time.Minute), *prefile.FlightPlan.ObservedAt)
+	require.Equal(t, time.Date(2026, time.July, 18, 11, 30, 0, 0, time.UTC), *prefile.PlannedTiming.EstimatedOffBlockTime)
+	require.Equal(t, time.Hour+45*time.Minute, *prefile.PlannedTiming.EstimatedEnrouteTime)
+	require.Nil(t, prefile.Surveillance)
+
+	require.NotNil(t, online.Surveillance)
+	require.Equal(t, 55.1, online.Surveillance.LatitudeDegrees)
+	require.Equal(t, 12.1, online.Surveillance.LongitudeDegrees)
+	require.Equal(t, 18000, *online.Surveillance.AltitudeFeet)
+	require.Equal(t, float64(420), *online.Surveillance.GroundspeedKnots)
+	require.Equal(t, uint64(now.UnixMilli()), *online.Surveillance.Sequence)
+	require.Equal(t, now, *online.Surveillance.ObservedAt)
+	require.Equal(t, now, *online.TakeoffDetected)
+	require.Nil(t, online.WakeCategory, "VATSIM does not provide a wake fact")
+	require.Nil(t, online.RequestedLevel, "VATSIM does not provide a requested-level fact")
+}
+
+func TestObservationWorkerPreservesFlightIDAndRejectsOlderFacts(t *testing.T) {
+	now := time.Date(2026, time.July, 18, 12, 0, 0, 0, time.UTC)
+	newer := Flight{CID: "101", Callsign: "SAS101", State: FlightStateOnline, Latitude: 55.1, Longitude: 12.1, Altitude: 18000, Groundspeed: 420, LastUpdated: now, FlightPlan: FlightPlan{Origin: "EGLL", Destination: "EKCH", Route: "NEW ROUTE", Revision: 8}}
+	cache := newReconciliationTestCache(now, newer)
+	sink := &observationTestSink{}
+	worker, _ := newObservationTestWorker(t, cache, &now, sink)
+	require.NoError(t, worker.Publish(context.Background()))
+	first := sink.observations[0]
+
+	older := newer
+	older.Callsign = "SAS102"
+	older.LastUpdated = now.Add(-time.Minute)
+	older.Latitude = 54.0
+	older.FlightPlan.Route = "OLD ROUTE"
+	older.FlightPlan.Revision = 7
+	setObservationCacheSnapshot(cache, now.Add(time.Second), nil, older)
+	now = now.Add(time.Second)
+	require.NoError(t, worker.Publish(context.Background()))
+	require.Len(t, sink.observations, 2)
+	second := sink.observations[1]
+	require.Equal(t, first.FlightID, second.FlightID, "callsign corrections must not rekey AMAN state")
+	require.Equal(t, "SAS102", second.Callsign)
+	require.Equal(t, "NEW ROUTE", *second.FiledRoute)
+	require.Equal(t, uint64(8), *second.FlightPlan.Revision)
+	require.Equal(t, 55.1, second.Surveillance.LatitudeDegrees)
+	require.Equal(t, *first.Surveillance.Sequence, *second.Surveillance.Sequence)
+}
+
+func TestObservationWorkerPublishesSourceStatusTransitionsWithoutFlooding(t *testing.T) {
+	now := time.Date(2026, time.July, 18, 12, 0, 0, 0, time.UTC)
+	flight := Flight{CID: "101", Callsign: "SAS101", State: FlightStatePrefile, LastUpdated: now, FlightPlan: FlightPlan{Origin: "ENGM", Destination: "EKCH", Revision: 1}}
+	cache := newReconciliationTestCache(now, flight)
+	sink := &observationTestSink{}
+	worker, _ := newObservationTestWorker(t, cache, &now, sink)
+
+	require.NoError(t, worker.Publish(context.Background()))
+	now = now.Add(2 * time.Minute)
+	require.NoError(t, worker.Publish(context.Background()))
+	require.NoError(t, worker.Publish(context.Background()), "unchanged stale state is not re-emitted")
+	setObservationCacheSnapshot(cache, cache.snapshot.timestamp, errors.New("network unavailable"))
+	require.NoError(t, worker.Publish(context.Background()))
+	setObservationCacheSnapshot(cache, now, nil, flight)
+	require.NoError(t, worker.Publish(context.Background()))
+
+	require.Len(t, sink.observations, 4)
+	require.Equal(t, []aman.DataStatus{aman.DataFresh, aman.DataStale, aman.DataDisconnected, aman.DataFresh}, []aman.DataStatus{
+		sink.observations[0].SourceStatus, sink.observations[1].SourceStatus, sink.observations[2].SourceStatus, sink.observations[3].SourceStatus,
+	})
+}
+
+func TestObservationWorkerIsolatedFromSATReconciliationFailure(t *testing.T) {
+	now := time.Date(2026, time.July, 18, 12, 0, 0, 0, time.UTC)
+	flight := Flight{CID: "101", Callsign: "SAS101", State: FlightStatePrefile, LastUpdated: now, FlightPlan: FlightPlan{Origin: "ENGM", Destination: "EKCH", Revision: 1}}
+	cache := newReconciliationTestCache(now, flight)
+	strips := &reconciliationTestStrips{bySession: map[int32][]*models.Strip{}}
+	reconciler := newTestReconciler(cache, reconciliationTestSessions{items: []*models.Session{{ID: 7, Airport: "EKCH"}}}, strips, reconciliationTestAssignments{}, nil, time.Second)
+	reconciler.arrivalLifecycle = failingArrivalLifecycle{}
+	require.Error(t, reconciler.Reconcile(context.Background()))
+
+	sink := &observationTestSink{}
+	worker, _ := newObservationTestWorker(t, cache, &now, sink)
+	require.NoError(t, worker.Publish(context.Background()))
+	require.Len(t, sink.observations, 1)
+}
+
+type failingArrivalLifecycle struct{}
+
+func (failingArrivalLifecycle) ProcessArrival(context.Context, int32, *models.Strip, ArrivalFlightInfo) error {
+	return errors.New("SAT unavailable")
+}
+
+func setObservationCacheSnapshot(cache *Cache, timestamp time.Time, refreshError error, flights ...Flight) {
+	snapshot := newCacheSnapshot(timestamp, timestamp)
+	for _, flight := range flights {
+		snapshot.add(flight)
+	}
+	cache.snapshot = snapshot
+	cache.lastRefreshError = refreshError
+}
+
+func TestObservationPackageForbidsSATEuroScopeAndETALeakage(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	source, err := os.ReadFile(filepath.Join(filepath.Dir(file), "aman_observations.go"))
+	require.NoError(t, err)
+	for _, forbidden := range []string{"internal/sat", "internal/euroscope", "ArrivalETA", "TETA", "FlightPlanDTO"} {
+		require.NotContains(t, string(source), forbidden)
+	}
+}

--- a/backend/internal/vatsim/aman_observations_test.go
+++ b/backend/internal/vatsim/aman_observations_test.go
@@ -46,11 +46,15 @@ func (b *observationTestBinder) BindVATSIMFlight(_ context.Context, identity ama
 type observationTestSink struct {
 	observations []aman.FlightObservation
 	err          error
+	errsByCID    map[string]error
 }
 
 func (s *observationTestSink) Observe(_ context.Context, observation aman.FlightObservation) error {
 	if s.err != nil {
 		return s.err
+	}
+	if err := s.errsByCID[observation.VATSIMCID]; err != nil {
+		return err
 	}
 	s.observations = append(s.observations, observation)
 	return nil
@@ -70,8 +74,8 @@ func newObservationTestWorker(t *testing.T, cache *Cache, now *time.Time, sink *
 func TestObservationWorkerMapsPrefileAndOnlineFlightsWithoutSession(t *testing.T) {
 	now := time.Date(2026, time.July, 18, 12, 0, 0, 0, time.UTC)
 	cache := newReconciliationTestCache(now,
-		Flight{CID: "101", Callsign: "SAS101", State: FlightStatePrefile, LastUpdated: now.Add(-time.Minute), FlightPlan: FlightPlan{Origin: "ENGM", Destination: "EKCH", AircraftShort: "A20N", Route: "NEXIL M725", EOBT: "1130", EnrouteDuration: "0145", Revision: 4}},
-		Flight{CID: "202", Callsign: "SAS202", State: FlightStateOnline, Latitude: 55.1, Longitude: 12.1, Altitude: 18000, Groundspeed: 420, LastUpdated: now, FlightPlan: FlightPlan{Origin: "EGLL", Destination: "EKCH", AircraftShort: "B738", Route: "L620", EOBT: "0930", EnrouteDuration: "0200", Revision: 7}},
+		Flight{CID: "101", Callsign: "SAS101", State: FlightStatePrefile, LastUpdated: now.Add(-time.Minute), FlightPlan: FlightPlan{Origin: "ENGM", Destination: "EKCH", Aircraft: "A20N/M-SDE2", AircraftShort: "A20N", RequestedLevel: "F350", Route: "NEXIL M725", EOBT: "1130", EnrouteDuration: "0145", Revision: 4}},
+		Flight{CID: "202", Callsign: "SAS202", State: FlightStateOnline, Latitude: 55.1, Longitude: 12.1, Altitude: 18000, Groundspeed: 420, LastUpdated: now, FlightPlan: FlightPlan{Origin: "EGLL", Destination: "EKCH", Aircraft: "B738/H-SDE2", AircraftShort: "B738", RequestedLevel: "34000", Route: "L620", EOBT: "0930", EnrouteDuration: "0200", Revision: 7}},
 	)
 	sink := &observationTestSink{}
 	worker, _ := newObservationTestWorker(t, cache, &now, sink)
@@ -85,6 +89,8 @@ func TestObservationWorkerMapsPrefileAndOnlineFlightsWithoutSession(t *testing.T
 	require.Equal(t, "ENGM", prefile.Origin)
 	require.Equal(t, "EKCH", prefile.Destination)
 	require.Equal(t, "A20N", *prefile.AircraftType)
+	require.Equal(t, "M", *prefile.WakeCategory)
+	require.Equal(t, 35000, *prefile.RequestedLevel)
 	require.Equal(t, "NEXIL M725", *prefile.FiledRoute)
 	require.Equal(t, uint64(4), *prefile.FlightPlan.Revision)
 	require.Equal(t, now.Add(-time.Minute), *prefile.FlightPlan.ObservedAt)
@@ -100,8 +106,43 @@ func TestObservationWorkerMapsPrefileAndOnlineFlightsWithoutSession(t *testing.T
 	require.Equal(t, uint64(now.UnixMilli()), *online.Surveillance.Sequence)
 	require.Equal(t, now, *online.Surveillance.ObservedAt)
 	require.Equal(t, now, *online.TakeoffDetected)
-	require.Nil(t, online.WakeCategory, "VATSIM does not provide a wake fact")
-	require.Nil(t, online.RequestedLevel, "VATSIM does not provide a requested-level fact")
+	require.Equal(t, "H", *online.WakeCategory)
+	require.Equal(t, 34000, *online.RequestedLevel)
+}
+
+func TestObservationWorkerUsesSourceObservedTimeForPlannedTimingAcrossRetry(t *testing.T) {
+	sourceTime := time.Date(2026, time.July, 18, 23, 58, 0, 0, time.UTC)
+	flight := Flight{CID: "101", Callsign: "SAS101", State: FlightStatePrefile, LastUpdated: sourceTime, FlightPlan: FlightPlan{Origin: "ENGM", Destination: "EKCH", EOBT: "0005", EnrouteDuration: "0100", Revision: 1}}
+	cache := newReconciliationTestCache(sourceTime, flight)
+	firstNow := sourceTime.Add(time.Minute)
+	firstSink := &observationTestSink{}
+	firstWorker, _ := newObservationTestWorker(t, cache, &firstNow, firstSink)
+	require.NoError(t, firstWorker.Publish(context.Background()))
+
+	// A restarted worker can retry the same source fact much later without
+	// changing the service day used for its planned departure time.
+	retryNow := sourceTime.Add(48 * time.Hour)
+	retrySink := &observationTestSink{}
+	retryWorker, _ := newObservationTestWorker(t, cache, &retryNow, retrySink)
+	require.NoError(t, retryWorker.Publish(context.Background()))
+	require.Equal(t, *firstSink.observations[0].PlannedTiming.EstimatedOffBlockTime, *retrySink.observations[0].PlannedTiming.EstimatedOffBlockTime)
+	require.Equal(t, time.Date(2026, time.July, 19, 0, 5, 0, 0, time.UTC), *retrySink.observations[0].PlannedTiming.EstimatedOffBlockTime)
+}
+
+func TestWakeCategoryAndRequestedLevelMappingRejectInvalidSourceValues(t *testing.T) {
+	for _, test := range []struct {
+		aircraft, level string
+		wake            *string
+		feet            *int
+	}{
+		{"A320/L-S", "FL250", stringPointer("L"), intPointer(25000)},
+		{"A388/J-S", "41000", stringPointer("J"), intPointer(41000)},
+		{"A320/X-S", "F999", nil, nil},
+		{"A320", "bad", nil, nil},
+	} {
+		require.Equal(t, test.wake, wakeCategory(test.aircraft))
+		require.Equal(t, test.feet, requestedLevelFeet(test.level))
+	}
 }
 
 func TestObservationWorkerPreservesFlightIDAndRejectsOlderFacts(t *testing.T) {
@@ -130,6 +171,45 @@ func TestObservationWorkerPreservesFlightIDAndRejectsOlderFacts(t *testing.T) {
 	require.Equal(t, uint64(8), *second.FlightPlan.Revision)
 	require.Equal(t, 55.1, second.Surveillance.LatitudeDegrees)
 	require.Equal(t, *first.Surveillance.Sequence, *second.Surveillance.Sequence)
+}
+
+func TestObservationWorkerReusesKnownIDButRebindsCallsignCorrection(t *testing.T) {
+	now := time.Date(2026, time.July, 18, 12, 0, 0, 0, time.UTC)
+	flight := Flight{CID: "101", Callsign: "SAS101", State: FlightStatePrefile, LastUpdated: now, FlightPlan: FlightPlan{Origin: "ENGM", Destination: "EKCH", Revision: 1}}
+	cache := newReconciliationTestCache(now, flight)
+	sink := &observationTestSink{}
+	worker, binder := newObservationTestWorker(t, cache, &now, sink)
+	require.NoError(t, worker.Publish(context.Background()))
+	require.NoError(t, worker.Publish(context.Background()))
+	require.Len(t, binder.bindings, 1, "unchanged source fact reuses the delivered FlightID")
+	flight.Callsign = "SAS102"
+	setObservationCacheSnapshot(cache, now.Add(time.Second), nil, flight)
+	now = now.Add(time.Second)
+	require.NoError(t, worker.Publish(context.Background()))
+	require.Len(t, binder.bindings, 2, "callsign correction must verify the active binding")
+}
+
+func TestObservationWorkerContinuesAfterPerFlightMappingAndDeliveryFailures(t *testing.T) {
+	now := time.Date(2026, time.July, 18, 12, 0, 0, 0, time.UTC)
+	malformed := Flight{CID: "101", Callsign: "BAD101", State: FlightStatePrefile, LastUpdated: now, FlightPlan: FlightPlan{Destination: "EKCH", Revision: 1}}
+	good := Flight{CID: "202", Callsign: "SAS202", State: FlightStatePrefile, LastUpdated: now, FlightPlan: FlightPlan{Origin: "ENGM", Destination: "EKCH", Revision: 1}}
+	deliveryFailure := Flight{CID: "303", Callsign: "SAS303", State: FlightStatePrefile, LastUpdated: now, FlightPlan: FlightPlan{Origin: "EGLL", Destination: "EKCH", Revision: 1}}
+	cache := newReconciliationTestCache(now, malformed, good, deliveryFailure)
+	sink := &observationTestSink{errsByCID: map[string]error{"303": errors.New("temporary sink failure")}}
+	worker, _ := newObservationTestWorker(t, cache, &now, sink)
+	err := worker.Publish(context.Background())
+	require.ErrorContains(t, err, "map VATSIM observation for CID 101")
+	require.ErrorContains(t, err, "publish VATSIM observation for CID 303")
+	require.Len(t, sink.observations, 1)
+	require.Equal(t, "202", sink.observations[0].VATSIMCID)
+	require.Contains(t, worker.known, "202")
+	require.NotContains(t, worker.known, "303")
+
+	delete(sink.errsByCID, "303")
+	setObservationCacheSnapshot(cache, now, nil, good, deliveryFailure)
+	require.NoError(t, worker.Publish(context.Background()))
+	require.Len(t, sink.observations, 2, "the valid retry publishes while already-delivered facts are not flooded")
+	require.Equal(t, "303", sink.observations[1].VATSIMCID)
 }
 
 func TestObservationWorkerPublishesSourceStatusTransitionsWithoutFlooding(t *testing.T) {
@@ -193,3 +273,6 @@ func TestObservationPackageForbidsSATEuroScopeAndETALeakage(t *testing.T) {
 		require.NotContains(t, string(source), forbidden)
 	}
 }
+
+func stringPointer(value string) *string { return &value }
+func intPointer(value int) *int          { return &value }

--- a/backend/internal/vatsim/cache.go
+++ b/backend/internal/vatsim/cache.go
@@ -40,6 +40,7 @@ type FlightPlan struct {
 	Alternate       string
 	EOBT            string
 	EnrouteDuration string
+	RequestedLevel  string
 	Remarks         string
 	Route           string
 	AssignedSquawk  string
@@ -170,6 +171,7 @@ type flightPlan struct {
 	Alternate           string `json:"alternate"`
 	DepartureTime       string `json:"deptime"`
 	EnrouteTime         string `json:"enroute_time"`
+	Altitude            string `json:"altitude"`
 	Remarks             string `json:"remarks"`
 	Route               string `json:"route"`
 	RevisionID          int64  `json:"revision_id"`
@@ -417,6 +419,7 @@ func toFlight(entry networkFlight, state FlightState) Flight {
 		Alternate:       entry.FlightPlan.Alternate,
 		EOBT:            entry.FlightPlan.DepartureTime,
 		EnrouteDuration: entry.FlightPlan.EnrouteTime,
+		RequestedLevel:  entry.FlightPlan.Altitude,
 		Remarks:         entry.FlightPlan.Remarks,
 		Route:           entry.FlightPlan.Route,
 		AssignedSquawk:  entry.FlightPlan.AssignedTransponder,

--- a/backend/internal/vatsim/cache_test.go
+++ b/backend/internal/vatsim/cache_test.go
@@ -46,7 +46,7 @@ func TestCacheSnapshotDecodesPilotsAndPrefiles(t *testing.T) {
   "pilots":[{
     "cid":1234567,"callsign":"dal123","latitude":55.618,"longitude":12.656,"altitude":34000,"groundspeed":456,
     "logon_time":"2026-07-12T08:00:00Z","last_updated":"2026-07-12T09:59:50Z",
-    "flight_plan":{"flight_rules":"I","aircraft":"A320/M-SDE2E3FGHIJ1RWXYZ/LB1","aircraft_faa":"A320/L","aircraft_short":"A320","departure":"EKCH","arrival":"EGLL","alternate":"EGKK","deptime":"0815","enroute_time":"0145","remarks":"PBN/B2","route":"DCT LAM","revision_id":4,"assigned_transponder":"1234"}
+    "flight_plan":{"flight_rules":"I","aircraft":"A320/M-SDE2E3FGHIJ1RWXYZ/LB1","aircraft_faa":"A320/L","aircraft_short":"A320","departure":"EKCH","arrival":"EGLL","alternate":"EGKK","deptime":"0815","enroute_time":"0145","altitude":"F350","remarks":"PBN/B2","route":"DCT LAM","revision_id":4,"assigned_transponder":"1234"}
   }],
   "prefiles":[{
     "cid":7654321,"callsign":" sas456 ","last_updated":"2026-07-12T09:58:00Z",
@@ -73,7 +73,7 @@ func TestCacheSnapshotDecodesPilotsAndPrefiles(t *testing.T) {
 	assert.Equal(t, time.Date(2026, 7, 12, 9, 59, 50, 0, time.UTC), pilot.LastUpdated)
 	assert.Equal(t, FlightPlan{
 		FlightRules: "I", Aircraft: "A320/M-SDE2E3FGHIJ1RWXYZ/LB1", AircraftFAA: "A320/L", AircraftShort: "A320",
-		Origin: "EKCH", Destination: "EGLL", Alternate: "EGKK", EOBT: "0815", EnrouteDuration: "0145",
+		Origin: "EKCH", Destination: "EGLL", Alternate: "EGKK", EOBT: "0815", EnrouteDuration: "0145", RequestedLevel: "F350",
 		Remarks: "PBN/B2", Route: "DCT LAM", AssignedSquawk: "1234", Revision: 4,
 	}, pilot.FlightPlan)
 

--- a/backend/internal/vatsim/cache_test.go
+++ b/backend/internal/vatsim/cache_test.go
@@ -46,7 +46,7 @@ func TestCacheSnapshotDecodesPilotsAndPrefiles(t *testing.T) {
   "pilots":[{
     "cid":1234567,"callsign":"dal123","latitude":55.618,"longitude":12.656,"altitude":34000,"groundspeed":456,
     "logon_time":"2026-07-12T08:00:00Z","last_updated":"2026-07-12T09:59:50Z",
-    "flight_plan":{"flight_rules":"I","aircraft":"A320/M-SDE2E3FGHIJ1RWXYZ/LB1","aircraft_faa":"A320/L","aircraft_short":"A320","departure":"EKCH","arrival":"EGLL","alternate":"EGKK","deptime":"0815","enroute_time":"0145","altitude":"F350","remarks":"PBN/B2","route":"DCT LAM","revision_id":4,"assigned_transponder":"1234"}
+    "flight_plan":{"flight_rules":"I","aircraft":"A320/M-SDE2E3FGHIJ1RWXYZ/LB1","aircraft_faa":"A320/L","aircraft_short":"A320","departure":"EKCH","arrival":"EGLL","alternate":"EGKK","deptime":"0815","enroute_time":"0145","altitude":"35000","remarks":"PBN/B2","route":"DCT LAM","revision_id":4,"assigned_transponder":"1234"}
   }],
   "prefiles":[{
     "cid":7654321,"callsign":" sas456 ","last_updated":"2026-07-12T09:58:00Z",
@@ -73,7 +73,7 @@ func TestCacheSnapshotDecodesPilotsAndPrefiles(t *testing.T) {
 	assert.Equal(t, time.Date(2026, 7, 12, 9, 59, 50, 0, time.UTC), pilot.LastUpdated)
 	assert.Equal(t, FlightPlan{
 		FlightRules: "I", Aircraft: "A320/M-SDE2E3FGHIJ1RWXYZ/LB1", AircraftFAA: "A320/L", AircraftShort: "A320",
-		Origin: "EKCH", Destination: "EGLL", Alternate: "EGKK", EOBT: "0815", EnrouteDuration: "0145", RequestedLevel: "F350",
+		Origin: "EKCH", Destination: "EGLL", Alternate: "EGKK", EOBT: "0815", EnrouteDuration: "0145", RequestedLevel: "35000",
 		Remarks: "PBN/B2", Route: "DCT LAM", AssignedSquawk: "1234", Revision: 4,
 	}, pilot.FlightPlan)
 

--- a/backend/migrations/0035-add-aman-vatsim-observation-identities.sql
+++ b/backend/migrations/0035-add-aman-vatsim-observation-identities.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS aman_vatsim_observation_identities (
+    flight_id VARCHAR PRIMARY KEY,
+    vatsim_cid VARCHAR NOT NULL,
+    current_callsign VARCHAR NOT NULL,
+    retired_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_aman_vatsim_observation_identities_active_cid
+    ON aman_vatsim_observation_identities (vatsim_cid)
+    WHERE retired_at IS NULL;

--- a/backend/queries/aman.sql
+++ b/backend/queries/aman.sql
@@ -1,6 +1,37 @@
 -- name: LockAMANCommand :exec
 SELECT pg_advisory_xact_lock(hashtextextended($1, 0));
 
+-- name: LockAMANVATSIMObservationIdentity :exec
+SELECT pg_advisory_xact_lock(hashtextextended($1, 0));
+
+-- name: GetActiveAMANVATSIMObservationIdentity :one
+SELECT flight_id, vatsim_cid, current_callsign, retired_at, created_at, updated_at
+FROM aman_vatsim_observation_identities
+WHERE vatsim_cid = $1
+  AND retired_at IS NULL;
+
+-- name: CreateAMANVATSIMObservationIdentity :one
+INSERT INTO aman_vatsim_observation_identities (
+    flight_id, vatsim_cid, current_callsign
+)
+VALUES ($1, $2, $3)
+RETURNING flight_id, vatsim_cid, current_callsign, retired_at, created_at, updated_at;
+
+-- name: UpdateAMANVATSIMObservationIdentityCallsign :one
+UPDATE aman_vatsim_observation_identities
+SET current_callsign = $2,
+    updated_at = NOW()
+WHERE flight_id = $1
+  AND retired_at IS NULL
+RETURNING flight_id, vatsim_cid, current_callsign, retired_at, created_at, updated_at;
+
+-- name: RetireAMANVATSIMObservationIdentity :execrows
+UPDATE aman_vatsim_observation_identities
+SET retired_at = NOW(),
+    updated_at = NOW()
+WHERE flight_id = $1
+  AND retired_at IS NULL;
+
 -- name: GetAMANAirportState :one
 SELECT *
 FROM aman_airport_states


### PR DESCRIPTION
## What

- Add a dedicated VATSIM-to-AMAN observation worker that runs without strip, SAT, session, or EuroScope dependencies.
- Normalize prefile and online source facts, including requested level in feet and provider-neutral wake category; preserve ordering fields and emit fresh, stale, disconnected, and restored status transitions without repeatedly publishing unchanged state.
- Interpret planned timing from source-observed time, so retries and restarts preserve the same service-day value.
- Persist active VATSIM-flight identity bindings with generated FlightIDs; callsign corrections retain the active ID and lifecycle retirement allows a later flight from the same CID to get a new ID.
- Assemble exactly one concrete source-observation worker at the configured surveillance interval, independently of Stand Assignment.

## Why

AMAN needs provider-neutral source observations before any controller connection, while VATSIM reconciliation must not become an ETA or Stand Assignment dependency for that path.

## Impact

- Read-only and authoritative rollout modes retain a single operational ETA owner through the existing runtime ownership switch.
- Per-flight mapping or delivery errors do not prevent other enabled-airport observations in the same source snapshot.
- No EuroScope geometry, TETA, SAT imports, or vendor DTOs enter the AMAN observation contract.
- Adds migration `0035-add-aman-vatsim-observation-identities.sql`.

## Checks

- `go test ./internal/aman ./internal/vatsim ./internal/app ./internal/repository/postgres -run 'Test(Observation|Wake|CacheSnapshotDecodes|AMANVATSIM|Runtime|BuildAdds)' -count=1`
- `go test ./...`

Closes #307