### PR TITLE
feat(aman): define navigation contracts

### DIFF
--- a/backend/internal/aman/navdata/README.md
+++ b/backend/internal/aman/navdata/README.md
@@ -1,0 +1,12 @@
+# AMAN navigation contracts
+
+`navdata` is the provider-independent boundary for acquiring and consuming
+canonical navigation geometry. A materializer composes `CycleSource`,
+`AirportSource`, `ProcedureSource`, `FixSource`, and `RouteResolver`, then
+writes a canonical cache. Runtime prediction and sequencing receive only the
+cache-only `GeometryReader`.
+
+The local `fixture` package proves source replacement, including EKCH SID,
+STAR, approach, HA/HF/HM, unsupported-vector, and DCT route fixtures. Shared
+checks are in `contracttest`; the AIRAC.NET adapter equivalence proof is owned
+by #310 and is deliberately not implemented in this package.

--- a/backend/internal/aman/navdata/cache.go
+++ b/backend/internal/aman/navdata/cache.go
@@ -1,0 +1,57 @@
+package navdata
+
+import (
+	"context"
+	"fmt"
+
+	"FlightStrips/internal/aman"
+)
+
+// Cache is an in-memory implementation of the runtime reader contract. It is
+// intentionally populated by its caller, so a runtime read cannot trigger an
+// import or a source request.
+type Cache struct {
+	Active   map[AirportID]DatasetVersion
+	Routes   map[RouteKey]RouteGeometry
+	Terminal map[terminalPathKey]TerminalPath
+}
+
+type terminalPathKey struct {
+	airport     AirportID
+	feeder      FeederID
+	runwayGroup aman.RunwayGroupID
+}
+
+func (c Cache) ActiveVersion(_ context.Context, airport AirportID) (DatasetVersion, error) {
+	version, ok := c.Active[airport]
+	if !ok {
+		return DatasetVersion{}, domainError(aman.ErrorNotFound, "cached active dataset was not found")
+	}
+	return version, nil
+}
+func (c Cache) Route(_ context.Context, key RouteKey) (RouteGeometry, error) {
+	route, ok := c.Routes[key]
+	if !ok {
+		return RouteGeometry{}, domainError(aman.ErrorNotFound, "cached route geometry was not found")
+	}
+	return route, nil
+}
+func (c Cache) TerminalPath(_ context.Context, airport AirportID, feeder FeederID, runwayGroup aman.RunwayGroupID) (TerminalPath, error) {
+	path, ok := c.Terminal[terminalPathKey{airport, feeder, runwayGroup}]
+	if !ok {
+		return TerminalPath{}, domainError(aman.ErrorNotFound, "cached terminal path was not found")
+	}
+	return path, nil
+}
+
+func NewCache(active map[AirportID]DatasetVersion, routes map[RouteKey]RouteGeometry, paths []TerminalPath) Cache {
+	terminal := make(map[terminalPathKey]TerminalPath, len(paths))
+	for _, path := range paths {
+		terminal[terminalPathKey{path.Airport, path.Feeder, path.RunwayGroup}] = path
+	}
+	return Cache{Active: active, Routes: routes, Terminal: terminal}
+}
+
+func domainError(class aman.ErrorClass, message string) error {
+	return &aman.DomainError{Class: class, Message: fmt.Sprintf("navigation cache: %s", message)}
+}

--- a/backend/internal/aman/navdata/cache.go
+++ b/backend/internal/aman/navdata/cache.go
@@ -3,6 +3,7 @@ package navdata
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"FlightStrips/internal/aman"
 )
@@ -11,9 +12,9 @@ import (
 // intentionally populated by its caller, so a runtime read cannot trigger an
 // import or a source request.
 type Cache struct {
-	Active   map[AirportID]DatasetVersion
-	Routes   map[RouteKey]RouteGeometry
-	Terminal map[terminalPathKey]TerminalPath
+	active   map[AirportID]DatasetVersion
+	routes   map[RouteKey]RouteGeometry
+	terminal map[terminalPathKey]TerminalPath
 }
 
 type terminalPathKey struct {
@@ -23,33 +24,92 @@ type terminalPathKey struct {
 }
 
 func (c Cache) ActiveVersion(_ context.Context, airport AirportID) (DatasetVersion, error) {
-	version, ok := c.Active[airport]
+	version, ok := c.active[airport]
 	if !ok {
 		return DatasetVersion{}, domainError(aman.ErrorNotFound, "cached active dataset was not found")
 	}
 	return version, nil
 }
 func (c Cache) Route(_ context.Context, key RouteKey) (RouteGeometry, error) {
-	route, ok := c.Routes[key]
+	route, ok := c.routes[key]
 	if !ok {
 		return RouteGeometry{}, domainError(aman.ErrorNotFound, "cached route geometry was not found")
 	}
-	return route, nil
+	return cloneRoute(route), nil
 }
 func (c Cache) TerminalPath(_ context.Context, airport AirportID, feeder FeederID, runwayGroup aman.RunwayGroupID) (TerminalPath, error) {
-	path, ok := c.Terminal[terminalPathKey{airport, feeder, runwayGroup}]
+	path, ok := c.terminal[terminalPathKey{airport, feeder, runwayGroup}]
 	if !ok {
 		return TerminalPath{}, domainError(aman.ErrorNotFound, "cached terminal path was not found")
 	}
-	return path, nil
+	return cloneTerminal(path), nil
 }
 
-func NewCache(active map[AirportID]DatasetVersion, routes map[RouteKey]RouteGeometry, paths []TerminalPath) Cache {
+func NewCache(active map[AirportID]DatasetVersion, routes map[RouteKey]RouteGeometry, paths []TerminalPath) (Cache, error) {
+	activeCopy := make(map[AirportID]DatasetVersion, len(active))
+	for airport, version := range active {
+		if !validIdentifier(string(airport)) {
+			return Cache{}, invalid("cached active airport is invalid")
+		}
+		if err := version.Validate(); err != nil {
+			return Cache{}, err
+		}
+		activeCopy[airport] = version
+	}
+	routeCopy := make(map[RouteKey]RouteGeometry, len(routes))
+	for key, route := range routes {
+		if key == "" {
+			return Cache{}, invalid("cached route key is required")
+		}
+		if err := route.Validate(); err != nil {
+			return Cache{}, err
+		}
+		routeCopy[key] = cloneRoute(route)
+	}
 	terminal := make(map[terminalPathKey]TerminalPath, len(paths))
 	for _, path := range paths {
-		terminal[terminalPathKey{path.Airport, path.Feeder, path.RunwayGroup}] = path
+		if err := path.Validate(); err != nil {
+			return Cache{}, err
+		}
+		key := terminalPathKey{path.Airport, path.Feeder, path.RunwayGroup}
+		if _, found := terminal[key]; found {
+			return Cache{}, invalid("cached terminal path is duplicated")
+		}
+		terminal[key] = cloneTerminal(path)
 	}
-	return Cache{Active: active, Routes: routes, Terminal: terminal}
+	return Cache{active: activeCopy, routes: routeCopy, terminal: terminal}, nil
+}
+
+func cloneRoute(value RouteGeometry) RouteGeometry {
+	value.Legs = cloneLegs(value.Legs)
+	value.HoldingIDs = slices.Clone(value.HoldingIDs)
+	value.Unresolved = slices.Clone(value.Unresolved)
+	return value
+}
+func cloneTerminal(value TerminalPath) TerminalPath {
+	value.Legs = cloneLegs(value.Legs)
+	value.HoldingIDs = slices.Clone(value.HoldingIDs)
+	value.Unresolved = slices.Clone(value.Unresolved)
+	return value
+}
+func cloneLegs(values []ProcedureLeg) []ProcedureLeg {
+	result := make([]ProcedureLeg, len(values))
+	for index, value := range values {
+		result[index] = value
+		result[index].FromFix = clonePtr(value.FromFix)
+		result[index].ToFix = clonePtr(value.ToFix)
+		result[index].CourseTrueDeg = clonePtr(value.CourseTrueDeg)
+		result[index].DistanceNM = clonePtr(value.DistanceNM)
+		result[index].HoldingID = clonePtr(value.HoldingID)
+	}
+	return result
+}
+func clonePtr[T any](value *T) *T {
+	if value == nil {
+		return nil
+	}
+	result := *value
+	return &result
 }
 
 func domainError(class aman.ErrorClass, message string) error {

--- a/backend/internal/aman/navdata/contracttest/contracttest.go
+++ b/backend/internal/aman/navdata/contracttest/contracttest.go
@@ -26,6 +26,8 @@ type Suite struct {
 	ProcedureCoverage map[navdata.ProcedureKind]navdata.Coverage
 	FixQuery          navdata.FixQuery
 	RouteQuery        navdata.RouteQuery
+	RouteDigest       string
+	HoldingDigests    map[navdata.HoldingID]string
 }
 
 func Run(t testing.TB, provider Provider, suite Suite) {
@@ -60,6 +62,15 @@ func Run(t testing.TB, provider Provider, suite Suite) {
 			if err := procedure.Validate(); err != nil {
 				t.Fatalf("procedure %q invalid: %v", procedure.ID, err)
 			}
+			for _, holding := range procedure.Holdings {
+				digest, err := navdata.HoldingDigest(holding)
+				if err != nil {
+					t.Fatalf("holding %q digest: %v", holding.ID, err)
+				}
+				if expected, ok := suite.HoldingDigests[holding.ID]; !ok || digest != expected {
+					t.Fatalf("holding %q digest = %q, want %q", holding.ID, digest, expected)
+				}
+			}
 		}
 	}
 	fixes, err := provider.Fixes(ctx, suite.FixQuery)
@@ -73,7 +84,11 @@ func Run(t testing.TB, provider Provider, suite Suite) {
 	if route.Coverage != navdata.CoveragePartial || len(route.Unresolved) == 0 {
 		t.Fatalf("route must retain unsupported geometry explicitly: %#v", route)
 	}
-	if _, err := navdata.RouteGeometryDigest(suite.RouteQuery, route.Legs, route.HoldingIDs, route.Coverage, route.Unresolved); err != nil {
+	digest, err := navdata.RouteGeometryDigest(suite.RouteQuery, route)
+	if err != nil {
 		t.Fatalf("route digest: %v", err)
+	}
+	if route.Digest != suite.RouteDigest || digest != suite.RouteDigest {
+		t.Fatalf("route digest = stored %q / computed %q, want %q", route.Digest, digest, suite.RouteDigest)
 	}
 }

--- a/backend/internal/aman/navdata/contracttest/contracttest.go
+++ b/backend/internal/aman/navdata/contracttest/contracttest.go
@@ -1,0 +1,79 @@
+// Package contracttest contains reusable source/resolver conformance checks.
+// The fixture source runs them now; #310 runs these same checks for AIRAC.NET.
+package contracttest
+
+import (
+	"context"
+	"testing"
+
+	"FlightStrips/internal/aman/navdata"
+)
+
+type Provider interface {
+	navdata.CycleSource
+	navdata.AirportSource
+	navdata.ProcedureSource
+	navdata.FixSource
+	navdata.RouteResolver
+}
+
+type Suite struct {
+	Version           navdata.DatasetVersion
+	Airport           navdata.AirportID
+	SIDQuery          navdata.ProcedureQuery
+	STARQuery         navdata.ProcedureQuery
+	ApproachQuery     navdata.ProcedureQuery
+	ProcedureCoverage map[navdata.ProcedureKind]navdata.Coverage
+	FixQuery          navdata.FixQuery
+	RouteQuery        navdata.RouteQuery
+}
+
+func Run(t testing.TB, provider Provider, suite Suite) {
+	t.Helper()
+	ctx := context.Background()
+	version, err := provider.LatestVersion(ctx)
+	if err != nil {
+		t.Fatalf("latest dataset version: %v", err)
+	}
+	if !version.Equal(suite.Version) {
+		t.Fatalf("dataset version = %#v, want %#v", version, suite.Version)
+	}
+	airport, err := provider.Airport(ctx, suite.Version, suite.Airport)
+	if err != nil || airport.ID != suite.Airport {
+		t.Fatalf("airport = %#v, %v", airport, err)
+	}
+	for _, query := range []navdata.ProcedureQuery{suite.SIDQuery, suite.STARQuery, suite.ApproachQuery} {
+		procedures, err := provider.Procedures(ctx, query)
+		if err != nil {
+			t.Fatalf("procedures for %v: %v", query.Kinds, err)
+		}
+		expectedCoverage := navdata.CoverageComplete
+		if len(query.Kinds) == 1 && suite.ProcedureCoverage != nil {
+			if expected, ok := suite.ProcedureCoverage[query.Kinds[0]]; ok {
+				expectedCoverage = expected
+			}
+		}
+		if procedures.Coverage != expectedCoverage || len(procedures.Procedures) == 0 {
+			t.Fatalf("procedures for %v have coverage %q and %d values", query.Kinds, procedures.Coverage, len(procedures.Procedures))
+		}
+		for _, procedure := range procedures.Procedures {
+			if err := procedure.Validate(); err != nil {
+				t.Fatalf("procedure %q invalid: %v", procedure.ID, err)
+			}
+		}
+	}
+	fixes, err := provider.Fixes(ctx, suite.FixQuery)
+	if err != nil || !fixes.Coverage.Authoritative() {
+		t.Fatalf("fixes = %#v, %v", fixes, err)
+	}
+	route, err := provider.Resolve(ctx, suite.RouteQuery)
+	if err != nil {
+		t.Fatalf("resolve DCT route: %v", err)
+	}
+	if route.Coverage != navdata.CoveragePartial || len(route.Unresolved) == 0 {
+		t.Fatalf("route must retain unsupported geometry explicitly: %#v", route)
+	}
+	if _, err := navdata.RouteGeometryDigest(suite.RouteQuery, route.Legs, route.HoldingIDs, route.Coverage, route.Unresolved); err != nil {
+		t.Fatalf("route digest: %v", err)
+	}
+}

--- a/backend/internal/aman/navdata/doc.go
+++ b/backend/internal/aman/navdata/doc.go
@@ -1,0 +1,4 @@
+// Package navdata defines provider-independent navigation acquisition and
+// runtime geometry contracts for AMAN. Source adapters live in child packages;
+// the cache-only GeometryReader deliberately has no dependency on them.
+package navdata

--- a/backend/internal/aman/navdata/fixture/source.go
+++ b/backend/internal/aman/navdata/fixture/source.go
@@ -104,7 +104,7 @@ func (s *Source) Resolve(_ context.Context, query navdata.RouteQuery) (navdata.R
 	}
 	return route, nil
 }
-func (s *Source) Cache() navdata.Cache {
+func (s *Source) Cache() (navdata.Cache, error) {
 	return navdata.NewCache(map[navdata.AirportID]navdata.DatasetVersion{"EKCH": s.dataset.Version}, s.dataset.Routes, s.dataset.TerminalPaths)
 }
 
@@ -160,14 +160,16 @@ func EKCH() Dataset {
 	sid := navdata.Procedure{ID: "KEMAX3A", Airport: "EKCH", Kind: navdata.ProcedureSID, Runways: []navdata.RunwayID{"22L"}, Provenance: provenance, Holdings: []navdata.HoldingPattern{hold(ha, kemax, navdata.HoldingToAltitude)}, Legs: []navdata.ProcedureLeg{{ID: "SID-1", PathTerminator: navdata.PathTF, ToFix: &kemax, CourseTrueDeg: &course, DistanceNM: &distance}, {ID: "SID-HOLD", PathTerminator: navdata.PathHA, ToFix: &kemax, HoldingID: &ha}}}
 	star := navdata.Procedure{ID: "SOK1P", Airport: "EKCH", Kind: navdata.ProcedureSTAR, Runways: []navdata.RunwayID{"22L"}, Provenance: provenance, Holdings: []navdata.HoldingPattern{hold(hf, sok, navdata.HoldingToFix)}, Legs: []navdata.ProcedureLeg{{ID: "STAR-HOLD", PathTerminator: navdata.PathHF, ToFix: &sok, HoldingID: &hf}}}
 	approach := navdata.Procedure{ID: "ILS22L", Airport: "EKCH", Kind: navdata.ProcedureApproach, Runways: []navdata.RunwayID{"22L"}, Provenance: provenance, Holdings: []navdata.HoldingPattern{hold(hm, rosbi, navdata.HoldingManual)}, Legs: []navdata.ProcedureLeg{{ID: "APP-HOLD", PathTerminator: navdata.PathHM, ToFix: &rosbi, HoldingID: &hm}, {ID: "VECTOR", PathTerminator: navdata.PathUnsupported}}}
-	query := navdata.RouteQuery{Version: version, Origin: "ENGM", Destination: "EKCH", FiledRoute: "DCT KEMAX", ArrivalProcedure: ptr(navdata.ProcedureID("SOK1P")), Runway: ptr(navdata.RunwayID("22L")), RunwayGroup: ptr(aman.RunwayGroupID("south"))}
+	query := navdata.RouteQuery{Version: version, Origin: "ENGM", Destination: "EKCH", FiledRoute: "DCT KEMAX", ArrivalProcedure: ptr(navdata.ProcedureID("SOK1P")), Runway: ptr(navdata.RunwayID("22L")), RunwayGroup: ptr(aman.RunwayGroupID("SOUTH"))}
 	routeLegs := []navdata.ProcedureLeg{{ID: "DCT-KEMAX", PathTerminator: navdata.PathDF, ToFix: &kemax, DistanceNM: &distance}, {ID: "VECTOR", PathTerminator: navdata.PathUnsupported}}
-	digest, _ := navdata.RouteGeometryDigest(query, routeLegs, []navdata.HoldingID{hf}, navdata.CoveragePartial, []string{"vector"})
+	route := navdata.RouteGeometry{Version: version, Legs: routeLegs, HoldingIDs: []navdata.HoldingID{hf}, TotalDistanceNM: distance, Coverage: navdata.CoveragePartial, Unresolved: []string{"vector"}, Provenance: provenance}
+	digest, _ := navdata.RouteGeometryDigest(query, route)
+	route.Digest = digest
 	key, _ := query.Key()
 	haDigest, _ := navdata.HoldingDigest(sid.Holdings[0])
 	hfDigest, _ := navdata.HoldingDigest(star.Holdings[0])
 	hmDigest, _ := navdata.HoldingDigest(approach.Holdings[0])
-	return Dataset{Version: version, Provenance: provenance, Airports: map[navdata.AirportID]navdata.Airport{"EKCH": {ID: "EKCH", Name: "Copenhagen", Position: navdata.Coordinate{LatitudeDeg: 55.618, LongitudeDeg: 12.656}, Provenance: provenance}}, Fixes: map[navdata.FixID]navdata.Fix{kemax: {ID: kemax, Position: navdata.Coordinate{LatitudeDeg: 55.8, LongitudeDeg: 12.4}, Provenance: provenance}, sok: {ID: sok, Position: navdata.Coordinate{LatitudeDeg: 55.7, LongitudeDeg: 12.2}, Provenance: provenance}, rosbi: {ID: rosbi, Position: navdata.Coordinate{LatitudeDeg: 55.6, LongitudeDeg: 12.7}, Provenance: provenance}}, Procedures: []navdata.Procedure{sid, star, approach}, Routes: map[navdata.RouteKey]navdata.RouteGeometry{key: {Version: version, Legs: routeLegs, HoldingIDs: []navdata.HoldingID{hf}, TotalDistanceNM: distance, Coverage: navdata.CoveragePartial, Unresolved: []string{"vector"}, Provenance: provenance, Digest: digest}}, HoldingDigests: map[navdata.HoldingID]string{ha: haDigest, hf: hfDigest, hm: hmDigest}, TerminalPaths: []navdata.TerminalPath{{Version: version, Airport: "EKCH", Feeder: "SOK", RunwayGroup: "south", Legs: star.Legs, HoldingIDs: []navdata.HoldingID{hf}, Coverage: navdata.CoverageComplete, Provenance: provenance, Digest: "fixture-terminal-sok"}}}
+	return Dataset{Version: version, Provenance: provenance, Airports: map[navdata.AirportID]navdata.Airport{"EKCH": {ID: "EKCH", Name: "Copenhagen", Position: navdata.Coordinate{LatitudeDeg: 55.618, LongitudeDeg: 12.656}, Provenance: provenance}}, Fixes: map[navdata.FixID]navdata.Fix{kemax: {ID: kemax, Position: navdata.Coordinate{LatitudeDeg: 55.8, LongitudeDeg: 12.4}, Provenance: provenance}, sok: {ID: sok, Position: navdata.Coordinate{LatitudeDeg: 55.7, LongitudeDeg: 12.2}, Provenance: provenance}, rosbi: {ID: rosbi, Position: navdata.Coordinate{LatitudeDeg: 55.6, LongitudeDeg: 12.7}, Provenance: provenance}}, Procedures: []navdata.Procedure{sid, star, approach}, Routes: map[navdata.RouteKey]navdata.RouteGeometry{key: route}, HoldingDigests: map[navdata.HoldingID]string{ha: haDigest, hf: hfDigest, hm: hmDigest}, TerminalPaths: []navdata.TerminalPath{{Version: version, Airport: "EKCH", Feeder: "SOK", RunwayGroup: "SOUTH", Legs: star.Legs, HoldingIDs: []navdata.HoldingID{hf}, Coverage: navdata.CoverageComplete, Provenance: provenance, Digest: "fixture-terminal-sok"}}}
 }
 
 func timeUTC(year, month, day int) time.Time {

--- a/backend/internal/aman/navdata/fixture/source.go
+++ b/backend/internal/aman/navdata/fixture/source.go
@@ -1,0 +1,175 @@
+// Package fixture supplies a local, deterministic source/resolver for contract
+// tests. It models no provider transport and is also a replacement-source proof.
+package fixture
+
+import (
+	"context"
+	"slices"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/aman/navdata"
+)
+
+type Dataset struct {
+	Version        navdata.DatasetVersion
+	Provenance     navdata.Provenance
+	Airports       map[navdata.AirportID]navdata.Airport
+	Fixes          map[navdata.FixID]navdata.Fix
+	Procedures     []navdata.Procedure
+	Routes         map[navdata.RouteKey]navdata.RouteGeometry
+	HoldingDigests map[navdata.HoldingID]string
+	TerminalPaths  []navdata.TerminalPath
+}
+
+type Source struct {
+	dataset Dataset
+	calls   int
+}
+
+func New(data Dataset) *Source { return &Source{dataset: data} }
+func (s *Source) Calls() int   { return s.calls }
+func (s *Source) LatestVersion(context.Context) (navdata.DatasetVersion, error) {
+	s.calls++
+	return s.dataset.Version, nil
+}
+func (s *Source) Airport(_ context.Context, version navdata.DatasetVersion, airport navdata.AirportID) (navdata.Airport, error) {
+	s.calls++
+	if err := matchVersion(s.dataset.Version, version); err != nil {
+		return navdata.Airport{}, err
+	}
+	value, ok := s.dataset.Airports[airport]
+	if !ok {
+		return navdata.Airport{}, unavailable(aman.ErrorNotFound, "airport was not found")
+	}
+	return value, nil
+}
+func (s *Source) Procedures(_ context.Context, query navdata.ProcedureQuery) (navdata.ProcedureSet, error) {
+	s.calls++
+	if err := query.Validate(); err != nil {
+		return navdata.ProcedureSet{}, err
+	}
+	if err := matchVersion(s.dataset.Version, query.Version); err != nil {
+		return navdata.ProcedureSet{}, err
+	}
+	procedures := make([]navdata.Procedure, 0)
+	coverage := navdata.CoverageComplete
+	for _, procedure := range s.dataset.Procedures {
+		if procedure.Airport == query.Airport && matchesProcedure(procedure, query) {
+			procedures = append(procedures, procedure)
+			for _, leg := range procedure.Legs {
+				if !leg.PathTerminator.Supported() {
+					coverage = navdata.CoveragePartial
+				}
+			}
+		}
+	}
+	if len(procedures) == 0 {
+		coverage = navdata.CoveragePartial
+	}
+	return navdata.ProcedureSet{Version: s.dataset.Version, Airport: query.Airport, Procedures: procedures, Coverage: coverage, Provenance: s.dataset.Provenance}, nil
+}
+func (s *Source) Fixes(_ context.Context, query navdata.FixQuery) (navdata.FixSet, error) {
+	s.calls++
+	if err := query.Validate(); err != nil {
+		return navdata.FixSet{}, err
+	}
+	if err := matchVersion(s.dataset.Version, query.Version); err != nil {
+		return navdata.FixSet{}, err
+	}
+	fixes := make([]navdata.Fix, 0, len(query.Identifiers))
+	for _, id := range query.Identifiers {
+		if fix, ok := s.dataset.Fixes[id]; ok {
+			fixes = append(fixes, fix)
+		}
+	}
+	coverage := navdata.CoverageComplete
+	if len(fixes) != len(query.Identifiers) {
+		coverage = navdata.CoveragePartial
+	}
+	return navdata.FixSet{Version: s.dataset.Version, Fixes: fixes, Coverage: coverage, Provenance: s.dataset.Provenance}, nil
+}
+func (s *Source) Resolve(_ context.Context, query navdata.RouteQuery) (navdata.RouteGeometry, error) {
+	s.calls++
+	key, err := query.Key()
+	if err != nil {
+		return navdata.RouteGeometry{}, err
+	}
+	if err := matchVersion(s.dataset.Version, query.Version); err != nil {
+		return navdata.RouteGeometry{}, err
+	}
+	route, ok := s.dataset.Routes[key]
+	if !ok {
+		return navdata.RouteGeometry{}, unavailable(aman.ErrorNotFound, "route was not found")
+	}
+	return route, nil
+}
+func (s *Source) Cache() navdata.Cache {
+	return navdata.NewCache(map[navdata.AirportID]navdata.DatasetVersion{"EKCH": s.dataset.Version}, s.dataset.Routes, s.dataset.TerminalPaths)
+}
+
+func matchesProcedure(procedure navdata.Procedure, query navdata.ProcedureQuery) bool {
+	if len(query.Kinds) > 0 && !slices.Contains(query.Kinds, procedure.Kind) {
+		return false
+	}
+	if len(query.Identifiers) > 0 && !slices.Contains(query.Identifiers, procedure.ID) {
+		return false
+	}
+	if len(query.Runways) == 0 {
+		return true
+	}
+	for _, runway := range procedure.Runways {
+		if slices.Contains(query.Runways, runway) {
+			return true
+		}
+	}
+	return false
+}
+func matchVersion(expected, actual navdata.DatasetVersion) error {
+	if !expected.Equal(actual) {
+		return unavailable(aman.ErrorDatasetMismatch, "dataset version does not match fixture")
+	}
+	return nil
+}
+func unavailable(class aman.ErrorClass, message string) error {
+	return &aman.DomainError{Class: class, Message: message}
+}
+
+var _ navdata.CycleSource = (*Source)(nil)
+var _ navdata.AirportSource = (*Source)(nil)
+var _ navdata.ProcedureSource = (*Source)(nil)
+var _ navdata.FixSource = (*Source)(nil)
+var _ navdata.RouteResolver = (*Source)(nil)
+var _ navdata.GeometryReader = (navdata.Cache{})
+
+func ptr[T any](value T) *T { return &value }
+func EKCH() Dataset {
+	from := timeUTC(2026, 7, 16)
+	until := timeUTC(2026, 8, 13)
+	imported := timeUTC(2026, 7, 17)
+	version := navdata.DatasetVersion{Cycle: "2608", SourceRevision: "fixture-r1", EffectiveFrom: from, EffectiveUntil: until}
+	provenance := navdata.Provenance{SourceID: "fixture", SourceRevision: "fixture-r1", ImportedAt: imported, EffectiveFrom: from, EffectiveUntil: until}
+	kemax, sok, rosbi := navdata.FixID("KEMAX"), navdata.FixID("SOK"), navdata.FixID("ROSBI")
+	ha, hf, hm := navdata.HoldingID("KEMAX-HA"), navdata.HoldingID("SOK-HF"), navdata.HoldingID("ROSBI-HM")
+	course := 220.0
+	distance := 5.0
+	holdTime := int64(60)
+	hold := func(id navdata.HoldingID, fix navdata.FixID, termination navdata.HoldingTermination) navdata.HoldingPattern {
+		return navdata.HoldingPattern{ID: id, Fix: fix, InboundCourseTrueDeg: course, TurnDirection: navdata.TurnRight, LegTimeSeconds: &holdTime, Termination: termination, Provenance: provenance}
+	}
+	sid := navdata.Procedure{ID: "KEMAX3A", Airport: "EKCH", Kind: navdata.ProcedureSID, Runways: []navdata.RunwayID{"22L"}, Provenance: provenance, Holdings: []navdata.HoldingPattern{hold(ha, kemax, navdata.HoldingToAltitude)}, Legs: []navdata.ProcedureLeg{{ID: "SID-1", PathTerminator: navdata.PathTF, ToFix: &kemax, CourseTrueDeg: &course, DistanceNM: &distance}, {ID: "SID-HOLD", PathTerminator: navdata.PathHA, ToFix: &kemax, HoldingID: &ha}}}
+	star := navdata.Procedure{ID: "SOK1P", Airport: "EKCH", Kind: navdata.ProcedureSTAR, Runways: []navdata.RunwayID{"22L"}, Provenance: provenance, Holdings: []navdata.HoldingPattern{hold(hf, sok, navdata.HoldingToFix)}, Legs: []navdata.ProcedureLeg{{ID: "STAR-HOLD", PathTerminator: navdata.PathHF, ToFix: &sok, HoldingID: &hf}}}
+	approach := navdata.Procedure{ID: "ILS22L", Airport: "EKCH", Kind: navdata.ProcedureApproach, Runways: []navdata.RunwayID{"22L"}, Provenance: provenance, Holdings: []navdata.HoldingPattern{hold(hm, rosbi, navdata.HoldingManual)}, Legs: []navdata.ProcedureLeg{{ID: "APP-HOLD", PathTerminator: navdata.PathHM, ToFix: &rosbi, HoldingID: &hm}, {ID: "VECTOR", PathTerminator: navdata.PathUnsupported}}}
+	query := navdata.RouteQuery{Version: version, Origin: "ENGM", Destination: "EKCH", FiledRoute: "DCT KEMAX", ArrivalProcedure: ptr(navdata.ProcedureID("SOK1P")), Runway: ptr(navdata.RunwayID("22L")), RunwayGroup: ptr(aman.RunwayGroupID("south"))}
+	routeLegs := []navdata.ProcedureLeg{{ID: "DCT-KEMAX", PathTerminator: navdata.PathDF, ToFix: &kemax, DistanceNM: &distance}, {ID: "VECTOR", PathTerminator: navdata.PathUnsupported}}
+	digest, _ := navdata.RouteGeometryDigest(query, routeLegs, []navdata.HoldingID{hf}, navdata.CoveragePartial, []string{"vector"})
+	key, _ := query.Key()
+	haDigest, _ := navdata.HoldingDigest(sid.Holdings[0])
+	hfDigest, _ := navdata.HoldingDigest(star.Holdings[0])
+	hmDigest, _ := navdata.HoldingDigest(approach.Holdings[0])
+	return Dataset{Version: version, Provenance: provenance, Airports: map[navdata.AirportID]navdata.Airport{"EKCH": {ID: "EKCH", Name: "Copenhagen", Position: navdata.Coordinate{LatitudeDeg: 55.618, LongitudeDeg: 12.656}, Provenance: provenance}}, Fixes: map[navdata.FixID]navdata.Fix{kemax: {ID: kemax, Position: navdata.Coordinate{LatitudeDeg: 55.8, LongitudeDeg: 12.4}, Provenance: provenance}, sok: {ID: sok, Position: navdata.Coordinate{LatitudeDeg: 55.7, LongitudeDeg: 12.2}, Provenance: provenance}, rosbi: {ID: rosbi, Position: navdata.Coordinate{LatitudeDeg: 55.6, LongitudeDeg: 12.7}, Provenance: provenance}}, Procedures: []navdata.Procedure{sid, star, approach}, Routes: map[navdata.RouteKey]navdata.RouteGeometry{key: {Version: version, Legs: routeLegs, HoldingIDs: []navdata.HoldingID{hf}, TotalDistanceNM: distance, Coverage: navdata.CoveragePartial, Unresolved: []string{"vector"}, Provenance: provenance, Digest: digest}}, HoldingDigests: map[navdata.HoldingID]string{ha: haDigest, hf: hfDigest, hm: hmDigest}, TerminalPaths: []navdata.TerminalPath{{Version: version, Airport: "EKCH", Feeder: "SOK", RunwayGroup: "south", Legs: star.Legs, HoldingIDs: []navdata.HoldingID{hf}, Coverage: navdata.CoverageComplete, Provenance: provenance, Digest: "fixture-terminal-sok"}}}
+}
+
+func timeUTC(year, month, day int) time.Time {
+	return time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
+}

--- a/backend/internal/aman/navdata/fixture/source_test.go
+++ b/backend/internal/aman/navdata/fixture/source_test.go
@@ -13,7 +13,10 @@ import (
 func TestEKCHFixturePassesSharedSourceResolverContract(t *testing.T) {
 	data := EKCH()
 	source := New(data)
-	contracttest.Run(t, source, contracttest.Suite{Version: data.Version, Airport: "EKCH", SIDQuery: navdata.ProcedureQuery{Version: data.Version, Airport: "EKCH", Kinds: []navdata.ProcedureKind{navdata.ProcedureSID}}, STARQuery: navdata.ProcedureQuery{Version: data.Version, Airport: "EKCH", Kinds: []navdata.ProcedureKind{navdata.ProcedureSTAR}}, ApproachQuery: navdata.ProcedureQuery{Version: data.Version, Airport: "EKCH", Kinds: []navdata.ProcedureKind{navdata.ProcedureApproach}}, ProcedureCoverage: map[navdata.ProcedureKind]navdata.Coverage{navdata.ProcedureApproach: navdata.CoveragePartial}, FixQuery: navdata.FixQuery{Version: data.Version, Identifiers: []navdata.FixID{"KEMAX", "SOK"}}, RouteQuery: EKCHRouteQuery(data.Version)})
+	query := EKCHRouteQuery(data.Version)
+	key, err := query.Key()
+	require.NoError(t, err)
+	contracttest.Run(t, source, contracttest.Suite{Version: data.Version, Airport: "EKCH", SIDQuery: navdata.ProcedureQuery{Version: data.Version, Airport: "EKCH", Kinds: []navdata.ProcedureKind{navdata.ProcedureSID}}, STARQuery: navdata.ProcedureQuery{Version: data.Version, Airport: "EKCH", Kinds: []navdata.ProcedureKind{navdata.ProcedureSTAR}}, ApproachQuery: navdata.ProcedureQuery{Version: data.Version, Airport: "EKCH", Kinds: []navdata.ProcedureKind{navdata.ProcedureApproach}}, ProcedureCoverage: map[navdata.ProcedureKind]navdata.Coverage{navdata.ProcedureApproach: navdata.CoveragePartial}, FixQuery: navdata.FixQuery{Version: data.Version, Identifiers: []navdata.FixID{"KEMAX", "SOK"}}, RouteQuery: query, RouteDigest: data.Routes[key].Digest, HoldingDigests: data.HoldingDigests})
 }
 
 func TestProcedureFiltersAndPublishedHoldsAreIndependent(t *testing.T) {
@@ -39,10 +42,34 @@ func TestProcedureFiltersAndPublishedHoldsAreIndependent(t *testing.T) {
 	}
 }
 
+func TestTypedProcedureQueriesSupportEachNarrowFilter(t *testing.T) {
+	data, source := EKCH(), New(EKCH())
+	tests := []struct {
+		name     string
+		query    navdata.ProcedureQuery
+		coverage navdata.Coverage
+	}{
+		{"SID only", navdata.ProcedureQuery{Version: data.Version, Airport: "EKCH", Kinds: []navdata.ProcedureKind{navdata.ProcedureSID}}, navdata.CoverageComplete},
+		{"STAR only", navdata.ProcedureQuery{Version: data.Version, Airport: "EKCH", Kinds: []navdata.ProcedureKind{navdata.ProcedureSTAR}}, navdata.CoverageComplete},
+		{"approach only", navdata.ProcedureQuery{Version: data.Version, Airport: "EKCH", Kinds: []navdata.ProcedureKind{navdata.ProcedureApproach}}, navdata.CoveragePartial},
+		{"identifier", navdata.ProcedureQuery{Version: data.Version, Airport: "EKCH", Identifiers: []navdata.ProcedureID{"SOK1P"}}, navdata.CoverageComplete},
+		{"runway", navdata.ProcedureQuery{Version: data.Version, Airport: "EKCH", Runways: []navdata.RunwayID{"22L"}, Identifiers: []navdata.ProcedureID{"KEMAX3A"}}, navdata.CoverageComplete},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			set, err := source.Procedures(context.Background(), test.query)
+			require.NoError(t, err)
+			require.Len(t, set.Procedures, 1)
+			require.Equal(t, test.coverage, set.Coverage)
+		})
+	}
+}
+
 func TestRuntimeCacheMakesNoSourceCalls(t *testing.T) {
 	data := EKCH()
 	source := New(data)
-	cache := source.Cache()
+	cache, err := source.Cache()
+	require.NoError(t, err)
 	before := source.Calls()
 	query := EKCHRouteQuery(data.Version)
 	key, err := query.Key()
@@ -51,14 +78,34 @@ func TestRuntimeCacheMakesNoSourceCalls(t *testing.T) {
 	require.NoError(t, err)
 	_, err = cache.Route(context.Background(), key)
 	require.NoError(t, err)
-	_, err = cache.TerminalPath(context.Background(), "EKCH", "SOK", aman.RunwayGroupID("south"))
+	_, err = cache.TerminalPath(context.Background(), "EKCH", "SOK", aman.RunwayGroupID("SOUTH"))
 	require.NoError(t, err)
 	require.Equal(t, before, source.Calls())
+}
+
+func TestRuntimeCacheDefensivelyClonesGeometry(t *testing.T) {
+	data, source := EKCH(), New(EKCH())
+	cache, err := source.Cache()
+	require.NoError(t, err)
+	query := EKCHRouteQuery(data.Version)
+	key, err := query.Key()
+	require.NoError(t, err)
+	source.dataset.Routes[key] = navdata.RouteGeometry{}
+	first, err := cache.Route(context.Background(), key)
+	require.NoError(t, err)
+	first.Legs[0].ID = "MUTATED"
+	first.HoldingIDs[0] = "MUTATED"
+	*first.Legs[0].ToFix = "MUTATED"
+	second, err := cache.Route(context.Background(), key)
+	require.NoError(t, err)
+	require.NotEqual(t, "MUTATED", second.Legs[0].ID)
+	require.NotEqual(t, navdata.HoldingID("MUTATED"), second.HoldingIDs[0])
+	require.NotEqual(t, navdata.FixID("MUTATED"), *second.Legs[0].ToFix)
 }
 
 func EKCHRouteQuery(version navdata.DatasetVersion) navdata.RouteQuery {
 	arrival := navdata.ProcedureID("SOK1P")
 	runway := navdata.RunwayID("22L")
-	group := aman.RunwayGroupID("south")
+	group := aman.RunwayGroupID("SOUTH")
 	return navdata.RouteQuery{Version: version, Origin: "ENGM", Destination: "EKCH", FiledRoute: " dct   kemax ", ArrivalProcedure: &arrival, Runway: &runway, RunwayGroup: &group}
 }

--- a/backend/internal/aman/navdata/fixture/source_test.go
+++ b/backend/internal/aman/navdata/fixture/source_test.go
@@ -1,0 +1,64 @@
+package fixture
+
+import (
+	"context"
+	"testing"
+
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/aman/navdata"
+	"FlightStrips/internal/aman/navdata/contracttest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEKCHFixturePassesSharedSourceResolverContract(t *testing.T) {
+	data := EKCH()
+	source := New(data)
+	contracttest.Run(t, source, contracttest.Suite{Version: data.Version, Airport: "EKCH", SIDQuery: navdata.ProcedureQuery{Version: data.Version, Airport: "EKCH", Kinds: []navdata.ProcedureKind{navdata.ProcedureSID}}, STARQuery: navdata.ProcedureQuery{Version: data.Version, Airport: "EKCH", Kinds: []navdata.ProcedureKind{navdata.ProcedureSTAR}}, ApproachQuery: navdata.ProcedureQuery{Version: data.Version, Airport: "EKCH", Kinds: []navdata.ProcedureKind{navdata.ProcedureApproach}}, ProcedureCoverage: map[navdata.ProcedureKind]navdata.Coverage{navdata.ProcedureApproach: navdata.CoveragePartial}, FixQuery: navdata.FixQuery{Version: data.Version, Identifiers: []navdata.FixID{"KEMAX", "SOK"}}, RouteQuery: EKCHRouteQuery(data.Version)})
+}
+
+func TestProcedureFiltersAndPublishedHoldsAreIndependent(t *testing.T) {
+	data := EKCH()
+	source := New(data)
+	set, err := source.Procedures(context.Background(), navdata.ProcedureQuery{Version: data.Version, Airport: "EKCH", Kinds: []navdata.ProcedureKind{navdata.ProcedureSTAR}, Runways: []navdata.RunwayID{"22L"}, Identifiers: []navdata.ProcedureID{"SOK1P"}})
+	require.NoError(t, err)
+	require.Len(t, set.Procedures, 1)
+	require.Equal(t, navdata.PathHF, set.Procedures[0].Legs[0].PathTerminator)
+	require.Equal(t, navdata.HoldingToFix, set.Procedures[0].Holdings[0].Termination)
+
+	missing, err := source.Procedures(context.Background(), navdata.ProcedureQuery{Version: data.Version, Airport: "EKCH", Kinds: []navdata.ProcedureKind{navdata.ProcedureSID}, Identifiers: []navdata.ProcedureID{"UNKNOWN"}})
+	require.NoError(t, err)
+	require.Equal(t, navdata.CoveragePartial, missing.Coverage)
+	require.Empty(t, missing.Procedures)
+
+	for _, procedure := range data.Procedures {
+		for _, holding := range procedure.Holdings {
+			digest, err := navdata.HoldingDigest(holding)
+			require.NoError(t, err)
+			require.Equal(t, data.HoldingDigests[holding.ID], digest)
+		}
+	}
+}
+
+func TestRuntimeCacheMakesNoSourceCalls(t *testing.T) {
+	data := EKCH()
+	source := New(data)
+	cache := source.Cache()
+	before := source.Calls()
+	query := EKCHRouteQuery(data.Version)
+	key, err := query.Key()
+	require.NoError(t, err)
+	_, err = cache.ActiveVersion(context.Background(), "EKCH")
+	require.NoError(t, err)
+	_, err = cache.Route(context.Background(), key)
+	require.NoError(t, err)
+	_, err = cache.TerminalPath(context.Background(), "EKCH", "SOK", aman.RunwayGroupID("south"))
+	require.NoError(t, err)
+	require.Equal(t, before, source.Calls())
+}
+
+func EKCHRouteQuery(version navdata.DatasetVersion) navdata.RouteQuery {
+	arrival := navdata.ProcedureID("SOK1P")
+	runway := navdata.RunwayID("22L")
+	group := aman.RunwayGroupID("south")
+	return navdata.RouteQuery{Version: version, Origin: "ENGM", Destination: "EKCH", FiledRoute: " dct   kemax ", ArrivalProcedure: &arrival, Runway: &runway, RunwayGroup: &group}
+}

--- a/backend/internal/aman/navdata/interfaces.go
+++ b/backend/internal/aman/navdata/interfaces.go
@@ -1,0 +1,44 @@
+package navdata
+
+import (
+	"context"
+
+	"FlightStrips/internal/aman"
+)
+
+// Acquisition interfaces are deliberately small. Application composition picks
+// the sources a materializer needs; implementations do not negotiate features.
+type CycleSource interface {
+	LatestVersion(context.Context) (DatasetVersion, error)
+}
+type AirportSource interface {
+	Airport(context.Context, DatasetVersion, AirportID) (Airport, error)
+}
+type ProcedureSource interface {
+	Procedures(context.Context, ProcedureQuery) (ProcedureSet, error)
+}
+type FixSource interface {
+	Fixes(context.Context, FixQuery) (FixSet, error)
+}
+type RouteResolver interface {
+	Resolve(context.Context, RouteQuery) (RouteGeometry, error)
+}
+
+// GeometryReader is the cache-only runtime boundary. It must not import data,
+// call an acquisition source, or report a source outage for usable cached data.
+type GeometryReader interface {
+	ActiveVersion(context.Context, AirportID) (DatasetVersion, error)
+	Route(context.Context, RouteKey) (RouteGeometry, error)
+	TerminalPath(context.Context, AirportID, FeederID, aman.RunwayGroupID) (TerminalPath, error)
+}
+
+// Stable provider-independent navigation error aliases.
+const (
+	ErrorInvalidRequest       = aman.ErrorInvalidArgument
+	ErrorNotFound             = aman.ErrorNotFound
+	ErrorIncompleteGeometry   = aman.ErrorDegradedOrIncompleteGeometry
+	ErrorUnsupportedLeg       = aman.ErrorUnsupportedLeg
+	ErrorDatasetMismatch      = aman.ErrorDatasetMismatch
+	ErrorSourceUnavailable    = aman.ErrorDependencyUnavailable
+	ErrorCorruptCanonicalData = aman.ErrorCorruptData
+)

--- a/backend/internal/aman/navdata/package_direction_test.go
+++ b/backend/internal/aman/navdata/package_direction_test.go
@@ -1,0 +1,39 @@
+package navdata
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestRuntimePackagesDoNotImportNavigationSources(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve package path")
+	}
+	internal := filepath.Dir(filepath.Dir(filepath.Dir(file)))
+	for _, directory := range []string{"aman", "frontend", "repository", "predictor", "sequence"} {
+		path := filepath.Join(internal, directory)
+		entries, err := os.ReadDir(path)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+				continue
+			}
+			contents, err := os.ReadFile(filepath.Join(path, entry.Name()))
+			if err != nil {
+				t.Fatalf("read %s: %v", entry.Name(), err)
+			}
+			if strings.Contains(string(contents), "FlightStrips/internal/aman/navdata/fixture") || strings.Contains(string(contents), "FlightStrips/internal/aman/navdata/airacnet") {
+				t.Errorf("%s must use cache-only navdata.GeometryReader, not a source adapter", filepath.Join(directory, entry.Name()))
+			}
+		}
+	}
+}

--- a/backend/internal/aman/navdata/types.go
+++ b/backend/internal/aman/navdata/types.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -109,6 +110,17 @@ type Airport struct {
 	Position   Coordinate
 	Provenance Provenance
 }
+
+func (a Airport) Validate() error {
+	if !validIdentifier(string(a.ID)) || strings.TrimSpace(a.Name) == "" {
+		return invalid("airport identity is incomplete")
+	}
+	if err := a.Position.Validate(); err != nil {
+		return err
+	}
+	return a.Provenance.Validate()
+}
+
 type Runway struct {
 	ID         RunwayID
 	Airport    AirportID
@@ -116,26 +128,87 @@ type Runway struct {
 	LengthNM   float64
 	Provenance Provenance
 }
+
+func (r Runway) Validate() error {
+	if !validIdentifier(string(r.ID)) || !validIdentifier(string(r.Airport)) || r.LengthNM <= 0 {
+		return invalid("runway identity or length is invalid")
+	}
+	if err := r.Threshold.Validate(); err != nil {
+		return err
+	}
+	return r.Provenance.Validate()
+}
+
 type Fix struct {
 	ID         FixID
 	Position   Coordinate
 	Provenance Provenance
 }
+
+func (f Fix) Validate() error {
+	if !validIdentifier(string(f.ID)) {
+		return invalid("fix ID is invalid")
+	}
+	if err := f.Position.Validate(); err != nil {
+		return err
+	}
+	return f.Provenance.Validate()
+}
+
 type Airway struct {
 	ID         AirwayID
 	Fixes      []FixID
 	Provenance Provenance
 }
+
+func (a Airway) Validate() error {
+	if !validIdentifier(string(a.ID)) || len(a.Fixes) < 2 {
+		return invalid("airway identity or fixes are invalid")
+	}
+	seen := map[FixID]struct{}{}
+	for _, fix := range a.Fixes {
+		if !validIdentifier(string(fix)) {
+			return invalid("airway fix is invalid")
+		}
+		if _, found := seen[fix]; found {
+			return invalid("airway contains duplicate fix")
+		}
+		seen[fix] = struct{}{}
+	}
+	return a.Provenance.Validate()
+}
+
 type Threshold struct {
 	Position      Coordinate
 	ElevationFt   *int
 	CourseTrueDeg *float64
 }
+
+func (t Threshold) Validate() error {
+	if err := t.Position.Validate(); err != nil {
+		return err
+	}
+	if t.CourseTrueDeg != nil && (*t.CourseTrueDeg < 0 || *t.CourseTrueDeg >= 360) {
+		return invalid("threshold course must be true degrees in [0,360)")
+	}
+	return nil
+}
+
 type FinalApproach struct {
 	Runway        RunwayID
 	Threshold     Threshold
 	CourseTrueDeg float64
 	Provenance    Provenance
+}
+
+func (f FinalApproach) Validate() error {
+	if !validIdentifier(string(f.Runway)) || f.CourseTrueDeg < 0 || f.CourseTrueDeg >= 360 {
+		return invalid("final approach identity or course is invalid")
+	}
+	if err := f.Threshold.Validate(); err != nil {
+		return err
+	}
+	return f.Provenance.Validate()
 }
 
 type ProcedureKind string
@@ -175,7 +248,14 @@ const (
 )
 
 func (p PathTerminator) IsHolding() bool { return p == PathHA || p == PathHF || p == PathHM }
-func (p PathTerminator) Supported() bool { return p != "" && p != PathUnsupported }
+func (p PathTerminator) Supported() bool {
+	switch p {
+	case PathIF, PathTF, PathCF, PathDF, PathAF, PathRF, PathCA, PathFA, PathFC, PathFD, PathVA, PathVM, PathVI, PathHA, PathHF, PathHM:
+		return true
+	default:
+		return false
+	}
+}
 
 type TurnDirection string
 
@@ -288,7 +368,17 @@ func (p Procedure) Validate() error {
 	if err := p.Provenance.Validate(); err != nil {
 		return err
 	}
-	holdings := make(map[HoldingID]struct{}, len(p.Holdings))
+	runways := make(map[RunwayID]struct{}, len(p.Runways))
+	for _, runway := range p.Runways {
+		if !validIdentifier(string(runway)) {
+			return invalid("procedure runway is invalid")
+		}
+		if _, found := runways[runway]; found {
+			return invalid("procedure contains duplicate runway")
+		}
+		runways[runway] = struct{}{}
+	}
+	holdings := make(map[HoldingID]HoldingPattern, len(p.Holdings))
 	for _, holding := range p.Holdings {
 		if err := holding.Validate(); err != nil {
 			return err
@@ -296,15 +386,27 @@ func (p Procedure) Validate() error {
 		if _, found := holdings[holding.ID]; found {
 			return invalid("procedure has duplicate holding ID")
 		}
-		holdings[holding.ID] = struct{}{}
+		holdings[holding.ID] = holding
 	}
+	legIDs := make(map[string]struct{}, len(p.Legs))
 	for _, leg := range p.Legs {
 		if err := leg.Validate(); err != nil {
 			return err
 		}
+		if _, found := legIDs[leg.ID]; found {
+			return invalid("procedure contains duplicate leg ID")
+		}
+		legIDs[leg.ID] = struct{}{}
 		if leg.HoldingID != nil {
-			if _, found := holdings[*leg.HoldingID]; !found {
+			holding, found := holdings[*leg.HoldingID]
+			if !found {
 				return invalid("holding leg references missing holding")
+			}
+			if (leg.PathTerminator == PathHA && holding.Termination != HoldingToAltitude) || (leg.PathTerminator == PathHF && holding.Termination != HoldingToFix) || (leg.PathTerminator == PathHM && holding.Termination != HoldingManual) {
+				return invalid("holding leg terminator does not match holding termination")
+			}
+			if (leg.FromFix != nil && *leg.FromFix != holding.Fix) || (leg.ToFix != nil && *leg.ToFix != holding.Fix) {
+				return invalid("holding leg fix does not match holding definition")
 			}
 		}
 	}
@@ -326,10 +428,21 @@ func (q ProcedureQuery) Validate() error {
 	if !validIdentifier(string(q.Airport)) {
 		return invalid("procedure query airport is required")
 	}
+	kinds := map[ProcedureKind]struct{}{}
 	for _, kind := range q.Kinds {
 		if !kind.Valid() {
 			return invalid("procedure query kind is invalid")
 		}
+		if _, found := kinds[kind]; found {
+			return invalid("procedure query has duplicate kind")
+		}
+		kinds[kind] = struct{}{}
+	}
+	if err := uniqueRunways(q.Runways); err != nil {
+		return err
+	}
+	if err := uniqueProcedures(q.Identifiers); err != nil {
+		return err
 	}
 	return nil
 }
@@ -355,6 +468,9 @@ func (s ProcedureSet) Validate() error {
 	if s.Coverage == CoverageComplete && len(s.Procedures) == 0 {
 		return invalid("complete procedure set cannot be empty")
 	}
+	if s.Coverage == CoverageUnavailable && len(s.Procedures) > 0 {
+		return invalid("unavailable procedure set cannot carry procedures")
+	}
 	for _, procedure := range s.Procedures {
 		if procedure.Airport != s.Airport {
 			return invalid("procedure set airport mismatch")
@@ -362,8 +478,19 @@ func (s ProcedureSet) Validate() error {
 		if err := procedure.Validate(); err != nil {
 			return err
 		}
+		if s.Coverage == CoverageComplete && procedure.HasUnsupportedLeg() {
+			return invalid("complete procedure set cannot retain unsupported leg")
+		}
 	}
 	return nil
+}
+func (p Procedure) HasUnsupportedLeg() bool {
+	for _, leg := range p.Legs {
+		if !leg.PathTerminator.Supported() {
+			return true
+		}
+	}
+	return false
 }
 
 // HoldingDigest supplies a stable comparison value for equivalent published
@@ -389,7 +516,7 @@ func HoldingDigest(holding HoldingPattern) (string, error) {
 	if holding.MaximumSpeedKt != nil {
 		speed = fmt.Sprintf("%d", *holding.MaximumSpeedKt)
 	}
-	values := []string{string(holding.ID), string(holding.Fix), fmt.Sprintf("%.9f", holding.InboundCourseTrueDeg), string(holding.TurnDirection), length, seconds, minimum, maximum, speed, string(holding.Termination), holding.Provenance.SourceID, holding.Provenance.SourceRevision, holding.Provenance.EffectiveFrom.UTC().Format(time.RFC3339), holding.Provenance.EffectiveUntil.UTC().Format(time.RFC3339)}
+	values := []string{string(holding.ID), string(holding.Fix), fmt.Sprintf("%.9f", holding.InboundCourseTrueDeg), string(holding.TurnDirection), length, seconds, minimum, maximum, speed, string(holding.Termination)}
 	sum := sha256.Sum256([]byte(strings.Join(values, "\x1f")))
 	return hex.EncodeToString(sum[:]), nil
 }
@@ -406,6 +533,16 @@ func (q FixQuery) Validate() error {
 	if len(q.Identifiers) == 0 {
 		return invalid("fix query identifiers are required")
 	}
+	fixes := map[FixID]struct{}{}
+	for _, fix := range q.Identifiers {
+		if !validIdentifier(string(fix)) {
+			return invalid("fix query identifier is invalid")
+		}
+		if _, found := fixes[fix]; found {
+			return invalid("fix query contains duplicate identifier")
+		}
+		fixes[fix] = struct{}{}
+	}
 	return nil
 }
 
@@ -414,6 +551,35 @@ type FixSet struct {
 	Fixes      []Fix
 	Coverage   Coverage
 	Provenance Provenance
+}
+
+func (s FixSet) Validate() error {
+	if err := s.Version.Validate(); err != nil {
+		return err
+	}
+	if !s.Coverage.Valid() {
+		return invalid("fix set coverage is invalid")
+	}
+	if err := s.Provenance.Validate(); err != nil {
+		return err
+	}
+	if s.Coverage == CoverageComplete && len(s.Fixes) == 0 {
+		return invalid("complete fix set cannot be empty")
+	}
+	if s.Coverage == CoverageUnavailable && len(s.Fixes) > 0 {
+		return invalid("unavailable fix set cannot carry fixes")
+	}
+	seen := map[FixID]struct{}{}
+	for _, fix := range s.Fixes {
+		if err := fix.Validate(); err != nil {
+			return err
+		}
+		if _, found := seen[fix.ID]; found {
+			return invalid("fix set contains duplicate fix")
+		}
+		seen[fix.ID] = struct{}{}
+	}
+	return nil
 }
 
 type RouteQuery struct {
@@ -432,6 +598,15 @@ func (q RouteQuery) Validate() error {
 	}
 	if !validIdentifier(string(q.Origin)) || !validIdentifier(string(q.Destination)) || normalizeRoute(q.FiledRoute) == "" {
 		return invalid("route query is incomplete")
+	}
+	if q.ArrivalProcedure != nil && !validIdentifier(string(*q.ArrivalProcedure)) {
+		return invalid("route query arrival procedure is invalid")
+	}
+	if q.Runway != nil && !validIdentifier(string(*q.Runway)) {
+		return invalid("route query runway is invalid")
+	}
+	if q.RunwayGroup != nil && !validIdentifier(string(*q.RunwayGroup)) {
+		return invalid("route query runway group is invalid")
 	}
 	return nil
 }
@@ -456,10 +631,20 @@ type RouteGeometry struct {
 }
 
 func (g RouteGeometry) Validate() error {
+	if err := g.validateCanonical(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(g.Digest) == "" {
+		return invalid("route geometry digest is required")
+	}
+	return nil
+}
+
+func (g RouteGeometry) validateCanonical() error {
 	if err := g.Version.Validate(); err != nil {
 		return err
 	}
-	if !g.Coverage.Valid() || g.TotalDistanceNM < 0 || strings.TrimSpace(g.Digest) == "" {
+	if !g.Coverage.Valid() || g.TotalDistanceNM < 0 {
 		return invalid("route geometry is incomplete")
 	}
 	if err := g.Provenance.Validate(); err != nil {
@@ -470,10 +655,13 @@ func (g RouteGeometry) Validate() error {
 			return err
 		}
 	}
-	if g.Coverage.Authoritative() && len(g.Unresolved) > 0 {
-		return invalid("complete geometry cannot retain unresolved elements")
+	if g.Coverage == CoverageComplete && (len(g.Unresolved) > 0 || hasUnsupportedLeg(g.Legs)) {
+		return invalid("complete geometry cannot retain unresolved or unsupported legs")
 	}
-	return nil
+	if g.Coverage == CoverageUnavailable && (len(g.Legs) > 0 || len(g.HoldingIDs) > 0 || len(g.Unresolved) > 0) {
+		return invalid("unavailable geometry cannot carry data")
+	}
+	return uniqueHoldings(g.HoldingIDs)
 }
 
 type TerminalPath struct {
@@ -489,29 +677,63 @@ type TerminalPath struct {
 	Digest      string
 }
 
-func RouteGeometryDigest(query RouteQuery, legs []ProcedureLeg, holdings []HoldingID, coverage Coverage, unresolved []string) (string, error) {
+func (p TerminalPath) Validate() error {
+	if err := p.Version.Validate(); err != nil {
+		return err
+	}
+	if !validIdentifier(string(p.Airport)) || !validIdentifier(string(p.Feeder)) || !validIdentifier(string(p.RunwayGroup)) || !p.Coverage.Valid() || strings.TrimSpace(p.Digest) == "" {
+		return invalid("terminal path is incomplete")
+	}
+	if err := p.Provenance.Validate(); err != nil {
+		return err
+	}
+	for _, leg := range p.Legs {
+		if err := leg.Validate(); err != nil {
+			return err
+		}
+	}
+	if p.Coverage == CoverageComplete && (len(p.Unresolved) > 0 || hasUnsupportedLeg(p.Legs)) {
+		return invalid("complete terminal path cannot retain unresolved or unsupported legs")
+	}
+	if p.Coverage == CoverageUnavailable && (len(p.Legs) > 0 || len(p.HoldingIDs) > 0 || len(p.Unresolved) > 0) {
+		return invalid("unavailable terminal path cannot carry data")
+	}
+	return uniqueHoldings(p.HoldingIDs)
+}
+
+func RouteGeometryDigest(query RouteQuery, geometry RouteGeometry) (string, error) {
 	key, err := query.Key()
 	if err != nil {
 		return "", err
 	}
-	legTokens := make([]string, 0, len(legs))
-	for _, leg := range legs {
-		legTokens = append(legTokens, fmt.Sprintf("%s/%s/%s/%s", leg.ID, leg.PathTerminator, optionalFix(leg.FromFix), optionalFix(leg.ToFix)))
+	if err := geometry.validateCanonical(); err != nil {
+		return "", err
 	}
-	holdings = slices.Clone(holdings)
+	legTokens := make([]string, 0, len(geometry.Legs))
+	for _, leg := range geometry.Legs {
+		course, distance := "", ""
+		if leg.CourseTrueDeg != nil {
+			course = strconv.FormatFloat(*leg.CourseTrueDeg, 'f', -1, 64)
+		}
+		if leg.DistanceNM != nil {
+			distance = strconv.FormatFloat(*leg.DistanceNM, 'f', -1, 64)
+		}
+		legTokens = append(legTokens, strings.Join([]string{leg.ID, string(leg.PathTerminator), optionalFix(leg.FromFix), optionalFix(leg.ToFix), course, distance, optionalHolding(leg.HoldingID)}, "/"))
+	}
+	holdings := slices.Clone(geometry.HoldingIDs)
 	slices.Sort(holdings)
-	unresolved = slices.Clone(unresolved)
+	unresolved := slices.Clone(geometry.Unresolved)
 	slices.Sort(unresolved)
-	sum := sha256.Sum256([]byte(strings.Join(append([]string{string(key), string(coverage)}, append(legTokens, append(stringifyHoldings(holdings), unresolved...)...)...), "\x1f")))
+	sum := sha256.Sum256([]byte(strings.Join(append([]string{string(key), strconv.FormatFloat(geometry.TotalDistanceNM, 'f', -1, 64), string(geometry.Coverage)}, append(legTokens, append(stringifyHoldings(holdings), unresolved...)...)...), "\x1f")))
 	return hex.EncodeToString(sum[:]), nil
 }
 
 func validIdentifier(value string) bool {
-	value = strings.TrimSpace(value)
-	if value == "" || value != strings.ToUpper(value) {
+	trimmed := strings.TrimSpace(value)
+	if value != trimmed || trimmed == "" || trimmed != strings.ToUpper(trimmed) {
 		return false
 	}
-	for _, r := range value {
+	for _, r := range trimmed {
 		if !(r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_') {
 			return false
 		}
@@ -554,10 +776,63 @@ func optionalFix(value *FixID) string {
 	}
 	return string(*value)
 }
+func optionalHolding(value *HoldingID) string {
+	if value == nil {
+		return ""
+	}
+	return string(*value)
+}
 func stringifyHoldings(values []HoldingID) []string {
 	result := make([]string, len(values))
 	for index, value := range values {
 		result[index] = string(value)
 	}
 	return result
+}
+func uniqueRunways(values []RunwayID) error {
+	seen := map[RunwayID]struct{}{}
+	for _, value := range values {
+		if !validIdentifier(string(value)) {
+			return invalid("runway identifier is invalid")
+		}
+		if _, found := seen[value]; found {
+			return invalid("duplicate runway identifier")
+		}
+		seen[value] = struct{}{}
+	}
+	return nil
+}
+func uniqueProcedures(values []ProcedureID) error {
+	seen := map[ProcedureID]struct{}{}
+	for _, value := range values {
+		if !validIdentifier(string(value)) {
+			return invalid("procedure identifier is invalid")
+		}
+		if _, found := seen[value]; found {
+			return invalid("duplicate procedure identifier")
+		}
+		seen[value] = struct{}{}
+	}
+	return nil
+}
+func uniqueHoldings(values []HoldingID) error {
+	seen := map[HoldingID]struct{}{}
+	for _, value := range values {
+		if !validIdentifier(string(value)) {
+			return invalid("holding identifier is invalid")
+		}
+		if _, found := seen[value]; found {
+			return invalid("duplicate holding identifier")
+		}
+		seen[value] = struct{}{}
+	}
+	return nil
+}
+func hasUnsupportedLeg(legs []ProcedureLeg) bool {
+	for _, leg := range legs {
+		if !leg.PathTerminator.Supported() {
+			return true
+		}
+	}
+	return false
 }

--- a/backend/internal/aman/navdata/types.go
+++ b/backend/internal/aman/navdata/types.go
@@ -1,0 +1,563 @@
+package navdata
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"FlightStrips/internal/aman"
+)
+
+type AirportID string
+type RunwayID string
+type FixID string
+type AirwayID string
+type ProcedureID string
+type HoldingID string
+type FeederID string
+type RouteKey string
+
+// DatasetVersion identifies a particular imported AIRAC dataset.  It contains
+// only navigation-data identity, never transport/cache implementation state.
+type DatasetVersion struct {
+	Cycle          string
+	SourceRevision string
+	EffectiveFrom  time.Time
+	EffectiveUntil time.Time
+}
+
+func (v DatasetVersion) Validate() error {
+	if !validIdentifier(v.Cycle) || strings.TrimSpace(v.SourceRevision) == "" {
+		return invalid("dataset version requires cycle and source revision")
+	}
+	if err := utc("dataset effective from", v.EffectiveFrom); err != nil {
+		return err
+	}
+	if err := utc("dataset effective until", v.EffectiveUntil); err != nil {
+		return err
+	}
+	if !v.EffectiveUntil.After(v.EffectiveFrom) {
+		return invalid("dataset effective interval is invalid")
+	}
+	return nil
+}
+
+func (v DatasetVersion) Equal(other DatasetVersion) bool {
+	return v.Cycle == other.Cycle && v.SourceRevision == other.SourceRevision &&
+		v.EffectiveFrom.Equal(other.EffectiveFrom) && v.EffectiveUntil.Equal(other.EffectiveUntil)
+}
+
+// Provenance is persisted alongside canonical data. Provider transport details
+// (URLs, cursors, HTTP headers and retry state) are intentionally absent.
+type Provenance struct {
+	SourceID       string
+	SourceRevision string
+	ImportedAt     time.Time
+	EffectiveFrom  time.Time
+	EffectiveUntil time.Time
+}
+
+func (p Provenance) Validate() error {
+	if strings.TrimSpace(p.SourceID) == "" || strings.TrimSpace(p.SourceRevision) == "" {
+		return invalid("provenance source is incomplete")
+	}
+	if err := utc("provenance imported at", p.ImportedAt); err != nil {
+		return err
+	}
+	if err := utc("provenance effective from", p.EffectiveFrom); err != nil {
+		return err
+	}
+	if err := utc("provenance effective until", p.EffectiveUntil); err != nil {
+		return err
+	}
+	if !p.EffectiveUntil.After(p.EffectiveFrom) {
+		return invalid("provenance effective interval is invalid")
+	}
+	return nil
+}
+
+type Coverage string
+
+const (
+	CoverageComplete    Coverage = "complete"
+	CoveragePartial     Coverage = "partial"
+	CoverageUnsupported Coverage = "unsupported"
+	CoverageUnavailable Coverage = "unavailable"
+)
+
+func (c Coverage) Valid() bool {
+	return c == CoverageComplete || c == CoveragePartial || c == CoverageUnsupported || c == CoverageUnavailable
+}
+func (c Coverage) Authoritative() bool { return c == CoverageComplete }
+
+// Coordinate is WGS84 latitude/longitude in degrees.
+type Coordinate struct{ LatitudeDeg, LongitudeDeg float64 }
+
+func (c Coordinate) Validate() error {
+	if c.LatitudeDeg < -90 || c.LatitudeDeg > 90 || c.LongitudeDeg < -180 || c.LongitudeDeg > 180 {
+		return invalid("coordinate is outside WGS84 bounds")
+	}
+	return nil
+}
+
+type Airport struct {
+	ID         AirportID
+	Name       string
+	Position   Coordinate
+	Provenance Provenance
+}
+type Runway struct {
+	ID         RunwayID
+	Airport    AirportID
+	Threshold  Threshold
+	LengthNM   float64
+	Provenance Provenance
+}
+type Fix struct {
+	ID         FixID
+	Position   Coordinate
+	Provenance Provenance
+}
+type Airway struct {
+	ID         AirwayID
+	Fixes      []FixID
+	Provenance Provenance
+}
+type Threshold struct {
+	Position      Coordinate
+	ElevationFt   *int
+	CourseTrueDeg *float64
+}
+type FinalApproach struct {
+	Runway        RunwayID
+	Threshold     Threshold
+	CourseTrueDeg float64
+	Provenance    Provenance
+}
+
+type ProcedureKind string
+
+const (
+	ProcedureSID      ProcedureKind = "sid"
+	ProcedureSTAR     ProcedureKind = "star"
+	ProcedureApproach ProcedureKind = "approach"
+)
+
+func (k ProcedureKind) Valid() bool {
+	return k == ProcedureSID || k == ProcedureSTAR || k == ProcedureApproach
+}
+
+// PathTerminator retains ARINC procedure semantics. Unsupported terminators are
+// retained as PathUnsupported instead of being silently discarded.
+type PathTerminator string
+
+const (
+	PathIF          PathTerminator = "IF"
+	PathTF          PathTerminator = "TF"
+	PathCF          PathTerminator = "CF"
+	PathDF          PathTerminator = "DF"
+	PathAF          PathTerminator = "AF"
+	PathRF          PathTerminator = "RF"
+	PathCA          PathTerminator = "CA"
+	PathFA          PathTerminator = "FA"
+	PathFC          PathTerminator = "FC"
+	PathFD          PathTerminator = "FD"
+	PathVA          PathTerminator = "VA"
+	PathVM          PathTerminator = "VM"
+	PathVI          PathTerminator = "VI"
+	PathHA          PathTerminator = "HA"
+	PathHF          PathTerminator = "HF"
+	PathHM          PathTerminator = "HM"
+	PathUnsupported PathTerminator = "UNSUPPORTED"
+)
+
+func (p PathTerminator) IsHolding() bool { return p == PathHA || p == PathHF || p == PathHM }
+func (p PathTerminator) Supported() bool { return p != "" && p != PathUnsupported }
+
+type TurnDirection string
+
+const (
+	TurnLeft  TurnDirection = "left"
+	TurnRight TurnDirection = "right"
+)
+
+func (d TurnDirection) Valid() bool { return d == TurnLeft || d == TurnRight }
+
+type HoldingTermination string
+
+const (
+	HoldingToAltitude HoldingTermination = "altitude"
+	HoldingToFix      HoldingTermination = "fix"
+	HoldingManual     HoldingTermination = "manual"
+)
+
+func (t HoldingTermination) Valid() bool {
+	return t == HoldingToAltitude || t == HoldingToFix || t == HoldingManual
+}
+
+// HoldingPattern is published procedure geometry only. It never authorizes a
+// predictor to add circuit delay without a separate operational policy/fact.
+type HoldingPattern struct {
+	ID                   HoldingID
+	Fix                  FixID
+	InboundCourseTrueDeg float64
+	TurnDirection        TurnDirection
+	LegLengthNM          *float64
+	LegTimeSeconds       *int64
+	MinimumAltitudeFt    *int
+	MaximumAltitudeFt    *int
+	MaximumSpeedKt       *int
+	Termination          HoldingTermination
+	Provenance           Provenance
+}
+
+func (h HoldingPattern) Validate() error {
+	if !validIdentifier(string(h.ID)) || !validIdentifier(string(h.Fix)) {
+		return invalid("holding identity is incomplete")
+	}
+	if h.InboundCourseTrueDeg < 0 || h.InboundCourseTrueDeg >= 360 {
+		return invalid("holding inbound course must be true degrees in [0,360)")
+	}
+	if !h.TurnDirection.Valid() || !h.Termination.Valid() {
+		return invalid("holding turn direction or termination is invalid")
+	}
+	if (h.LegLengthNM == nil) == (h.LegTimeSeconds == nil) {
+		return invalid("holding requires exactly one time or distance construction")
+	}
+	if h.LegLengthNM != nil && *h.LegLengthNM <= 0 {
+		return invalid("holding leg distance must be positive")
+	}
+	if h.LegTimeSeconds != nil && *h.LegTimeSeconds <= 0 {
+		return invalid("holding leg time must be positive")
+	}
+	if h.MinimumAltitudeFt != nil && h.MaximumAltitudeFt != nil && *h.MinimumAltitudeFt > *h.MaximumAltitudeFt {
+		return invalid("holding altitude constraints conflict")
+	}
+	if h.MaximumSpeedKt != nil && *h.MaximumSpeedKt <= 0 {
+		return invalid("holding speed constraint must be positive")
+	}
+	return h.Provenance.Validate()
+}
+
+type ProcedureLeg struct {
+	ID             string
+	PathTerminator PathTerminator
+	FromFix        *FixID
+	ToFix          *FixID
+	CourseTrueDeg  *float64
+	DistanceNM     *float64
+	HoldingID      *HoldingID
+}
+
+func (l ProcedureLeg) Validate() error {
+	if strings.TrimSpace(l.ID) == "" || l.PathTerminator == "" {
+		return invalid("procedure leg identity is incomplete")
+	}
+	if l.CourseTrueDeg != nil && (*l.CourseTrueDeg < 0 || *l.CourseTrueDeg >= 360) {
+		return invalid("leg course must be true degrees in [0,360)")
+	}
+	if l.DistanceNM != nil && *l.DistanceNM < 0 {
+		return invalid("leg distance cannot be negative")
+	}
+	if l.PathTerminator.IsHolding() && l.HoldingID == nil {
+		return invalid("holding leg requires holding ID")
+	}
+	if !l.PathTerminator.IsHolding() && l.HoldingID != nil {
+		return invalid("only holding legs may reference holding ID")
+	}
+	return nil
+}
+
+type Procedure struct {
+	ID         ProcedureID
+	Airport    AirportID
+	Kind       ProcedureKind
+	Runways    []RunwayID
+	Legs       []ProcedureLeg
+	Holdings   []HoldingPattern
+	Provenance Provenance
+}
+
+func (p Procedure) Validate() error {
+	if !validIdentifier(string(p.ID)) || !validIdentifier(string(p.Airport)) || !p.Kind.Valid() {
+		return invalid("procedure identity is incomplete")
+	}
+	if err := p.Provenance.Validate(); err != nil {
+		return err
+	}
+	holdings := make(map[HoldingID]struct{}, len(p.Holdings))
+	for _, holding := range p.Holdings {
+		if err := holding.Validate(); err != nil {
+			return err
+		}
+		if _, found := holdings[holding.ID]; found {
+			return invalid("procedure has duplicate holding ID")
+		}
+		holdings[holding.ID] = struct{}{}
+	}
+	for _, leg := range p.Legs {
+		if err := leg.Validate(); err != nil {
+			return err
+		}
+		if leg.HoldingID != nil {
+			if _, found := holdings[*leg.HoldingID]; !found {
+				return invalid("holding leg references missing holding")
+			}
+		}
+	}
+	return nil
+}
+
+type ProcedureQuery struct {
+	Version     DatasetVersion
+	Airport     AirportID
+	Kinds       []ProcedureKind
+	Runways     []RunwayID
+	Identifiers []ProcedureID
+}
+
+func (q ProcedureQuery) Validate() error {
+	if err := q.Version.Validate(); err != nil {
+		return err
+	}
+	if !validIdentifier(string(q.Airport)) {
+		return invalid("procedure query airport is required")
+	}
+	for _, kind := range q.Kinds {
+		if !kind.Valid() {
+			return invalid("procedure query kind is invalid")
+		}
+	}
+	return nil
+}
+
+type ProcedureSet struct {
+	Version    DatasetVersion
+	Airport    AirportID
+	Procedures []Procedure
+	Coverage   Coverage
+	Provenance Provenance
+}
+
+func (s ProcedureSet) Validate() error {
+	if err := s.Version.Validate(); err != nil {
+		return err
+	}
+	if !validIdentifier(string(s.Airport)) || !s.Coverage.Valid() {
+		return invalid("procedure set identity or coverage is invalid")
+	}
+	if err := s.Provenance.Validate(); err != nil {
+		return err
+	}
+	if s.Coverage == CoverageComplete && len(s.Procedures) == 0 {
+		return invalid("complete procedure set cannot be empty")
+	}
+	for _, procedure := range s.Procedures {
+		if procedure.Airport != s.Airport {
+			return invalid("procedure set airport mismatch")
+		}
+		if err := procedure.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// HoldingDigest supplies a stable comparison value for equivalent published
+// holdings across source implementations. It intentionally excludes adapter
+// details and imported timestamps.
+func HoldingDigest(holding HoldingPattern) (string, error) {
+	if err := holding.Validate(); err != nil {
+		return "", err
+	}
+	length, seconds, minimum, maximum, speed := "", "", "", "", ""
+	if holding.LegLengthNM != nil {
+		length = fmt.Sprintf("%.9f", *holding.LegLengthNM)
+	}
+	if holding.LegTimeSeconds != nil {
+		seconds = fmt.Sprintf("%d", *holding.LegTimeSeconds)
+	}
+	if holding.MinimumAltitudeFt != nil {
+		minimum = fmt.Sprintf("%d", *holding.MinimumAltitudeFt)
+	}
+	if holding.MaximumAltitudeFt != nil {
+		maximum = fmt.Sprintf("%d", *holding.MaximumAltitudeFt)
+	}
+	if holding.MaximumSpeedKt != nil {
+		speed = fmt.Sprintf("%d", *holding.MaximumSpeedKt)
+	}
+	values := []string{string(holding.ID), string(holding.Fix), fmt.Sprintf("%.9f", holding.InboundCourseTrueDeg), string(holding.TurnDirection), length, seconds, minimum, maximum, speed, string(holding.Termination), holding.Provenance.SourceID, holding.Provenance.SourceRevision, holding.Provenance.EffectiveFrom.UTC().Format(time.RFC3339), holding.Provenance.EffectiveUntil.UTC().Format(time.RFC3339)}
+	sum := sha256.Sum256([]byte(strings.Join(values, "\x1f")))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+type FixQuery struct {
+	Version     DatasetVersion
+	Identifiers []FixID
+}
+
+func (q FixQuery) Validate() error {
+	if err := q.Version.Validate(); err != nil {
+		return err
+	}
+	if len(q.Identifiers) == 0 {
+		return invalid("fix query identifiers are required")
+	}
+	return nil
+}
+
+type FixSet struct {
+	Version    DatasetVersion
+	Fixes      []Fix
+	Coverage   Coverage
+	Provenance Provenance
+}
+
+type RouteQuery struct {
+	Version          DatasetVersion
+	Origin           AirportID
+	Destination      AirportID
+	FiledRoute       string
+	ArrivalProcedure *ProcedureID
+	Runway           *RunwayID
+	RunwayGroup      *aman.RunwayGroupID
+}
+
+func (q RouteQuery) Validate() error {
+	if err := q.Version.Validate(); err != nil {
+		return err
+	}
+	if !validIdentifier(string(q.Origin)) || !validIdentifier(string(q.Destination)) || normalizeRoute(q.FiledRoute) == "" {
+		return invalid("route query is incomplete")
+	}
+	return nil
+}
+func (q RouteQuery) Key() (RouteKey, error) {
+	if err := q.Validate(); err != nil {
+		return "", err
+	}
+	semantic := strings.Join([]string{q.Version.Cycle, q.Version.SourceRevision, q.Version.EffectiveFrom.UTC().Format(time.RFC3339), q.Version.EffectiveUntil.UTC().Format(time.RFC3339), string(q.Origin), string(q.Destination), normalizeRoute(q.FiledRoute), optionalProcedure(q.ArrivalProcedure), optionalRunway(q.Runway), optionalGroup(q.RunwayGroup)}, "\x1f")
+	sum := sha256.Sum256([]byte(semantic))
+	return RouteKey(hex.EncodeToString(sum[:])), nil
+}
+
+type RouteGeometry struct {
+	Version         DatasetVersion
+	Legs            []ProcedureLeg
+	HoldingIDs      []HoldingID
+	TotalDistanceNM float64
+	Coverage        Coverage
+	Unresolved      []string
+	Provenance      Provenance
+	Digest          string
+}
+
+func (g RouteGeometry) Validate() error {
+	if err := g.Version.Validate(); err != nil {
+		return err
+	}
+	if !g.Coverage.Valid() || g.TotalDistanceNM < 0 || strings.TrimSpace(g.Digest) == "" {
+		return invalid("route geometry is incomplete")
+	}
+	if err := g.Provenance.Validate(); err != nil {
+		return err
+	}
+	for _, leg := range g.Legs {
+		if err := leg.Validate(); err != nil {
+			return err
+		}
+	}
+	if g.Coverage.Authoritative() && len(g.Unresolved) > 0 {
+		return invalid("complete geometry cannot retain unresolved elements")
+	}
+	return nil
+}
+
+type TerminalPath struct {
+	Version     DatasetVersion
+	Airport     AirportID
+	Feeder      FeederID
+	RunwayGroup aman.RunwayGroupID
+	Legs        []ProcedureLeg
+	HoldingIDs  []HoldingID
+	Coverage    Coverage
+	Unresolved  []string
+	Provenance  Provenance
+	Digest      string
+}
+
+func RouteGeometryDigest(query RouteQuery, legs []ProcedureLeg, holdings []HoldingID, coverage Coverage, unresolved []string) (string, error) {
+	key, err := query.Key()
+	if err != nil {
+		return "", err
+	}
+	legTokens := make([]string, 0, len(legs))
+	for _, leg := range legs {
+		legTokens = append(legTokens, fmt.Sprintf("%s/%s/%s/%s", leg.ID, leg.PathTerminator, optionalFix(leg.FromFix), optionalFix(leg.ToFix)))
+	}
+	holdings = slices.Clone(holdings)
+	slices.Sort(holdings)
+	unresolved = slices.Clone(unresolved)
+	slices.Sort(unresolved)
+	sum := sha256.Sum256([]byte(strings.Join(append([]string{string(key), string(coverage)}, append(legTokens, append(stringifyHoldings(holdings), unresolved...)...)...), "\x1f")))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func validIdentifier(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" || value != strings.ToUpper(value) {
+		return false
+	}
+	for _, r := range value {
+		if !(r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_') {
+			return false
+		}
+	}
+	return true
+}
+func utc(name string, value time.Time) error {
+	if value.IsZero() || value.Location() != time.UTC {
+		return invalid(name + " must be UTC")
+	}
+	return nil
+}
+func invalid(message string) error {
+	return &aman.DomainError{Class: aman.ErrorInvalidArgument, Message: message}
+}
+func normalizeRoute(value string) string {
+	return strings.ToUpper(strings.Join(strings.Fields(value), " "))
+}
+func optionalProcedure(value *ProcedureID) string {
+	if value == nil {
+		return ""
+	}
+	return string(*value)
+}
+func optionalRunway(value *RunwayID) string {
+	if value == nil {
+		return ""
+	}
+	return string(*value)
+}
+func optionalGroup(value *aman.RunwayGroupID) string {
+	if value == nil {
+		return ""
+	}
+	return string(*value)
+}
+func optionalFix(value *FixID) string {
+	if value == nil {
+		return ""
+	}
+	return string(*value)
+}
+func stringifyHoldings(values []HoldingID) []string {
+	result := make([]string, len(values))
+	for index, value := range values {
+		result[index] = string(value)
+	}
+	return result
+}

--- a/backend/internal/aman/navdata/types.go
+++ b/backend/internal/aman/navdata/types.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"slices"
 	"strconv"
 	"strings"
@@ -98,6 +99,9 @@ func (c Coverage) Authoritative() bool { return c == CoverageComplete }
 type Coordinate struct{ LatitudeDeg, LongitudeDeg float64 }
 
 func (c Coordinate) Validate() error {
+	if !finite(c.LatitudeDeg) || !finite(c.LongitudeDeg) {
+		return invalid("coordinate must be finite")
+	}
 	if c.LatitudeDeg < -90 || c.LatitudeDeg > 90 || c.LongitudeDeg < -180 || c.LongitudeDeg > 180 {
 		return invalid("coordinate is outside WGS84 bounds")
 	}
@@ -130,7 +134,7 @@ type Runway struct {
 }
 
 func (r Runway) Validate() error {
-	if !validIdentifier(string(r.ID)) || !validIdentifier(string(r.Airport)) || r.LengthNM <= 0 {
+	if !validIdentifier(string(r.ID)) || !validIdentifier(string(r.Airport)) || !finite(r.LengthNM) || r.LengthNM <= 0 {
 		return invalid("runway identity or length is invalid")
 	}
 	if err := r.Threshold.Validate(); err != nil {
@@ -188,7 +192,7 @@ func (t Threshold) Validate() error {
 	if err := t.Position.Validate(); err != nil {
 		return err
 	}
-	if t.CourseTrueDeg != nil && (*t.CourseTrueDeg < 0 || *t.CourseTrueDeg >= 360) {
+	if t.CourseTrueDeg != nil && (!finite(*t.CourseTrueDeg) || *t.CourseTrueDeg < 0 || *t.CourseTrueDeg >= 360) {
 		return invalid("threshold course must be true degrees in [0,360)")
 	}
 	return nil
@@ -202,7 +206,7 @@ type FinalApproach struct {
 }
 
 func (f FinalApproach) Validate() error {
-	if !validIdentifier(string(f.Runway)) || f.CourseTrueDeg < 0 || f.CourseTrueDeg >= 360 {
+	if !validIdentifier(string(f.Runway)) || !finite(f.CourseTrueDeg) || f.CourseTrueDeg < 0 || f.CourseTrueDeg >= 360 {
 		return invalid("final approach identity or course is invalid")
 	}
 	if err := f.Threshold.Validate(); err != nil {
@@ -298,7 +302,7 @@ func (h HoldingPattern) Validate() error {
 	if !validIdentifier(string(h.ID)) || !validIdentifier(string(h.Fix)) {
 		return invalid("holding identity is incomplete")
 	}
-	if h.InboundCourseTrueDeg < 0 || h.InboundCourseTrueDeg >= 360 {
+	if !finite(h.InboundCourseTrueDeg) || h.InboundCourseTrueDeg < 0 || h.InboundCourseTrueDeg >= 360 {
 		return invalid("holding inbound course must be true degrees in [0,360)")
 	}
 	if !h.TurnDirection.Valid() || !h.Termination.Valid() {
@@ -307,7 +311,7 @@ func (h HoldingPattern) Validate() error {
 	if (h.LegLengthNM == nil) == (h.LegTimeSeconds == nil) {
 		return invalid("holding requires exactly one time or distance construction")
 	}
-	if h.LegLengthNM != nil && *h.LegLengthNM <= 0 {
+	if h.LegLengthNM != nil && (!finite(*h.LegLengthNM) || *h.LegLengthNM <= 0) {
 		return invalid("holding leg distance must be positive")
 	}
 	if h.LegTimeSeconds != nil && *h.LegTimeSeconds <= 0 {
@@ -333,13 +337,13 @@ type ProcedureLeg struct {
 }
 
 func (l ProcedureLeg) Validate() error {
-	if strings.TrimSpace(l.ID) == "" || l.PathTerminator == "" {
+	if !validIdentifier(l.ID) || l.PathTerminator == "" {
 		return invalid("procedure leg identity is incomplete")
 	}
-	if l.CourseTrueDeg != nil && (*l.CourseTrueDeg < 0 || *l.CourseTrueDeg >= 360) {
+	if l.CourseTrueDeg != nil && (!finite(*l.CourseTrueDeg) || *l.CourseTrueDeg < 0 || *l.CourseTrueDeg >= 360) {
 		return invalid("leg course must be true degrees in [0,360)")
 	}
-	if l.DistanceNM != nil && *l.DistanceNM < 0 {
+	if l.DistanceNM != nil && (!finite(*l.DistanceNM) || *l.DistanceNM < 0) {
 		return invalid("leg distance cannot be negative")
 	}
 	if l.PathTerminator.IsHolding() && l.HoldingID == nil {
@@ -644,7 +648,7 @@ func (g RouteGeometry) validateCanonical() error {
 	if err := g.Version.Validate(); err != nil {
 		return err
 	}
-	if !g.Coverage.Valid() || g.TotalDistanceNM < 0 {
+	if !g.Coverage.Valid() || !finite(g.TotalDistanceNM) || g.TotalDistanceNM < 0 {
 		return invalid("route geometry is incomplete")
 	}
 	if err := g.Provenance.Validate(); err != nil {
@@ -702,6 +706,12 @@ func (p TerminalPath) Validate() error {
 }
 
 func RouteGeometryDigest(query RouteQuery, geometry RouteGeometry) (string, error) {
+	if err := query.Validate(); err != nil {
+		return "", err
+	}
+	if !query.Version.Equal(geometry.Version) {
+		return "", &aman.DomainError{Class: ErrorDatasetMismatch, Message: "route query and geometry dataset versions differ"}
+	}
 	key, err := query.Key()
 	if err != nil {
 		return "", err
@@ -836,3 +846,4 @@ func hasUnsupportedLeg(legs []ProcedureLeg) bool {
 	}
 	return false
 }
+func finite(value float64) bool { return !math.IsNaN(value) && !math.IsInf(value, 0) }

--- a/backend/internal/aman/navdata/types_test.go
+++ b/backend/internal/aman/navdata/types_test.go
@@ -1,0 +1,92 @@
+package navdata
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRouteKeyNormalizesFormattingButPreservesDCTSemantics(t *testing.T) {
+	version := testVersion()
+	one := RouteQuery{Version: version, Origin: "ENGM", Destination: "EKCH", FiledRoute: "DCT KEMAX"}
+	two := one
+	two.FiledRoute = " dct   kemax "
+	first, err := one.Key()
+	require.NoError(t, err)
+	second, err := two.Key()
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+}
+
+func TestHoldingAndLegValidationRejectsUnsafeDefinitions(t *testing.T) {
+	provenance := testProvenance()
+	timeSeconds, distance := int64(60), 2.0
+	holding := HoldingPattern{ID: "HOLD", Fix: "KEMAX", InboundCourseTrueDeg: 360, TurnDirection: TurnRight, LegTimeSeconds: &timeSeconds, Termination: HoldingManual, Provenance: provenance}
+	assertInvalid(t, holding.Validate())
+	holding.InboundCourseTrueDeg = 180
+	holding.LegLengthNM = &distance
+	assertInvalid(t, holding.Validate())
+	leg := ProcedureLeg{ID: "H", PathTerminator: PathHA}
+	assertInvalid(t, leg.Validate())
+	for _, terminator := range []PathTerminator{PathHA, PathHF, PathHM} {
+		leg = ProcedureLeg{ID: string(terminator), PathTerminator: terminator}
+		assertInvalid(t, leg.Validate())
+	}
+	holding = HoldingPattern{ID: "HOLD", Fix: "KEMAX", InboundCourseTrueDeg: 180, TurnDirection: "wrong", LegTimeSeconds: &timeSeconds, Termination: "wrong", Provenance: provenance}
+	assertInvalid(t, holding.Validate())
+	minimum, maximum, speed := 5000, 4000, 0
+	holding = HoldingPattern{ID: "HOLD", Fix: "KEMAX", InboundCourseTrueDeg: 180, TurnDirection: TurnRight, LegTimeSeconds: &timeSeconds, MinimumAltitudeFt: &minimum, MaximumAltitudeFt: &maximum, MaximumSpeedKt: &speed, Termination: HoldingManual, Provenance: provenance}
+	assertInvalid(t, holding.Validate())
+}
+
+func TestCanonicalModelsContainNoHTTPOrVendorFields(t *testing.T) {
+	for _, model := range []any{DatasetVersion{}, Provenance{}, Airport{}, Runway{}, Fix{}, Airway{}, Procedure{}, RouteGeometry{}, TerminalPath{}} {
+		modelType := reflect.TypeOf(model)
+		for index := range modelType.NumField() {
+			field := strings.ToLower(modelType.Field(index).Name)
+			if strings.Contains(field, "http") || strings.Contains(field, "etag") || strings.Contains(field, "url") || strings.Contains(field, "cursor") || strings.Contains(field, "retry") {
+				t.Errorf("%s.%s leaks provider transport state", modelType.Name(), modelType.Field(index).Name)
+			}
+		}
+	}
+}
+
+func TestProcedureRequiresExactlyOneReferencedHolding(t *testing.T) {
+	provenance := testProvenance()
+	timeSeconds := int64(60)
+	holding := HoldingPattern{ID: "HOLD", Fix: "KEMAX", InboundCourseTrueDeg: 180, TurnDirection: TurnRight, LegTimeSeconds: &timeSeconds, Termination: HoldingManual, Provenance: provenance}
+	missing := HoldingID("MISSING")
+	procedure := Procedure{ID: "SOK1P", Airport: "EKCH", Kind: ProcedureSTAR, Provenance: provenance, Holdings: []HoldingPattern{holding}, Legs: []ProcedureLeg{{ID: "H", PathTerminator: PathHF, HoldingID: &missing}}}
+	assertInvalid(t, procedure.Validate())
+}
+
+func TestRouteDigestIsDeterministicForHoldingAndUnresolvedOrdering(t *testing.T) {
+	query := RouteQuery{Version: testVersion(), Origin: "ENGM", Destination: "EKCH", FiledRoute: "DCT KEMAX"}
+	legs := []ProcedureLeg{{ID: "DCT", PathTerminator: PathDF}}
+	first, err := RouteGeometryDigest(query, legs, []HoldingID{"B", "A"}, CoveragePartial, []string{"vector", "missing"})
+	require.NoError(t, err)
+	second, err := RouteGeometryDigest(query, legs, []HoldingID{"A", "B"}, CoveragePartial, []string{"missing", "vector"})
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+}
+
+func testVersion() DatasetVersion {
+	from := time.Date(2026, 7, 16, 0, 0, 0, 0, time.UTC)
+	return DatasetVersion{Cycle: "2608", SourceRevision: "r1", EffectiveFrom: from, EffectiveUntil: from.AddDate(0, 0, 28)}
+}
+func testProvenance() Provenance {
+	version := testVersion()
+	return Provenance{SourceID: "fixture", SourceRevision: "r1", ImportedAt: version.EffectiveFrom, EffectiveFrom: version.EffectiveFrom, EffectiveUntil: version.EffectiveUntil}
+}
+func assertInvalid(t *testing.T, err error) {
+	t.Helper()
+	var domain *aman.DomainError
+	require.Error(t, err)
+	require.True(t, errors.As(err, &domain))
+	require.Equal(t, aman.ErrorInvalidArgument, domain.Class)
+}

--- a/backend/internal/aman/navdata/types_test.go
+++ b/backend/internal/aman/navdata/types_test.go
@@ -65,14 +65,84 @@ func TestProcedureRequiresExactlyOneReferencedHolding(t *testing.T) {
 	assertInvalid(t, procedure.Validate())
 }
 
+func TestProcedureHoldingTerminatorAndFixMustMatchDefinition(t *testing.T) {
+	provenance := testProvenance()
+	seconds := int64(60)
+	holdingID, holdingFix := HoldingID("HOLD"), FixID("KEMAX")
+	holding := HoldingPattern{ID: holdingID, Fix: holdingFix, InboundCourseTrueDeg: 180, TurnDirection: TurnRight, LegTimeSeconds: &seconds, Termination: HoldingToFix, Provenance: provenance}
+	procedure := Procedure{ID: "SOK1P", Airport: "EKCH", Kind: ProcedureSTAR, Provenance: provenance, Holdings: []HoldingPattern{holding}, Legs: []ProcedureLeg{{ID: "H", PathTerminator: PathHA, HoldingID: &holdingID}}}
+	assertInvalid(t, procedure.Validate())
+	procedure.Legs[0].PathTerminator = PathHF
+	wrongFix := FixID("ROSBI")
+	procedure.Legs[0].ToFix = &wrongFix
+	assertInvalid(t, procedure.Validate())
+}
+
+func TestCompleteCoverageRejectsUnsupportedAndUnresolvedGeometry(t *testing.T) {
+	version, provenance := testVersion(), testProvenance()
+	unsupported := Procedure{ID: "ILS22L", Airport: "EKCH", Kind: ProcedureApproach, Provenance: provenance, Legs: []ProcedureLeg{{ID: "V", PathTerminator: PathUnsupported}}}
+	assertInvalid(t, ProcedureSet{Version: version, Airport: "EKCH", Procedures: []Procedure{unsupported}, Coverage: CoverageComplete, Provenance: provenance}.Validate())
+	geometry := RouteGeometry{Version: version, Legs: []ProcedureLeg{{ID: "V", PathTerminator: PathUnsupported}}, Coverage: CoverageComplete, Provenance: provenance, Digest: "digest"}
+	assertInvalid(t, geometry.Validate())
+	path := TerminalPath{Version: version, Airport: "EKCH", Feeder: "SOK", RunwayGroup: "SOUTH", Legs: []ProcedureLeg{{ID: "V", PathTerminator: PathUnsupported}}, Coverage: CoverageComplete, Provenance: provenance, Digest: "digest"}
+	assertInvalid(t, path.Validate())
+}
+
+func TestQueriesRejectNonCanonicalOptionalIdentifiers(t *testing.T) {
+	version := testVersion()
+	procedure := ProcedureID("SOK1P")
+	runway := RunwayID("22L")
+	group := aman.RunwayGroupID("south")
+	assertInvalid(t, ProcedureQuery{Version: version, Airport: " EKCH", Kinds: []ProcedureKind{ProcedureSID}}.Validate())
+	assertInvalid(t, FixQuery{Version: version, Identifiers: []FixID{"KEMAX", "KEMAX"}}.Validate())
+	assertInvalid(t, RouteQuery{Version: version, Origin: "ENGM", Destination: "EKCH", FiledRoute: "DCT", ArrivalProcedure: &procedure, Runway: &runway, RunwayGroup: &group}.Validate())
+}
+
 func TestRouteDigestIsDeterministicForHoldingAndUnresolvedOrdering(t *testing.T) {
 	query := RouteQuery{Version: testVersion(), Origin: "ENGM", Destination: "EKCH", FiledRoute: "DCT KEMAX"}
-	legs := []ProcedureLeg{{ID: "DCT", PathTerminator: PathDF}}
-	first, err := RouteGeometryDigest(query, legs, []HoldingID{"B", "A"}, CoveragePartial, []string{"vector", "missing"})
+	course, distance := 180.0, 12.5
+	geometry := RouteGeometry{Version: query.Version, Legs: []ProcedureLeg{{ID: "DCT", PathTerminator: PathDF, CourseTrueDeg: &course, DistanceNM: &distance}}, HoldingIDs: []HoldingID{"B", "A"}, TotalDistanceNM: distance, Coverage: CoveragePartial, Unresolved: []string{"vector", "missing"}, Provenance: testProvenance()}
+	first, err := RouteGeometryDigest(query, geometry)
 	require.NoError(t, err)
-	second, err := RouteGeometryDigest(query, legs, []HoldingID{"A", "B"}, CoveragePartial, []string{"missing", "vector"})
+	geometry.HoldingIDs = []HoldingID{"A", "B"}
+	geometry.Unresolved = []string{"missing", "vector"}
+	second, err := RouteGeometryDigest(query, geometry)
 	require.NoError(t, err)
 	require.Equal(t, first, second)
+}
+
+func TestRouteDigestIncludesEveryMaterialGeometryField(t *testing.T) {
+	query := RouteQuery{Version: testVersion(), Origin: "ENGM", Destination: "EKCH", FiledRoute: "DCT KEMAX"}
+	course, distance := 180.0, 12.5
+	holding := HoldingID("HOLD")
+	from, to := FixID("KEMAX"), FixID("KEMAX")
+	base := RouteGeometry{Version: query.Version, Legs: []ProcedureLeg{{ID: "DCT", PathTerminator: PathHF, FromFix: &from, ToFix: &to, CourseTrueDeg: &course, DistanceNM: &distance, HoldingID: &holding}}, HoldingIDs: []HoldingID{holding}, TotalDistanceNM: distance, Coverage: CoveragePartial, Unresolved: []string{"vector"}, Provenance: testProvenance()}
+	baseline, err := RouteGeometryDigest(query, base)
+	require.NoError(t, err)
+	changes := []func(*RouteGeometry){func(g *RouteGeometry) { value := 181.0; g.Legs[0].CourseTrueDeg = &value }, func(g *RouteGeometry) { value := 13.0; g.Legs[0].DistanceNM = &value }, func(g *RouteGeometry) { value := HoldingID("OTHER"); g.Legs[0].HoldingID = &value }, func(g *RouteGeometry) { value := FixID("ROSBI"); g.Legs[0].FromFix = &value }, func(g *RouteGeometry) { value := FixID("ROSBI"); g.Legs[0].ToFix = &value }, func(g *RouteGeometry) { g.Legs[0].PathTerminator = PathHA }, func(g *RouteGeometry) { g.TotalDistanceNM = 13 }, func(g *RouteGeometry) { g.HoldingIDs = []HoldingID{"OTHER"} }, func(g *RouteGeometry) { g.Coverage = CoverageUnsupported }, func(g *RouteGeometry) { g.Unresolved = []string{"other"} }, func(g *RouteGeometry) { g.Legs[0].ID = "OTHER" }}
+	for _, change := range changes {
+		candidate := cloneRoute(base)
+		change(&candidate)
+		digest, err := RouteGeometryDigest(query, candidate)
+		require.NoError(t, err)
+		require.NotEqual(t, baseline, digest)
+	}
+}
+
+func TestHoldingDigestExcludesProvenanceButIncludesGeometry(t *testing.T) {
+	seconds := int64(60)
+	base := HoldingPattern{ID: "HOLD", Fix: "KEMAX", InboundCourseTrueDeg: 180, TurnDirection: TurnRight, LegTimeSeconds: &seconds, Termination: HoldingManual, Provenance: testProvenance()}
+	first, err := HoldingDigest(base)
+	require.NoError(t, err)
+	other := base
+	other.Provenance = Provenance{SourceID: "airacnet", SourceRevision: "different", ImportedAt: time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC), EffectiveFrom: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), EffectiveUntil: time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)}
+	second, err := HoldingDigest(other)
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+	other.InboundCourseTrueDeg = 181
+	changed, err := HoldingDigest(other)
+	require.NoError(t, err)
+	require.NotEqual(t, first, changed)
 }
 
 func testVersion() DatasetVersion {

--- a/backend/internal/aman/navdata/types_test.go
+++ b/backend/internal/aman/navdata/types_test.go
@@ -2,6 +2,7 @@ package navdata
 
 import (
 	"errors"
+	"math"
 	"reflect"
 	"strings"
 	"testing"
@@ -96,6 +97,27 @@ func TestQueriesRejectNonCanonicalOptionalIdentifiers(t *testing.T) {
 	assertInvalid(t, ProcedureQuery{Version: version, Airport: " EKCH", Kinds: []ProcedureKind{ProcedureSID}}.Validate())
 	assertInvalid(t, FixQuery{Version: version, Identifiers: []FixID{"KEMAX", "KEMAX"}}.Validate())
 	assertInvalid(t, RouteQuery{Version: version, Origin: "ENGM", Destination: "EKCH", FiledRoute: "DCT", ArrivalProcedure: &procedure, Runway: &runway, RunwayGroup: &group}.Validate())
+}
+
+func TestCanonicalFloatFieldsRejectNaNAndInfinity(t *testing.T) {
+	assertInvalid(t, Coordinate{LatitudeDeg: math.NaN(), LongitudeDeg: 12}.Validate())
+	provenance, seconds := testProvenance(), int64(60)
+	assertInvalid(t, HoldingPattern{ID: "HOLD", Fix: "KEMAX", InboundCourseTrueDeg: math.Inf(1), TurnDirection: TurnRight, LegTimeSeconds: &seconds, Termination: HoldingManual, Provenance: provenance}.Validate())
+	distance := math.Inf(1)
+	assertInvalid(t, ProcedureLeg{ID: "LEG", PathTerminator: PathDF, DistanceNM: &distance}.Validate())
+	assertInvalid(t, ProcedureLeg{ID: "leg/with delimiter", PathTerminator: PathDF}.Validate())
+	assertInvalid(t, RouteGeometry{Version: testVersion(), TotalDistanceNM: math.NaN(), Coverage: CoveragePartial, Provenance: provenance, Digest: "digest"}.Validate())
+}
+
+func TestRouteDigestRejectsDatasetMismatch(t *testing.T) {
+	query := RouteQuery{Version: testVersion(), Origin: "ENGM", Destination: "EKCH", FiledRoute: "DCT KEMAX"}
+	geometry := RouteGeometry{Version: query.Version, Coverage: CoveragePartial, Provenance: testProvenance()}
+	geometry.Version.SourceRevision = "other"
+	_, err := RouteGeometryDigest(query, geometry)
+	var domain *aman.DomainError
+	require.Error(t, err)
+	require.True(t, errors.As(err, &domain))
+	require.Equal(t, ErrorDatasetMismatch, domain.Class)
 }
 
 func TestRouteDigestIsDeterministicForHoldingAndUnresolvedOrdering(t *testing.T) {


### PR DESCRIPTION
## What changed

- Added provider-independent AMAN navigation data contracts for versioned source queries, canonical aviation geometry, route resolution, provenance, stable errors, and cache-only runtime reads.
- Added deterministic EKCH fixture-source data covering SID, STAR, approach, HA/HF/HM published holds, a retained unsupported vector leg, and a canonical DCT route.
- Added reusable source/resolver contract checks plus package-direction and cache-isolation tests.

## Why

AMAN needs a stable canonical navigation boundary so acquisition providers can be replaced without changing predictor, sequencing, frontend, or canonical persistence consumers.

## Impact

This introduces contracts only: no HTTP adapter, persistence/materialization, operational EKCH selection policy, prediction, or UI behavior. The fixture source proves a non-network implementation today. AIRAC.NET adapter equivalence through the shared contract suite is completed by #310, not by this PR.

## Checks

- `go test ./internal/aman/navdata/...`
- `go test ./...`

Closes #311
