### PR TITLE
feat(aman): implement AIRAC.NET navigation adapter

### DIFF
--- a/backend/internal/aman/navdata/airacnet/adapter.go
+++ b/backend/internal/aman/navdata/airacnet/adapter.go
@@ -111,15 +111,16 @@ type Config struct {
 // Adapter implements the acquisition interfaces. It is never a runtime
 // GeometryReader: materializers persist its output to the canonical cache.
 type Adapter struct {
-	baseURL     *url.URL
-	client      *http.Client
-	timeout     time.Duration
-	retries     int
-	backoff     time.Duration
-	userAgent   string
-	checkpoints CheckpointStore
-	now         func() time.Time
-	requests    chan struct{}
+	baseURL      *url.URL
+	client       *http.Client
+	timeout      time.Duration
+	retries      int
+	backoff      time.Duration
+	userAgent    string
+	checkpoints  CheckpointStore
+	now          func() time.Time
+	requests     chan struct{}
+	requestMaker func(context.Context, string, string, io.Reader) (*http.Request, error)
 }
 
 func New(config Config) (*Adapter, error) {
@@ -155,7 +156,7 @@ func New(config Config) (*Adapter, error) {
 	if config.Now == nil {
 		config.Now = time.Now
 	}
-	return &Adapter{baseURL: parsed, client: config.HTTPClient, timeout: config.Timeout, retries: config.Retries, backoff: config.RetryBackoff, userAgent: config.UserAgent, checkpoints: config.Checkpoints, now: config.Now, requests: make(chan struct{}, config.MaxConcurrent)}, nil
+	return &Adapter{baseURL: parsed, client: config.HTTPClient, timeout: config.Timeout, retries: config.Retries, backoff: config.RetryBackoff, userAgent: config.UserAgent, checkpoints: config.Checkpoints, now: config.Now, requests: make(chan struct{}, config.MaxConcurrent), requestMaker: http.NewRequestWithContext}, nil
 }
 
 func (a *Adapter) LatestVersion(ctx context.Context) (navdata.DatasetVersion, error) {
@@ -186,7 +187,9 @@ func (a *Adapter) Airport(ctx context.Context, version navdata.DatasetVersion, i
 		return navdata.Airport{}, err
 	}
 	var response airportResponse
-	if err := a.getJSON(ctx, "airports/"+url.PathEscape(string(id)), nil, &response); err != nil {
+	if err := a.getJSON(ctx, "airports/"+url.PathEscape(string(id)), nil, &response); isHTTPStatus(err, http.StatusNotFound) {
+		return navdata.Airport{}, notFound("AIRAC.NET airport was not found")
+	} else if err != nil {
 		return navdata.Airport{}, err
 	}
 	airport, err := a.airport(version, response.Data)
@@ -411,6 +414,9 @@ func (a *Adapter) listProcedurePage(ctx context.Context, parameters url.Values) 
 func (a *Adapter) procedure(ctx context.Context, version navdata.DatasetVersion, item procedureListItem) (navdata.Procedure, bool, error) {
 	var response procedureDetailResponse
 	if err := a.getJSON(ctx, path.Join("procedures", item.Airport, item.Identifier), nil, &response); err != nil {
+		if isHTTPStatus(err, http.StatusNotFound) {
+			return navdata.Procedure{}, false, unavailable("AIRAC.NET procedure changed during retrieval")
+		}
 		return navdata.Procedure{}, false, err
 	}
 	detail := response.Data
@@ -468,6 +474,10 @@ func (a *Adapter) fix(version navdata.DatasetVersion, value waypointDTO) (navdat
 }
 func (a *Adapter) routeGeometry(query navdata.RouteQuery, result routeData) (navdata.RouteGeometry, error) {
 	geometry := navdata.RouteGeometry{Version: query.Version, TotalDistanceNM: result.TotalDistance, Coverage: navdata.CoverageComplete, Provenance: a.provenance(query.Version)}
+	if query.ArrivalProcedure != nil {
+		geometry.Coverage = navdata.CoveragePartial
+		geometry.Unresolved = append(geometry.Unresolved, "PUBLISHED_HOLDING_DATA_UNAVAILABLE")
+	}
 	if len(result.Segments) == 0 {
 		geometry.Coverage = navdata.CoveragePartial
 		geometry.Unresolved = append(geometry.Unresolved, "route-empty")
@@ -520,16 +530,19 @@ func (a *Adapter) getJSON(ctx context.Context, endpoint string, parameters url.V
 			return ctx.Err()
 		}
 		requestCtx, cancel := context.WithTimeout(ctx, a.timeout)
-		request, err := http.NewRequestWithContext(requestCtx, http.MethodGet, requestURL.String(), nil)
-		if err == nil {
-			request.Header.Set("Accept", "application/json")
-			request.Header.Set("User-Agent", a.userAgent)
-			if cached && checkpoint.ETag != "" {
-				request.Header.Set("If-None-Match", checkpoint.ETag)
-			}
-			if cached && checkpoint.LastModified != "" {
-				request.Header.Set("If-Modified-Since", checkpoint.LastModified)
-			}
+		request, err := a.requestMaker(requestCtx, http.MethodGet, requestURL.String(), nil)
+		if err != nil {
+			cancel()
+			<-a.requests
+			return invalid("construct AIRAC.NET request")
+		}
+		request.Header.Set("Accept", "application/json")
+		request.Header.Set("User-Agent", a.userAgent)
+		if cached && checkpoint.ETag != "" {
+			request.Header.Set("If-None-Match", checkpoint.ETag)
+		}
+		if cached && checkpoint.LastModified != "" {
+			request.Header.Set("If-Modified-Since", checkpoint.LastModified)
 		}
 		response, doErr := a.client.Do(request)
 		if doErr != nil {
@@ -551,6 +564,9 @@ func (a *Adapter) getJSON(ctx context.Context, endpoint string, parameters url.V
 		cancel()
 		<-a.requests
 		if readErr != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			if retryableTransport(readErr) && attempt < a.retries {
 				if err := wait(ctx, a.backoff, attempt); err != nil {
 					return err
@@ -726,6 +742,10 @@ type httpStatusError struct {
 func (e *httpStatusError) Error() string {
 	return fmt.Sprintf("AIRAC.NET request to %s returned HTTP %d", e.endpoint, e.status)
 }
+func isHTTPStatus(err error, status int) bool {
+	var value *httpStatusError
+	return errors.As(err, &value) && value.status == status
+}
 
 func firstWaypoint(raw json.RawMessage) (waypointDTO, bool, error) {
 	var one waypointDTO
@@ -864,6 +884,9 @@ func nextPage(hasMore bool, page int) int {
 	return 0
 }
 func retryableTransport(err error) bool {
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
 	var network net.Error
 	return errors.As(err, &network) && (network.Timeout() || network.Temporary())
 }
@@ -886,6 +909,9 @@ func wait(ctx context.Context, base time.Duration, attempt int) error {
 }
 func invalid(message string) error {
 	return &aman.DomainError{Class: navdata.ErrorInvalidRequest, Message: message}
+}
+func notFound(message string) error {
+	return &aman.DomainError{Class: navdata.ErrorNotFound, Message: message}
 }
 func incomplete(message string) error {
 	return &aman.DomainError{Class: navdata.ErrorIncompleteGeometry, Message: message}

--- a/backend/internal/aman/navdata/airacnet/adapter.go
+++ b/backend/internal/aman/navdata/airacnet/adapter.go
@@ -1,0 +1,901 @@
+// Package airacnet adapts the public AIRAC.NET HTTP API to the provider-neutral
+// AMAN navigation contracts.  HTTP DTOs and checkpoint state intentionally stay
+// in this package.
+package airacnet
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"path"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/aman/navdata"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const defaultBaseURL = "https://airac.net/api/v1"
+
+// Checkpoint is adapter-private HTTP state. It is deliberately not embedded in
+// canonical navigation values or their digests.
+type Checkpoint struct {
+	ETag         string
+	LastModified string
+	NextPage     int
+	Body         []byte
+}
+
+type CheckpointStore interface {
+	Load(context.Context, string) (Checkpoint, bool, error)
+	Save(context.Context, string, Checkpoint) error
+}
+
+// PostgresCheckpoints is the durable production checkpoint implementation.
+// Its table and raw response body are source-adapter state, never canonical
+// AMAN cache data.
+type PostgresCheckpoints struct{ db checkpointDB }
+
+type checkpointDB interface {
+	QueryRow(context.Context, string, ...any) pgx.Row
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+}
+
+func NewPostgresCheckpoints(pool *pgxpool.Pool) *PostgresCheckpoints {
+	return &PostgresCheckpoints{db: pool}
+}
+
+func (s *PostgresCheckpoints) Load(ctx context.Context, key string) (Checkpoint, bool, error) {
+	var value Checkpoint
+	err := s.db.QueryRow(ctx, `SELECT etag, last_modified, next_page, response_body FROM airacnet_http_checkpoints WHERE request_key = $1`, key).Scan(&value.ETag, &value.LastModified, &value.NextPage, &value.Body)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Checkpoint{}, false, nil
+	}
+	if err != nil {
+		return Checkpoint{}, false, err
+	}
+	return value, true, nil
+}
+
+func (s *PostgresCheckpoints) Save(ctx context.Context, key string, value Checkpoint) error {
+	_, err := s.db.Exec(ctx, `INSERT INTO airacnet_http_checkpoints (request_key, etag, last_modified, next_page, response_body, updated_at) VALUES ($1, $2, $3, $4, $5, now()) ON CONFLICT (request_key) DO UPDATE SET etag = EXCLUDED.etag, last_modified = EXCLUDED.last_modified, next_page = EXCLUDED.next_page, response_body = EXCLUDED.response_body, updated_at = EXCLUDED.updated_at`, key, value.ETag, value.LastModified, value.NextPage, value.Body)
+	return err
+}
+
+type MemoryCheckpoints struct {
+	mu     sync.Mutex
+	values map[string]Checkpoint
+}
+
+func NewMemoryCheckpoints() *MemoryCheckpoints {
+	return &MemoryCheckpoints{values: map[string]Checkpoint{}}
+}
+func (s *MemoryCheckpoints) Load(_ context.Context, key string) (Checkpoint, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	value, ok := s.values[key]
+	value.Body = slices.Clone(value.Body)
+	return value, ok, nil
+}
+func (s *MemoryCheckpoints) Save(_ context.Context, key string, value Checkpoint) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	value.Body = slices.Clone(value.Body)
+	s.values[key] = value
+	return nil
+}
+
+type Config struct {
+	BaseURL       string
+	HTTPClient    *http.Client
+	Timeout       time.Duration
+	MaxConcurrent int
+	Retries       int
+	RetryBackoff  time.Duration
+	UserAgent     string
+	Checkpoints   CheckpointStore
+	Now           func() time.Time
+}
+
+// Adapter implements the acquisition interfaces. It is never a runtime
+// GeometryReader: materializers persist its output to the canonical cache.
+type Adapter struct {
+	baseURL     *url.URL
+	client      *http.Client
+	timeout     time.Duration
+	retries     int
+	backoff     time.Duration
+	userAgent   string
+	checkpoints CheckpointStore
+	now         func() time.Time
+	requests    chan struct{}
+}
+
+func New(config Config) (*Adapter, error) {
+	base := config.BaseURL
+	if base == "" {
+		base = defaultBaseURL
+	}
+	parsed, err := url.Parse(base)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return nil, fmt.Errorf("AIRAC.NET base URL is invalid")
+	}
+	if config.Timeout <= 0 {
+		config.Timeout = 10 * time.Second
+	}
+	if config.MaxConcurrent <= 0 {
+		config.MaxConcurrent = 4
+	}
+	if config.Retries < 0 {
+		return nil, fmt.Errorf("AIRAC.NET retries cannot be negative")
+	}
+	if config.RetryBackoff <= 0 {
+		config.RetryBackoff = 50 * time.Millisecond
+	}
+	if config.UserAgent == "" {
+		config.UserAgent = "FlightStrips-AMAN/1.0 (+https://github.com/flightstrips/FlightStrips)"
+	}
+	if config.HTTPClient == nil {
+		config.HTTPClient = &http.Client{}
+	}
+	if config.Checkpoints == nil {
+		return nil, fmt.Errorf("AIRAC.NET checkpoint store is required")
+	}
+	if config.Now == nil {
+		config.Now = time.Now
+	}
+	return &Adapter{baseURL: parsed, client: config.HTTPClient, timeout: config.Timeout, retries: config.Retries, backoff: config.RetryBackoff, userAgent: config.UserAgent, checkpoints: config.Checkpoints, now: config.Now, requests: make(chan struct{}, config.MaxConcurrent)}, nil
+}
+
+func (a *Adapter) LatestVersion(ctx context.Context) (navdata.DatasetVersion, error) {
+	var result cycleResponse
+	if err := a.getJSON(ctx, "airac/current", nil, &result); err != nil {
+		return navdata.DatasetVersion{}, err
+	}
+	from, err := parseTime(result.Data.EffectiveDate)
+	if err != nil {
+		return navdata.DatasetVersion{}, invalid("AIRAC.NET cycle effective_date")
+	}
+	until, err := parseTime(result.Data.ExpirationDate)
+	if err != nil {
+		return navdata.DatasetVersion{}, invalid("AIRAC.NET cycle expiration_date")
+	}
+	version := navdata.DatasetVersion{Cycle: upper(result.Data.Cycle), SourceRevision: "airac.net-" + upper(result.Data.Cycle), EffectiveFrom: from, EffectiveUntil: until}
+	if err := version.Validate(); err != nil {
+		return navdata.DatasetVersion{}, invalid("AIRAC.NET cycle response")
+	}
+	return version, nil
+}
+
+func (a *Adapter) Airport(ctx context.Context, version navdata.DatasetVersion, id navdata.AirportID) (navdata.Airport, error) {
+	if err := version.Validate(); err != nil {
+		return navdata.Airport{}, err
+	}
+	if err := a.matchVersion(ctx, version); err != nil {
+		return navdata.Airport{}, err
+	}
+	var response airportResponse
+	if err := a.getJSON(ctx, "airports/"+url.PathEscape(string(id)), nil, &response); err != nil {
+		return navdata.Airport{}, err
+	}
+	airport, err := a.airport(version, response.Data)
+	if err != nil {
+		return navdata.Airport{}, err
+	}
+	if airport.ID != id {
+		return navdata.Airport{}, invalid("AIRAC.NET airport identifier mismatch")
+	}
+	return airport, nil
+}
+
+func (a *Adapter) Procedures(ctx context.Context, query navdata.ProcedureQuery) (navdata.ProcedureSet, error) {
+	if err := query.Validate(); err != nil {
+		return navdata.ProcedureSet{}, err
+	}
+	if err := a.matchVersion(ctx, query.Version); err != nil {
+		return navdata.ProcedureSet{}, err
+	}
+	listing, err := a.listProcedures(ctx, query)
+	if err != nil {
+		return navdata.ProcedureSet{}, err
+	}
+	values := make([]navdata.Procedure, len(listing))
+	partial := false
+	var partialMu sync.Mutex
+	if err := a.parallel(ctx, len(listing), func(ctx context.Context, index int) error {
+		procedure, incomplete, err := a.procedure(ctx, query.Version, listing[index])
+		if err != nil {
+			return err
+		}
+		values[index] = procedure
+		if incomplete {
+			partialMu.Lock()
+			partial = true
+			partialMu.Unlock()
+		}
+		return nil
+	}); err != nil {
+		return navdata.ProcedureSet{}, err
+	}
+	if len(values) == 0 {
+		partial = true
+	}
+	coverage := navdata.CoverageComplete
+	if partial {
+		coverage = navdata.CoveragePartial
+	}
+	result := navdata.ProcedureSet{Version: query.Version, Airport: query.Airport, Procedures: values, Coverage: coverage, Provenance: a.provenance(query.Version)}
+	if err := result.Validate(); err != nil {
+		return navdata.ProcedureSet{}, invalid("AIRAC.NET procedure response")
+	}
+	return result, nil
+}
+
+func (a *Adapter) Fixes(ctx context.Context, query navdata.FixQuery) (navdata.FixSet, error) {
+	if err := query.Validate(); err != nil {
+		return navdata.FixSet{}, err
+	}
+	if err := a.matchVersion(ctx, query.Version); err != nil {
+		return navdata.FixSet{}, err
+	}
+	values := make([]navdata.Fix, len(query.Identifiers))
+	found := make([]bool, len(query.Identifiers))
+	if err := a.parallel(ctx, len(query.Identifiers), func(ctx context.Context, index int) error {
+		var response waypointResponse
+		err := a.getJSON(ctx, "waypoints/"+url.PathEscape(string(query.Identifiers[index])), nil, &response)
+		var status *httpStatusError
+		if errors.As(err, &status) && status.status == http.StatusNotFound {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		item, ok, err := firstWaypoint(response.Data)
+		if err != nil {
+			return incomplete("AIRAC.NET waypoint response is ambiguous")
+		}
+		if !ok {
+			return nil
+		}
+		fix, err := a.fix(query.Version, item)
+		if err != nil {
+			return err
+		}
+		if fix.ID != query.Identifiers[index] {
+			return nil
+		}
+		values[index], found[index] = fix, true
+		return nil
+	}); err != nil {
+		return navdata.FixSet{}, err
+	}
+	fixes := make([]navdata.Fix, 0, len(values))
+	for index, value := range values {
+		if found[index] {
+			fixes = append(fixes, value)
+		}
+	}
+	coverage := navdata.CoverageComplete
+	if len(fixes) != len(query.Identifiers) {
+		coverage = navdata.CoveragePartial
+	}
+	result := navdata.FixSet{Version: query.Version, Fixes: fixes, Coverage: coverage, Provenance: a.provenance(query.Version)}
+	if err := result.Validate(); err != nil {
+		return navdata.FixSet{}, invalid("AIRAC.NET waypoint response")
+	}
+	return result, nil
+}
+
+func (a *Adapter) Resolve(ctx context.Context, query navdata.RouteQuery) (navdata.RouteGeometry, error) {
+	if err := query.Validate(); err != nil {
+		return navdata.RouteGeometry{}, err
+	}
+	if err := a.matchVersion(ctx, query.Version); err != nil {
+		return navdata.RouteGeometry{}, err
+	}
+	// The key is deliberately calculated before AIRAC.NET's DCT/STAR workaround.
+	if _, err := query.Key(); err != nil {
+		return navdata.RouteGeometry{}, err
+	}
+	route := transformedRoute(query)
+	if route == "" {
+		return navdata.RouteGeometry{}, invalid("AIRAC.NET route is empty after DCT removal")
+	}
+	parameters := url.Values{"origin": {string(query.Origin)}, "destination": {string(query.Destination)}, "route": {route}}
+	if query.Runway != nil {
+		parameters.Set("arrival_runway", string(*query.Runway))
+	}
+	var response routeResponse
+	if err := a.getJSON(ctx, "routes/parse", parameters, &response); err != nil {
+		return navdata.RouteGeometry{}, err
+	}
+	geometry, err := a.routeGeometry(query, response.Data)
+	if err != nil {
+		return navdata.RouteGeometry{}, err
+	}
+	return geometry, nil
+}
+
+func (a *Adapter) listProcedures(ctx context.Context, query navdata.ProcedureQuery) ([]procedureListItem, error) {
+	queries := []url.Values{{"airport": {string(query.Airport)}}}
+	if len(query.Kinds) > 0 {
+		queries = queries[:0]
+		for _, kind := range query.Kinds {
+			queries = append(queries, url.Values{"airport": {string(query.Airport)}, "type": {vendorKind(kind)}})
+		}
+	}
+	if len(query.Identifiers) > 0 {
+		queries = queries[:0]
+		for _, identifier := range query.Identifiers {
+			for _, kind := range kindsOrAll(query.Kinds) {
+				queries = append(queries, url.Values{"airport": {string(query.Airport)}, "identifier": {string(identifier)}, "type": {vendorKind(kind)}})
+			}
+		}
+	}
+	result := make([]procedureListItem, 0)
+	seen := map[string]struct{}{}
+	for _, parameters := range queries {
+		if len(query.Runways) == 0 {
+			items, err := a.listProcedurePage(ctx, parameters)
+			if err != nil {
+				return nil, err
+			}
+			for _, item := range items {
+				if matchesListing(item, query) {
+					key := item.Airport + "/" + item.Identifier + "/" + item.Type.Code
+					if _, ok := seen[key]; !ok {
+						seen[key] = struct{}{}
+						result = append(result, item)
+					}
+				}
+			}
+			continue
+		}
+		for _, runway := range query.Runways {
+			request := cloneValues(parameters)
+			request.Set("runway", string(runway))
+			items, err := a.listProcedurePage(ctx, request)
+			if err != nil {
+				return nil, err
+			}
+			for _, item := range items {
+				if matchesListing(item, query) {
+					key := item.Airport + "/" + item.Identifier + "/" + item.Type.Code
+					if _, ok := seen[key]; !ok {
+						seen[key] = struct{}{}
+						result = append(result, item)
+					}
+				}
+			}
+		}
+	}
+	return result, nil
+}
+
+func (a *Adapter) listProcedurePage(ctx context.Context, parameters url.Values) ([]procedureListItem, error) {
+	page := 1
+	result := []procedureListItem{}
+	for {
+		request := cloneValues(parameters)
+		request.Set("page", strconv.Itoa(page))
+		request.Set("per_page", "100")
+		var response procedureListResponse
+		if err := a.getJSON(ctx, "procedures", request, &response); err != nil {
+			return nil, err
+		}
+		if err := a.saveNextPage(ctx, "procedures", request, nextPage(response.Pagination.HasMore, page)); err != nil {
+			return nil, unavailable("save AIRAC.NET pagination checkpoint")
+		}
+		result = append(result, response.Data...)
+		if !response.Pagination.HasMore {
+			return result, nil
+		}
+		page++
+		if page > 10000 {
+			return nil, unavailable("AIRAC.NET procedure pagination did not terminate")
+		}
+	}
+}
+
+func (a *Adapter) procedure(ctx context.Context, version navdata.DatasetVersion, item procedureListItem) (navdata.Procedure, bool, error) {
+	var response procedureDetailResponse
+	if err := a.getJSON(ctx, path.Join("procedures", item.Airport, item.Identifier), nil, &response); err != nil {
+		return navdata.Procedure{}, false, err
+	}
+	detail := response.Data
+	if detail.Identifier == "" {
+		detail.Identifier = item.Identifier
+	}
+	if detail.Airport == "" {
+		detail.Airport = item.Airport
+	}
+	if detail.Type.Code == "" {
+		detail.Type = item.Type
+	}
+	procedure := navdata.Procedure{ID: navdata.ProcedureID(upper(detail.Identifier)), Airport: navdata.AirportID(upper(detail.Airport)), Kind: canonicalKind(detail.Type.Code), Runways: canonicalRunways(item.Runway, detail.AvailableRunways), Provenance: a.provenance(version)}
+	if !procedure.Kind.Valid() {
+		return navdata.Procedure{}, false, invalid("AIRAC.NET procedure type")
+	}
+	segments := detail.Segments
+	incomplete := false
+	if len(segments) == 0 && len(detail.CommonRoute) > 0 {
+		incomplete = true // Structured common routes omit documented path terminators.
+		for _, leg := range detail.CommonRoute {
+			segments = append(segments, segmentDTO{Sequence: leg.Sequence, FixIdentifier: leg.FixIdentifier})
+		}
+	}
+	if len(segments) == 0 {
+		incomplete = true
+	}
+	for index, segment := range segments {
+		leg, incompleteLeg := procedureLeg(segment, index)
+		procedure.Legs = append(procedure.Legs, leg)
+		incomplete = incomplete || incompleteLeg
+	}
+	// AIRAC.NET's documented procedure payload has no published holding
+	// definition fields. A supplied HA/HF/HM without an authoritative definition
+	// stays unsupported rather than becoming an empty confirmed holding result.
+	if err := procedure.Validate(); err != nil {
+		return navdata.Procedure{}, false, invalid("AIRAC.NET procedure geometry")
+	}
+	return procedure, incomplete, nil
+}
+
+func (a *Adapter) airport(version navdata.DatasetVersion, value airportDTO) (navdata.Airport, error) {
+	item := navdata.Airport{ID: navdata.AirportID(upper(value.ICAO)), Name: strings.TrimSpace(value.Name), Position: coordinate(value.Latitude, value.Longitude, value.Coordinates), Provenance: a.provenance(version)}
+	if err := item.Validate(); err != nil {
+		return navdata.Airport{}, invalid("AIRAC.NET airport geometry")
+	}
+	return item, nil
+}
+func (a *Adapter) fix(version navdata.DatasetVersion, value waypointDTO) (navdata.Fix, error) {
+	item := navdata.Fix{ID: navdata.FixID(upper(value.Identifier)), Position: coordinate(value.Latitude, value.Longitude, value.Coordinates), Provenance: a.provenance(version)}
+	if err := item.Validate(); err != nil {
+		return navdata.Fix{}, invalid("AIRAC.NET waypoint geometry")
+	}
+	return item, nil
+}
+func (a *Adapter) routeGeometry(query navdata.RouteQuery, result routeData) (navdata.RouteGeometry, error) {
+	geometry := navdata.RouteGeometry{Version: query.Version, TotalDistanceNM: result.TotalDistance, Coverage: navdata.CoverageComplete, Provenance: a.provenance(query.Version)}
+	if len(result.Segments) == 0 {
+		geometry.Coverage = navdata.CoveragePartial
+		geometry.Unresolved = append(geometry.Unresolved, "route-empty")
+	}
+	for index, segment := range result.Segments {
+		from, to := navdata.FixID(upper(segment.From.Identifier)), navdata.FixID(upper(segment.To.Identifier))
+		if from == "" || to == "" {
+			geometry.Coverage = navdata.CoveragePartial
+			geometry.Unresolved = append(geometry.Unresolved, fmt.Sprintf("route-segment-%d", index))
+			continue
+		}
+		course, distance := canonicalCourse(segment.Bearing), segment.Distance
+		// /routes/parse supplies explicit from/to points and a true bearing for
+		// each expanded segment, which maps to a track-to-fix geometric leg.
+		geometry.Legs = append(geometry.Legs, navdata.ProcedureLeg{ID: fmt.Sprintf("ROUTE-%04d", index+1), PathTerminator: navdata.PathTF, FromFix: &from, ToFix: &to, CourseTrueDeg: &course, DistanceNM: &distance})
+	}
+	for _, problem := range result.Errors {
+		if problem.Type != "" {
+			geometry.Coverage = navdata.CoveragePartial
+			geometry.Unresolved = append(geometry.Unresolved, upper(problem.Type))
+		}
+	}
+	if geometry.TotalDistanceNM < 0 {
+		return navdata.RouteGeometry{}, invalid("AIRAC.NET route distance")
+	}
+	digest, err := navdata.RouteGeometryDigest(query, geometry)
+	if err != nil {
+		return navdata.RouteGeometry{}, invalid("AIRAC.NET route geometry")
+	}
+	geometry.Digest = digest
+	return geometry, nil
+}
+
+func (a *Adapter) getJSON(ctx context.Context, endpoint string, parameters url.Values, output any) error {
+	requestURL := *a.baseURL
+	requestURL.Path = path.Join(a.baseURL.Path, endpoint)
+	requestURL.RawQuery = parameters.Encode()
+	key := requestURL.Path + "?" + requestURL.RawQuery
+	checkpoint, cached, err := a.checkpoints.Load(ctx, key)
+	if err != nil {
+		return unavailable("load AIRAC.NET checkpoint")
+	}
+	for attempt := 0; ; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		select {
+		case a.requests <- struct{}{}:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		requestCtx, cancel := context.WithTimeout(ctx, a.timeout)
+		request, err := http.NewRequestWithContext(requestCtx, http.MethodGet, requestURL.String(), nil)
+		if err == nil {
+			request.Header.Set("Accept", "application/json")
+			request.Header.Set("User-Agent", a.userAgent)
+			if cached && checkpoint.ETag != "" {
+				request.Header.Set("If-None-Match", checkpoint.ETag)
+			}
+			if cached && checkpoint.LastModified != "" {
+				request.Header.Set("If-Modified-Since", checkpoint.LastModified)
+			}
+		}
+		response, doErr := a.client.Do(request)
+		if doErr != nil {
+			cancel()
+			<-a.requests
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if retryableTransport(doErr) && attempt < a.retries {
+				if err := wait(ctx, a.backoff, attempt); err != nil {
+					return err
+				}
+				continue
+			}
+			return unavailable("AIRAC.NET request failed")
+		}
+		body, readErr := io.ReadAll(io.LimitReader(response.Body, 8<<20))
+		response.Body.Close()
+		cancel()
+		<-a.requests
+		if readErr != nil {
+			if retryableTransport(readErr) && attempt < a.retries {
+				if err := wait(ctx, a.backoff, attempt); err != nil {
+					return err
+				}
+				continue
+			}
+			return unavailable("read AIRAC.NET response")
+		}
+		if response.StatusCode == http.StatusNotModified {
+			if !cached || len(checkpoint.Body) == 0 {
+				return unavailable("AIRAC.NET returned uncached conditional response")
+			}
+			return json.Unmarshal(checkpoint.Body, output)
+		}
+		if response.StatusCode < 200 || response.StatusCode >= 300 {
+			if (response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= 500) && attempt < a.retries {
+				if err := wait(ctx, a.backoff, attempt); err != nil {
+					return err
+				}
+				continue
+			}
+			return &httpStatusError{status: response.StatusCode, endpoint: requestURL.Path}
+		}
+		var envelope struct {
+			Status string `json:"status"`
+		}
+		if err := json.Unmarshal(body, &envelope); err != nil || envelope.Status != "success" {
+			return invalid("malformed AIRAC.NET response")
+		}
+		if err := json.Unmarshal(body, output); err != nil {
+			return invalid("malformed AIRAC.NET response")
+		}
+		if err := a.checkpoints.Save(ctx, key, Checkpoint{ETag: response.Header.Get("ETag"), LastModified: response.Header.Get("Last-Modified"), NextPage: checkpoint.NextPage, Body: body}); err != nil {
+			return unavailable("save AIRAC.NET checkpoint")
+		}
+		return nil
+	}
+}
+
+func (a *Adapter) saveNextPage(ctx context.Context, endpoint string, parameters url.Values, page int) error {
+	requestURL := *a.baseURL
+	requestURL.Path = path.Join(a.baseURL.Path, endpoint)
+	requestURL.RawQuery = parameters.Encode()
+	key := requestURL.Path + "?" + requestURL.RawQuery
+	checkpoint, found, err := a.checkpoints.Load(ctx, key)
+	if err != nil || !found {
+		return err
+	}
+	checkpoint.NextPage = page
+	return a.checkpoints.Save(ctx, key, checkpoint)
+}
+
+func (a *Adapter) matchVersion(ctx context.Context, requested navdata.DatasetVersion) error {
+	actual, err := a.LatestVersion(ctx)
+	if err != nil {
+		return err
+	}
+	if !actual.Equal(requested) {
+		return &aman.DomainError{Class: navdata.ErrorDatasetMismatch, Message: "AIRAC.NET dataset version does not match request"}
+	}
+	return nil
+}
+func (a *Adapter) provenance(version navdata.DatasetVersion) navdata.Provenance {
+	return navdata.Provenance{SourceID: "airac.net", SourceRevision: version.SourceRevision, ImportedAt: a.now().UTC(), EffectiveFrom: version.EffectiveFrom, EffectiveUntil: version.EffectiveUntil}
+}
+func (a *Adapter) parallel(ctx context.Context, count int, fn func(context.Context, int) error) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	var group sync.WaitGroup
+	var once sync.Once
+	var result error
+	for index := 0; index < count; index++ {
+		index := index
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			if err := fn(ctx, index); err != nil {
+				once.Do(func() { result = err; cancel() })
+			}
+		}()
+	}
+	group.Wait()
+	return result
+}
+
+type cycleResponse struct {
+	Data struct {
+		Cycle          string `json:"cycle"`
+		EffectiveDate  string `json:"effective_date"`
+		ExpirationDate string `json:"expiration_date"`
+	} `json:"data"`
+}
+type coordinateDTO struct {
+	Lat float64 `json:"lat"`
+	Lon float64 `json:"lon"`
+}
+type airportDTO struct {
+	ICAO        string        `json:"icao"`
+	Name        string        `json:"name"`
+	Latitude    float64       `json:"latitude"`
+	Longitude   float64       `json:"longitude"`
+	Coordinates coordinateDTO `json:"coordinates"`
+}
+type airportResponse struct {
+	Data airportDTO `json:"data"`
+}
+type waypointDTO struct {
+	Identifier  string        `json:"identifier"`
+	Latitude    float64       `json:"latitude"`
+	Longitude   float64       `json:"longitude"`
+	Coordinates coordinateDTO `json:"coordinates"`
+}
+type waypointResponse struct {
+	Data json.RawMessage `json:"data"`
+}
+type procedureTypeDTO struct {
+	Code string `json:"code"`
+}
+type procedureListItem struct {
+	Airport    string           `json:"airport"`
+	Identifier string           `json:"identifier"`
+	Type       procedureTypeDTO `json:"type"`
+	Runway     string           `json:"runway"`
+}
+type paginationDTO struct {
+	HasMore bool `json:"has_more"`
+}
+type procedureListResponse struct {
+	Data       []procedureListItem `json:"data"`
+	Pagination paginationDTO       `json:"pagination"`
+}
+type segmentDTO struct {
+	Sequence       int    `json:"sequence"`
+	PathTerminator string `json:"path_terminator"`
+	FixIdentifier  string `json:"fix_identifier"`
+}
+type procedureDetailDTO struct {
+	Airport          string           `json:"airport"`
+	Identifier       string           `json:"identifier"`
+	Type             procedureTypeDTO `json:"type"`
+	Segments         []segmentDTO     `json:"segments"`
+	CommonRoute      []segmentDTO     `json:"common_route"`
+	AvailableRunways []string         `json:"available_runways"`
+}
+type procedureDetailResponse struct {
+	Data procedureDetailDTO `json:"data"`
+}
+type routePointDTO struct {
+	Identifier string `json:"identifier"`
+}
+type routeSegmentDTO struct {
+	From     routePointDTO `json:"from"`
+	To       routePointDTO `json:"to"`
+	Distance float64       `json:"distance"`
+	Bearing  float64       `json:"bearing"`
+}
+type routeErrorDTO struct {
+	Type string `json:"type"`
+}
+type routeData struct {
+	TotalDistance float64           `json:"total_distance"`
+	Segments      []routeSegmentDTO `json:"segments"`
+	Errors        []routeErrorDTO   `json:"errors"`
+}
+type routeResponse struct {
+	Data routeData `json:"data"`
+}
+type httpStatusError struct {
+	status   int
+	endpoint string
+}
+
+func (e *httpStatusError) Error() string {
+	return fmt.Sprintf("AIRAC.NET request to %s returned HTTP %d", e.endpoint, e.status)
+}
+
+func firstWaypoint(raw json.RawMessage) (waypointDTO, bool, error) {
+	var one waypointDTO
+	if err := json.Unmarshal(raw, &one); err == nil && one.Identifier != "" {
+		return one, true, nil
+	}
+	var many []waypointDTO
+	if err := json.Unmarshal(raw, &many); err != nil {
+		return waypointDTO{}, false, err
+	}
+	if len(many) == 0 {
+		return waypointDTO{}, false, nil
+	}
+	if len(many) != 1 {
+		return waypointDTO{}, false, errors.New("ambiguous waypoint response")
+	}
+	return many[0], true, nil
+}
+func parseTime(value string) (time.Time, error) {
+	parsed, err := time.Parse(time.RFC3339, value)
+	return parsed.UTC(), err
+}
+func coordinate(lat, lon float64, nested coordinateDTO) navdata.Coordinate {
+	if nested.Lat != 0 || nested.Lon != 0 {
+		lat, lon = nested.Lat, nested.Lon
+	}
+	return navdata.Coordinate{LatitudeDeg: lat, LongitudeDeg: lon}
+}
+func canonicalCourse(value float64) float64 {
+	if value == 360 {
+		return 0
+	}
+	return value
+}
+func canonicalKind(value string) navdata.ProcedureKind {
+	switch upper(value) {
+	case "SID":
+		return navdata.ProcedureSID
+	case "STAR":
+		return navdata.ProcedureSTAR
+	case "APP":
+		return navdata.ProcedureApproach
+	default:
+		return ""
+	}
+}
+func vendorKind(kind navdata.ProcedureKind) string {
+	switch kind {
+	case navdata.ProcedureSID:
+		return "SID"
+	case navdata.ProcedureSTAR:
+		return "STAR"
+	case navdata.ProcedureApproach:
+		return "APP"
+	default:
+		return ""
+	}
+}
+func kindsOrAll(kinds []navdata.ProcedureKind) []navdata.ProcedureKind {
+	if len(kinds) > 0 {
+		return kinds
+	}
+	return []navdata.ProcedureKind{navdata.ProcedureSID, navdata.ProcedureSTAR, navdata.ProcedureApproach}
+}
+func canonicalRunways(listing string, detail []string) []navdata.RunwayID {
+	seen := map[navdata.RunwayID]struct{}{}
+	result := []navdata.RunwayID{}
+	for _, value := range append([]string{listing}, detail...) {
+		runway := navdata.RunwayID(upper(value))
+		if runway != "" {
+			if _, ok := seen[runway]; !ok {
+				seen[runway] = struct{}{}
+				result = append(result, runway)
+			}
+		}
+	}
+	return result
+}
+func procedureLeg(segment segmentDTO, index int) (navdata.ProcedureLeg, bool) {
+	terminator := navdata.PathTerminator(upper(segment.PathTerminator))
+	incomplete := false
+	if !terminator.Supported() || terminator.IsHolding() {
+		terminator, incomplete = navdata.PathUnsupported, true
+	}
+	leg := navdata.ProcedureLeg{ID: fmt.Sprintf("LEG-%04d", sequence(segment.Sequence, index)), PathTerminator: terminator}
+	if fix := navdata.FixID(upper(segment.FixIdentifier)); fix != "" {
+		leg.ToFix = &fix
+	}
+	return leg, incomplete
+}
+func sequence(value, fallback int) int {
+	if value > 0 {
+		return value
+	}
+	return fallback + 1
+}
+func matchesListing(item procedureListItem, query navdata.ProcedureQuery) bool {
+	if navdata.AirportID(upper(item.Airport)) != query.Airport {
+		return false
+	}
+	if len(query.Kinds) > 0 && !slices.Contains(query.Kinds, canonicalKind(item.Type.Code)) {
+		return false
+	}
+	if len(query.Identifiers) > 0 && !slices.Contains(query.Identifiers, navdata.ProcedureID(upper(item.Identifier))) {
+		return false
+	}
+	if len(query.Runways) > 0 && !slices.Contains(query.Runways, navdata.RunwayID(upper(item.Runway))) {
+		return false
+	}
+	return true
+}
+func transformedRoute(query navdata.RouteQuery) string {
+	tokens := []string{}
+	for _, token := range strings.Fields(strings.ToUpper(query.FiledRoute)) {
+		if token != "DCT" {
+			tokens = append(tokens, token)
+		}
+	}
+	if query.ArrivalProcedure != nil && !slices.Contains(tokens, string(*query.ArrivalProcedure)) {
+		tokens = append(tokens, string(*query.ArrivalProcedure))
+	}
+	return strings.Join(tokens, " ")
+}
+func cloneValues(values url.Values) url.Values {
+	result := url.Values{}
+	for key, value := range values {
+		result[key] = slices.Clone(value)
+	}
+	return result
+}
+func upper(value string) string { return strings.ToUpper(strings.TrimSpace(value)) }
+func nextPage(hasMore bool, page int) int {
+	if hasMore {
+		return page + 1
+	}
+	return 0
+}
+func retryableTransport(err error) bool {
+	var network net.Error
+	return errors.As(err, &network) && (network.Timeout() || network.Temporary())
+}
+func wait(ctx context.Context, base time.Duration, attempt int) error {
+	if attempt > 20 {
+		attempt = 20
+	}
+	delay := base * time.Duration(1<<attempt)
+	if delay < 0 || delay > time.Minute {
+		delay = time.Minute
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+func invalid(message string) error {
+	return &aman.DomainError{Class: navdata.ErrorInvalidRequest, Message: message}
+}
+func incomplete(message string) error {
+	return &aman.DomainError{Class: navdata.ErrorIncompleteGeometry, Message: message}
+}
+func unavailable(message string) error {
+	return &aman.DomainError{Class: navdata.ErrorSourceUnavailable, Message: message}
+}
+
+var _ navdata.CycleSource = (*Adapter)(nil)
+var _ navdata.AirportSource = (*Adapter)(nil)
+var _ navdata.ProcedureSource = (*Adapter)(nil)
+var _ navdata.FixSource = (*Adapter)(nil)
+var _ navdata.RouteResolver = (*Adapter)(nil)

--- a/backend/internal/aman/navdata/airacnet/adapter_test.go
+++ b/backend/internal/aman/navdata/airacnet/adapter_test.go
@@ -1,0 +1,533 @@
+package airacnet
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/aman/navdata"
+	"FlightStrips/internal/aman/navdata/contracttest"
+	"FlightStrips/internal/aman/navdata/fixture"
+	pdctestdata "FlightStrips/internal/pdc/testdata"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdapterPassesSharedSourceResolverContract(t *testing.T) {
+	server := newAPIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/airac/current":
+			writeJSON(w, cycleJSON())
+		case "/api/v1/airports/EKCH":
+			writeJSON(w, map[string]any{"data": map[string]any{"icao": "EKCH", "name": "Copenhagen", "coordinates": map[string]any{"lat": 55.618, "lon": 12.656}}})
+		case "/api/v1/procedures":
+			writeJSON(w, procedurePage(r.URL.Query(), false))
+		case "/api/v1/procedures/EKCH/KEMAX3A":
+			writeJSON(w, detailJSON("EKCH", "KEMAX3A", "SID", "TF", "KEMAX"))
+		case "/api/v1/procedures/EKCH/SOK1P":
+			writeJSON(w, detailJSON("EKCH", "SOK1P", "STAR", "TF", "SOK"))
+		case "/api/v1/procedures/EKCH/ILS22L":
+			writeJSON(w, detailJSON("EKCH", "ILS22L", "APP", "TF", "ROSBI"))
+		case "/api/v1/waypoints/KEMAX", "/api/v1/waypoints/SOK":
+			writeJSON(w, map[string]any{"data": map[string]any{"identifier": r.URL.Path[len("/api/v1/waypoints/"):], "coordinates": map[string]any{"lat": 55.8, "lon": 12.4}}})
+		case "/api/v1/routes/parse":
+			require.Equal(t, "KEMAX SOK1P", r.URL.Query().Get("route"))
+			require.Equal(t, "22L", r.URL.Query().Get("arrival_runway"))
+			writeJSON(w, routeJSON())
+		default:
+			t.Errorf("unexpected endpoint %s", r.URL.String())
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	checkpoints := NewMemoryCheckpoints()
+	adapter := testAdapter(t, server.URL, Config{Checkpoints: checkpoints})
+	version, err := adapter.LatestVersion(context.Background())
+	require.NoError(t, err)
+	query := routeQuery(version)
+	expected, err := expectedRoute(query)
+	require.NoError(t, err)
+	contracttest.Run(t, adapter, contracttest.Suite{
+		Version: version, Airport: "EKCH",
+		SIDQuery:      navdata.ProcedureQuery{Version: version, Airport: "EKCH", Kinds: []navdata.ProcedureKind{navdata.ProcedureSID}},
+		STARQuery:     navdata.ProcedureQuery{Version: version, Airport: "EKCH", Kinds: []navdata.ProcedureKind{navdata.ProcedureSTAR}},
+		ApproachQuery: navdata.ProcedureQuery{Version: version, Airport: "EKCH", Kinds: []navdata.ProcedureKind{navdata.ProcedureApproach}},
+		FixQuery:      navdata.FixQuery{Version: version, Identifiers: []navdata.FixID{"KEMAX", "SOK"}}, RouteQuery: query, RouteDigest: expected.Digest,
+	})
+}
+
+func TestProcedureFiltersPaginationAndUndocumentedHoldsRemainPartial(t *testing.T) {
+	var calls []url.Values
+	var mu sync.Mutex
+	server := newAPIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/airac/current":
+			writeJSON(w, cycleJSON())
+		case "/api/v1/procedures":
+			mu.Lock()
+			calls = append(calls, r.URL.Query())
+			mu.Unlock()
+			writeJSON(w, procedurePage(r.URL.Query(), true))
+		case "/api/v1/procedures/EKCH/SOK1P":
+			writeJSON(w, detailJSON("EKCH", "SOK1P", "STAR", "HF", "SOK"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	checkpoints := NewMemoryCheckpoints()
+	adapter := testAdapter(t, server.URL, Config{Checkpoints: checkpoints})
+	version, err := adapter.LatestVersion(context.Background())
+	require.NoError(t, err)
+	set, err := adapter.Procedures(context.Background(), navdata.ProcedureQuery{Version: version, Airport: "EKCH", Kinds: []navdata.ProcedureKind{navdata.ProcedureSTAR}, Runways: []navdata.RunwayID{"22L"}, Identifiers: []navdata.ProcedureID{"SOK1P"}})
+	require.NoError(t, err)
+	require.Equal(t, navdata.CoveragePartial, set.Coverage)
+	require.Len(t, set.Procedures, 1)
+	require.Equal(t, navdata.PathUnsupported, set.Procedures[0].Legs[0].PathTerminator)
+	require.Empty(t, set.Procedures[0].Holdings, "AIRAC.NET documents no holding definition schema")
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, calls, 2, "page based pagination")
+	for _, query := range calls {
+		require.Equal(t, "STAR", query.Get("type"))
+		require.Equal(t, "SOK1P", query.Get("identifier"))
+		require.Equal(t, "22L", query.Get("runway"))
+	}
+	checkpoint, found, err := checkpoints.Load(context.Background(), "/api/v1/procedures?airport=EKCH&identifier=SOK1P&page=1&per_page=100&runway=22L&type=STAR")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, 2, checkpoint.NextPage)
+}
+
+func TestHoldingTerminatorsWithoutOfficialDefinitionsAreAlwaysIncomplete(t *testing.T) {
+	for _, terminator := range []string{"HA", "HF", "HM"} {
+		t.Run(terminator, func(t *testing.T) {
+			server := newAPIServer(t, func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/v1/airac/current":
+					writeJSON(w, cycleJSON())
+				case "/api/v1/procedures":
+					writeJSON(w, procedurePage(r.URL.Query(), false))
+				case "/api/v1/procedures/EKCH/SOK1P":
+					writeJSON(w, detailJSON("EKCH", "SOK1P", "STAR", terminator, "SOK"))
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			})
+			adapter := testAdapter(t, server.URL, Config{})
+			version, err := adapter.LatestVersion(context.Background())
+			require.NoError(t, err)
+			set, err := adapter.Procedures(context.Background(), navdata.ProcedureQuery{Version: version, Airport: "EKCH", Kinds: []navdata.ProcedureKind{navdata.ProcedureSTAR}})
+			require.NoError(t, err)
+			require.Equal(t, navdata.CoveragePartial, set.Coverage)
+			require.Empty(t, set.Procedures[0].Holdings)
+			require.Equal(t, navdata.PathUnsupported, set.Procedures[0].Legs[0].PathTerminator)
+		})
+	}
+}
+
+func TestConditionalRetryTimeoutCancellationRedactionAndConcurrency(t *testing.T) {
+	t.Run("conditional", func(t *testing.T) {
+		var calls atomic.Int32
+		server := newAPIServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if calls.Add(1) == 1 {
+				w.Header().Set("ETag", `"cycle"`)
+				w.Header().Set("Last-Modified", "Thu, 16 Jul 2026 00:00:00 GMT")
+				writeJSON(w, cycleJSON())
+				return
+			}
+			require.Equal(t, `"cycle"`, r.Header.Get("If-None-Match"))
+			w.WriteHeader(http.StatusNotModified)
+		})
+		adapter := testAdapter(t, server.URL, Config{})
+		first, err := adapter.LatestVersion(context.Background())
+		require.NoError(t, err)
+		second, err := adapter.LatestVersion(context.Background())
+		require.NoError(t, err)
+		require.True(t, first.Equal(second))
+		require.Equal(t, int32(2), calls.Load())
+	})
+	t.Run("rate retry", func(t *testing.T) {
+		var calls atomic.Int32
+		server := newAPIServer(t, func(w http.ResponseWriter, _ *http.Request) {
+			if calls.Add(1) == 1 {
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			writeJSON(w, cycleJSON())
+		})
+		adapter := testAdapter(t, server.URL, Config{Retries: 1, RetryBackoff: time.Millisecond})
+		_, err := adapter.LatestVersion(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, int32(2), calls.Load())
+	})
+	t.Run("server retry", func(t *testing.T) {
+		var calls atomic.Int32
+		server := newAPIServer(t, func(w http.ResponseWriter, _ *http.Request) {
+			if calls.Add(1) == 1 {
+				w.WriteHeader(http.StatusBadGateway)
+				return
+			}
+			writeJSON(w, cycleJSON())
+		})
+		adapter := testAdapter(t, server.URL, Config{Retries: 1, RetryBackoff: time.Millisecond})
+		_, err := adapter.LatestVersion(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, int32(2), calls.Load())
+	})
+	t.Run("timeout cancellation and redaction", func(t *testing.T) {
+		server := newAPIServer(t, func(w http.ResponseWriter, _ *http.Request) {
+			time.Sleep(100 * time.Millisecond)
+			writeJSON(w, cycleJSON())
+		})
+		adapter := testAdapter(t, server.URL, Config{Timeout: 10 * time.Millisecond})
+		_, err := adapter.LatestVersion(context.Background())
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), "secret")
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err = adapter.LatestVersion(ctx)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+	t.Run("redacts vendor body", func(t *testing.T) {
+		server := newAPIServer(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte(`{"token":"secret"}`))
+		})
+		adapter := testAdapter(t, server.URL, Config{})
+		_, err := adapter.LatestVersion(context.Background())
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), "secret")
+	})
+	t.Run("bounded fix concurrency", func(t *testing.T) {
+		var current, maximum atomic.Int32
+		server := newAPIServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/v1/airac/current" {
+				writeJSON(w, cycleJSON())
+				return
+			}
+			now := current.Add(1)
+			for {
+				previous := maximum.Load()
+				if now <= previous || maximum.CompareAndSwap(previous, now) {
+					break
+				}
+			}
+			time.Sleep(15 * time.Millisecond)
+			current.Add(-1)
+			id := r.URL.Path[len("/api/v1/waypoints/"):]
+			writeJSON(w, map[string]any{"data": map[string]any{"identifier": id, "coordinates": map[string]any{"lat": 1, "lon": 1}}})
+		})
+		adapter := testAdapter(t, server.URL, Config{MaxConcurrent: 2})
+		version, err := adapter.LatestVersion(context.Background())
+		require.NoError(t, err)
+		_, err = adapter.Fixes(context.Background(), navdata.FixQuery{Version: version, Identifiers: []navdata.FixID{"ONE", "TWO", "THREE"}})
+		require.NoError(t, err)
+		require.LessOrEqual(t, maximum.Load(), int32(2))
+	})
+}
+
+func TestMalformedAndVersionMismatchFailClosed(t *testing.T) {
+	server := newAPIServer(t, func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("not json")) })
+	adapter := testAdapter(t, server.URL, Config{})
+	_, err := adapter.LatestVersion(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "malformed")
+
+	server = newAPIServer(t, func(w http.ResponseWriter, _ *http.Request) { writeJSON(w, cycleJSON()) })
+	adapter = testAdapter(t, server.URL, Config{})
+	wrong := navdata.DatasetVersion{Cycle: "9999", SourceRevision: "airac.net-9999", EffectiveFrom: time.Date(2026, 7, 16, 0, 0, 0, 0, time.UTC), EffectiveUntil: time.Date(2026, 8, 13, 0, 0, 0, 0, time.UTC)}
+	_, err = adapter.Airport(context.Background(), wrong, "EKCH")
+	var domain *aman.DomainError
+	require.ErrorAs(t, err, &domain)
+	require.Equal(t, navdata.ErrorDatasetMismatch, domain.Class)
+}
+
+func TestPostgresCheckpointsSurviveAdapterRestartAndConditionalResponse(t *testing.T) {
+	db := &fakeCheckpointDB{values: map[string]Checkpoint{}}
+	store := &PostgresCheckpoints{db: db}
+	var calls atomic.Int32
+	server := newAPIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			w.Header().Set("ETag", `"cycle"`)
+			writeJSON(w, cycleJSON())
+			return
+		}
+		require.Equal(t, `"cycle"`, r.Header.Get("If-None-Match"))
+		w.WriteHeader(http.StatusNotModified)
+	})
+	first := testAdapter(t, server.URL, Config{Checkpoints: store})
+	version, err := first.LatestVersion(context.Background())
+	require.NoError(t, err)
+	second := testAdapter(t, server.URL, Config{Checkpoints: store})
+	again, err := second.LatestVersion(context.Background())
+	require.NoError(t, err)
+	require.True(t, version.Equal(again))
+	require.Equal(t, int32(2), calls.Load())
+
+	_, err = New(Config{})
+	require.Error(t, err, "production configuration must choose a durable checkpoint store")
+}
+
+func TestPostgresCheckpointMigrationSurvivesRestartAnd304(t *testing.T) {
+	pool, _ := pdctestdata.SetupTestDB(t)
+	store := NewPostgresCheckpoints(pool)
+	var calls atomic.Int32
+	server := newAPIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			w.Header().Set("ETag", `"cycle"`)
+			w.Header().Set("Last-Modified", "Thu, 16 Jul 2026 00:00:00 GMT")
+			writeJSON(w, cycleJSON())
+			return
+		}
+		require.Equal(t, `"cycle"`, r.Header.Get("If-None-Match"))
+		w.WriteHeader(http.StatusNotModified)
+	})
+	first := testAdapter(t, server.URL, Config{Checkpoints: store})
+	version, err := first.LatestVersion(context.Background())
+	require.NoError(t, err)
+	second := testAdapter(t, server.URL, Config{Checkpoints: NewPostgresCheckpoints(pool)})
+	again, err := second.LatestVersion(context.Background())
+	require.NoError(t, err)
+	require.True(t, version.Equal(again))
+	require.Equal(t, int32(2), calls.Load())
+	checkpoint, found, err := store.Load(context.Background(), "/api/v1/airac/current?")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, `"cycle"`, checkpoint.ETag)
+	require.NotEmpty(t, checkpoint.Body)
+}
+
+func TestAmbiguousWaypointIsNotArbitrarilySelected(t *testing.T) {
+	server := newAPIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/airac/current" {
+			writeJSON(w, cycleJSON())
+			return
+		}
+		writeJSON(w, map[string]any{"data": []any{map[string]any{"identifier": "DUP", "coordinates": map[string]any{"lat": 1, "lon": 1}}, map[string]any{"identifier": "DUP", "coordinates": map[string]any{"lat": 2, "lon": 2}}}})
+	})
+	adapter := testAdapter(t, server.URL, Config{})
+	version, err := adapter.LatestVersion(context.Background())
+	require.NoError(t, err)
+	_, err = adapter.Fixes(context.Background(), navdata.FixQuery{Version: version, Identifiers: []navdata.FixID{"DUP"}})
+	var domain *aman.DomainError
+	require.ErrorAs(t, err, &domain)
+	require.Equal(t, navdata.ErrorIncompleteGeometry, domain.Class)
+}
+
+func TestRouteKeyPrecedesTransformsAndWarmCacheNeedsNoNetwork(t *testing.T) {
+	var calls atomic.Int32
+	server := newAPIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		switch r.URL.Path {
+		case "/api/v1/airac/current":
+			writeJSON(w, cycleJSON())
+		case "/api/v1/routes/parse":
+			require.Equal(t, "KEMAX P60 TUDLO SOK1P", r.URL.Query().Get("route"))
+			require.Equal(t, "22L", r.URL.Query().Get("arrival_runway"))
+			writeJSON(w, routeJSON())
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	adapter := testAdapter(t, server.URL, Config{})
+	version, err := adapter.LatestVersion(context.Background())
+	require.NoError(t, err)
+	query := routeQuery(version)
+	query.FiledRoute = "DCT KEMAX P60 TUDLO"
+	key, err := query.Key()
+	require.NoError(t, err)
+	geometry, err := adapter.Resolve(context.Background(), query)
+	require.NoError(t, err)
+	cache, err := navdata.NewCache(map[navdata.AirportID]navdata.DatasetVersion{"EKCH": version}, map[navdata.RouteKey]navdata.RouteGeometry{key: geometry}, nil)
+	require.NoError(t, err)
+	before := calls.Load()
+	server.Close()
+	warm, err := cache.Route(context.Background(), key)
+	require.NoError(t, err)
+	require.Equal(t, geometry.Digest, warm.Digest)
+	require.Equal(t, before, calls.Load())
+	expected, err := expectedRoute(query)
+	require.NoError(t, err)
+	require.Equal(t, expected.Digest, geometry.Digest)
+	data := fixture.EKCH()
+	data.Version = version
+	data.Provenance = expected.Provenance
+	data.Routes = map[navdata.RouteKey]navdata.RouteGeometry{key: expected}
+	replacement := fixture.New(data)
+	equivalent, err := replacement.Resolve(context.Background(), query)
+	require.NoError(t, err)
+	require.Equal(t, geometry.Digest, equivalent.Digest)
+	require.Empty(t, equivalent.HoldingIDs)
+}
+
+func TestErrorEnvelopeAndPermanentTransportFailureFailClosed(t *testing.T) {
+	server := newAPIServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		writeJSONRaw(w, map[string]any{"status": "error", "message": "secret vendor reason"})
+	})
+	adapter := testAdapter(t, server.URL, Config{})
+	_, err := adapter.LatestVersion(context.Background())
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "secret")
+	var requests atomic.Int32
+	adapter = testAdapter(t, server.URL, Config{Retries: 2, HTTPClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) { requests.Add(1); return nil, errors.New("permanent") })}})
+	_, err = adapter.LatestVersion(context.Background())
+	require.Error(t, err)
+	require.Equal(t, int32(1), requests.Load())
+}
+
+func TestVendorAdapterCannotLeakIntoRuntimeOrCanonicalPackages(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	internal := filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(file))))
+	for _, directory := range []string{"predictor", "sequence", "frontend", "repository", "aman"} {
+		root := filepath.Join(internal, directory)
+		err := filepath.WalkDir(root, func(name string, entry os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if entry.IsDir() && filepath.Clean(name) == filepath.Join(internal, "aman", "navdata", "airacnet") {
+				return filepath.SkipDir
+			}
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+				return nil
+			}
+			contents, err := os.ReadFile(name)
+			if err != nil {
+				return err
+			}
+			require.NotContains(t, string(contents), "FlightStrips/internal/aman/navdata/airacnet", name)
+			return nil
+		})
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		require.NoError(t, err)
+	}
+}
+
+type fakeCheckpointDB struct {
+	mu     sync.Mutex
+	values map[string]Checkpoint
+}
+
+func (db *fakeCheckpointDB) QueryRow(_ context.Context, _ string, values ...any) pgx.Row {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	value, found := db.values[values[0].(string)]
+	if !found {
+		return fakeCheckpointRow{err: pgx.ErrNoRows}
+	}
+	return fakeCheckpointRow{value: value}
+}
+func (db *fakeCheckpointDB) Exec(_ context.Context, _ string, values ...any) (pgconn.CommandTag, error) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	db.values[values[0].(string)] = Checkpoint{ETag: values[1].(string), LastModified: values[2].(string), NextPage: values[3].(int), Body: append([]byte(nil), values[4].([]byte)...)}
+	return pgconn.NewCommandTag("INSERT 0 1"), nil
+}
+
+type fakeCheckpointRow struct {
+	value Checkpoint
+	err   error
+}
+
+func (r fakeCheckpointRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	*dest[0].(*string) = r.value.ETag
+	*dest[1].(*string) = r.value.LastModified
+	*dest[2].(*int) = r.value.NextPage
+	*dest[3].(*[]byte) = append([]byte(nil), r.value.Body...)
+	return nil
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) { return fn(request) }
+
+func newAPIServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(handler)
+}
+func testAdapter(t *testing.T, baseURL string, config Config) *Adapter {
+	t.Helper()
+	if config.BaseURL == "" {
+		config.BaseURL = baseURL + "/api/v1"
+	}
+	if config.Checkpoints == nil {
+		config.Checkpoints = NewMemoryCheckpoints()
+	}
+	config.Now = func() time.Time { return time.Date(2026, 7, 17, 0, 0, 0, 0, time.UTC) }
+	adapter, err := New(config)
+	require.NoError(t, err)
+	return adapter
+}
+func writeJSON(w http.ResponseWriter, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	encoded, _ := json.Marshal(value)
+	var envelope map[string]any
+	_ = json.Unmarshal(encoded, &envelope)
+	envelope["status"] = "success"
+	_ = json.NewEncoder(w).Encode(envelope)
+}
+func writeJSONRaw(w http.ResponseWriter, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(value)
+}
+func cycleJSON() any {
+	return map[string]any{"data": map[string]any{"cycle": "2608", "effective_date": "2026-07-16T00:00:00+00:00", "expiration_date": "2026-08-13T00:00:00+00:00"}}
+}
+func procedurePage(query url.Values, paged bool) any {
+	page := query.Get("page")
+	if paged && page == "1" {
+		return map[string]any{"data": []any{}, "pagination": map[string]any{"has_more": true}}
+	}
+	kind, id := query.Get("type"), query.Get("identifier")
+	if kind == "" {
+		kind = "STAR"
+	}
+	if id == "" {
+		switch kind {
+		case "SID":
+			id = "KEMAX3A"
+		case "APP":
+			id = "ILS22L"
+		default:
+			id = "SOK1P"
+		}
+	}
+	return map[string]any{"data": []any{map[string]any{"airport": "EKCH", "identifier": id, "type": map[string]any{"code": kind}, "runway": "22L"}}, "pagination": map[string]any{"has_more": false}}
+}
+func detailJSON(airport, identifier, kind, terminator, fix string) any {
+	return map[string]any{"data": map[string]any{"airport": airport, "identifier": identifier, "type": map[string]any{"code": kind}, "available_runways": []string{"22L"}, "segments": []any{map[string]any{"sequence": 10, "path_terminator": terminator, "fix_identifier": fix}}}}
+}
+func routeJSON() any {
+	return map[string]any{"data": map[string]any{"total_distance": 100.5, "segments": []any{map[string]any{"from": map[string]any{"identifier": "EHAM"}, "to": map[string]any{"identifier": "KEMAX"}, "distance": 80.0, "bearing": 45.0}, map[string]any{"from": map[string]any{"identifier": "KEMAX"}, "to": map[string]any{"identifier": "EKCH"}, "distance": 20.5, "bearing": 90.0}}, "errors": []any{map[string]any{"type": "airway_not_found"}}}}
+}
+func routeQuery(version navdata.DatasetVersion) navdata.RouteQuery {
+	arrival, runway := navdata.ProcedureID("SOK1P"), navdata.RunwayID("22L")
+	group := aman.RunwayGroupID("SOUTH")
+	return navdata.RouteQuery{Version: version, Origin: "EHAM", Destination: "EKCH", FiledRoute: "DCT KEMAX", ArrivalProcedure: &arrival, Runway: &runway, RunwayGroup: &group}
+}
+func expectedRoute(query navdata.RouteQuery) (navdata.RouteGeometry, error) {
+	from, to, ekch := navdata.FixID("EHAM"), navdata.FixID("KEMAX"), navdata.FixID("EKCH")
+	firstCourse, secondCourse, firstDistance, secondDistance := 45.0, 90.0, 80.0, 20.5
+	provenance := navdata.Provenance{SourceID: "airac.net", SourceRevision: query.Version.SourceRevision, ImportedAt: time.Date(2026, 7, 17, 0, 0, 0, 0, time.UTC), EffectiveFrom: query.Version.EffectiveFrom, EffectiveUntil: query.Version.EffectiveUntil}
+	geometry := navdata.RouteGeometry{Version: query.Version, TotalDistanceNM: 100.5, Coverage: navdata.CoveragePartial, Unresolved: []string{"AIRWAY_NOT_FOUND"}, Provenance: provenance, Legs: []navdata.ProcedureLeg{{ID: "ROUTE-0001", PathTerminator: navdata.PathTF, FromFix: &from, ToFix: &to, CourseTrueDeg: &firstCourse, DistanceNM: &firstDistance}, {ID: "ROUTE-0002", PathTerminator: navdata.PathTF, FromFix: &to, ToFix: &ekch, CourseTrueDeg: &secondCourse, DistanceNM: &secondDistance}}}
+	digest, err := navdata.RouteGeometryDigest(query, geometry)
+	geometry.Digest = digest
+	return geometry, err
+}

--- a/backend/internal/aman/navdata/airacnet/adapter_test.go
+++ b/backend/internal/aman/navdata/airacnet/adapter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -21,6 +22,7 @@ import (
 	"FlightStrips/internal/aman/navdata/contracttest"
 	"FlightStrips/internal/aman/navdata/fixture"
 	pdctestdata "FlightStrips/internal/pdc/testdata"
+	"FlightStrips/internal/repository/postgres"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
@@ -387,6 +389,94 @@ func TestErrorEnvelopeAndPermanentTransportFailureFailClosed(t *testing.T) {
 	require.Equal(t, int32(1), requests.Load())
 }
 
+func TestRequestConstructionBodyCancellationAndTruncationAreTyped(t *testing.T) {
+	t.Run("request construction", func(t *testing.T) {
+		adapter := testAdapter(t, "http://example.test", Config{})
+		adapter.requestMaker = func(context.Context, string, string, io.Reader) (*http.Request, error) {
+			return nil, errors.New("invalid request")
+		}
+		_, err := adapter.LatestVersion(context.Background())
+		var domain *aman.DomainError
+		require.ErrorAs(t, err, &domain)
+		require.Equal(t, navdata.ErrorInvalidRequest, domain.Class)
+	})
+	t.Run("parent cancellation while reading", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		var requests atomic.Int32
+		adapter := testAdapter(t, "http://example.test", Config{Retries: 2, HTTPClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			requests.Add(1)
+			return &http.Response{StatusCode: http.StatusOK, Body: cancelingBody{cancel: cancel}}, nil
+		})}})
+		_, err := adapter.LatestVersion(ctx)
+		require.ErrorIs(t, err, context.Canceled)
+		require.Equal(t, int32(1), requests.Load())
+	})
+	t.Run("truncated body retry", func(t *testing.T) {
+		var requests atomic.Int32
+		adapter := testAdapter(t, "http://example.test", Config{Retries: 1, RetryBackoff: time.Millisecond, HTTPClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			if requests.Add(1) == 1 {
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(unexpectedEOFReader{})}, nil
+			}
+			body, _ := json.Marshal(map[string]any{"status": "success", "data": map[string]any{"cycle": "2608", "effective_date": "2026-07-16T00:00:00+00:00", "expiration_date": "2026-08-13T00:00:00+00:00"}})
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(string(body)))}, nil
+		})}})
+		_, err := adapter.LatestVersion(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, int32(2), requests.Load())
+	})
+}
+
+func TestAirportNotFoundAndWarmPostgresRouteSurviveSourceOutage(t *testing.T) {
+	t.Run("airport not found", func(t *testing.T) {
+		server := newAPIServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/v1/airac/current" {
+				writeJSON(w, cycleJSON())
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		})
+		adapter := testAdapter(t, server.URL, Config{})
+		version, err := adapter.LatestVersion(context.Background())
+		require.NoError(t, err)
+		_, err = adapter.Airport(context.Background(), version, "MISSING")
+		var domain *aman.DomainError
+		require.ErrorAs(t, err, &domain)
+		require.Equal(t, navdata.ErrorNotFound, domain.Class)
+	})
+	t.Run("durable warm route", func(t *testing.T) {
+		pool, _ := pdctestdata.SetupTestDB(t)
+		var calls atomic.Int32
+		server := newAPIServer(t, func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			if r.URL.Path == "/api/v1/airac/current" {
+				writeJSON(w, cycleJSON())
+				return
+			}
+			if r.URL.Path == "/api/v1/routes/parse" {
+				writeJSON(w, routeJSON())
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		})
+		adapter := testAdapter(t, server.URL, Config{})
+		version, err := adapter.LatestVersion(context.Background())
+		require.NoError(t, err)
+		query := routeQuery(version)
+		query.FiledRoute = "DCT KEMAX P60 TUDLO"
+		geometry, err := adapter.Resolve(context.Background(), query)
+		require.NoError(t, err)
+		first := postgres.NewNavigationCache(pool)
+		key, err := first.PutRoute(context.Background(), navdata.RouteCandidate{Query: query, Geometry: geometry, CreatedAt: time.Date(2026, 7, 17, 0, 0, 0, 0, time.UTC), ResolverVersion: "airacnet-v1", SchemaVersion: navdata.CanonicalSchemaVersion})
+		require.NoError(t, err)
+		before := calls.Load()
+		server.Close()
+		warm, err := postgres.NewNavigationCache(pool).Route(context.Background(), key)
+		require.NoError(t, err)
+		require.Equal(t, geometry.Digest, warm.Digest)
+		require.Equal(t, before, calls.Load())
+	})
+}
+
 func TestVendorAdapterCannotLeakIntoRuntimeOrCanonicalPackages(t *testing.T) {
 	_, file, _, ok := runtime.Caller(0)
 	require.True(t, ok)
@@ -458,6 +548,15 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) { return fn(request) }
 
+type cancelingBody struct{ cancel context.CancelFunc }
+
+func (b cancelingBody) Read([]byte) (int, error) { b.cancel(); return 0, io.ErrUnexpectedEOF }
+func (cancelingBody) Close() error               { return nil }
+
+type unexpectedEOFReader struct{}
+
+func (unexpectedEOFReader) Read([]byte) (int, error) { return 0, io.ErrUnexpectedEOF }
+
 func newAPIServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(handler)
@@ -515,7 +614,7 @@ func detailJSON(airport, identifier, kind, terminator, fix string) any {
 	return map[string]any{"data": map[string]any{"airport": airport, "identifier": identifier, "type": map[string]any{"code": kind}, "available_runways": []string{"22L"}, "segments": []any{map[string]any{"sequence": 10, "path_terminator": terminator, "fix_identifier": fix}}}}
 }
 func routeJSON() any {
-	return map[string]any{"data": map[string]any{"total_distance": 100.5, "segments": []any{map[string]any{"from": map[string]any{"identifier": "EHAM"}, "to": map[string]any{"identifier": "KEMAX"}, "distance": 80.0, "bearing": 45.0}, map[string]any{"from": map[string]any{"identifier": "KEMAX"}, "to": map[string]any{"identifier": "EKCH"}, "distance": 20.5, "bearing": 90.0}}, "errors": []any{map[string]any{"type": "airway_not_found"}}}}
+	return map[string]any{"data": map[string]any{"total_distance": 116.0, "segments": []any{map[string]any{"from": map[string]any{"identifier": "EHAM"}, "to": map[string]any{"identifier": "KEMAX"}, "distance": 40.0, "bearing": 45.0}, map[string]any{"from": map[string]any{"identifier": "KEMAX"}, "to": map[string]any{"identifier": "SUGOL"}, "distance": 20.0, "bearing": 60.0}, map[string]any{"from": map[string]any{"identifier": "SUGOL"}, "to": map[string]any{"identifier": "TUDLO"}, "distance": 20.0, "bearing": 80.0}, map[string]any{"from": map[string]any{"identifier": "TUDLO"}, "to": map[string]any{"identifier": "SOK"}, "distance": 20.0, "bearing": 100.0}, map[string]any{"from": map[string]any{"identifier": "SOK"}, "to": map[string]any{"identifier": "EKCH"}, "distance": 16.0, "bearing": 120.0}}, "errors": []any{}}}
 }
 func routeQuery(version navdata.DatasetVersion) navdata.RouteQuery {
 	arrival, runway := navdata.ProcedureID("SOK1P"), navdata.RunwayID("22L")
@@ -523,10 +622,11 @@ func routeQuery(version navdata.DatasetVersion) navdata.RouteQuery {
 	return navdata.RouteQuery{Version: version, Origin: "EHAM", Destination: "EKCH", FiledRoute: "DCT KEMAX", ArrivalProcedure: &arrival, Runway: &runway, RunwayGroup: &group}
 }
 func expectedRoute(query navdata.RouteQuery) (navdata.RouteGeometry, error) {
-	from, to, ekch := navdata.FixID("EHAM"), navdata.FixID("KEMAX"), navdata.FixID("EKCH")
-	firstCourse, secondCourse, firstDistance, secondDistance := 45.0, 90.0, 80.0, 20.5
+	from, kemax, sugol, tudlo, sok, ekch := navdata.FixID("EHAM"), navdata.FixID("KEMAX"), navdata.FixID("SUGOL"), navdata.FixID("TUDLO"), navdata.FixID("SOK"), navdata.FixID("EKCH")
+	firstCourse, secondCourse, thirdCourse, fourthCourse, fifthCourse := 45.0, 60.0, 80.0, 100.0, 120.0
+	firstDistance, secondDistance, thirdDistance, fourthDistance, fifthDistance := 40.0, 20.0, 20.0, 20.0, 16.0
 	provenance := navdata.Provenance{SourceID: "airac.net", SourceRevision: query.Version.SourceRevision, ImportedAt: time.Date(2026, 7, 17, 0, 0, 0, 0, time.UTC), EffectiveFrom: query.Version.EffectiveFrom, EffectiveUntil: query.Version.EffectiveUntil}
-	geometry := navdata.RouteGeometry{Version: query.Version, TotalDistanceNM: 100.5, Coverage: navdata.CoveragePartial, Unresolved: []string{"AIRWAY_NOT_FOUND"}, Provenance: provenance, Legs: []navdata.ProcedureLeg{{ID: "ROUTE-0001", PathTerminator: navdata.PathTF, FromFix: &from, ToFix: &to, CourseTrueDeg: &firstCourse, DistanceNM: &firstDistance}, {ID: "ROUTE-0002", PathTerminator: navdata.PathTF, FromFix: &to, ToFix: &ekch, CourseTrueDeg: &secondCourse, DistanceNM: &secondDistance}}}
+	geometry := navdata.RouteGeometry{Version: query.Version, TotalDistanceNM: 116, Coverage: navdata.CoveragePartial, Unresolved: []string{"PUBLISHED_HOLDING_DATA_UNAVAILABLE"}, Provenance: provenance, Legs: []navdata.ProcedureLeg{{ID: "ROUTE-0001", PathTerminator: navdata.PathTF, FromFix: &from, ToFix: &kemax, CourseTrueDeg: &firstCourse, DistanceNM: &firstDistance}, {ID: "ROUTE-0002", PathTerminator: navdata.PathTF, FromFix: &kemax, ToFix: &sugol, CourseTrueDeg: &secondCourse, DistanceNM: &secondDistance}, {ID: "ROUTE-0003", PathTerminator: navdata.PathTF, FromFix: &sugol, ToFix: &tudlo, CourseTrueDeg: &thirdCourse, DistanceNM: &thirdDistance}, {ID: "ROUTE-0004", PathTerminator: navdata.PathTF, FromFix: &tudlo, ToFix: &sok, CourseTrueDeg: &fourthCourse, DistanceNM: &fourthDistance}, {ID: "ROUTE-0005", PathTerminator: navdata.PathTF, FromFix: &sok, ToFix: &ekch, CourseTrueDeg: &fifthCourse, DistanceNM: &fifthDistance}}}
 	digest, err := navdata.RouteGeometryDigest(query, geometry)
 	geometry.Digest = digest
 	return geometry, err

--- a/backend/migrations/0037-add-airacnet-http-checkpoints.sql
+++ b/backend/migrations/0037-add-airacnet-http-checkpoints.sql
@@ -1,0 +1,11 @@
+-- AIRAC.NET HTTP cache validators and response bodies are adapter-private
+-- checkpoints. They are intentionally separate from canonical AMAN nav cache
+-- fragments, manifests and route digests.
+CREATE TABLE IF NOT EXISTS airacnet_http_checkpoints (
+    request_key TEXT PRIMARY KEY,
+    etag TEXT NOT NULL DEFAULT '',
+    last_modified TEXT NOT NULL DEFAULT '',
+    next_page INTEGER NOT NULL DEFAULT 0 CHECK (next_page >= 0),
+    response_body BYTEA NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);


### PR DESCRIPTION
## What

Adds the private `aman/navdata/airacnet` adapter for the #311 source and resolver interfaces, plus durable adapter-private HTTP checkpoints in migration 0037.

## Why

AMAN materialization can acquire current AIRAC.NET cycle, airport, procedure, fix, and parsed-route data without leaking vendor DTOs, transport state, or endpoint behavior into canonical navigation or runtime prediction.

## Scope

- Maps documented cycle, airport, procedure, waypoint, and route-parse responses to canonical contracts.
- Applies private DCT removal, selected STAR append, and arrival-runway route parsing after canonical `RouteQuery.Key()` calculation.
- Bounds concurrency/timeouts, supports cancellation and conditional requests, retries only temporary transport failures/429/5xx, and redacts vendor bodies/headers from errors.
- Persists ETag, Last-Modified, pagination state, and raw public response bodies only in `airacnet_http_checkpoints`.
- Treats HA/HF/HM without a documented AIRAC.NET holding-definition payload as unsupported/partial; it does not fabricate canonical holdings. EKCH overlay composition remains #309/#312 territory.

## Official API sources

- https://airac.net/ — public API documentation, reviewed 2026-07-18: `/airac/current`, `/airports/{icao}`, `/procedures`, `/procedures/{airport}/{identifier}`, `/waypoints/{identifier}`, and `/routes/parse`.
- The documented procedure transition segment has `path_terminator`; the public contract documents no holding-definition fields or holding endpoint.

## Validation

- `gofmt`
- `git diff --check`
- `go test ./internal/aman/navdata/airacnet -count=1` (including testcontainers/Postgres migration/restart/304 coverage)
- `go test ./internal/aman/navdata/... ./internal/repository/postgres/...`
- `go test ./...`

Closes #310