### PR TITLE
feat(aman): add baseline arrival estimates

### DIFF
--- a/backend/internal/aman/predictor/baseline.go
+++ b/backend/internal/aman/predictor/baseline.go
@@ -1,0 +1,440 @@
+// Package predictor contains deterministic AMAN prediction inputs. It is
+// independent of source adapters, persistence, EuroScope, and navigation
+// acquisition. Route-aware calculation will replace the great-circle fallback
+// supplied here.
+package predictor
+
+import (
+	"FlightStrips/internal/aman"
+	"math"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultEXOT is the planning-only estimated taxi-out duration added to a
+	// filed EOBT. It is never an operational arrival timeline value.
+	DefaultEXOT          = 15 * time.Minute
+	defaultModelVersion  = "aman-baseline-v1"
+	defaultConfigVersion = "aman-baseline-defaults-v1"
+)
+
+// Status reports whether an estimate may be consumed, is usable with an
+// explicitly degraded source, or needs policy/input before it can be used.
+type Status string
+
+const (
+	StatusAvailable      Status = "available"
+	StatusDegraded       Status = "degraded"
+	StatusUnavailable    Status = "unavailable"
+	StatusPolicyRequired Status = "policy_required"
+)
+
+// Reason is stable caller-visible context for a non-normal baseline result.
+// A zero Result never represents an unknown arrival timestamp.
+type Reason string
+
+const (
+	ReasonNone                            Reason = "none"
+	ReasonMissingDepartureTime            Reason = "missing_departure_time"
+	ReasonMissingFlightDuration           Reason = "missing_flight_duration"
+	ReasonNegativeFlightDuration          Reason = "negative_flight_duration"
+	ReasonInvalidTimestamp                Reason = "invalid_timestamp"
+	ReasonDestinationMismatch             Reason = "destination_mismatch"
+	ReasonObservationInFuture             Reason = "observation_in_future"
+	ReasonObservationTooOld               Reason = "observation_too_old"
+	ReasonArrivalInPast                   Reason = "arrival_in_past"
+	ReasonSuddenAppearancePolicyRequired  Reason = "sudden_appearance_policy_required"
+	ReasonMissingGreatCircleInput         Reason = "missing_great_circle_input"
+	ReasonMissingAircraftSpeed            Reason = "missing_aircraft_speed"
+	ReasonHeldFirstAirborneBaseline       Reason = "held_first_airborne_baseline"
+	ReasonUnstableReviewReset             Reason = "unstable_review_reset"
+	ReasonRouteAwareSupersedesGreatCircle Reason = "route_aware_supersedes_great_circle"
+)
+
+// AircraftCategory selects a documented default speed for a degraded
+// great-circle estimate. Speeds are knots and distances are nautical miles.
+type AircraftCategory string
+
+const (
+	CategoryLight  AircraftCategory = "light"
+	CategoryMedium AircraftCategory = "medium"
+	CategoryHeavy  AircraftCategory = "heavy"
+	CategorySuper  AircraftCategory = "super"
+)
+
+// SpeedDefaults is versioned performance configuration, not handler policy.
+// Callers should persist the selected version in ConfigVersion when changing
+// these values operationally.
+type SpeedDefaults struct {
+	Version string
+	Knots   map[AircraftCategory]float64
+}
+
+// SpeedDefaultsV1 returns the initial explicit ground-speed defaults used only
+// for a great-circle fallback. Values are knots: L 180, M 420, H 440, J 460.
+func SpeedDefaultsV1() SpeedDefaults {
+	return SpeedDefaults{
+		Version: "aircraft-category-speeds-v1",
+		Knots: map[AircraftCategory]float64{
+			CategoryLight:  180,
+			CategoryMedium: 420,
+			CategoryHeavy:  440,
+			CategorySuper:  460,
+		},
+	}
+}
+
+// Config controls the pure reducer. Now is always supplied with Input, making
+// observation-age evaluation deterministic and independently testable.
+type Config struct {
+	EXOT              time.Duration
+	MaxObservationAge time.Duration
+	SpeedDefaults     SpeedDefaults
+	ModelVersion      string
+	ConfigVersion     string
+}
+
+// Reducer calculates and holds only the baseline layer. It has no clock,
+// repository, source, navigation reader, or mutable process state.
+type Reducer struct {
+	config Config
+}
+
+// NewReducer validates and snapshots its versioned configuration.
+func NewReducer(config Config) (Reducer, error) {
+	if config.EXOT == 0 {
+		config.EXOT = DefaultEXOT
+	}
+	if config.EXOT < 0 || config.MaxObservationAge <= 0 {
+		return Reducer{}, errInvalidConfig
+	}
+	if config.SpeedDefaults.Version == "" {
+		config.SpeedDefaults = SpeedDefaultsV1()
+	}
+	if !validSpeedDefaults(config.SpeedDefaults) {
+		return Reducer{}, errInvalidConfig
+	}
+	if config.ModelVersion == "" {
+		config.ModelVersion = defaultModelVersion
+	}
+	if config.ConfigVersion == "" {
+		config.ConfigVersion = defaultConfigVersion
+	}
+	config.SpeedDefaults.Knots = cloneSpeeds(config.SpeedDefaults.Knots)
+	return Reducer{config: config}, nil
+}
+
+// Timing exposes each source fact independently so the precedence is visible:
+// EOBT is preferred over EstimatedDeparture, and FiledEET is preferred over
+// APIEstimatedFlightTime. EOBT receives EXOT; EstimatedDeparture already
+// represents departure and does not receive EXOT.
+type Timing struct {
+	EOBT                   *time.Time
+	EstimatedDeparture     *time.Time
+	FiledEET               *time.Duration
+	APIEstimatedFlightTime *time.Duration
+}
+
+// AirborneObservation carries the result of the existing source movement
+// classifier. The predictor deliberately does not classify positions, altitude
+// or groundspeed itself.
+type AirborneObservation struct {
+	SensedAt           *time.Time
+	PreviouslyObserved bool
+}
+
+// GreatCircleInput is a cache-/adapter-supplied position pair. It has no route
+// geometry: DistanceNM is calculated with the haversine formula as a degraded
+// remaining-distance estimate.
+type GreatCircleInput struct {
+	LatitudeDegrees             float64
+	LongitudeDegrees            float64
+	DestinationLatitudeDegrees  float64
+	DestinationLongitudeDegrees float64
+	AircraftCategory            AircraftCategory
+}
+
+// RouteAwareEstimate is supplied by the later route-aware layer. Its presence
+// explicitly supersedes a great-circle fallback after an Unstable reset.
+type RouteAwareEstimate struct {
+	ArrivalAt  time.Time
+	Confidence aman.Confidence
+}
+
+// Input is package-owned and contains no vendor DTOs. ExpectedDestination is
+// the configured AMAN airport that must match Destination case-insensitively.
+type Input struct {
+	Now                  time.Time
+	ExpectedDestination  string
+	Destination          string
+	Timing               Timing
+	Airborne             AirborneObservation
+	GreatCircle          *GreatCircleInput
+	RouteAware           *RouteAwareEstimate
+	FlightPlanRevision   *uint64
+	FlightPlanObservedAt *time.Time
+	ResetHeldAirborne    bool
+}
+
+// Result always labels its source and reason. ArrivalAt and State are nil when
+// unavailable or when #320 sudden-appearance policy must decide what happens.
+type Result struct {
+	Status     Status
+	Reason     Reason
+	ArrivalAt  *time.Time
+	Source     aman.BaselineSource
+	Confidence aman.Confidence
+	State      *aman.BaselineState
+}
+
+// Reduce produces a deterministic planned or first-airborne baseline. A prior
+// held baseline wins unchanged until ResetHeldAirborne is explicitly true; the
+// caller, not this package, owns the Unstable-review transition and commit.
+func (r Reducer) Reduce(input Input, prior *aman.BaselineState) Result {
+	if prior != nil && !input.ResetHeldAirborne {
+		if prior.Validate() != nil {
+			return unavailable(ReasonInvalidTimestamp)
+		}
+		return held(*prior)
+	}
+	if prior != nil && input.ResetHeldAirborne {
+		// The next model layer owns recalculation after an explicit review.
+		// Do not infer that review from time, position, or a lifecycle enum.
+		if input.RouteAware == nil {
+			return unavailable(ReasonUnstableReviewReset)
+		}
+	}
+	if !validUTC(input.Now) || !destinationMatches(input.ExpectedDestination, input.Destination) {
+		if !validUTC(input.Now) {
+			return unavailable(ReasonInvalidTimestamp)
+		}
+		return unavailable(ReasonDestinationMismatch)
+	}
+	if result := r.routeAware(input); result != nil {
+		return *result
+	}
+	if input.Airborne.SensedAt != nil {
+		return r.firstAirborne(input)
+	}
+	return r.planned(input)
+}
+
+func (r Reducer) routeAware(input Input) *Result {
+	if input.RouteAware == nil {
+		return nil
+	}
+	if !validUTC(input.RouteAware.ArrivalAt) || !validUTC(input.Now) {
+		result := unavailable(ReasonInvalidTimestamp)
+		return &result
+	}
+	if !input.RouteAware.ArrivalAt.After(input.Now) {
+		result := unavailable(ReasonArrivalInPast)
+		return &result
+	}
+	confidence := input.RouteAware.Confidence
+	if !confidence.Valid() || confidence == aman.ConfidenceUnknown {
+		confidence = aman.ConfidenceMedium
+	}
+	arrival := input.RouteAware.ArrivalAt
+	return &Result{Status: StatusAvailable, Reason: ReasonRouteAwareSupersedesGreatCircle, ArrivalAt: &arrival, Source: aman.BaselineSourceRouteAware, Confidence: confidence}
+}
+
+func (r Reducer) firstAirborne(input Input) Result {
+	sensed := *input.Airborne.SensedAt
+	if !validUTC(sensed) {
+		return unavailable(ReasonInvalidTimestamp)
+	}
+	if sensed.After(input.Now) {
+		return unavailable(ReasonObservationInFuture)
+	}
+	if input.Now.Sub(sensed) > r.config.MaxObservationAge {
+		return unavailable(ReasonObservationTooOld)
+	}
+	if !input.Airborne.PreviouslyObserved {
+		return Result{Status: StatusPolicyRequired, Reason: ReasonSuddenAppearancePolicyRequired, Source: aman.BaselineSourceNone, Confidence: aman.ConfidenceUnknown}
+	}
+
+	duration, source, reason := preferredDuration(input.Timing)
+	if duration != nil {
+		return r.hold(input, sensed, *duration, source, reason)
+	}
+	if reason == ReasonNegativeFlightDuration {
+		return unavailable(reason)
+	}
+	return r.greatCircle(input, sensed)
+}
+
+func (r Reducer) planned(input Input) Result {
+	departure, source, reason := r.departure(input.Timing)
+	if departure == nil {
+		return unavailable(reason)
+	}
+	duration, durationSource, durationReason := preferredDuration(input.Timing)
+	if duration == nil {
+		return unavailable(durationReason)
+	}
+	arrival := departure.Add(*duration)
+	if !arrival.After(input.Now) {
+		return unavailable(ReasonArrivalInPast)
+	}
+	return Result{Status: statusFor(durationReason), Reason: durationReason, ArrivalAt: pointer(arrival), Source: plannedSource(source, durationSource), Confidence: confidenceFor(durationReason)}
+}
+
+func (r Reducer) departure(timing Timing) (*time.Time, aman.BaselineSource, Reason) {
+	if timing.EOBT != nil {
+		if !validUTC(*timing.EOBT) {
+			return nil, aman.BaselineSourceNone, ReasonInvalidTimestamp
+		}
+		value := timing.EOBT.Add(r.config.EXOT)
+		return &value, aman.BaselineSourcePlannedEOBTFiledEET, ReasonNone
+	}
+	if timing.EstimatedDeparture != nil {
+		if !validUTC(*timing.EstimatedDeparture) {
+			return nil, aman.BaselineSourceNone, ReasonInvalidTimestamp
+		}
+		value := *timing.EstimatedDeparture
+		return &value, aman.BaselineSourcePlannedEstimatedDepartureFiledEET, ReasonNone
+	}
+	return nil, aman.BaselineSourceNone, ReasonMissingDepartureTime
+}
+
+func (r Reducer) hold(input Input, sensed time.Time, duration time.Duration, source aman.BaselineSource, reason Reason) Result {
+	arrival := sensed.Add(duration)
+	if !arrival.After(input.Now) {
+		return unavailable(ReasonArrivalInPast)
+	}
+	if input.FlightPlanObservedAt == nil || !validUTC(*input.FlightPlanObservedAt) {
+		return unavailable(ReasonInvalidTimestamp)
+	}
+	state := aman.BaselineState{
+		ArrivalAt: arrival, AirborneSensedAt: sensed, Source: source, Confidence: confidenceFor(reason),
+		FlightPlanRevision: input.FlightPlanRevision, FlightPlanObservedAt: *input.FlightPlanObservedAt,
+		ModelVersion: r.config.ModelVersion, ConfigVersion: r.config.ConfigVersion,
+	}
+	if reason != ReasonNone {
+		value := string(reason)
+		state.DegradationReason = &value
+	}
+	return Result{Status: statusFor(reason), Reason: reason, ArrivalAt: pointer(arrival), Source: source, Confidence: state.Confidence, State: &state}
+}
+
+func (r Reducer) greatCircle(input Input, sensed time.Time) Result {
+	if input.GreatCircle == nil || !validCoordinates(input.GreatCircle.LatitudeDegrees, input.GreatCircle.LongitudeDegrees) || !validCoordinates(input.GreatCircle.DestinationLatitudeDegrees, input.GreatCircle.DestinationLongitudeDegrees) {
+		return unavailable(ReasonMissingGreatCircleInput)
+	}
+	speed, found := r.config.SpeedDefaults.Knots[input.GreatCircle.AircraftCategory]
+	if !found || speed <= 0 {
+		return unavailable(ReasonMissingAircraftSpeed)
+	}
+	distance := greatCircleDistanceNM(input.GreatCircle.LatitudeDegrees, input.GreatCircle.LongitudeDegrees, input.GreatCircle.DestinationLatitudeDegrees, input.GreatCircle.DestinationLongitudeDegrees)
+	if distance <= 0 || math.IsNaN(distance) || math.IsInf(distance, 0) {
+		return unavailable(ReasonMissingGreatCircleInput)
+	}
+	duration := time.Duration(float64(time.Hour) * distance / speed)
+	return r.hold(input, sensed, duration, aman.BaselineSourceAirborneGreatCircle, ReasonMissingFlightDuration)
+}
+
+func preferredDuration(timing Timing) (*time.Duration, aman.BaselineSource, Reason) {
+	if timing.FiledEET != nil {
+		if *timing.FiledEET <= 0 {
+			return nil, aman.BaselineSourceNone, ReasonNegativeFlightDuration
+		}
+		value := *timing.FiledEET
+		return &value, aman.BaselineSourceAirborneFiledEET, ReasonNone
+	}
+	if timing.APIEstimatedFlightTime != nil {
+		if *timing.APIEstimatedFlightTime <= 0 {
+			return nil, aman.BaselineSourceNone, ReasonNegativeFlightDuration
+		}
+		value := *timing.APIEstimatedFlightTime
+		return &value, aman.BaselineSourceAirborneAPIEstimatedFlightTime, ReasonMissingFlightDuration
+	}
+	return nil, aman.BaselineSourceNone, ReasonMissingFlightDuration
+}
+
+func plannedSource(departure, duration aman.BaselineSource) aman.BaselineSource {
+	if departure == aman.BaselineSourcePlannedEOBTFiledEET {
+		if duration == aman.BaselineSourceAirborneFiledEET {
+			return aman.BaselineSourcePlannedEOBTFiledEET
+		}
+		return aman.BaselineSourcePlannedEOBTAPIEstimatedFlightTime
+	}
+	if duration == aman.BaselineSourceAirborneFiledEET {
+		return aman.BaselineSourcePlannedEstimatedDepartureFiledEET
+	}
+	return aman.BaselineSourcePlannedEstimatedDepartureAPIEstimatedFlightTime
+}
+
+func unavailable(reason Reason) Result {
+	return Result{Status: StatusUnavailable, Reason: reason, Source: aman.BaselineSourceNone, Confidence: aman.ConfidenceUnknown}
+}
+
+func held(state aman.BaselineState) Result {
+	arrival := state.ArrivalAt
+	return Result{Status: statusForReasonPointer(state.DegradationReason), Reason: ReasonHeldFirstAirborneBaseline, ArrivalAt: &arrival, Source: state.Source, Confidence: state.Confidence, State: &state}
+}
+
+func statusFor(reason Reason) Status {
+	if reason == ReasonNone {
+		return StatusAvailable
+	}
+	return StatusDegraded
+}
+
+func statusForReasonPointer(reason *string) Status {
+	if reason == nil {
+		return StatusAvailable
+	}
+	return StatusDegraded
+}
+
+func confidenceFor(reason Reason) aman.Confidence {
+	if reason == ReasonNone {
+		return aman.ConfidenceMedium
+	}
+	return aman.ConfidenceLow
+}
+
+func destinationMatches(expected, actual string) bool {
+	expected, actual = strings.ToUpper(strings.TrimSpace(expected)), strings.ToUpper(strings.TrimSpace(actual))
+	return expected != "" && expected == actual
+}
+
+func validUTC(value time.Time) bool { return !value.IsZero() && value.Location() == time.UTC }
+
+func validCoordinates(latitude, longitude float64) bool {
+	return latitude >= -90 && latitude <= 90 && longitude >= -180 && longitude <= 180 && (latitude != 0 || longitude != 0)
+}
+
+func greatCircleDistanceNM(latitudeA, longitudeA, latitudeB, longitudeB float64) float64 {
+	const earthRadiusNM = 3440.065
+	latA, latB := latitudeA*math.Pi/180, latitudeB*math.Pi/180
+	deltaLat, deltaLon := (latitudeB-latitudeA)*math.Pi/180, (longitudeB-longitudeA)*math.Pi/180
+	a := math.Sin(deltaLat/2)*math.Sin(deltaLat/2) + math.Cos(latA)*math.Cos(latB)*math.Sin(deltaLon/2)*math.Sin(deltaLon/2)
+	return earthRadiusNM * 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+}
+
+func validSpeedDefaults(defaults SpeedDefaults) bool {
+	if strings.TrimSpace(defaults.Version) == "" {
+		return false
+	}
+	for _, category := range []AircraftCategory{CategoryLight, CategoryMedium, CategoryHeavy, CategorySuper} {
+		if defaults.Knots[category] <= 0 || math.IsNaN(defaults.Knots[category]) || math.IsInf(defaults.Knots[category], 0) {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneSpeeds(values map[AircraftCategory]float64) map[AircraftCategory]float64 {
+	cloned := make(map[AircraftCategory]float64, len(values))
+	for category, speed := range values {
+		cloned[category] = speed
+	}
+	return cloned
+}
+
+func pointer(value time.Time) *time.Time { return &value }
+
+var errInvalidConfig = &aman.DomainError{Class: aman.ErrorInvalidArgument, Message: "baseline predictor configuration is invalid"}

--- a/backend/internal/aman/predictor/baseline.go
+++ b/backend/internal/aman/predictor/baseline.go
@@ -14,9 +14,16 @@ import (
 const (
 	// DefaultEXOT is the planning-only estimated taxi-out duration added to a
 	// filed EOBT. It is never an operational arrival timeline value.
-	DefaultEXOT          = 15 * time.Minute
-	defaultModelVersion  = "aman-baseline-v1"
-	defaultConfigVersion = "aman-baseline-defaults-v1"
+	DefaultEXOT = 15 * time.Minute
+	// DefaultMaxFlightDuration accepts an aviation-long filed duration while
+	// bounding malformed input before time arithmetic.
+	DefaultMaxFlightDuration = 24 * time.Hour
+	// DefaultMaxArrivalHorizon bounds planning and route-aware arrival instants
+	// relative to the injected clock. It is intentionally longer than the
+	// maximum duration to allow a next-service-day EOBT.
+	DefaultMaxArrivalHorizon = 36 * time.Hour
+	defaultModelVersion      = "aman-baseline-v1"
+	defaultConfigVersion     = "aman-baseline-defaults-v1"
 )
 
 // Status reports whether an estimate may be consumed, is usable with an
@@ -35,21 +42,28 @@ const (
 type Reason string
 
 const (
-	ReasonNone                            Reason = "none"
-	ReasonMissingDepartureTime            Reason = "missing_departure_time"
-	ReasonMissingFlightDuration           Reason = "missing_flight_duration"
-	ReasonNegativeFlightDuration          Reason = "negative_flight_duration"
-	ReasonInvalidTimestamp                Reason = "invalid_timestamp"
-	ReasonDestinationMismatch             Reason = "destination_mismatch"
-	ReasonObservationInFuture             Reason = "observation_in_future"
-	ReasonObservationTooOld               Reason = "observation_too_old"
-	ReasonArrivalInPast                   Reason = "arrival_in_past"
-	ReasonSuddenAppearancePolicyRequired  Reason = "sudden_appearance_policy_required"
-	ReasonMissingGreatCircleInput         Reason = "missing_great_circle_input"
-	ReasonMissingAircraftSpeed            Reason = "missing_aircraft_speed"
-	ReasonHeldFirstAirborneBaseline       Reason = "held_first_airborne_baseline"
-	ReasonUnstableReviewReset             Reason = "unstable_review_reset"
-	ReasonRouteAwareSupersedesGreatCircle Reason = "route_aware_supersedes_great_circle"
+	ReasonNone                             Reason = "none"
+	ReasonMissingDepartureTime             Reason = "missing_departure_time"
+	ReasonMissingFlightDuration            Reason = "missing_flight_duration"
+	ReasonMissingFlightDurationAndGeometry Reason = "missing_flight_duration_and_great_circle_input"
+	ReasonNegativeFlightDuration           Reason = "negative_flight_duration"
+	ReasonFlightDurationTooLong            Reason = "flight_duration_too_long"
+	ReasonInvalidTimestamp                 Reason = "invalid_timestamp"
+	ReasonDestinationMismatch              Reason = "destination_mismatch"
+	ReasonObservationInFuture              Reason = "observation_in_future"
+	ReasonFlightPlanObservedInFuture       Reason = "flight_plan_observed_in_future"
+	ReasonObservationTooOld                Reason = "observation_too_old"
+	ReasonArrivalInPast                    Reason = "arrival_in_past"
+	ReasonTimestampBeyondHorizon           Reason = "timestamp_beyond_arrival_horizon"
+	ReasonArrivalBeyondHorizon             Reason = "arrival_beyond_horizon"
+	ReasonSuddenAppearancePolicyRequired   Reason = "sudden_appearance_policy_required"
+	ReasonMissingGreatCircleInput          Reason = "missing_great_circle_input"
+	ReasonMissingAircraftSpeed             Reason = "missing_aircraft_speed"
+	ReasonFiledEETMissingAPIUsed           Reason = "filed_eet_missing_api_estimated_flight_time_used"
+	ReasonGreatCircleUsed                  Reason = "route_geometry_or_duration_unavailable_great_circle_used"
+	ReasonHeldFirstAirborneBaseline        Reason = "held_first_airborne_baseline"
+	ReasonUnstableReviewReset              Reason = "unstable_review_reset"
+	ReasonRouteAwareSupersedesGreatCircle  Reason = "route_aware_supersedes_great_circle"
 )
 
 // AircraftCategory selects a documented default speed for a degraded
@@ -90,6 +104,12 @@ func SpeedDefaultsV1() SpeedDefaults {
 type Config struct {
 	EXOT              time.Duration
 	MaxObservationAge time.Duration
+	// MaxFlightDuration bounds positive filed/API and great-circle durations;
+	// zero selects DefaultMaxFlightDuration.
+	MaxFlightDuration time.Duration
+	// MaxArrivalHorizon bounds accepted departure and arrival instants from Now;
+	// zero selects DefaultMaxArrivalHorizon.
+	MaxArrivalHorizon time.Duration
 	SpeedDefaults     SpeedDefaults
 	ModelVersion      string
 	ConfigVersion     string
@@ -106,7 +126,13 @@ func NewReducer(config Config) (Reducer, error) {
 	if config.EXOT == 0 {
 		config.EXOT = DefaultEXOT
 	}
-	if config.EXOT < 0 || config.MaxObservationAge <= 0 {
+	if config.MaxFlightDuration == 0 {
+		config.MaxFlightDuration = DefaultMaxFlightDuration
+	}
+	if config.MaxArrivalHorizon == 0 {
+		config.MaxArrivalHorizon = DefaultMaxArrivalHorizon
+	}
+	if config.EXOT < 0 || config.MaxObservationAge <= 0 || config.MaxFlightDuration <= 0 || config.MaxArrivalHorizon <= 0 {
 		return Reducer{}, errInvalidConfig
 	}
 	if config.SpeedDefaults.Version == "" {
@@ -192,55 +218,51 @@ type Result struct {
 // held baseline wins unchanged until ResetHeldAirborne is explicitly true; the
 // caller, not this package, owns the Unstable-review transition and commit.
 func (r Reducer) Reduce(input Input, prior *aman.BaselineState) Result {
+	// Invalid current facts must never let a persisted baseline cross an
+	// airport boundary or make the injected clock irrelevant.
+	if !validUTC(input.Now) {
+		return unavailable(ReasonInvalidTimestamp)
+	}
+	if !destinationMatches(input.ExpectedDestination, input.Destination) {
+		return unavailable(ReasonDestinationMismatch)
+	}
 	if prior != nil && !input.ResetHeldAirborne {
 		if prior.Validate() != nil {
 			return unavailable(ReasonInvalidTimestamp)
 		}
 		return held(*prior)
 	}
-	if prior != nil && input.ResetHeldAirborne {
-		// The next model layer owns recalculation after an explicit review.
-		// Do not infer that review from time, position, or a lifecycle enum.
-		if input.RouteAware == nil {
+	if input.Airborne.SensedAt == nil {
+		if input.ResetHeldAirborne {
 			return unavailable(ReasonUnstableReviewReset)
 		}
+		return r.planned(input)
 	}
-	if !validUTC(input.Now) || !destinationMatches(input.ExpectedDestination, input.Destination) {
-		if !validUTC(input.Now) {
-			return unavailable(ReasonInvalidTimestamp)
-		}
-		return unavailable(ReasonDestinationMismatch)
-	}
-	if result := r.routeAware(input); result != nil {
-		return *result
-	}
-	if input.Airborne.SensedAt != nil {
-		return r.firstAirborne(input)
-	}
-	return r.planned(input)
+	return r.airborne(input)
 }
 
-func (r Reducer) routeAware(input Input) *Result {
+func (r Reducer) routeAware(input Input) Result {
 	if input.RouteAware == nil {
-		return nil
+		return unavailable(ReasonUnstableReviewReset)
 	}
-	if !validUTC(input.RouteAware.ArrivalAt) || !validUTC(input.Now) {
-		result := unavailable(ReasonInvalidTimestamp)
-		return &result
+	if !validUTC(input.RouteAware.ArrivalAt) {
+		return unavailable(ReasonInvalidTimestamp)
 	}
 	if !input.RouteAware.ArrivalAt.After(input.Now) {
-		result := unavailable(ReasonArrivalInPast)
-		return &result
+		return unavailable(ReasonArrivalInPast)
+	}
+	if beyondHorizon(input.Now, input.RouteAware.ArrivalAt, r.config.MaxArrivalHorizon) {
+		return unavailable(ReasonArrivalBeyondHorizon)
 	}
 	confidence := input.RouteAware.Confidence
 	if !confidence.Valid() || confidence == aman.ConfidenceUnknown {
 		confidence = aman.ConfidenceMedium
 	}
 	arrival := input.RouteAware.ArrivalAt
-	return &Result{Status: StatusAvailable, Reason: ReasonRouteAwareSupersedesGreatCircle, ArrivalAt: &arrival, Source: aman.BaselineSourceRouteAware, Confidence: confidence}
+	return Result{Status: StatusAvailable, Reason: ReasonRouteAwareSupersedesGreatCircle, ArrivalAt: &arrival, Source: aman.BaselineSourceRouteAware, Confidence: confidence}
 }
 
-func (r Reducer) firstAirborne(input Input) Result {
+func (r Reducer) airborne(input Input) Result {
 	sensed := *input.Airborne.SensedAt
 	if !validUTC(sensed) {
 		return unavailable(ReasonInvalidTimestamp)
@@ -254,6 +276,11 @@ func (r Reducer) firstAirborne(input Input) Result {
 	if !input.Airborne.PreviouslyObserved {
 		return Result{Status: StatusPolicyRequired, Reason: ReasonSuddenAppearancePolicyRequired, Source: aman.BaselineSourceNone, Confidence: aman.ConfidenceUnknown}
 	}
+	if input.ResetHeldAirborne {
+		// The next model layer owns recalculation after an explicit review.
+		// Do not infer that review from time, position, or a lifecycle enum.
+		return r.routeAware(input)
+	}
 
 	duration, source, reason := preferredDuration(input.Timing)
 	if duration != nil {
@@ -262,11 +289,11 @@ func (r Reducer) firstAirborne(input Input) Result {
 	if reason == ReasonNegativeFlightDuration {
 		return unavailable(reason)
 	}
-	return r.greatCircle(input, sensed)
+	return r.greatCircle(input, sensed, reason)
 }
 
 func (r Reducer) planned(input Input) Result {
-	departure, source, reason := r.departure(input.Timing)
+	departure, source, reason := r.departure(input, input.Timing)
 	if departure == nil {
 		return unavailable(reason)
 	}
@@ -274,17 +301,29 @@ func (r Reducer) planned(input Input) Result {
 	if duration == nil {
 		return unavailable(durationReason)
 	}
+	if *duration > r.config.MaxFlightDuration {
+		return unavailable(ReasonFlightDurationTooLong)
+	}
+	if beyondHorizon(input.Now, *departure, r.config.MaxArrivalHorizon) {
+		return unavailable(ReasonTimestampBeyondHorizon)
+	}
 	arrival := departure.Add(*duration)
 	if !arrival.After(input.Now) {
 		return unavailable(ReasonArrivalInPast)
 	}
+	if beyondHorizon(input.Now, arrival, r.config.MaxArrivalHorizon) {
+		return unavailable(ReasonArrivalBeyondHorizon)
+	}
 	return Result{Status: statusFor(durationReason), Reason: durationReason, ArrivalAt: pointer(arrival), Source: plannedSource(source, durationSource), Confidence: confidenceFor(durationReason)}
 }
 
-func (r Reducer) departure(timing Timing) (*time.Time, aman.BaselineSource, Reason) {
+func (r Reducer) departure(input Input, timing Timing) (*time.Time, aman.BaselineSource, Reason) {
 	if timing.EOBT != nil {
 		if !validUTC(*timing.EOBT) {
 			return nil, aman.BaselineSourceNone, ReasonInvalidTimestamp
+		}
+		if beyondHorizon(input.Now, *timing.EOBT, r.config.MaxArrivalHorizon) {
+			return nil, aman.BaselineSourceNone, ReasonTimestampBeyondHorizon
 		}
 		value := timing.EOBT.Add(r.config.EXOT)
 		return &value, aman.BaselineSourcePlannedEOBTFiledEET, ReasonNone
@@ -293,6 +332,9 @@ func (r Reducer) departure(timing Timing) (*time.Time, aman.BaselineSource, Reas
 		if !validUTC(*timing.EstimatedDeparture) {
 			return nil, aman.BaselineSourceNone, ReasonInvalidTimestamp
 		}
+		if beyondHorizon(input.Now, *timing.EstimatedDeparture, r.config.MaxArrivalHorizon) {
+			return nil, aman.BaselineSourceNone, ReasonTimestampBeyondHorizon
+		}
 		value := *timing.EstimatedDeparture
 		return &value, aman.BaselineSourcePlannedEstimatedDepartureFiledEET, ReasonNone
 	}
@@ -300,27 +342,44 @@ func (r Reducer) departure(timing Timing) (*time.Time, aman.BaselineSource, Reas
 }
 
 func (r Reducer) hold(input Input, sensed time.Time, duration time.Duration, source aman.BaselineSource, reason Reason) Result {
+	if duration <= 0 {
+		return unavailable(ReasonNegativeFlightDuration)
+	}
+	if duration > r.config.MaxFlightDuration {
+		return unavailable(ReasonFlightDurationTooLong)
+	}
 	arrival := sensed.Add(duration)
 	if !arrival.After(input.Now) {
 		return unavailable(ReasonArrivalInPast)
 	}
+	if beyondHorizon(input.Now, arrival, r.config.MaxArrivalHorizon) {
+		return unavailable(ReasonArrivalBeyondHorizon)
+	}
 	if input.FlightPlanObservedAt == nil || !validUTC(*input.FlightPlanObservedAt) {
 		return unavailable(ReasonInvalidTimestamp)
 	}
+	if input.FlightPlanObservedAt.After(input.Now) {
+		return unavailable(ReasonFlightPlanObservedInFuture)
+	}
 	state := aman.BaselineState{
 		ArrivalAt: arrival, AirborneSensedAt: sensed, Source: source, Confidence: confidenceFor(reason),
-		FlightPlanRevision: input.FlightPlanRevision, FlightPlanObservedAt: *input.FlightPlanObservedAt,
+		FlightPlanRevision: cloneUint64(input.FlightPlanRevision), FlightPlanObservedAt: *input.FlightPlanObservedAt,
 		ModelVersion: r.config.ModelVersion, ConfigVersion: r.config.ConfigVersion,
 	}
-	if reason != ReasonNone {
-		value := string(reason)
-		state.DegradationReason = &value
+	if degradation := degradationFor(reason); degradation != nil {
+		state.DegradationReason = degradation
 	}
-	return Result{Status: statusFor(reason), Reason: reason, ArrivalAt: pointer(arrival), Source: source, Confidence: state.Confidence, State: &state}
+	if source == aman.BaselineSourceAirborneGreatCircle {
+		state.SpeedDefaultsVersion = r.config.SpeedDefaults.Version
+	}
+	return Result{Status: statusFor(reason), Reason: reason, ArrivalAt: pointer(arrival), Source: source, Confidence: state.Confidence, State: cloneBaselineState(&state)}
 }
 
-func (r Reducer) greatCircle(input Input, sensed time.Time) Result {
+func (r Reducer) greatCircle(input Input, sensed time.Time, durationReason Reason) Result {
 	if input.GreatCircle == nil || !validCoordinates(input.GreatCircle.LatitudeDegrees, input.GreatCircle.LongitudeDegrees) || !validCoordinates(input.GreatCircle.DestinationLatitudeDegrees, input.GreatCircle.DestinationLongitudeDegrees) {
+		if durationReason == ReasonMissingFlightDuration {
+			return unavailable(ReasonMissingFlightDurationAndGeometry)
+		}
 		return unavailable(ReasonMissingGreatCircleInput)
 	}
 	speed, found := r.config.SpeedDefaults.Knots[input.GreatCircle.AircraftCategory]
@@ -331,8 +390,12 @@ func (r Reducer) greatCircle(input Input, sensed time.Time) Result {
 	if distance <= 0 || math.IsNaN(distance) || math.IsInf(distance, 0) {
 		return unavailable(ReasonMissingGreatCircleInput)
 	}
-	duration := time.Duration(float64(time.Hour) * distance / speed)
-	return r.hold(input, sensed, duration, aman.BaselineSourceAirborneGreatCircle, ReasonMissingFlightDuration)
+	durationHours := distance / speed
+	if durationHours > float64(r.config.MaxFlightDuration)/float64(time.Hour) {
+		return unavailable(ReasonFlightDurationTooLong)
+	}
+	duration := time.Duration(float64(time.Hour) * durationHours)
+	return r.hold(input, sensed, duration, aman.BaselineSourceAirborneGreatCircle, ReasonGreatCircleUsed)
 }
 
 func preferredDuration(timing Timing) (*time.Duration, aman.BaselineSource, Reason) {
@@ -348,7 +411,7 @@ func preferredDuration(timing Timing) (*time.Duration, aman.BaselineSource, Reas
 			return nil, aman.BaselineSourceNone, ReasonNegativeFlightDuration
 		}
 		value := *timing.APIEstimatedFlightTime
-		return &value, aman.BaselineSourceAirborneAPIEstimatedFlightTime, ReasonMissingFlightDuration
+		return &value, aman.BaselineSourceAirborneAPIEstimatedFlightTime, ReasonFiledEETMissingAPIUsed
 	}
 	return nil, aman.BaselineSourceNone, ReasonMissingFlightDuration
 }
@@ -371,8 +434,9 @@ func unavailable(reason Reason) Result {
 }
 
 func held(state aman.BaselineState) Result {
-	arrival := state.ArrivalAt
-	return Result{Status: statusForReasonPointer(state.DegradationReason), Reason: ReasonHeldFirstAirborneBaseline, ArrivalAt: &arrival, Source: state.Source, Confidence: state.Confidence, State: &state}
+	copy := cloneBaselineState(&state)
+	arrival := copy.ArrivalAt
+	return Result{Status: statusForBaselineDegradation(copy.DegradationReason), Reason: ReasonHeldFirstAirborneBaseline, ArrivalAt: &arrival, Source: copy.Source, Confidence: copy.Confidence, State: copy}
 }
 
 func statusFor(reason Reason) Status {
@@ -382,11 +446,24 @@ func statusFor(reason Reason) Status {
 	return StatusDegraded
 }
 
-func statusForReasonPointer(reason *string) Status {
+func statusForBaselineDegradation(reason *aman.BaselineDegradationReason) Status {
 	if reason == nil {
 		return StatusAvailable
 	}
 	return StatusDegraded
+}
+
+func degradationFor(reason Reason) *aman.BaselineDegradationReason {
+	var value aman.BaselineDegradationReason
+	switch reason {
+	case ReasonFiledEETMissingAPIUsed:
+		value = aman.BaselineDegradationFiledEETMissingAPIUsed
+	case ReasonGreatCircleUsed:
+		value = aman.BaselineDegradationGreatCircleUsed
+	default:
+		return nil
+	}
+	return &value
 }
 
 func confidenceFor(reason Reason) aman.Confidence {
@@ -402,6 +479,10 @@ func destinationMatches(expected, actual string) bool {
 }
 
 func validUTC(value time.Time) bool { return !value.IsZero() && value.Location() == time.UTC }
+
+func beyondHorizon(now, value time.Time, horizon time.Duration) bool {
+	return value.After(now.Add(horizon))
+}
 
 func validCoordinates(latitude, longitude float64) bool {
 	return latitude >= -90 && latitude <= 90 && longitude >= -180 && longitude <= 180 && (latitude != 0 || longitude != 0)
@@ -436,5 +517,26 @@ func cloneSpeeds(values map[AircraftCategory]float64) map[AircraftCategory]float
 }
 
 func pointer(value time.Time) *time.Time { return &value }
+
+func cloneUint64(value *uint64) *uint64 {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func cloneBaselineState(value *aman.BaselineState) *aman.BaselineState {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	copy.FlightPlanRevision = cloneUint64(value.FlightPlanRevision)
+	if value.DegradationReason != nil {
+		degradation := *value.DegradationReason
+		copy.DegradationReason = &degradation
+	}
+	return &copy
+}
 
 var errInvalidConfig = &aman.DomainError{Class: aman.ErrorInvalidArgument, Message: "baseline predictor configuration is invalid"}

--- a/backend/internal/aman/predictor/baseline_test.go
+++ b/backend/internal/aman/predictor/baseline_test.go
@@ -1,0 +1,191 @@
+package predictor
+
+import (
+	"FlightStrips/internal/aman"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var baselineNow = time.Date(2026, time.July, 18, 12, 0, 0, 0, time.UTC)
+
+func TestPlannedTimingPrecedenceTable(t *testing.T) {
+	eobt := baselineNow.Add(time.Hour)
+	estimatedDeparture := baselineNow.Add(2 * time.Hour)
+	filed := 90 * time.Minute
+	api := 2 * time.Hour
+	reducer := testReducer(t)
+
+	for _, test := range []struct {
+		name    string
+		timing  Timing
+		arrival time.Time
+		source  aman.BaselineSource
+		status  Status
+		reason  Reason
+	}{
+		{"EOBT and filed EET", Timing{EOBT: &eobt, EstimatedDeparture: &estimatedDeparture, FiledEET: &filed, APIEstimatedFlightTime: &api}, eobt.Add(DefaultEXOT + filed), aman.BaselineSourcePlannedEOBTFiledEET, StatusAvailable, ReasonNone},
+		{"estimated departure and filed EET", Timing{EstimatedDeparture: &estimatedDeparture, FiledEET: &filed, APIEstimatedFlightTime: &api}, estimatedDeparture.Add(filed), aman.BaselineSourcePlannedEstimatedDepartureFiledEET, StatusAvailable, ReasonNone},
+		{"EOBT and API estimate", Timing{EOBT: &eobt, APIEstimatedFlightTime: &api}, eobt.Add(DefaultEXOT + api), aman.BaselineSourcePlannedEOBTAPIEstimatedFlightTime, StatusDegraded, ReasonMissingFlightDuration},
+		{"estimated departure and API estimate", Timing{EstimatedDeparture: &estimatedDeparture, APIEstimatedFlightTime: &api}, estimatedDeparture.Add(api), aman.BaselineSourcePlannedEstimatedDepartureAPIEstimatedFlightTime, StatusDegraded, ReasonMissingFlightDuration},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result := reducer.Reduce(plannedInput(test.timing), nil)
+			require.Equal(t, test.status, result.Status)
+			require.Equal(t, test.reason, result.Reason)
+			require.Equal(t, test.source, result.Source)
+			require.Equal(t, test.arrival, *result.ArrivalAt)
+		})
+	}
+}
+
+func TestBaselineRejectsTimestampDurationAndDestinationBoundaries(t *testing.T) {
+	reducer := testReducer(t)
+	eobt := baselineNow.Add(time.Hour)
+	filed := time.Hour
+	observed := baselineNow.Add(-time.Minute)
+	flightPlanObserved := baselineNow.Add(-2 * time.Minute)
+
+	for _, test := range []struct {
+		name   string
+		input  Input
+		reason Reason
+	}{
+		{"destination mismatch", Input{Now: baselineNow, ExpectedDestination: "EKCH", Destination: "EKRN", Timing: Timing{EOBT: &eobt, FiledEET: &filed}}, ReasonDestinationMismatch},
+		{"non UTC EOBT", plannedInput(Timing{EOBT: timePointer(eobt.In(time.FixedZone("CEST", 7200))), FiledEET: &filed}), ReasonInvalidTimestamp},
+		{"negative filed EET", plannedInput(Timing{EOBT: &eobt, FiledEET: durationPointer(-time.Minute)}), ReasonNegativeFlightDuration},
+		{"past planned arrival", plannedInput(Timing{EOBT: timePointer(baselineNow.Add(-2 * time.Hour)), FiledEET: &filed}), ReasonArrivalInPast},
+		{"future observation", airborneInput(baselineNow.Add(time.Second), &filed, &flightPlanObserved), ReasonObservationInFuture},
+		{"over age observation", airborneInput(baselineNow.Add(-3*time.Minute), &filed, &flightPlanObserved), ReasonObservationTooOld},
+		{"past airborne arrival", airborneInput(observed, durationPointer(30*time.Second), &flightPlanObserved), ReasonArrivalInPast},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result := reducer.Reduce(test.input, nil)
+			require.Equal(t, StatusUnavailable, result.Status)
+			require.Equal(t, test.reason, result.Reason)
+			require.Nil(t, result.ArrivalAt)
+			require.Nil(t, result.State)
+		})
+	}
+}
+
+func TestFirstAirborneHoldsAcrossFreshReducerUntilExplicitReset(t *testing.T) {
+	reducer := testReducer(t)
+	filed := 90 * time.Minute
+	flightPlanObserved := baselineNow.Add(-time.Minute)
+	input := airborneInput(baselineNow.Add(-time.Minute), &filed, &flightPlanObserved)
+
+	first := reducer.Reduce(input, nil)
+	require.Equal(t, StatusAvailable, first.Status)
+	require.Equal(t, aman.BaselineSourceAirborneFiledEET, first.Source)
+	require.NotNil(t, first.State)
+	require.Equal(t, (*input.Airborne.SensedAt).Add(filed), *first.ArrivalAt)
+
+	// This mimics a restarted process receiving a later source observation and
+	// the state reconstructed by the #306 aggregate repository.
+	freshReducer := testReducer(t)
+	later := input
+	later.Now = baselineNow.Add(time.Minute)
+	later.Airborne.SensedAt = timePointer(baselineNow)
+	later.Timing.FiledEET = durationPointer(3 * time.Hour)
+	held := freshReducer.Reduce(later, first.State)
+	require.Equal(t, ReasonHeldFirstAirborneBaseline, held.Reason)
+	require.Equal(t, *first.State, *held.State)
+	require.Equal(t, *first.ArrivalAt, *held.ArrivalAt)
+
+	later.ResetHeldAirborne = true
+	reset := freshReducer.Reduce(later, first.State)
+	require.Equal(t, StatusUnavailable, reset.Status)
+	require.Equal(t, ReasonUnstableReviewReset, reset.Reason)
+}
+
+func TestFirstSeenAirborneRequiresSuddenAppearancePolicy(t *testing.T) {
+	reducer := testReducer(t)
+	filed := time.Hour
+	flightPlanObserved := baselineNow.Add(-time.Minute)
+	input := airborneInput(baselineNow.Add(-time.Minute), &filed, &flightPlanObserved)
+	input.Airborne.PreviouslyObserved = false
+
+	result := reducer.Reduce(input, nil)
+	require.Equal(t, StatusPolicyRequired, result.Status)
+	require.Equal(t, ReasonSuddenAppearancePolicyRequired, result.Reason)
+	require.Nil(t, result.ArrivalAt)
+	require.Nil(t, result.State)
+}
+
+func TestGreatCircleFallbackUsesVersionedCategorySpeedAndRouteAwareSupersedesIt(t *testing.T) {
+	reducer := testReducer(t)
+	flightPlanObserved := baselineNow.Add(-time.Minute)
+	input := airborneInput(baselineNow.Add(-time.Minute), nil, &flightPlanObserved)
+	input.GreatCircle = &GreatCircleInput{
+		LatitudeDegrees: 55.0, LongitudeDegrees: 11.0,
+		DestinationLatitudeDegrees: 55.6, DestinationLongitudeDegrees: 12.6,
+		AircraftCategory: CategoryMedium,
+	}
+
+	fallback := reducer.Reduce(input, nil)
+	require.Equal(t, StatusDegraded, fallback.Status)
+	require.Equal(t, aman.BaselineSourceAirborneGreatCircle, fallback.Source)
+	require.Equal(t, ReasonMissingFlightDuration, fallback.Reason)
+	require.Equal(t, "aircraft-category-speeds-v1", reducer.config.SpeedDefaults.Version)
+	require.NotNil(t, fallback.State)
+
+	input.RouteAware = &RouteAwareEstimate{ArrivalAt: baselineNow.Add(20 * time.Minute), Confidence: aman.ConfidenceHigh}
+	routeAware := reducer.Reduce(input, &aman.BaselineState{
+		ArrivalAt: fallback.State.ArrivalAt, AirborneSensedAt: fallback.State.AirborneSensedAt, Source: fallback.State.Source, Confidence: fallback.State.Confidence,
+		DegradationReason: fallback.State.DegradationReason, FlightPlanObservedAt: fallback.State.FlightPlanObservedAt, ModelVersion: fallback.State.ModelVersion, ConfigVersion: fallback.State.ConfigVersion,
+	})
+	require.Equal(t, ReasonHeldFirstAirborneBaseline, routeAware.Reason, "a held first-airborne baseline is not silently replaced")
+
+	input.ResetHeldAirborne = true
+	routeAware = reducer.Reduce(input, fallback.State)
+	require.Equal(t, StatusAvailable, routeAware.Status)
+	require.Equal(t, ReasonRouteAwareSupersedesGreatCircle, routeAware.Reason)
+	require.Equal(t, aman.BaselineSourceRouteAware, routeAware.Source)
+}
+
+func TestGreatCircleAndAircraftCategoryDefaultsUseDocumentedUnits(t *testing.T) {
+	// One degree of latitude is about 60 NM. The calculation uses WGS84-style
+	// degrees at its boundary and returns nautical miles.
+	require.InDelta(t, 60.04, greatCircleDistanceNM(55, 12, 56, 12), 0.05)
+	require.Equal(t, map[AircraftCategory]float64{
+		CategoryLight: 180, CategoryMedium: 420, CategoryHeavy: 440, CategorySuper: 460,
+	}, SpeedDefaultsV1().Knots)
+}
+
+func TestPredictorPackageDoesNotDependOnSourceOrEuroScopeAdapters(t *testing.T) {
+	command := exec.Command("go", "list", "-f", "{{join .Imports \"\\n\"}}", ".")
+	output, err := command.Output()
+	require.NoError(t, err)
+	for _, importPath := range strings.Fields(string(output)) {
+		require.NotContains(t, importPath, "vatsim")
+		require.NotContains(t, importPath, "euroscope")
+		require.NotContains(t, importPath, "navdata/airacnet")
+	}
+}
+
+func testReducer(t *testing.T) Reducer {
+	t.Helper()
+	reducer, err := NewReducer(Config{MaxObservationAge: 2 * time.Minute})
+	require.NoError(t, err)
+	return reducer
+}
+
+func plannedInput(timing Timing) Input {
+	return Input{Now: baselineNow, ExpectedDestination: "EKCH", Destination: "EKCH", Timing: timing}
+}
+
+func airborneInput(sensed time.Time, filed *time.Duration, flightPlanObserved *time.Time) Input {
+	return Input{
+		Now: baselineNow, ExpectedDestination: "EKCH", Destination: "EKCH",
+		Timing:               Timing{FiledEET: filed},
+		Airborne:             AirborneObservation{SensedAt: &sensed, PreviouslyObserved: true},
+		FlightPlanObservedAt: flightPlanObserved,
+	}
+}
+
+func timePointer(value time.Time) *time.Time             { return &value }
+func durationPointer(value time.Duration) *time.Duration { return &value }

--- a/backend/internal/aman/predictor/baseline_test.go
+++ b/backend/internal/aman/predictor/baseline_test.go
@@ -29,8 +29,8 @@ func TestPlannedTimingPrecedenceTable(t *testing.T) {
 	}{
 		{"EOBT and filed EET", Timing{EOBT: &eobt, EstimatedDeparture: &estimatedDeparture, FiledEET: &filed, APIEstimatedFlightTime: &api}, eobt.Add(DefaultEXOT + filed), aman.BaselineSourcePlannedEOBTFiledEET, StatusAvailable, ReasonNone},
 		{"estimated departure and filed EET", Timing{EstimatedDeparture: &estimatedDeparture, FiledEET: &filed, APIEstimatedFlightTime: &api}, estimatedDeparture.Add(filed), aman.BaselineSourcePlannedEstimatedDepartureFiledEET, StatusAvailable, ReasonNone},
-		{"EOBT and API estimate", Timing{EOBT: &eobt, APIEstimatedFlightTime: &api}, eobt.Add(DefaultEXOT + api), aman.BaselineSourcePlannedEOBTAPIEstimatedFlightTime, StatusDegraded, ReasonMissingFlightDuration},
-		{"estimated departure and API estimate", Timing{EstimatedDeparture: &estimatedDeparture, APIEstimatedFlightTime: &api}, estimatedDeparture.Add(api), aman.BaselineSourcePlannedEstimatedDepartureAPIEstimatedFlightTime, StatusDegraded, ReasonMissingFlightDuration},
+		{"EOBT and API estimate", Timing{EOBT: &eobt, APIEstimatedFlightTime: &api}, eobt.Add(DefaultEXOT + api), aman.BaselineSourcePlannedEOBTAPIEstimatedFlightTime, StatusDegraded, ReasonFiledEETMissingAPIUsed},
+		{"estimated departure and API estimate", Timing{EstimatedDeparture: &estimatedDeparture, APIEstimatedFlightTime: &api}, estimatedDeparture.Add(api), aman.BaselineSourcePlannedEstimatedDepartureAPIEstimatedFlightTime, StatusDegraded, ReasonFiledEETMissingAPIUsed},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			result := reducer.Reduce(plannedInput(test.timing), nil)
@@ -61,6 +61,7 @@ func TestBaselineRejectsTimestampDurationAndDestinationBoundaries(t *testing.T) 
 		{"future observation", airborneInput(baselineNow.Add(time.Second), &filed, &flightPlanObserved), ReasonObservationInFuture},
 		{"over age observation", airborneInput(baselineNow.Add(-3*time.Minute), &filed, &flightPlanObserved), ReasonObservationTooOld},
 		{"past airborne arrival", airborneInput(observed, durationPointer(30*time.Second), &flightPlanObserved), ReasonArrivalInPast},
+		{"no duration or geometry", airborneInput(observed, nil, &flightPlanObserved), ReasonMissingFlightDurationAndGeometry},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			result := reducer.Reduce(test.input, nil)
@@ -70,6 +71,21 @@ func TestBaselineRejectsTimestampDurationAndDestinationBoundaries(t *testing.T) 
 			require.Nil(t, result.State)
 		})
 	}
+}
+
+func TestAirborneAPIFallbackPersistsTypedDegradation(t *testing.T) {
+	reducer := testReducer(t)
+	api := 90 * time.Minute
+	observed := baselineNow.Add(-time.Minute)
+	input := airborneInput(observed, nil, &observed)
+	input.Timing.APIEstimatedFlightTime = &api
+	result := reducer.Reduce(input, nil)
+	require.Equal(t, StatusDegraded, result.Status)
+	require.Equal(t, ReasonFiledEETMissingAPIUsed, result.Reason)
+	require.Equal(t, aman.BaselineSourceAirborneAPIEstimatedFlightTime, result.Source)
+	require.NotNil(t, result.State.DegradationReason)
+	require.Equal(t, aman.BaselineDegradationFiledEETMissingAPIUsed, *result.State.DegradationReason)
+	require.NoError(t, result.State.Validate())
 }
 
 func TestFirstAirborneHoldsAcrossFreshReducerUntilExplicitReset(t *testing.T) {
@@ -116,6 +132,118 @@ func TestFirstSeenAirborneRequiresSuddenAppearancePolicy(t *testing.T) {
 	require.Nil(t, result.State)
 }
 
+func TestRouteAwareCannotBypassBaselineObservationGate(t *testing.T) {
+	reducer := testReducer(t)
+	filed := time.Hour
+	observed := baselineNow.Add(-time.Minute)
+	route := &RouteAwareEstimate{ArrivalAt: baselineNow.Add(20 * time.Minute), Confidence: aman.ConfidenceHigh}
+	prior := heldBaseline(t, reducer, observed, filed)
+
+	for _, test := range []struct {
+		name   string
+		input  Input
+		prior  *aman.BaselineState
+		status Status
+		reason Reason
+		source aman.BaselineSource
+	}{
+		{
+			name: "planned input remains planned", input: Input{Now: baselineNow, ExpectedDestination: "EKCH", Destination: "EKCH", Timing: Timing{EOBT: timePointer(baselineNow.Add(time.Hour)), FiledEET: &filed}, RouteAware: route},
+			status: StatusAvailable, reason: ReasonNone, source: aman.BaselineSourcePlannedEOBTFiledEET,
+		},
+		{
+			name: "normal first airborne remains filed baseline", input: Input{Now: baselineNow, ExpectedDestination: "EKCH", Destination: "EKCH", Timing: Timing{FiledEET: &filed}, RouteAware: route, Airborne: AirborneObservation{SensedAt: &observed, PreviouslyObserved: true}, FlightPlanObservedAt: &observed},
+			status: StatusAvailable, reason: ReasonNone, source: aman.BaselineSourceAirborneFiledEET,
+		},
+		{
+			name: "future airborne observation", input: routeInput(baselineNow.Add(time.Second), true, route),
+			status: StatusUnavailable, reason: ReasonObservationInFuture, source: aman.BaselineSourceNone,
+		},
+		{
+			name: "stale airborne observation", input: routeInput(baselineNow.Add(-3*time.Minute), true, route),
+			status: StatusUnavailable, reason: ReasonObservationTooOld, source: aman.BaselineSourceNone,
+		},
+		{
+			name: "sudden appearance", input: routeInput(observed, false, route),
+			status: StatusPolicyRequired, reason: ReasonSuddenAppearancePolicyRequired, source: aman.BaselineSourceNone,
+		},
+		{
+			name: "prior cannot cross destination", input: Input{Now: baselineNow, ExpectedDestination: "EKCH", Destination: "EKRN"}, prior: prior,
+			status: StatusUnavailable, reason: ReasonDestinationMismatch, source: aman.BaselineSourceNone,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result := reducer.Reduce(test.input, test.prior)
+			require.Equal(t, test.status, result.Status)
+			require.Equal(t, test.reason, result.Reason)
+			require.Equal(t, test.source, result.Source)
+		})
+	}
+}
+
+func TestDurationAndTimestampBoundsAreTypedAndCheckedBeforeArrivalArithmetic(t *testing.T) {
+	reducer, err := NewReducer(Config{MaxObservationAge: 2 * time.Minute, MaxFlightDuration: 2 * time.Hour, MaxArrivalHorizon: 3 * time.Hour})
+	require.NoError(t, err)
+	flightPlanObserved := baselineNow.Add(-time.Minute)
+	departure := baselineNow.Add(time.Hour)
+
+	for _, test := range []struct {
+		name   string
+		input  Input
+		reason Reason
+	}{
+		{"zero duration", plannedInput(Timing{EOBT: &departure, FiledEET: durationPointer(0)}), ReasonNegativeFlightDuration},
+		{"negative duration", plannedInput(Timing{EOBT: &departure, FiledEET: durationPointer(-time.Minute)}), ReasonNegativeFlightDuration},
+		{"maximum duration edge", plannedInput(Timing{EOBT: &departure, FiledEET: durationPointer(2 * time.Hour)}), ReasonArrivalBeyondHorizon},
+		{"over maximum duration", plannedInput(Timing{EOBT: &departure, FiledEET: durationPointer(2*time.Hour + time.Second)}), ReasonFlightDurationTooLong},
+		{"far future departure", plannedInput(Timing{EOBT: timePointer(baselineNow.Add(4 * time.Hour)), FiledEET: durationPointer(time.Hour)}), ReasonTimestampBeyondHorizon},
+		{"far future route result", resetRouteInput(baselineNow.Add(-time.Minute), &RouteAwareEstimate{ArrivalAt: baselineNow.Add(4 * time.Hour), Confidence: aman.ConfidenceHigh}), ReasonArrivalBeyondHorizon},
+		{"future flight plan observed", airborneInput(baselineNow.Add(-time.Minute), durationPointer(time.Hour), timePointer(baselineNow.Add(time.Second))), ReasonFlightPlanObservedInFuture},
+		{"reset without current airborne route", Input{Now: baselineNow, ExpectedDestination: "EKCH", Destination: "EKCH", ResetHeldAirborne: true, FlightPlanObservedAt: &flightPlanObserved}, ReasonUnstableReviewReset},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result := reducer.Reduce(test.input, nil)
+			if test.name == "maximum duration edge" {
+				require.Equal(t, StatusUnavailable, result.Status)
+			} else {
+				require.Equal(t, StatusUnavailable, result.Status)
+			}
+			require.Equal(t, test.reason, result.Reason)
+		})
+	}
+
+	// Exactly at the max duration remains valid when it is within the horizon.
+	withinHorizon, err := NewReducer(Config{MaxObservationAge: 2 * time.Minute, MaxFlightDuration: 2 * time.Hour, MaxArrivalHorizon: 4 * time.Hour})
+	require.NoError(t, err)
+	result := withinHorizon.Reduce(plannedInput(Timing{EOBT: &departure, FiledEET: durationPointer(2 * time.Hour)}), nil)
+	require.Equal(t, StatusAvailable, result.Status)
+}
+
+func TestBaselineStateDoesNotAliasInputOrPriorPointers(t *testing.T) {
+	reducer := testReducer(t)
+	filed := time.Hour
+	observed := baselineNow.Add(-time.Minute)
+	revision := uint64(4)
+	input := airborneInput(observed, &filed, timePointer(observed))
+	input.FlightPlanRevision = &revision
+	first := reducer.Reduce(input, nil)
+	require.NotNil(t, first.State)
+
+	revision = 9
+	require.Equal(t, uint64(4), *first.State.FlightPlanRevision)
+	degradation := aman.BaselineDegradationGreatCircleUsed
+	prior := *first.State
+	prior.DegradationReason = &degradation
+	prior.Source = aman.BaselineSourceAirborneGreatCircle
+	prior.SpeedDefaultsVersion = "speed-v1"
+	held := reducer.Reduce(Input{Now: baselineNow, ExpectedDestination: "EKCH", Destination: "EKCH"}, &prior)
+	require.NotNil(t, held.State)
+	*held.State.FlightPlanRevision = 12
+	*held.State.DegradationReason = aman.BaselineDegradationFiledEETMissingAPIUsed
+	require.Equal(t, uint64(4), *prior.FlightPlanRevision)
+	require.Equal(t, aman.BaselineDegradationGreatCircleUsed, *prior.DegradationReason)
+}
+
 func TestGreatCircleFallbackUsesVersionedCategorySpeedAndRouteAwareSupersedesIt(t *testing.T) {
 	reducer := testReducer(t)
 	flightPlanObserved := baselineNow.Add(-time.Minute)
@@ -129,15 +257,12 @@ func TestGreatCircleFallbackUsesVersionedCategorySpeedAndRouteAwareSupersedesIt(
 	fallback := reducer.Reduce(input, nil)
 	require.Equal(t, StatusDegraded, fallback.Status)
 	require.Equal(t, aman.BaselineSourceAirborneGreatCircle, fallback.Source)
-	require.Equal(t, ReasonMissingFlightDuration, fallback.Reason)
+	require.Equal(t, ReasonGreatCircleUsed, fallback.Reason)
 	require.Equal(t, "aircraft-category-speeds-v1", reducer.config.SpeedDefaults.Version)
 	require.NotNil(t, fallback.State)
 
 	input.RouteAware = &RouteAwareEstimate{ArrivalAt: baselineNow.Add(20 * time.Minute), Confidence: aman.ConfidenceHigh}
-	routeAware := reducer.Reduce(input, &aman.BaselineState{
-		ArrivalAt: fallback.State.ArrivalAt, AirborneSensedAt: fallback.State.AirborneSensedAt, Source: fallback.State.Source, Confidence: fallback.State.Confidence,
-		DegradationReason: fallback.State.DegradationReason, FlightPlanObservedAt: fallback.State.FlightPlanObservedAt, ModelVersion: fallback.State.ModelVersion, ConfigVersion: fallback.State.ConfigVersion,
-	})
+	routeAware := reducer.Reduce(input, fallback.State)
 	require.Equal(t, ReasonHeldFirstAirborneBaseline, routeAware.Reason, "a held first-airborne baseline is not silently replaced")
 
 	input.ResetHeldAirborne = true
@@ -150,10 +275,42 @@ func TestGreatCircleFallbackUsesVersionedCategorySpeedAndRouteAwareSupersedesIt(
 func TestGreatCircleAndAircraftCategoryDefaultsUseDocumentedUnits(t *testing.T) {
 	// One degree of latitude is about 60 NM. The calculation uses WGS84-style
 	// degrees at its boundary and returns nautical miles.
-	require.InDelta(t, 60.04, greatCircleDistanceNM(55, 12, 56, 12), 0.05)
+	distance := greatCircleDistanceNM(55, 12, 56, 12)
+	require.InDelta(t, 60.04, distance, 0.05)
+	defaults := SpeedDefaultsV1()
 	require.Equal(t, map[AircraftCategory]float64{
 		CategoryLight: 180, CategoryMedium: 420, CategoryHeavy: 440, CategorySuper: 460,
-	}, SpeedDefaultsV1().Knots)
+	}, defaults.Knots)
+
+	flightPlanObserved := baselineNow.Add(-time.Minute)
+	for category, speed := range defaults.Knots {
+		t.Run(string(category), func(t *testing.T) {
+			reducer := testReducer(t)
+			input := airborneInput(baselineNow.Add(-time.Minute), nil, &flightPlanObserved)
+			input.GreatCircle = &GreatCircleInput{LatitudeDegrees: 55, LongitudeDegrees: 12, DestinationLatitudeDegrees: 56, DestinationLongitudeDegrees: 12, AircraftCategory: category}
+			result := reducer.Reduce(input, nil)
+			require.Equal(t, StatusDegraded, result.Status)
+			require.Equal(t, ReasonGreatCircleUsed, result.Reason)
+			require.Equal(t, aman.BaselineSourceAirborneGreatCircle, result.Source)
+			expected := time.Duration(float64(time.Hour) * distance / speed)
+			require.InDelta(t, expected, result.State.ArrivalAt.Sub(*input.Airborne.SensedAt), float64(time.Second))
+			require.Equal(t, defaults.Version, result.State.SpeedDefaultsVersion)
+		})
+	}
+}
+
+func TestGreatCirclePersistsCustomSpeedDefaultVersion(t *testing.T) {
+	defaults := SpeedDefaultsV1()
+	defaults.Version = "aircraft-category-speeds-v2"
+	defaults.Knots[CategoryMedium] = 400
+	reducer, err := NewReducer(Config{MaxObservationAge: 2 * time.Minute, SpeedDefaults: defaults, ConfigVersion: "configuration-v2"})
+	require.NoError(t, err)
+	flightPlanObserved := baselineNow.Add(-time.Minute)
+	input := airborneInput(baselineNow.Add(-time.Minute), nil, &flightPlanObserved)
+	input.GreatCircle = &GreatCircleInput{LatitudeDegrees: 55, LongitudeDegrees: 12, DestinationLatitudeDegrees: 56, DestinationLongitudeDegrees: 12, AircraftCategory: CategoryMedium}
+	result := reducer.Reduce(input, nil)
+	require.Equal(t, "aircraft-category-speeds-v2", result.State.SpeedDefaultsVersion)
+	require.NoError(t, result.State.Validate())
 }
 
 func TestPredictorPackageDoesNotDependOnSourceOrEuroScopeAdapters(t *testing.T) {
@@ -185,6 +342,27 @@ func airborneInput(sensed time.Time, filed *time.Duration, flightPlanObserved *t
 		Airborne:             AirborneObservation{SensedAt: &sensed, PreviouslyObserved: true},
 		FlightPlanObservedAt: flightPlanObserved,
 	}
+}
+
+func routeInput(sensed time.Time, previouslyObserved bool, route *RouteAwareEstimate) Input {
+	return Input{
+		Now: baselineNow, ExpectedDestination: "EKCH", Destination: "EKCH", RouteAware: route,
+		Airborne: AirborneObservation{SensedAt: &sensed, PreviouslyObserved: previouslyObserved},
+	}
+}
+
+func resetRouteInput(sensed time.Time, route *RouteAwareEstimate) Input {
+	input := routeInput(sensed, true, route)
+	input.ResetHeldAirborne = true
+	return input
+}
+
+func heldBaseline(t *testing.T, reducer Reducer, sensed time.Time, filed time.Duration) *aman.BaselineState {
+	t.Helper()
+	observed := sensed
+	result := reducer.Reduce(airborneInput(sensed, &filed, &observed), nil)
+	require.NotNil(t, result.State)
+	return result.State
 }
 
 func timePointer(value time.Time) *time.Time             { return &value }

--- a/backend/internal/aman/types.go
+++ b/backend/internal/aman/types.go
@@ -122,6 +122,20 @@ func (s BaselineSource) Valid() bool {
 	}
 }
 
+// BaselineDegradationReason is persisted with a successful degraded baseline.
+// It is deliberately separate from transient unavailable reasons so corrupt
+// aggregate JSON cannot claim a successful fallback with arbitrary text.
+type BaselineDegradationReason string
+
+const (
+	BaselineDegradationFiledEETMissingAPIUsed BaselineDegradationReason = "filed_eet_missing_api_estimated_flight_time_used"
+	BaselineDegradationGreatCircleUsed        BaselineDegradationReason = "route_geometry_or_duration_unavailable_great_circle_used"
+)
+
+func (r BaselineDegradationReason) Valid() bool {
+	return r == BaselineDegradationFiledEETMissingAPIUsed || r == BaselineDegradationGreatCircleUsed
+}
+
 // FreezeReason is the only representation of an operational TETA/slot freeze.
 // A flight must not add a parallel state or locked boolean.
 type FreezeReason string
@@ -222,7 +236,8 @@ type BaselineState struct {
 	AirborneSensedAt     time.Time
 	Source               BaselineSource
 	Confidence           Confidence
-	DegradationReason    *string
+	DegradationReason    *BaselineDegradationReason
+	SpeedDefaultsVersion string
 	FlightPlanRevision   *uint64
 	FlightPlanObservedAt time.Time
 	ModelVersion         string
@@ -444,6 +459,9 @@ func (b BaselineState) Validate() error {
 	if err := requireUTCTime("baseline airborne sensed at", b.AirborneSensedAt); err != nil {
 		return err
 	}
+	if !b.ArrivalAt.After(b.AirborneSensedAt) {
+		return invalid("baseline arrival must be after airborne sensed at")
+	}
 	if err := requireUTCTime("baseline flight plan observed at", b.FlightPlanObservedAt); err != nil {
 		return err
 	}
@@ -452,6 +470,20 @@ func (b BaselineState) Validate() error {
 	}
 	if strings.TrimSpace(b.ModelVersion) == "" || strings.TrimSpace(b.ConfigVersion) == "" {
 		return invalid("baseline model and config versions are required")
+	}
+	switch b.Source {
+	case BaselineSourceAirborneFiledEET:
+		if b.DegradationReason != nil || b.SpeedDefaultsVersion != "" {
+			return invalid("filed airborne baseline must not claim degradation or speed defaults")
+		}
+	case BaselineSourceAirborneAPIEstimatedFlightTime:
+		if b.DegradationReason == nil || *b.DegradationReason != BaselineDegradationFiledEETMissingAPIUsed || b.SpeedDefaultsVersion != "" {
+			return invalid("API airborne baseline provenance is invalid")
+		}
+	case BaselineSourceAirborneGreatCircle:
+		if b.DegradationReason == nil || *b.DegradationReason != BaselineDegradationGreatCircleUsed || strings.TrimSpace(b.SpeedDefaultsVersion) == "" {
+			return invalid("great-circle airborne baseline provenance is invalid")
+		}
 	}
 	return nil
 }

--- a/backend/internal/aman/types.go
+++ b/backend/internal/aman/types.go
@@ -86,6 +86,42 @@ func (c Confidence) Valid() bool {
 	}
 }
 
+// BaselineSource identifies the deterministic input used before the
+// route-aware predictor can calculate a replacement raw prediction.
+//
+// The source is retained with a held first-airborne baseline so a restored
+// aggregate retains the exact provenance of its initial prediction.
+type BaselineSource string
+
+const (
+	BaselineSourceNone                                            BaselineSource = "none"
+	BaselineSourcePlannedEOBTFiledEET                             BaselineSource = "planned_eobt_filed_eet"
+	BaselineSourcePlannedEstimatedDepartureFiledEET               BaselineSource = "planned_estimated_departure_filed_eet"
+	BaselineSourcePlannedEOBTAPIEstimatedFlightTime               BaselineSource = "planned_eobt_api_estimated_flight_time"
+	BaselineSourcePlannedEstimatedDepartureAPIEstimatedFlightTime BaselineSource = "planned_estimated_departure_api_estimated_flight_time"
+	BaselineSourceAirborneFiledEET                                BaselineSource = "airborne_filed_eet"
+	BaselineSourceAirborneAPIEstimatedFlightTime                  BaselineSource = "airborne_api_estimated_flight_time"
+	BaselineSourceAirborneGreatCircle                             BaselineSource = "airborne_great_circle"
+	BaselineSourceRouteAware                                      BaselineSource = "route_aware"
+)
+
+func (s BaselineSource) Valid() bool {
+	switch s {
+	case BaselineSourceNone,
+		BaselineSourcePlannedEOBTFiledEET,
+		BaselineSourcePlannedEstimatedDepartureFiledEET,
+		BaselineSourcePlannedEOBTAPIEstimatedFlightTime,
+		BaselineSourcePlannedEstimatedDepartureAPIEstimatedFlightTime,
+		BaselineSourceAirborneFiledEET,
+		BaselineSourceAirborneAPIEstimatedFlightTime,
+		BaselineSourceAirborneGreatCircle,
+		BaselineSourceRouteAware:
+		return true
+	default:
+		return false
+	}
+}
+
 // FreezeReason is the only representation of an operational TETA/slot freeze.
 // A flight must not add a parallel state or locked boolean.
 type FreezeReason string
@@ -177,6 +213,22 @@ type Prediction struct {
 	Sources              []string
 }
 
+// BaselineState is the narrow persisted result of the first normal airborne
+// calculation. It is held unchanged until the owning state engine supplies an
+// explicit Unstable-review reset. The baseline predictor owns how this value
+// is created; the aggregate owns its persistence through StateCommit.
+type BaselineState struct {
+	ArrivalAt            time.Time
+	AirborneSensedAt     time.Time
+	Source               BaselineSource
+	Confidence           Confidence
+	DegradationReason    *string
+	FlightPlanRevision   *uint64
+	FlightPlanObservedAt time.Time
+	ModelVersion         string
+	ConfigVersion        string
+}
+
 // Slot is a committed sequencing result. It intentionally has no locked
 // field: freezes are represented exclusively by AMANFlight.FreezeReason.
 type Slot struct {
@@ -224,6 +276,7 @@ type AMANFlight struct {
 	State                 FlightState
 	DataStatus            DataStatus
 	Prediction            *Prediction
+	ArrivalBaseline       *BaselineState
 	SelectedRunwayGroup   *RunwayGroupID
 	SelectedFeeder        *string
 	SelectedHolding       *string
@@ -384,6 +437,31 @@ func (p Prediction) Validate() error {
 	return nil
 }
 
+func (b BaselineState) Validate() error {
+	if err := requireUTCTime("baseline arrival", b.ArrivalAt); err != nil {
+		return err
+	}
+	if err := requireUTCTime("baseline airborne sensed at", b.AirborneSensedAt); err != nil {
+		return err
+	}
+	if err := requireUTCTime("baseline flight plan observed at", b.FlightPlanObservedAt); err != nil {
+		return err
+	}
+	if !b.Source.Valid() || !b.Source.holdsAirborneBaseline() || !b.Confidence.Valid() {
+		return invalid("baseline provenance is invalid")
+	}
+	if strings.TrimSpace(b.ModelVersion) == "" || strings.TrimSpace(b.ConfigVersion) == "" {
+		return invalid("baseline model and config versions are required")
+	}
+	return nil
+}
+
+func (s BaselineSource) holdsAirborneBaseline() bool {
+	return s == BaselineSourceAirborneFiledEET ||
+		s == BaselineSourceAirborneAPIEstimatedFlightTime ||
+		s == BaselineSourceAirborneGreatCircle
+}
+
 func (f AMANFlight) Validate() error {
 	if strings.TrimSpace(string(f.ID)) == "" {
 		return invalid("flight ID is required")
@@ -396,6 +474,11 @@ func (f AMANFlight) Validate() error {
 	}
 	if f.Prediction != nil {
 		if err := f.Prediction.Validate(); err != nil {
+			return err
+		}
+	}
+	if f.ArrivalBaseline != nil {
+		if err := f.ArrivalBaseline.Validate(); err != nil {
 			return err
 		}
 	}

--- a/backend/internal/aman/types_test.go
+++ b/backend/internal/aman/types_test.go
@@ -47,6 +47,7 @@ func TestDomainTypesDoNotDeclareWireJSONTags(t *testing.T) {
 		reflect.TypeFor[FlightPlanFact](),
 		reflect.TypeFor[SurveillanceFact](),
 		reflect.TypeFor[Prediction](),
+		reflect.TypeFor[BaselineState](),
 		reflect.TypeFor[Slot](),
 		reflect.TypeFor[RouteFact](),
 		reflect.TypeFor[ETAReview](),

--- a/backend/internal/aman/types_test.go
+++ b/backend/internal/aman/types_test.go
@@ -99,6 +99,30 @@ func TestFlightFreezeHasOneCanonicalRepresentation(t *testing.T) {
 	}
 }
 
+func TestBaselineStateRejectsCorruptHeldProvenance(t *testing.T) {
+	now := time.Date(2026, time.July, 18, 12, 0, 0, 0, time.UTC)
+	baseline := BaselineState{
+		ArrivalAt: now.Add(time.Hour), AirborneSensedAt: now, Source: BaselineSourceAirborneGreatCircle,
+		Confidence: ConfidenceLow, FlightPlanObservedAt: now, ModelVersion: "baseline-v1", ConfigVersion: "config-v1",
+		SpeedDefaultsVersion: "speed-v1",
+	}
+	degradation := BaselineDegradationGreatCircleUsed
+	baseline.DegradationReason = &degradation
+	if err := baseline.Validate(); err != nil {
+		t.Fatalf("validate great-circle baseline: %v", err)
+	}
+
+	baseline.ArrivalAt = now
+	assertInvalidArgument(t, baseline.Validate())
+	baseline.ArrivalAt = now.Add(time.Hour)
+	baseline.Source = BaselineSourcePlannedEOBTFiledEET
+	assertInvalidArgument(t, baseline.Validate())
+	baseline.Source = BaselineSourceAirborneGreatCircle
+	invalidDegradation := BaselineDegradationReason("unknown")
+	baseline.DegradationReason = &invalidDegradation
+	assertInvalidArgument(t, baseline.Validate())
+}
+
 func TestFlightCallsignCorrectionKeepsFlightIDAndVATSIMCID(t *testing.T) {
 	now := time.Date(2026, time.July, 18, 12, 0, 0, 0, time.UTC)
 	flight := validFlight(now)

--- a/backend/internal/repository/postgres/aman_test.go
+++ b/backend/internal/repository/postgres/aman_test.go
@@ -108,10 +108,12 @@ func TestAMANRepositoryRestoresHeldAirborneBaselineForFreshPredictor(t *testing.
 	require.NoError(t, err)
 	require.Equal(t, first.State, restored.Flights[0].ArrivalBaseline)
 
-	// A fresh reducer receives the stored baseline and preserves it instead of
-	// recalculating from a changed source duration after restart.
+	// A newly constructed reducer receives the stored baseline and preserves it
+	// instead of recalculating from a changed source duration after restart.
+	freshReducer, err := predictor.NewReducer(predictor.Config{MaxObservationAge: 2 * time.Minute})
+	require.NoError(t, err)
 	changedEET := 3 * time.Hour
-	held := reducer.Reduce(predictor.Input{
+	held := freshReducer.Reduce(predictor.Input{
 		Now: amanTestTime.Add(time.Minute), ExpectedDestination: "EKCH", Destination: "EKCH",
 		Timing:               predictor.Timing{FiledEET: &changedEET},
 		Airborne:             predictor.AirborneObservation{SensedAt: &amanTestTime, PreviouslyObserved: true},

--- a/backend/internal/repository/postgres/aman_test.go
+++ b/backend/internal/repository/postgres/aman_test.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"FlightStrips/internal/aman"
+	"FlightStrips/internal/aman/predictor"
 	"FlightStrips/internal/pdc/testdata"
 	"context"
 	"errors"
@@ -82,6 +83,42 @@ func TestAMANRepositoryRoundTripIdempotencyAndRollback(t *testing.T) {
 	loaded, err = repo.LoadAirportState(ctx, first.Airport)
 	require.NoError(t, err)
 	require.Equal(t, corrected, loaded, "a failed transaction must leave the complete prior aggregate")
+}
+
+func TestAMANRepositoryRestoresHeldAirborneBaselineForFreshPredictor(t *testing.T) {
+	pool, _ := testdata.SetupTestDB(t)
+	ctx := context.Background()
+	reducer, err := predictor.NewReducer(predictor.Config{MaxObservationAge: 2 * time.Minute})
+	require.NoError(t, err)
+	filedEET := 90 * time.Minute
+	flightPlanObserved := amanTestTime.Add(-time.Minute)
+	first := reducer.Reduce(predictor.Input{
+		Now: amanTestTime, ExpectedDestination: "EKCH", Destination: "EKCH",
+		Timing:               predictor.Timing{FiledEET: &filedEET},
+		Airborne:             predictor.AirborneObservation{SensedAt: &flightPlanObserved, PreviouslyObserved: true},
+		FlightPlanObservedAt: &flightPlanObserved,
+	}, nil)
+	require.NotNil(t, first.State)
+
+	state := amanState(1, "CID-1", "SAS123")
+	state.Flights[0].ArrivalBaseline = first.State
+	_, err = NewAMANRepository(pool).Commit(ctx, aman.StateCommit{ExpectedRevision: 0, State: state})
+	require.NoError(t, err)
+	restored, err := NewAMANRepository(pool).LoadAirportState(ctx, state.Airport)
+	require.NoError(t, err)
+	require.Equal(t, first.State, restored.Flights[0].ArrivalBaseline)
+
+	// A fresh reducer receives the stored baseline and preserves it instead of
+	// recalculating from a changed source duration after restart.
+	changedEET := 3 * time.Hour
+	held := reducer.Reduce(predictor.Input{
+		Now: amanTestTime.Add(time.Minute), ExpectedDestination: "EKCH", Destination: "EKCH",
+		Timing:               predictor.Timing{FiledEET: &changedEET},
+		Airborne:             predictor.AirborneObservation{SensedAt: &amanTestTime, PreviouslyObserved: true},
+		FlightPlanObservedAt: &flightPlanObserved,
+	}, restored.Flights[0].ArrivalBaseline)
+	require.Equal(t, predictor.ReasonHeldFirstAirborneBaseline, held.Reason)
+	require.Equal(t, first.State, held.State)
 }
 
 func TestAMANRepositoryCompareAndSwapAllocatesOneRevision(t *testing.T) {

--- a/backend/internal/vatsim/aman_baseline.go
+++ b/backend/internal/vatsim/aman_baseline.go
@@ -1,0 +1,25 @@
+package vatsim
+
+import (
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/aman/predictor"
+	"time"
+)
+
+// AMANBaselineInput maps only the normalized AMAN facts the VATSIM boundary
+// actually has. In particular VATSIM supplies its service-day EOBT and filed
+// EET; it does not manufacture an API estimated flight time or route geometry.
+// TakeoffDetected is produced by the existing VATSIM movement classifier.
+func AMANBaselineInput(now time.Time, expectedDestination string, observation aman.FlightObservation, previouslyObserved, resetHeldAirborne bool) predictor.Input {
+	input := predictor.Input{
+		Now: now, ExpectedDestination: expectedDestination, Destination: observation.Destination,
+		Airborne:           predictor.AirborneObservation{SensedAt: observation.TakeoffDetected, PreviouslyObserved: previouslyObserved},
+		FlightPlanRevision: observation.FlightPlan.Revision, FlightPlanObservedAt: observation.FlightPlan.ObservedAt,
+		ResetHeldAirborne: resetHeldAirborne,
+	}
+	if observation.PlannedTiming != nil {
+		input.Timing.EOBT = observation.PlannedTiming.EstimatedOffBlockTime
+		input.Timing.FiledEET = observation.PlannedTiming.EstimatedEnrouteTime
+	}
+	return input
+}

--- a/backend/internal/vatsim/aman_baseline_test.go
+++ b/backend/internal/vatsim/aman_baseline_test.go
@@ -1,0 +1,28 @@
+package vatsim
+
+import (
+	"FlightStrips/internal/aman"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAMANBaselineInputUsesNormalizedFactsAndExistingTakeoffDetection(t *testing.T) {
+	now := time.Date(2026, time.July, 18, 12, 0, 0, 0, time.UTC)
+	eobt := now.Add(time.Hour)
+	eet := 90 * time.Minute
+	observation := aman.FlightObservation{
+		Destination: "EKCH", TakeoffDetected: &now,
+		PlannedTiming: &aman.PlannedTiming{EstimatedOffBlockTime: &eobt, EstimatedEnrouteTime: &eet},
+		FlightPlan:    aman.FlightPlanFact{ObservedAt: &now},
+	}
+
+	input := AMANBaselineInput(now, "EKCH", observation, true, false)
+	require.Equal(t, eobt, *input.Timing.EOBT)
+	require.Equal(t, eet, *input.Timing.FiledEET)
+	require.Equal(t, now, *input.Airborne.SensedAt)
+	require.True(t, input.Airborne.PreviouslyObserved)
+	require.Nil(t, input.Timing.APIEstimatedFlightTime, "VATSIM does not manufacture an API estimate")
+	require.Nil(t, input.GreatCircle, "coordinates/route geometry are not part of this source adapter")
+}


### PR DESCRIPTION
## Summary

Implements #315's deterministic planned and first-airborne AMAN baseline reducer, including review hardening.

- Planned precedence is EOBT + 15 minute EXOT before estimated departure, and filed EET before API estimated flight time.
- A normal first airborne observation always creates and holds `airborne_sensed_at + filed EET`; merely supplying a route-aware value cannot bypass that baseline. Route-aware output is accepted only after an explicit Unstable-review reset and a current valid, previously observed airborne fact.
- First-seen airborne flights return `sudden_appearance_policy_required` for #320. Invalid/missing, stale, future, mismatched, over-duration, and beyond-horizon values return typed unavailable/degraded outcomes without zero timestamps.
- Successful fallback reasons are explicit and persisted: `filed_eet_missing_api_estimated_flight_time_used` and `route_geometry_or_duration_unavailable_great_circle_used`.

## Boundaries and persistence

The pure predictor has no VATSIM DTO, EuroScope, persistence, or navigation-source dependency. The VATSIM boundary maps only existing normalized facts (`TakeoffDetected`, service-day EOBT, filed EET) and does not invent API estimates or geometry.

`ArrivalBaseline` uses the existing #306 aggregate JSON `StateCommit` seam; no table or store was added. Held state validates source/degradation combinations, preserves copied input pointers, requires an arrival after sensed airborne time, and records `SpeedDefaults.Version` for great-circle provenance. Default configurable bounds are a 24-hour flight duration and a 36-hour arrival horizon.

State-engine/ObservationSink wiring and the operational TETA projection remain intentionally out of scope.

## Validation

- `go test ./...` from `backend`
- `go test -race ./internal/aman ./internal/aman/predictor ./internal/vatsim ./internal/repository/postgres`
- Precedence, gate bypass, timestamp/duration bounds, pointer aliasing, known-distance/category, custom speed-version, no-EuroScope package direction, VATSIM boundary, and Postgres fresh-reducer restore tests.

## Stack

Base: `codex/aman-312-cycle-activation` at `fc9b5c654e8323ddca10053a24d7067a17100378`.

Closes #315