### PR TITLE
feat(aman): calculate route trajectory and DTG

### DIFF
--- a/backend/internal/aman/navdata/persistence.go
+++ b/backend/internal/aman/navdata/persistence.go
@@ -198,6 +198,29 @@ type ActiveManifestReader interface {
 	ActiveManifest(context.Context, AirportID) (ActiveManifest, error)
 }
 
+// GeometrySnapshotReader is the cache-only, manifest-consistent reference
+// read used by route projection.  Unlike GeometryReader it deliberately
+// returns the complete immutable reference set needed to turn canonical FixID
+// references into WGS84 geometry.  It is not an acquisition interface.
+type GeometrySnapshotReader interface {
+	ActiveGeometrySnapshot(context.Context, AirportID) (ActiveGeometrySnapshot, error)
+}
+
+// ActiveGeometrySnapshot is one exact active manifest.  Every value is drawn
+// from the fragment digests named by Manifest; callers must treat it as
+// immutable.  Holding definitions include published procedure definitions and
+// terminal/AIP overlay definitions after conflict validation.
+type ActiveGeometrySnapshot struct {
+	Manifest         ManifestCandidate
+	ManifestRevision int64
+	Airport          Airport
+	Runways          []Runway
+	Fixes            []Fix
+	Procedures       []Procedure
+	TerminalPaths    []TerminalPath
+	Holdings         []HoldingPattern
+}
+
 type ActiveManifest struct {
 	Candidate  ManifestCandidate
 	Revision   int64

--- a/backend/internal/aman/trajectory/trajectory.go
+++ b/backend/internal/aman/trajectory/trajectory.go
@@ -1,0 +1,528 @@
+// Package trajectory projects observations onto canonical cache-backed AMAN
+// geometry. It owns no source acquisition and has no EuroScope dependency.
+package trajectory
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"slices"
+	"strings"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/aman/navdata"
+)
+
+const (
+	defaultMaxCrossTrackNM = 12.0
+	defaultJitterNM        = 0.25
+	defaultForwardSearchNM = 50.0
+)
+
+type Completeness string
+
+const (
+	Complete      Completeness = "complete"
+	Partial       Completeness = "partial"
+	OffRoute      Completeness = "off_route"
+	Unresolved    Completeness = "unresolved"
+	StalePosition Completeness = "stale_position"
+)
+
+type Config struct {
+	MaxCrossTrackNM, JitterToleranceNM, MaxForwardSearchNM float64
+	ReferenceTime                                          time.Time
+	MaxObservationAge                                      time.Duration
+}
+
+func (c Config) normalized() Config {
+	if c.MaxCrossTrackNM <= 0 {
+		c.MaxCrossTrackNM = defaultMaxCrossTrackNM
+	}
+	if c.JitterToleranceNM <= 0 {
+		c.JitterToleranceNM = defaultJitterNM
+	}
+	if c.MaxForwardSearchNM <= 0 {
+		c.MaxForwardSearchNM = defaultForwardSearchNM
+	}
+	return c
+}
+
+// Input selects already-materialized geometry. Approach and missed approach
+// are explicit: projection never guesses them from a runway or route string.
+type Input struct {
+	Airport            navdata.AirportID
+	RouteKey           navdata.RouteKey
+	Feeder             navdata.FeederID
+	RunwayGroup        aman.RunwayGroupID
+	Approach           *navdata.ProcedureID
+	MissedApproach     *navdata.ProcedureID
+	FlightPlanRevision uint64
+	Observation        aman.SurveillanceFact
+	RouteFact          *aman.RouteFact
+	Prior              *aman.RouteProgress
+}
+
+type RemainingLeg struct {
+	ID         string
+	From, To   navdata.FixID
+	DistanceNM float64
+}
+type Result struct {
+	Remaining       []RemainingLeg
+	AlongTrackNM    float64
+	CrossTrackNM    float64
+	DistanceToGoNM  *float64
+	Completeness    Completeness
+	Reasons         []string
+	GeometryDigest  string
+	SelectedHolding *navdata.HoldingPattern
+	Progress        *aman.RouteProgress
+}
+
+type Readers struct {
+	Geometry navdata.GeometryReader
+	Snapshot navdata.GeometrySnapshotReader
+}
+
+// Project performs only cache reads then delegates to the deterministic reducer.
+func Project(ctx context.Context, readers Readers, input Input, config Config) (Result, error) {
+	if readers.Geometry == nil || readers.Snapshot == nil {
+		return Result{}, fmt.Errorf("trajectory requires cache-only geometry and snapshot readers")
+	}
+	route, err := readers.Geometry.Route(ctx, input.RouteKey)
+	if err != nil {
+		return Result{}, err
+	}
+	snapshot, err := readers.Snapshot.ActiveGeometrySnapshot(ctx, input.Airport)
+	if err != nil {
+		return Result{}, err
+	}
+	return Reduce(snapshot, route, input, config), nil
+}
+
+// Reduce is pure: callers can persist Result.Progress with their aggregate
+// commit, and a restart receives the same compatibility/reset behavior.
+func Reduce(snapshot navdata.ActiveGeometrySnapshot, route navdata.RouteGeometry, input Input, config Config) Result {
+	config = config.normalized()
+	result := Result{GeometryDigest: route.Digest}
+	if !route.Version.Equal(snapshot.Manifest.Version) {
+		return unresolved(result, "DATASET_VERSION_MISMATCH")
+	}
+	if input.Observation.ObservedAt == nil || (config.MaxObservationAge > 0 && !config.ReferenceTime.IsZero() && input.Observation.ObservedAt.Before(config.ReferenceTime.Add(-config.MaxObservationAge))) {
+		result.Completeness, result.Reasons = StalePosition, []string{"STALE_POSITION"}
+		return result
+	}
+	if !finite(input.Observation.LatitudeDegrees) || !finite(input.Observation.LongitudeDegrees) || input.Observation.LatitudeDegrees < -90 || input.Observation.LatitudeDegrees > 90 || input.Observation.LongitudeDegrees < -180 || input.Observation.LongitudeDegrees > 180 {
+		return unresolved(result, "INVALID_POSITION")
+	}
+	fixes := make(map[navdata.FixID]navdata.Fix, len(snapshot.Fixes))
+	for _, fix := range snapshot.Fixes {
+		fixes[fix.ID] = fix
+	}
+	baseCompatible := baseCompatible(input.Prior, route.Digest, snapshot, input)
+	legs, reasons, holding, directRejoin := compose(snapshot, route, input, fixes, baseCompatible)
+	if len(legs) == 0 {
+		result.Reasons = reasons
+		if len(reasons) == 0 {
+			result.Reasons = []string{"NO_USABLE_GEOMETRY"}
+		}
+		result.Completeness = Unresolved
+		return result
+	}
+	compatible := compatible(input.Prior, route.Digest, snapshot, input)
+	start := 0
+	if compatible {
+		start = min(input.Prior.LegIndex, len(legs)-1)
+	}
+	obs := coordinate(input.Observation.LatitudeDegrees, input.Observation.LongitudeDegrees)
+	best, ok, progressOutOfRange := projectForward(obs, legs, start, config.MaxCrossTrackNM, config.MaxForwardSearchNM, config.JitterToleranceNM, input.Prior, compatible)
+	if !ok {
+		if progressOutOfRange && best.cross <= config.MaxCrossTrackNM {
+			result.Completeness, result.Reasons, result.CrossTrackNM = Partial, append(reasons, "FORWARD_PROGRESS_OUT_OF_RANGE"), best.cross
+			return result
+		}
+		result.Completeness, result.Reasons, result.CrossTrackNM = OffRoute, append(reasons, "OFF_ROUTE"), best.cross
+		return result
+	}
+	progress := best.before + best.along
+	if compatible && progress < input.Prior.AlongTrackNM {
+		observedCross := best.cross
+		progress = input.Prior.AlongTrackNM
+		best = projectionAt(legs, progress)
+		best.cross = observedCross
+	}
+	result.AlongTrackNM, result.CrossTrackNM, result.SelectedHolding = progress, best.cross, holding
+	dtg := remainingDistance(legs, progress)
+	result.DistanceToGoNM = &dtg
+	result.Remaining = remaining(legs, best.index, best.along)
+	if len(reasons) == 0 && route.Coverage == navdata.CoverageComplete {
+		result.Completeness = Complete
+	} else {
+		result.Completeness = Partial
+	}
+	result.Reasons = reasons
+	routeFactID := ""
+	if activeRouteFact(input.RouteFact) {
+		routeFactID = input.RouteFact.ID
+	}
+	rejoin := best.index
+	if activeRouteFact(input.RouteFact) && directRejoin >= 0 {
+		rejoin = directRejoin
+	}
+	result.Progress = &aman.RouteProgress{GeometryDigest: route.Digest, ManifestRevision: snapshot.ManifestRevision, TerminalDigest: snapshot.Manifest.TerminalDigest, FlightPlanRevision: input.FlightPlanRevision, RouteFactID: routeFactID, RunwayGroupID: input.RunwayGroup, LegIndex: best.index, RejoinLegIndex: rejoin, AlongTrackNM: progress}
+	return result
+}
+
+type leg struct {
+	id       string
+	from, to navdata.FixID
+	a, b     navdata.Coordinate
+	distance float64
+}
+
+func compose(snapshot navdata.ActiveGeometrySnapshot, route navdata.RouteGeometry, input Input, fixes map[navdata.FixID]navdata.Fix, baseCompatible bool) ([]leg, []string, *navdata.HoldingPattern, int) {
+	var all []navdata.ProcedureLeg
+	all = append(all, route.Legs...)
+	var terminal *navdata.TerminalPath
+	for i := range snapshot.TerminalPaths {
+		p := &snapshot.TerminalPaths[i]
+		if p.Feeder == input.Feeder && p.RunwayGroup == input.RunwayGroup {
+			terminal = p
+			all = append(all, p.Legs...)
+			break
+		}
+	}
+	reasons := slices.Clone(route.Unresolved)
+	if terminal == nil {
+		reasons = append(reasons, "TERMINAL_PATH_UNRESOLVED")
+	} else {
+		reasons = append(reasons, terminal.Unresolved...)
+	}
+	procedure := func(id *navdata.ProcedureID, label string) {
+		if id == nil {
+			if label == "APPROACH" {
+				reasons = append(reasons, "APPROACH_NOT_SELECTED")
+			}
+			return
+		}
+		for _, p := range snapshot.Procedures {
+			if p.ID == *id {
+				all = append(all, p.Legs...)
+				return
+			}
+		}
+		reasons = append(reasons, label+"_UNRESOLVED:"+string(*id))
+	}
+	procedure(input.Approach, "APPROACH")
+	procedure(input.MissedApproach, "MISSED_APPROACH")
+	holdings := map[navdata.HoldingID]navdata.HoldingPattern{}
+	for _, h := range snapshot.Holdings {
+		holdings[h.ID] = h
+	}
+	var selected *navdata.HoldingPattern
+	if terminal != nil {
+		for _, id := range terminal.HoldingIDs {
+			if h, ok := holdings[id]; ok {
+				copy := h
+				selected = &copy
+				break
+			}
+		}
+	}
+	var out []leg
+	var last navdata.FixID
+	for _, value := range all {
+		if value.PathTerminator.IsHolding() {
+			if value.HoldingID != nil && selected == nil {
+				if h, ok := holdings[*value.HoldingID]; ok {
+					copy := h
+					selected = &copy
+				}
+			}
+			continue
+		}
+		if value.PathTerminator == navdata.PathVA || value.PathTerminator == navdata.PathVM || value.PathTerminator == navdata.PathVI || value.PathTerminator == navdata.PathUnsupported {
+			reasons = append(reasons, "UNSUPPORTED_LEG:"+value.ID+":"+string(value.PathTerminator))
+			last = "" // never bridge an unsupported/vector gap implicitly.
+			continue
+		}
+		from := last
+		if value.FromFix != nil {
+			from = *value.FromFix
+		}
+		to := navdata.FixID("")
+		if value.ToFix != nil {
+			to = *value.ToFix
+		}
+		if from == "" || to == "" {
+			reasons = append(reasons, "UNRESOLVED_LEG:"+value.ID+":MISSING_FIX")
+			if to != "" {
+				last = to
+			}
+			continue
+		}
+		f, fok := fixes[from]
+		t, tok := fixes[to]
+		if !fok || !tok {
+			reasons = append(reasons, "UNRESOLVED_LEG:"+value.ID+":FIX_NOT_IN_MANIFEST")
+			last = to
+			continue
+		}
+		d := wgs84NM(f.Position, t.Position)
+		out = append(out, leg{id: value.ID, from: from, to: to, a: f.Position, b: t.Position, distance: d})
+		last = to
+	}
+	if activeRouteFact(input.RouteFact) {
+		target := navdata.FixID(input.RouteFact.Fix)
+		targetFix, ok := fixes[target]
+		if !ok {
+			return out, append(reasons, "DIRECT_TO_TARGET_UNRESOLVED:"+input.RouteFact.Fix), selected, -1
+		}
+		rejoin := -1
+		floor := 0
+		if baseCompatible && input.Prior != nil {
+			floor = input.Prior.RejoinLegIndex
+		}
+		for i := floor; i < len(out); i++ {
+			if out[i].to == target {
+				rejoin = i
+				break
+			}
+		}
+		if rejoin < 0 {
+			return out, append(reasons, "DIRECT_TO_TARGET_NOT_ON_FORWARD_PATH:"+input.RouteFact.Fix), selected, -1
+		}
+		current := coordinate(input.Observation.LatitudeDegrees, input.Observation.LongitudeDegrees)
+		direct := leg{id: "DIRECT_TO:" + string(target), from: "", to: target, a: current, b: targetFix.Position, distance: wgs84NM(current, targetFix.Position)}
+		out = append([]leg{direct}, out[rejoin+1:]...)
+		return out, dedupe(reasons), selected, rejoin
+	}
+	return out, dedupe(reasons), selected, -1
+}
+
+func compatible(p *aman.RouteProgress, digest string, snapshot navdata.ActiveGeometrySnapshot, in Input) bool {
+	if !baseCompatible(p, digest, snapshot, in) {
+		return false
+	}
+	id := ""
+	if activeRouteFact(in.RouteFact) {
+		id = in.RouteFact.ID
+	}
+	return p.RouteFactID == id
+}
+func baseCompatible(p *aman.RouteProgress, digest string, snapshot navdata.ActiveGeometrySnapshot, in Input) bool {
+	if p == nil {
+		return false
+	}
+	return p.GeometryDigest == digest && p.ManifestRevision == snapshot.ManifestRevision && p.TerminalDigest == snapshot.Manifest.TerminalDigest && p.FlightPlanRevision == in.FlightPlanRevision && p.RunwayGroupID == in.RunwayGroup
+}
+
+type projected struct {
+	index                int
+	along, before, cross float64
+}
+
+func projectForward(p navdata.Coordinate, legs []leg, start int, maxCross, maxForward, jitter float64, prior *aman.RouteProgress, compatible bool) (projected, bool, bool) {
+	best, nearest, geometryNearest := projected{}, projected{}, projected{}
+	found, nearestFound, geometryFound := false, false, false
+	before := 0.0
+	minProgress, maxProgress := 0.0, math.Inf(1)
+	if compatible {
+		minProgress = math.Max(0, prior.AlongTrackNM-jitter)
+		maxProgress = prior.AlongTrackNM + maxForward
+	}
+	for i, value := range legs {
+		if i < start {
+			before += value.distance
+			continue
+		}
+		frac, cross := geodesicProject(p, value.a, value.b, value.distance)
+		candidate := before + frac*value.distance
+		candidateProjection := projected{i, frac * value.distance, before, cross}
+		if !geometryFound || cross < geometryNearest.cross || (cross == geometryNearest.cross && i < geometryNearest.index) {
+			geometryNearest, geometryFound = candidateProjection, true
+		}
+		if candidate >= minProgress && candidate <= maxProgress {
+			if !nearestFound || cross < nearest.cross || (cross == nearest.cross && i < nearest.index) {
+				nearest, nearestFound = candidateProjection, true
+			}
+			if cross <= maxCross && (!found || (!compatible && i < best.index) || (compatible && (cross < best.cross || (cross == best.cross && i < best.index)))) {
+				best, found = candidateProjection, true
+			}
+		}
+		before += value.distance
+	}
+	if found {
+		return best, true, false
+	}
+	if nearestFound {
+		return nearest, false, false
+	}
+	return geometryNearest, false, geometryFound
+}
+func activeRouteFact(value *aman.RouteFact) bool {
+	return value != nil && (value.State == "" || value.State == aman.RouteFactActive)
+}
+func finite(value float64) bool { return !math.IsNaN(value) && !math.IsInf(value, 0) }
+func projectionAt(legs []leg, distance float64) projected {
+	before := 0.0
+	for i, v := range legs {
+		if distance <= before+v.distance {
+			return projected{i, distance - before, before, 0}
+		}
+		before += v.distance
+	}
+	return projected{len(legs) - 1, legs[len(legs)-1].distance, before - legs[len(legs)-1].distance, 0}
+}
+func remainingDistance(legs []leg, progress float64) float64 {
+	total := 0.0
+	for _, l := range legs {
+		total += l.distance
+	}
+	return math.Max(0, total-progress)
+}
+func remaining(legs []leg, index int, along float64) []RemainingLeg {
+	out := make([]RemainingLeg, 0, len(legs)-index)
+	for i := index; i < len(legs); i++ {
+		d := legs[i].distance
+		if i == index {
+			d -= along
+		}
+		out = append(out, RemainingLeg{legs[i].id, legs[i].from, legs[i].to, math.Max(0, d)})
+	}
+	return out
+}
+func unresolved(r Result, reason string) Result {
+	r.Completeness = rUnresolved(reason)
+	r.Reasons = []string{reason}
+	return r
+}
+func rUnresolved(_ string) Completeness { return Unresolved }
+func coordinate(lat, lon float64) navdata.Coordinate {
+	return navdata.Coordinate{LatitudeDeg: lat, LongitudeDeg: lon}
+}
+func dedupe(in []string) []string {
+	out := make([]string, 0, len(in))
+	seen := map[string]bool{}
+	for _, v := range in {
+		v = strings.TrimSpace(v)
+		if v != "" && !seen[v] {
+			seen[v] = true
+			out = append(out, v)
+		}
+	}
+	return out
+}
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// wgs84Inverse is Vincenty's inverse solution on WGS84. Accumulated DTG and
+// every partial leg use this geodesic distance rather than a planar estimate.
+func wgs84Inverse(a, b navdata.Coordinate) (float64, float64) {
+	const aa = 6378137.0
+	const f = 1 / 298.257223563
+	const nm = 1852.0
+	phi1, phi2 := a.LatitudeDeg*math.Pi/180, b.LatitudeDeg*math.Pi/180
+	l := (b.LongitudeDeg - a.LongitudeDeg) * math.Pi / 180
+	u1, u2 := math.Atan((1-f)*math.Tan(phi1)), math.Atan((1-f)*math.Tan(phi2))
+	su1, cu1, su2, cu2 := math.Sin(u1), math.Cos(u1), math.Sin(u2), math.Cos(u2)
+	lambda := l
+	var sigma, ss, cs, sa, c2a, cm float64
+	for i := 0; i < 100; i++ {
+		sl, cl := math.Sin(lambda), math.Cos(lambda)
+		ss = math.Hypot(cu2*sl, cu1*su2-su1*cu2*cl)
+		if ss == 0 {
+			return 0, 0
+		}
+		cs = su1*su2 + cu1*cu2*cl
+		sigma = math.Atan2(ss, cs)
+		sa = cu1 * cu2 * sl / ss
+		c2a = 1 - sa*sa
+		if c2a == 0 {
+			cm = 0
+		} else {
+			cm = cs - 2*su1*su2/c2a
+		}
+		c := f / 16 * c2a * (4 + f*(4-3*c2a))
+		next := l + (1-c)*f*sa*(sigma+c*ss*(cm+c*cs*(-1+2*cm*cm)))
+		if math.Abs(next-lambda) < 1e-12 {
+			lambda = next
+			break
+		}
+		lambda = next
+	}
+	u2v := c2a * (aa*aa - (aa*(1-f))*(aa*(1-f))) / ((aa * (1 - f)) * (aa * (1 - f)))
+	A := 1 + u2v/16384*(4096+u2v*(-768+u2v*(320-175*u2v)))
+	B := u2v / 1024 * (256 + u2v*(-128+u2v*(74-47*u2v)))
+	delta := B * ss * (cm + B/4*(cs*(-1+2*cm*cm)-B/6*cm*(-3+4*ss*ss)*(-3+4*cm*cm)))
+	distance := (aa * (1 - f) * A * (sigma - delta)) / nm
+	bearing := math.Atan2(cu2*math.Sin(lambda), cu1*su2-su1*cu2*math.Cos(lambda))
+	return distance, math.Mod(bearing+2*math.Pi, 2*math.Pi)
+}
+func wgs84NM(a, b navdata.Coordinate) float64 { distance, _ := wgs84Inverse(a, b); return distance }
+
+// geodesicProject finds the closest point on the WGS84 geodesic with a bounded
+// ternary search. The result is deterministic and handles long route legs;
+// no longitude/latitude planar fraction is used.
+func geodesicProject(p, a, b navdata.Coordinate, totalNM float64) (float64, float64) {
+	if totalNM == 0 {
+		return 0, wgs84NM(p, a)
+	}
+	_, initialBearing := wgs84Inverse(a, b)
+	lo, hi := 0.0, 1.0
+	for range 48 {
+		left, right := (2*lo+hi)/3, (lo+2*hi)/3
+		if wgs84NM(p, wgs84Direct(a, initialBearing, totalNM*left)) <= wgs84NM(p, wgs84Direct(a, initialBearing, totalNM*right)) {
+			hi = right
+		} else {
+			lo = left
+		}
+	}
+	fraction := (lo + hi) / 2
+	return fraction, wgs84NM(p, wgs84Direct(a, initialBearing, totalNM*fraction))
+}
+
+func wgs84Direct(start navdata.Coordinate, bearing, distanceNM float64) navdata.Coordinate {
+	const aa = 6378137.0
+	const f = 1 / 298.257223563
+	const nm = 1852.0
+	b := aa * (1 - f)
+	alpha1 := bearing
+	sinAlpha1, cosAlpha1 := math.Sin(alpha1), math.Cos(alpha1)
+	phi1 := start.LatitudeDeg * math.Pi / 180
+	tanU1 := (1 - f) * math.Tan(phi1)
+	cosU1 := 1 / math.Sqrt(1+tanU1*tanU1)
+	sinU1 := tanU1 * cosU1
+	sigma1 := math.Atan2(tanU1, cosAlpha1)
+	sinAlpha := cosU1 * sinAlpha1
+	cosSqAlpha := 1 - sinAlpha*sinAlpha
+	uSq := cosSqAlpha * (aa*aa - b*b) / (b * b)
+	A := 1 + uSq/16384*(4096+uSq*(-768+uSq*(320-175*uSq)))
+	B := uSq / 1024 * (256 + uSq*(-128+uSq*(74-47*uSq)))
+	sigma := distanceNM * nm / (b * A)
+	var cos2SigmaM, sinSigma, cosSigma float64
+	for range 100 {
+		cos2SigmaM = math.Cos(2*sigma1 + sigma)
+		sinSigma = math.Sin(sigma)
+		cosSigma = math.Cos(sigma)
+		delta := B * sinSigma * (cos2SigmaM + B/4*(cosSigma*(-1+2*cos2SigmaM*cos2SigmaM)-B/6*cos2SigmaM*(-3+4*sinSigma*sinSigma)*(-3+4*cos2SigmaM*cos2SigmaM)))
+		next := distanceNM*nm/(b*A) + delta
+		if math.Abs(next-sigma) < 1e-12 {
+			sigma = next
+			break
+		}
+		sigma = next
+	}
+	tmp := sinU1*sinSigma - cosU1*cosSigma*cosAlpha1
+	phi2 := math.Atan2(sinU1*cosSigma+cosU1*sinSigma*cosAlpha1, (1-f)*math.Sqrt(sinAlpha*sinAlpha+tmp*tmp))
+	lambda := math.Atan2(sinSigma*sinAlpha1, cosU1*cosSigma-sinU1*sinSigma*cosAlpha1)
+	C := f / 16 * cosSqAlpha * (4 + f*(4-3*cosSqAlpha))
+	L := lambda - (1-C)*f*sinAlpha*(sigma+C*sinSigma*(cos2SigmaM+C*cosSigma*(-1+2*cos2SigmaM*cos2SigmaM)))
+	return navdata.Coordinate{LatitudeDeg: phi2 * 180 / math.Pi, LongitudeDeg: math.Mod(start.LongitudeDeg+L*180/math.Pi+540, 360) - 180}
+}

--- a/backend/internal/aman/trajectory/trajectory_test.go
+++ b/backend/internal/aman/trajectory/trajectory_test.go
@@ -1,0 +1,238 @@
+package trajectory
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/aman/navdata"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReduceGoldenDTGMonotonicJitterAndCompatibilityReset(t *testing.T) {
+	snapshot, route, input := fixtureInput(t)
+	first := Reduce(snapshot, route, input, Config{})
+	require.Equal(t, Complete, first.Completeness)
+	require.InDelta(t, 90, *first.DistanceToGoNM, 1)
+	input.Observation.LongitudeDegrees = .75
+	input.Prior = first.Progress
+	forward := Reduce(snapshot, route, input, Config{})
+	require.Less(t, *forward.DistanceToGoNM, *first.DistanceToGoNM)
+	input.Observation.LongitudeDegrees = .7465 // routine backward tracking jitter
+	input.Observation.LatitudeDegrees = .01
+	input.Prior = forward.Progress
+	jitter := Reduce(snapshot, route, input, Config{})
+	require.Equal(t, forward.AlongTrackNM, jitter.AlongTrackNM, "compatible progress never moves backward")
+	require.Greater(t, jitter.CrossTrackNM, 0.5, "clamping retains observed lateral error")
+	input.FlightPlanRevision++
+	reset := Reduce(snapshot, route, input, Config{})
+	require.Less(t, reset.AlongTrackNM, forward.AlongTrackNM)
+}
+
+func TestReduceReportsActualOffRouteCrossTrackAndThreshold(t *testing.T) {
+	snapshot, route, input := fixtureInput(t)
+	input.Observation.LatitudeDegrees, input.Observation.LongitudeDegrees = .21, .5
+	off := Reduce(snapshot, route, input, Config{MaxCrossTrackNM: 12})
+	_, want := geodesicProject(coordinate(.21, .5), coordinate(0, 0), coordinate(0, 1), wgs84NM(coordinate(0, 0), coordinate(0, 1)))
+	require.Equal(t, OffRoute, off.Completeness)
+	require.InDelta(t, want, off.CrossTrackNM, .01)
+	require.Greater(t, off.CrossTrackNM, 12.0)
+	input.Observation.LatitudeDegrees = .19
+	on := Reduce(snapshot, route, input, Config{MaxCrossTrackNM: 12})
+	require.NotEqual(t, OffRoute, on.Completeness)
+	require.LessOrEqual(t, on.CrossTrackNM, 12.0)
+}
+
+func TestReduceDistinguishesForwardProgressJumpFromOffRoute(t *testing.T) {
+	snapshot, route, input := fixtureInput(t)
+	input.Prior = &aman.RouteProgress{GeometryDigest: "digest", ManifestRevision: 1, TerminalDigest: "term", FlightPlanRevision: 7, RunwayGroupID: "G", LegIndex: 0, RejoinLegIndex: 0, AlongTrackNM: 6}
+	input.Observation.LongitudeDegrees = .9
+	onRoute := Reduce(snapshot, route, input, Config{MaxForwardSearchNM: 10})
+	require.Equal(t, Partial, onRoute.Completeness)
+	require.Contains(t, onRoute.Reasons, "FORWARD_PROGRESS_OUT_OF_RANGE")
+	require.NotContains(t, onRoute.Reasons, "OFF_ROUTE")
+	require.InDelta(t, 0, onRoute.CrossTrackNM, .01)
+	input.Observation.LatitudeDegrees = 1
+	lateral := Reduce(snapshot, route, input, Config{MaxForwardSearchNM: 10})
+	require.Equal(t, OffRoute, lateral.Completeness)
+	require.Contains(t, lateral.Reasons, "OFF_ROUTE")
+	require.Greater(t, lateral.CrossTrackNM, 12.0)
+}
+
+func TestComposeOrderedRouteTerminalApproachMissedAndUnsupportedGap(t *testing.T) {
+	snapshot, route, input := fixtureInput(t)
+	a, b, c, d, e := navdata.FixID("A"), navdata.FixID("B"), navdata.FixID("C"), navdata.FixID("D"), navdata.FixID("E")
+	snapshot.Fixes = []navdata.Fix{{ID: a, Position: coordinate(0, 0)}, {ID: b, Position: coordinate(0, 1)}, {ID: c, Position: coordinate(0, 2)}, {ID: d, Position: coordinate(0, 3)}, {ID: e, Position: coordinate(0, 4)}}
+	app, missed := navdata.ProcedureID("APP"), navdata.ProcedureID("MISSED")
+	snapshot.Procedures = []navdata.Procedure{{ID: app, Legs: []navdata.ProcedureLeg{{ID: "APPLEG", PathTerminator: navdata.PathTF, FromFix: &c, ToFix: &d}}}, {ID: missed, Legs: []navdata.ProcedureLeg{{ID: "MISSEDLEG", PathTerminator: navdata.PathTF, FromFix: &d, ToFix: &e}}}}
+	snapshot.TerminalPaths[0].Legs = []navdata.ProcedureLeg{{ID: "TERM", PathTerminator: navdata.PathTF, FromFix: &b, ToFix: &c}}
+	route.Legs = []navdata.ProcedureLeg{{ID: "FILED", PathTerminator: navdata.PathTF, FromFix: &a, ToFix: &b}}
+	input.Approach, input.MissedApproach = &app, &missed
+	result := Reduce(snapshot, route, input, Config{})
+	require.Equal(t, []string{"FILED", "TERM", "APPLEG", "MISSEDLEG"}, legIDs(result.Remaining))
+	vectorTo := c
+	route.Legs = []navdata.ProcedureLeg{{ID: "FILED", PathTerminator: navdata.PathTF, FromFix: &a, ToFix: &b}, {ID: "VECTOR", PathTerminator: navdata.PathUnsupported, ToFix: &vectorTo}, {ID: "AFTER", PathTerminator: navdata.PathTF, ToFix: &d}}
+	input.Approach, input.MissedApproach = nil, nil
+	gap := Reduce(snapshot, route, input, Config{})
+	require.Equal(t, []string{"FILED", "TERM"}, legIDs(gap.Remaining))
+	require.Contains(t, gap.Reasons, "UNRESOLVED_LEG:AFTER:MISSING_FIX")
+}
+
+func TestDirectToRepeatedTargetUsesOnlyCompatibleRejoinFloor(t *testing.T) {
+	snapshot, route, input := fixtureInput(t)
+	a, b, c := navdata.FixID("A"), navdata.FixID("B"), navdata.FixID("C")
+	route.Legs = []navdata.ProcedureLeg{{ID: "L1", PathTerminator: navdata.PathTF, FromFix: &a, ToFix: &b}, {ID: "L2", PathTerminator: navdata.PathTF, FromFix: &b, ToFix: &a}, {ID: "L3", PathTerminator: navdata.PathTF, FromFix: &a, ToFix: &b}, {ID: "L4", PathTerminator: navdata.PathTF, FromFix: &b, ToFix: &a}, {ID: "L5", PathTerminator: navdata.PathTF, FromFix: &a, ToFix: &c}}
+	input.RouteFact = &aman.RouteFact{ID: "dct", Fix: "A"}
+	input.Prior = &aman.RouteProgress{GeometryDigest: "digest", ManifestRevision: 1, TerminalDigest: "term", FlightPlanRevision: 7, RouteFactID: "dct", RunwayGroupID: "G", LegIndex: 0, RejoinLegIndex: 3, AlongTrackNM: 0}
+	stable := Reduce(snapshot, route, input, Config{})
+	require.Equal(t, []string{"DIRECT_TO:A", "L5"}, legIDs(stable.Remaining))
+	require.Equal(t, 3, stable.Progress.RejoinLegIndex)
+	route.Digest = "amended"
+	amended := Reduce(snapshot, route, input, Config{})
+	require.Equal(t, []string{"DIRECT_TO:A", "L3", "L4", "L5"}, legIDs(amended.Remaining))
+	require.Equal(t, 1, amended.Progress.RejoinLegIndex)
+}
+
+func TestReduceProjectsLongLegAndPositionsBeforeAndAfterPath(t *testing.T) {
+	snapshot, route, input := fixtureInput(t)
+	route.Legs = route.Legs[:1]
+	snapshot.Fixes[1].Position.LongitudeDeg = 5
+	input.Observation.LongitudeDegrees = .5
+	middle := Reduce(snapshot, route, input, Config{})
+	require.Equal(t, Complete, middle.Completeness)
+	require.InDelta(t, 270, *middle.DistanceToGoNM, 3)
+	input.Observation.LongitudeDegrees = -.1
+	before := Reduce(snapshot, route, input, Config{})
+	require.InDelta(t, routeDistance(snapshot, "A", "B"), *before.DistanceToGoNM, .1)
+	input.Observation.LongitudeDegrees = 5.1
+	after := Reduce(snapshot, route, input, Config{})
+	require.InDelta(t, 0, *after.DistanceToGoNM, .1)
+}
+
+func TestReduceRepeatedFixAndCrossingChoosePlausibleForwardLeg(t *testing.T) {
+	snapshot, route, input := fixtureInput(t)
+	a, b, c, d := navdata.FixID("A"), navdata.FixID("B"), navdata.FixID("C"), navdata.FixID("D")
+	snapshot.Fixes = []navdata.Fix{{ID: a, Position: coordinate(-1, -1)}, {ID: b, Position: coordinate(1, 1)}, {ID: c, Position: coordinate(-1, 1)}, {ID: d, Position: coordinate(1, -1)}}
+	route.Legs = []navdata.ProcedureLeg{{ID: "EARLY", PathTerminator: navdata.PathTF, FromFix: &a, ToFix: &b}, {ID: "JOIN", PathTerminator: navdata.PathTF, FromFix: &b, ToFix: &c}, {ID: "LATE", PathTerminator: navdata.PathTF, FromFix: &c, ToFix: &d}}
+	input.Observation.LatitudeDegrees, input.Observation.LongitudeDegrees = 0, 0
+	first := Reduce(snapshot, route, input, Config{})
+	require.NotEmpty(t, first.Remaining, first.Reasons)
+	require.Equal(t, "EARLY", first.Remaining[0].ID, "without progress, earliest plausible crossing wins")
+	input.Prior = &aman.RouteProgress{GeometryDigest: "digest", ManifestRevision: 1, TerminalDigest: "term", FlightPlanRevision: 7, RunwayGroupID: "G", LegIndex: 0, RejoinLegIndex: 0, AlongTrackNM: 80}
+	input.Observation.LatitudeDegrees, input.Observation.LongitudeDegrees = .1, .1
+	next := Reduce(snapshot, route, input, Config{MaxForwardSearchNM: 20})
+	require.Equal(t, "EARLY", next.Remaining[0].ID, "a later crossing cannot steal projection")
+}
+
+func TestReduceDirectToEmptyStateRestartAndHoldingWithoutCircuit(t *testing.T) {
+	snapshot, route, input := fixtureInput(t)
+	holdID := navdata.HoldingID("HOLD")
+	snapshot.Holdings = []navdata.HoldingPattern{{ID: holdID, Fix: "B"}}
+	snapshot.TerminalPaths[0].HoldingIDs = []navdata.HoldingID{holdID}
+	base := Reduce(snapshot, route, input, Config{})
+	input.RouteFact = &aman.RouteFact{ID: "dct", Fix: "B"} // legacy empty state remains active
+	input.Prior = base.Progress
+	direct := Reduce(snapshot, route, input, Config{})
+	require.Equal(t, "DIRECT_TO:B", direct.Remaining[0].ID)
+	require.NotNil(t, direct.SelectedHolding)
+	require.InDelta(t, wgs84NM(coordinate(0, .5), coordinate(0, 1))+wgs84NM(coordinate(0, 1), coordinate(0, 2)), *direct.DistanceToGoNM, .1, "published hold adds no circuit distance")
+	input.Prior = direct.Progress
+	restarted := Reduce(snapshot, route, input, Config{})
+	require.Equal(t, direct.Progress.RejoinLegIndex, restarted.Progress.RejoinLegIndex)
+	input.RouteFact.State = aman.RouteFactExpired
+	expired := Reduce(snapshot, route, input, Config{})
+	require.NotEqual(t, "DIRECT_TO:B", expired.Remaining[0].ID)
+}
+
+func TestReduceResetsForManifestRunwayRouteAmendmentAndReportsFragments(t *testing.T) {
+	snapshot, route, input := fixtureInput(t)
+	first := Reduce(snapshot, route, input, Config{})
+	input.Prior = first.Progress
+	input.Observation.LongitudeDegrees = .9
+	snapshot.ManifestRevision++
+	manifestReset := Reduce(snapshot, route, input, Config{})
+	require.False(t, compatible(first.Progress, route.Digest, snapshot, input))
+	require.Equal(t, snapshot.ManifestRevision, manifestReset.Progress.ManifestRevision)
+	input.Prior = first.Progress
+	input.RunwayGroup = "OTHER"
+	runwayReset := Reduce(snapshot, route, input, Config{})
+	require.False(t, compatible(first.Progress, route.Digest, snapshot, input))
+	require.Contains(t, runwayReset.Reasons, "TERMINAL_PATH_UNRESOLVED")
+	input.RunwayGroup = "G"
+	input.Prior = first.Progress
+	route.Digest = "amended"
+	amended := Reduce(snapshot, route, input, Config{})
+	require.NotEqual(t, first.Progress.GeometryDigest, amended.Progress.GeometryDigest)
+	route.Legs[1].PathTerminator = navdata.PathUnsupported
+	partial := Reduce(snapshot, route, input, Config{})
+	require.Equal(t, Partial, partial.Completeness)
+	require.Equal(t, "L1", partial.Remaining[0].ID)
+	require.Contains(t, partial.Reasons, "UNSUPPORTED_LEG:L2:UNSUPPORTED")
+	input.Observation.LatitudeDegrees = math.NaN()
+	invalid := Reduce(snapshot, route, input, Config{})
+	require.Equal(t, Unresolved, invalid.Completeness)
+	require.Contains(t, invalid.Reasons, "INVALID_POSITION")
+}
+
+func TestReduceOffRouteStaleDirectAndPartialReasons(t *testing.T) {
+	snapshot, route, input := fixtureInput(t)
+	input.Observation.LatitudeDegrees = 5
+	off := Reduce(snapshot, route, input, Config{})
+	require.Equal(t, OffRoute, off.Completeness)
+	input.Observation.LatitudeDegrees, input.Observation.LongitudeDegrees = 0, .25
+	input.RouteFact = &aman.RouteFact{ID: "dct-1", Fix: "B", State: aman.RouteFactActive}
+	direct := Reduce(snapshot, route, input, Config{})
+	require.Equal(t, "DIRECT_TO:B", direct.Remaining[0].ID)
+	require.Equal(t, navdata.FixID("C"), direct.Remaining[len(direct.Remaining)-1].To)
+	input.RouteFact.State = aman.RouteFactExpired
+	expired := Reduce(snapshot, route, input, Config{})
+	require.NotEqual(t, "DIRECT_TO:B", expired.Remaining[0].ID)
+	now := time.Date(2026, 1, 1, 0, 2, 0, 0, time.UTC)
+	input.Observation.ObservedAt = ptr(now.Add(-3 * time.Minute))
+	stale := Reduce(snapshot, route, input, Config{ReferenceTime: now, MaxObservationAge: time.Minute})
+	require.Equal(t, StalePosition, stale.Completeness)
+	route.Legs[1].PathTerminator = navdata.PathUnsupported
+	partial := Reduce(snapshot, route, input, Config{})
+	require.Contains(t, partial.Reasons, "UNSUPPORTED_LEG:L2:UNSUPPORTED")
+}
+
+func TestRouteProgressRejectsNonFiniteValue(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	f := validFlight(now)
+	f.RouteProgress = &aman.RouteProgress{GeometryDigest: "digest", ManifestRevision: 1, LegIndex: 0, RejoinLegIndex: 0, AlongTrackNM: math.NaN()}
+	require.Error(t, f.Validate())
+}
+
+func fixtureInput(t *testing.T) (navdata.ActiveGeometrySnapshot, navdata.RouteGeometry, Input) {
+	t.Helper()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	v := navdata.DatasetVersion{Cycle: "2601", SourceRevision: "r1", EffectiveFrom: now.Add(-time.Hour), EffectiveUntil: now.Add(time.Hour)}
+	fix := func(id string, lon float64) navdata.Fix {
+		return navdata.Fix{ID: navdata.FixID(id), Position: navdata.Coordinate{LatitudeDeg: 0, LongitudeDeg: lon}}
+	}
+	a, b, c := navdata.FixID("A"), navdata.FixID("B"), navdata.FixID("C")
+	legs := []navdata.ProcedureLeg{{ID: "L1", PathTerminator: navdata.PathTF, FromFix: &a, ToFix: &b}, {ID: "L2", PathTerminator: navdata.PathTF, FromFix: &b, ToFix: &c}}
+	approach := navdata.ProcedureID("APP")
+	s := navdata.ActiveGeometrySnapshot{Manifest: navdata.ManifestCandidate{Airport: "EKCH", Version: v, TerminalDigest: "term"}, ManifestRevision: 1, Fixes: []navdata.Fix{fix("A", 0), fix("B", 1), fix("C", 2)}, Procedures: []navdata.Procedure{{ID: approach}}, TerminalPaths: []navdata.TerminalPath{{Airport: "EKCH", Feeder: "F", RunwayGroup: "G"}}}
+	r := navdata.RouteGeometry{Version: v, Legs: legs, Coverage: navdata.CoverageComplete, Digest: "digest"}
+	return s, r, Input{Airport: "EKCH", RouteKey: "route", Feeder: "F", RunwayGroup: "G", Approach: &approach, FlightPlanRevision: 7, Observation: aman.SurveillanceFact{LatitudeDegrees: 0, LongitudeDegrees: .5, ObservedAt: ptr(now)}}
+}
+func ptr[T any](v T) *T { return &v }
+func legIDs(legs []RemainingLeg) []string {
+	out := make([]string, len(legs))
+	for i, leg := range legs {
+		out[i] = leg.ID
+	}
+	return out
+}
+func routeDistance(snapshot navdata.ActiveGeometrySnapshot, from, to navdata.FixID) float64 {
+	fixes := map[navdata.FixID]navdata.Coordinate{}
+	for _, fix := range snapshot.Fixes {
+		fixes[fix.ID] = fix.Position
+	}
+	return wgs84NM(fixes[from], fixes[to])
+}
+func validFlight(now time.Time) aman.AMANFlight {
+	return aman.AMANFlight{ID: "f", VATSIMCID: "1", CurrentCallsign: "SAS1", State: aman.StateAirborne, DataStatus: aman.DataFresh, FreezeReason: aman.FreezeNone, UpdatedAt: now}
+}

--- a/backend/internal/aman/types.go
+++ b/backend/internal/aman/types.go
@@ -2,6 +2,7 @@ package aman
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"time"
 )
@@ -261,6 +262,33 @@ type RouteFact struct {
 	ID         string
 	Fix        string
 	ObservedAt time.Time
+	State      RouteFactState
+}
+
+// RouteFactState is supplied by the direct-to fact owner. Trajectory consumes
+// it and never infers expiry from wall-clock time.
+type RouteFactState string
+
+const (
+	RouteFactActive  RouteFactState = "active"
+	RouteFactExpired RouteFactState = "expired"
+)
+
+func (s RouteFactState) Valid() bool { return s == "" || s == RouteFactActive || s == RouteFactExpired }
+
+// RouteProgress is task-owned projection state persisted inside AMANFlight's
+// aggregate JSON. The compatibility identity intentionally includes exact
+// manifest/terminal revisions so same-cycle terminal activation resets safely.
+type RouteProgress struct {
+	GeometryDigest     string
+	ManifestRevision   int64
+	TerminalDigest     string
+	FlightPlanRevision uint64
+	RouteFactID        string
+	RunwayGroupID      RunwayGroupID
+	LegIndex           int
+	RejoinLegIndex     int
+	AlongTrackNM       float64
 }
 
 // ETAReview and GoAroundDetectionState reserve the aggregate's owned state
@@ -296,6 +324,7 @@ type AMANFlight struct {
 	SelectedFeeder        *string
 	SelectedHolding       *string
 	ActiveRouteFact       *RouteFact
+	RouteProgress         *RouteProgress
 	FreezeReason          FreezeReason
 	FrozenAt              *time.Time
 	FrozenOperationalTETA *time.Time
@@ -512,6 +541,14 @@ func (f AMANFlight) Validate() error {
 	if f.ArrivalBaseline != nil {
 		if err := f.ArrivalBaseline.Validate(); err != nil {
 			return err
+		}
+	}
+	if f.ActiveRouteFact != nil && !f.ActiveRouteFact.State.Valid() {
+		return invalid("route fact state is invalid")
+	}
+	if f.RouteProgress != nil {
+		if strings.TrimSpace(f.RouteProgress.GeometryDigest) == "" || f.RouteProgress.ManifestRevision < 1 || f.RouteProgress.LegIndex < 0 || f.RouteProgress.RejoinLegIndex < 0 || f.RouteProgress.AlongTrackNM < 0 || math.IsNaN(f.RouteProgress.AlongTrackNM) || math.IsInf(f.RouteProgress.AlongTrackNM, 0) {
+			return invalid("route progress is invalid")
 		}
 	}
 	if err := f.validateFreeze(); err != nil {

--- a/backend/internal/repository/postgres/navigation_cache.go
+++ b/backend/internal/repository/postgres/navigation_cache.go
@@ -223,6 +223,93 @@ func (r *navigationCache) ActiveManifest(ctx context.Context, airport navdata.Ai
 	}
 	return result, nil
 }
+
+// ActiveGeometrySnapshot reads the active-manifest pointer and all named
+// fragments in a single repeatable-read transaction. Activation swaps that
+// pointer atomically, so callers cannot observe mixed fragment revisions.
+func (r *navigationCache) ActiveGeometrySnapshot(ctx context.Context, airport navdata.AirportID) (navdata.ActiveGeometrySnapshot, error) {
+	tx, err := r.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.RepeatableRead})
+	if err != nil {
+		return navdata.ActiveGeometrySnapshot{}, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	var result navdata.ActiveGeometrySnapshot
+	var procedureDigests []byte
+	err = tx.QueryRow(ctx, `SELECT m.revision,m.cycle,m.source_revision,m.effective_from,m.effective_until,m.airport_digest,m.procedure_digests,m.fix_digest,COALESCE(m.terminal_digest,'') FROM aman_nav_active_manifests a JOIN aman_nav_manifests m ON m.manifest_id=a.manifest_id WHERE a.airport=$1`, airport).Scan(&result.ManifestRevision, &result.Manifest.Version.Cycle, &result.Manifest.Version.SourceRevision, &result.Manifest.Version.EffectiveFrom, &result.Manifest.Version.EffectiveUntil, &result.Manifest.AirportDigest, &procedureDigests, &result.Manifest.FixDigest, &result.Manifest.TerminalDigest)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return result, cacheNotFound("active geometry snapshot was not found")
+	}
+	if err != nil {
+		return result, err
+	}
+	result.Manifest.Airport, result.Manifest.ExpectedRevision = airport, result.ManifestRevision
+	result.Manifest.Version.EffectiveFrom = result.Manifest.Version.EffectiveFrom.UTC()
+	result.Manifest.Version.EffectiveUntil = result.Manifest.Version.EffectiveUntil.UTC()
+	if err := json.Unmarshal(procedureDigests, &result.Manifest.ProcedureDigests); err != nil {
+		return result, cacheCorrupt("decode active snapshot procedure digests")
+	}
+	if err := r.validateManifest(ctx, tx, result.Manifest); err != nil {
+		return result, err
+	}
+	airportFragment, err := loadAirportFragment(ctx, tx, result.Manifest.AirportDigest)
+	if err != nil {
+		return result, err
+	}
+	fixFragment, err := loadFixFragment(ctx, tx, result.Manifest.FixDigest)
+	if err != nil {
+		return result, err
+	}
+	result.Airport = airportFragment.Airport
+	result.Runways = append([]navdata.Runway(nil), airportFragment.Runways...)
+	result.Fixes = append([]navdata.Fix(nil), fixFragment.Fixes...)
+	holdingDigests := map[navdata.HoldingID]string{}
+	addHolding := func(value navdata.HoldingPattern) error {
+		digest, digestErr := navdata.HoldingDigest(value)
+		if digestErr != nil {
+			return cacheCorrupt("calculate snapshot holding digest")
+		}
+		if previous, exists := holdingDigests[value.ID]; exists {
+			if previous != digest {
+				return cacheCorrupt("snapshot has conflicting holding definitions")
+			}
+			return nil
+		}
+		holdingDigests[value.ID] = digest
+		result.Holdings = append(result.Holdings, value)
+		return nil
+	}
+	for _, digest := range result.Manifest.ProcedureDigests {
+		fragment, loadErr := loadProcedureFragment(ctx, tx, digest)
+		if loadErr != nil {
+			return result, loadErr
+		}
+		for _, procedure := range fragment.Procedures {
+			result.Procedures = append(result.Procedures, procedure)
+			for _, holding := range procedure.Holdings {
+				if addErr := addHolding(holding); addErr != nil {
+					return result, addErr
+				}
+			}
+		}
+	}
+	if result.Manifest.TerminalDigest != "" {
+		fragment, loadErr := loadTerminalFragment(ctx, tx, result.Manifest.TerminalDigest)
+		if loadErr != nil {
+			return result, loadErr
+		}
+		result.TerminalPaths = append([]navdata.TerminalPath(nil), fragment.Paths...)
+		for _, holding := range fragment.Holdings {
+			if addErr := addHolding(holding); addErr != nil {
+				return result, addErr
+			}
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return navdata.ActiveGeometrySnapshot{}, err
+	}
+	return result, nil
+}
+
 func (r *navigationCache) Route(ctx context.Context, key navdata.RouteKey) (navdata.RouteGeometry, error) {
 	var queryJSON, payload []byte
 	var resolver, schema string
@@ -626,6 +713,7 @@ var (
 	_ navdata.NavigationManifestActivator = (*navigationCache)(nil)
 	_ navdata.ActiveManifestReader        = (*navigationCache)(nil)
 	_ navdata.GeometryReader              = (*navigationCache)(nil)
+	_ navdata.GeometrySnapshotReader      = (*navigationCache)(nil)
 	_ terminal.ReferenceReader            = (*navigationCache)(nil)
 	_ aman.Component                      = (*navigationCache)(nil)
 )

--- a/backend/internal/repository/postgres/navigation_cache_test.go
+++ b/backend/internal/repository/postgres/navigation_cache_test.go
@@ -58,6 +58,16 @@ func TestNavigationCacheReadsManifestConsistentTerminalReferences(t *testing.T) 
 	require.NotEmpty(t, references.Runways)
 	require.NotEmpty(t, references.Fixes)
 	require.NotEmpty(t, references.Procedures)
+	snapshot, err := repo.ActiveGeometrySnapshot(ctx, "EKCH")
+	require.NoError(t, err)
+	require.EqualValues(t, 1, snapshot.ManifestRevision)
+	require.NotEmpty(t, snapshot.Fixes)
+	require.NotEmpty(t, snapshot.Holdings)
+	// Returned snapshot values are detached from cache persistence.
+	snapshot.Fixes[0].Position.LatitudeDeg = 0
+	fresh, err := repo.ActiveGeometrySnapshot(ctx, "EKCH")
+	require.NoError(t, err)
+	require.NotZero(t, fresh.Fixes[0].Position.LatitudeDeg)
 }
 
 func TestNavigationCacheActivatesOfficialTerminalHoldingFallback(t *testing.T) {
@@ -278,9 +288,13 @@ func TestNavigationCacheRejectsTerminalPathMissingFixAndCoherentActiveReads(t *t
 			case <-done:
 				return
 			default:
-				_, err := repo.ActiveVersion(ctx, "EKCH")
+				snapshot, err := repo.ActiveGeometrySnapshot(ctx, "EKCH")
 				if err != nil {
 					readErrors <- err
+					return
+				}
+				if snapshot.ManifestRevision < 1 || len(snapshot.Fixes) == 0 || len(snapshot.Procedures) == 0 {
+					readErrors <- errors.New("mixed geometry snapshot")
 					return
 				}
 			}


### PR DESCRIPTION
## Summary
- add a cache-only, coherent active-manifest geometry snapshot for authoritative fix, procedure, terminal, and holding reads
- project observations onto WGS84 route and terminal geometry using a bounded closest-point search along WGS84 geodesics, deterministic forward-leg selection, actual cross-track diagnostics, and strictly monotonic compatible progress
- persist compatible route progress in the AMAN aggregate, resetting for geometry digest, manifest/terminal revision, flight-plan revision, runway group, or route-fact changes

## Boundary
Prediction reads only `navdata.GeometryReader` plus the cache-only `GeometrySnapshotReader`; it imports no navigation source, EuroScope geometry, or legacy TETA. Direct-to treats legacy empty route-fact state as active, consumes explicit expired state without inferring time-based expiry, and rejoins only canonical snapshot geometry. Published holding geometry returns selected metadata only and adds no circuit distance/time.

## Diagnostics and validation
A projection outside the forward-progress window but geometrically on-route reports `FORWARD_PROGRESS_OUT_OF_RANGE` with real cross-track; `OFF_ROUTE` is reserved for excessive cross-track.

- `go test ./...`
- `go test -race ./internal/aman/trajectory ./internal/repository/postgres`
- `git diff --check`

Coverage includes golden/long-leg DTG, before/after and exact off-route cross-track, forward-progress jumps, monotonic lateral jitter, repeated fixes/crossings, ordered filed/terminal/approach/missed composition, unsupported gaps, direct-to active/expired/restart/amendment, route amendment/runway/manifest resets, holdings, and non-finite/stale positions.

## Stack
Base: `codex/aman-315-baseline-estimates`

Closes #316