### PR TITLE
feat(aman): add performance and wind correction

### DIFF
--- a/backend/internal/aman/predictor/openmeteo/adapter.go
+++ b/backend/internal/aman/predictor/openmeteo/adapter.go
@@ -1,0 +1,232 @@
+// Package openmeteo adapts the Open-Meteo GFS HTTP API to predictor's small,
+// provider-neutral wind-profile contract. Its response DTOs remain private.
+package openmeteo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"FlightStrips/internal/aman/predictor"
+)
+
+const (
+	defaultBaseURL   = "https://api.open-meteo.com/v1/gfs"
+	defaultTimeout   = 5 * time.Second
+	defaultCacheTTL  = 30 * time.Minute
+	maxResponseBytes = 1 << 20
+)
+
+type Config struct {
+	BaseURL  string
+	Client   *http.Client
+	Now      func() time.Time
+	CacheTTL time.Duration
+}
+type cacheEntry struct {
+	levels                []predictor.WindLevel
+	observedAt, expiresAt time.Time
+}
+type Adapter struct {
+	baseURL  string
+	client   *http.Client
+	now      func() time.Time
+	cacheTTL time.Duration
+	mu       sync.RWMutex
+	cache    map[string]cacheEntry
+}
+
+func New(config Config) *Adapter {
+	if strings.TrimSpace(config.BaseURL) == "" {
+		config.BaseURL = defaultBaseURL
+	}
+	if config.Client == nil {
+		config.Client = &http.Client{Timeout: defaultTimeout}
+	}
+	if config.Now == nil {
+		config.Now = time.Now
+	}
+	if config.CacheTTL <= 0 {
+		config.CacheTTL = defaultCacheTTL
+	}
+	return &Adapter{baseURL: config.BaseURL, client: config.Client, now: config.Now, cacheTTL: config.CacheTTL, cache: make(map[string]cacheEntry)}
+}
+
+// WindProfile caches each grid coordinate plus forecast hour. Returned samples
+// are rewritten to the current request instant/coordinate and deep-copied, so
+// callers cannot mutate cache state. A failed refresh returns its last profile
+// with its original expiry; the predictor then rejects stale data explicitly.
+func (a *Adapter) WindProfile(ctx context.Context, request predictor.WindProfileRequest) (predictor.WindProfile, error) {
+	if len(request.Samples) == 0 {
+		return predictor.WindProfile{}, fmt.Errorf("wind request has no samples")
+	}
+	profile := predictor.WindProfile{SourceID: "open-meteo-gfs", SourceRevision: "gfs"}
+	for _, sample := range request.Samples {
+		entry, err := a.sample(ctx, sample)
+		if err != nil {
+			return predictor.WindProfile{}, err
+		}
+		profile.Samples = append(profile.Samples, predictor.WindSample{Position: sample.Position, At: sample.At, Levels: cloneLevels(entry.levels)})
+		if profile.ObservedAt.IsZero() || entry.observedAt.Before(profile.ObservedAt) {
+			profile.ObservedAt = entry.observedAt
+		}
+		if profile.ExpiresAt.IsZero() || entry.expiresAt.Before(profile.ExpiresAt) {
+			profile.ExpiresAt = entry.expiresAt
+		}
+	}
+	return profile, nil
+}
+
+func (a *Adapter) sample(ctx context.Context, sample predictor.WindSampleRequest) (cacheEntry, error) {
+	key, err := cacheKey(sample)
+	if err != nil {
+		return cacheEntry{}, err
+	}
+	now := a.now().UTC()
+	a.mu.RLock()
+	cached, found := a.cache[key]
+	a.mu.RUnlock()
+	if found && now.Before(cached.expiresAt) {
+		return cloneEntry(cached), nil
+	}
+	levels, err := a.fetchSample(ctx, sample)
+	if err != nil {
+		if found {
+			return cloneEntry(cached), nil
+		}
+		return cacheEntry{}, err
+	}
+	entry := cacheEntry{levels: levels, observedAt: now, expiresAt: now.Add(a.cacheTTL)}
+	a.mu.Lock()
+	a.cache[key] = cloneEntry(entry)
+	a.mu.Unlock()
+	return cloneEntry(entry), nil
+}
+
+func (a *Adapter) fetchSample(ctx context.Context, sample predictor.WindSampleRequest) ([]predictor.WindLevel, error) {
+	requestContext, cancel := context.WithTimeout(ctx, defaultTimeout)
+	defer cancel()
+	u, err := url.Parse(a.baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse Open-Meteo URL: %w", err)
+	}
+	q := u.Query()
+	q.Set("latitude", strconv.FormatFloat(sample.Position.LatitudeDegrees, 'f', 6, 64))
+	q.Set("longitude", strconv.FormatFloat(sample.Position.LongitudeDegrees, 'f', 6, 64))
+	q.Set("hourly", "wind_speed_1000hPa,wind_direction_1000hPa,geopotential_height_1000hPa,wind_speed_850hPa,wind_direction_850hPa,geopotential_height_850hPa,wind_speed_700hPa,wind_direction_700hPa,geopotential_height_700hPa,wind_speed_500hPa,wind_direction_500hPa,geopotential_height_500hPa,wind_speed_300hPa,wind_direction_300hPa,geopotential_height_300hPa,wind_speed_250hPa,wind_direction_250hPa,geopotential_height_250hPa,wind_speed_200hPa,wind_direction_200hPa,geopotential_height_200hPa,wind_speed_150hPa,wind_direction_150hPa,geopotential_height_150hPa")
+	q.Set("wind_speed_unit", "kn")
+	q.Set("timezone", "UTC")
+	u.RawQuery = q.Encode()
+	req, err := http.NewRequestWithContext(requestContext, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	response, err := a.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Open-Meteo request: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 4096))
+		return nil, fmt.Errorf("Open-Meteo status %d", response.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxResponseBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > maxResponseBytes {
+		return nil, fmt.Errorf("Open-Meteo response exceeds %d bytes", maxResponseBytes)
+	}
+	var payload gfsResponse
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("decode Open-Meteo response: %w", err)
+	}
+	index, err := payload.Hourly.indexAt(sample.At)
+	if err != nil {
+		return nil, err
+	}
+	return payload.Hourly.levels(index)
+}
+
+func cacheKey(sample predictor.WindSampleRequest) (string, error) {
+	if sample.At.IsZero() || sample.At.Location() != time.UTC || !finite(sample.Position.LatitudeDegrees) || !finite(sample.Position.LongitudeDegrees) || sample.Position.LatitudeDegrees < -90 || sample.Position.LatitudeDegrees > 90 || sample.Position.LongitudeDegrees < -180 || sample.Position.LongitudeDegrees > 180 || !finite(sample.AltitudeFeet) || sample.AltitudeFeet < 0 {
+		return "", fmt.Errorf("wind sample is invalid")
+	}
+	return fmt.Sprintf("%.4f:%.4f:%s", sample.Position.LatitudeDegrees, sample.Position.LongitudeDegrees, sample.At.UTC().Truncate(time.Hour).Format(time.RFC3339)), nil
+}
+func cloneEntry(value cacheEntry) cacheEntry { value.levels = cloneLevels(value.levels); return value }
+func cloneLevels(value []predictor.WindLevel) []predictor.WindLevel {
+	return append([]predictor.WindLevel(nil), value...)
+}
+
+// gfsResponse is deliberately adapter-private: vendor JSON never reaches the predictor contract.
+type gfsResponse struct {
+	Hourly gfsHourly `json:"hourly"`
+}
+type gfsHourly struct {
+	Time          []string   `json:"time"`
+	Speed1000     []*float64 `json:"wind_speed_1000hPa"`
+	Direction1000 []*float64 `json:"wind_direction_1000hPa"`
+	Height1000    []*float64 `json:"geopotential_height_1000hPa"`
+	Speed850      []*float64 `json:"wind_speed_850hPa"`
+	Direction850  []*float64 `json:"wind_direction_850hPa"`
+	Height850     []*float64 `json:"geopotential_height_850hPa"`
+	Speed700      []*float64 `json:"wind_speed_700hPa"`
+	Direction700  []*float64 `json:"wind_direction_700hPa"`
+	Height700     []*float64 `json:"geopotential_height_700hPa"`
+	Speed500      []*float64 `json:"wind_speed_500hPa"`
+	Direction500  []*float64 `json:"wind_direction_500hPa"`
+	Height500     []*float64 `json:"geopotential_height_500hPa"`
+	Speed300      []*float64 `json:"wind_speed_300hPa"`
+	Direction300  []*float64 `json:"wind_direction_300hPa"`
+	Height300     []*float64 `json:"geopotential_height_300hPa"`
+	Speed250      []*float64 `json:"wind_speed_250hPa"`
+	Direction250  []*float64 `json:"wind_direction_250hPa"`
+	Height250     []*float64 `json:"geopotential_height_250hPa"`
+	Speed200      []*float64 `json:"wind_speed_200hPa"`
+	Direction200  []*float64 `json:"wind_direction_200hPa"`
+	Height200     []*float64 `json:"geopotential_height_200hPa"`
+	Speed150      []*float64 `json:"wind_speed_150hPa"`
+	Direction150  []*float64 `json:"wind_direction_150hPa"`
+	Height150     []*float64 `json:"geopotential_height_150hPa"`
+}
+
+func (h gfsHourly) indexAt(at time.Time) (int, error) {
+	lengths := []int{len(h.Time), len(h.Speed1000), len(h.Direction1000), len(h.Height1000), len(h.Speed850), len(h.Direction850), len(h.Height850), len(h.Speed700), len(h.Direction700), len(h.Height700), len(h.Speed500), len(h.Direction500), len(h.Height500), len(h.Speed300), len(h.Direction300), len(h.Height300), len(h.Speed250), len(h.Direction250), len(h.Height250), len(h.Speed200), len(h.Direction200), len(h.Height200), len(h.Speed150), len(h.Direction150), len(h.Height150)}
+	for _, length := range lengths {
+		if length != len(h.Time) || length == 0 {
+			return 0, fmt.Errorf("Open-Meteo hourly response is incomplete")
+		}
+	}
+	target := at.UTC().Truncate(time.Hour)
+	for i, value := range h.Time {
+		parsed, err := time.Parse("2006-01-02T15:04", value)
+		if err == nil && parsed.Equal(target) {
+			return i, nil
+		}
+	}
+	return 0, fmt.Errorf("Open-Meteo response has no wind at %s", target.Format(time.RFC3339))
+}
+func (h gfsHourly) levels(i int) ([]predictor.WindLevel, error) {
+	values := [][]*float64{{h.Height1000[i], h.Speed1000[i], h.Direction1000[i]}, {h.Height850[i], h.Speed850[i], h.Direction850[i]}, {h.Height700[i], h.Speed700[i], h.Direction700[i]}, {h.Height500[i], h.Speed500[i], h.Direction500[i]}, {h.Height300[i], h.Speed300[i], h.Direction300[i]}, {h.Height250[i], h.Speed250[i], h.Direction250[i]}, {h.Height200[i], h.Speed200[i], h.Direction200[i]}, {h.Height150[i], h.Speed150[i], h.Direction150[i]}}
+	levels := make([]predictor.WindLevel, 0, len(values))
+	for _, value := range values {
+		if value[0] == nil || value[1] == nil || value[2] == nil || !finite(*value[0]) || !finite(*value[1]) || !finite(*value[2]) {
+			return nil, fmt.Errorf("Open-Meteo wind level is null or non-finite")
+		}
+		radians := *value[2] * math.Pi / 180
+		levels = append(levels, predictor.WindLevel{AltitudeFeet: *value[0] * 3.28084, EastKnots: -*value[1] * math.Sin(radians), NorthKnots: -*value[1] * math.Cos(radians)})
+	}
+	return levels, nil
+}
+func finite(v float64) bool { return !math.IsNaN(v) && !math.IsInf(v, 0) }
+
+var _ predictor.WindProfileReader = (*Adapter)(nil)

--- a/backend/internal/aman/predictor/openmeteo/adapter_test.go
+++ b/backend/internal/aman/predictor/openmeteo/adapter_test.go
@@ -1,0 +1,139 @@
+package openmeteo
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"FlightStrips/internal/aman/predictor"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdapterMapsPrivateVendorPayloadAndCachesDeepCopy(t *testing.T) {
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		require.Equal(t, "kn", r.URL.Query().Get("wind_speed_unit"))
+		require.Contains(t, r.URL.Query().Get("hourly"), "geopotential_height_300hPa")
+		if calls > 1 {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		_, _ = w.Write([]byte(gfsPayload()))
+	}))
+	defer server.Close()
+	adapter := New(Config{BaseURL: server.URL, Now: func() time.Time { return now }})
+	request := predictor.WindProfileRequest{Samples: []predictor.WindSampleRequest{{Position: predictor.WindCoordinate{LatitudeDegrees: 55, LongitudeDegrees: 12}, At: now.Add(10 * time.Minute), AltitudeFeet: 10000}}}
+	first, err := adapter.WindProfile(context.Background(), request)
+	require.NoError(t, err)
+	require.Equal(t, "open-meteo-gfs", first.SourceID)
+	require.Len(t, first.Samples[0].Levels, 8)
+	require.InDelta(t, 20, first.Samples[0].Levels[0].EastKnots, .001)
+	first.Samples[0].Levels[0].EastKnots = 999
+	request.Samples[0].At = request.Samples[0].At.Add(20 * time.Second)
+	cached, err := adapter.WindProfile(context.Background(), request)
+	require.NoError(t, err)
+	require.InDelta(t, 20, cached.Samples[0].Levels[0].EastKnots, .001)
+	require.Equal(t, 1, calls, "same coordinate and forecast hour reuses cache")
+}
+
+func TestAdapterUsesGeopotentialHeightAtHighAltitude(t *testing.T) {
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(gfsPayload())) }))
+	defer server.Close()
+	adapter := New(Config{BaseURL: server.URL, Now: func() time.Time { return now }})
+	profile, err := adapter.WindProfile(context.Background(), predictor.WindProfileRequest{Samples: []predictor.WindSampleRequest{{At: now.Add(5 * time.Minute), AltitudeFeet: 38000}}})
+	require.NoError(t, err)
+	east, _, ok := interpolate(profile.Samples[0].Levels, 38000)
+	require.True(t, ok)
+	require.Greater(t, east, 0.0)
+}
+
+func TestAdapterRejectsNonSuccessAndIncompletePayload(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusServiceUnavailable) }))
+	defer server.Close()
+	adapter := New(Config{BaseURL: server.URL})
+	_, err := adapter.WindProfile(context.Background(), predictor.WindProfileRequest{Samples: []predictor.WindSampleRequest{{Position: predictor.WindCoordinate{}, At: time.Now().UTC(), AltitudeFeet: 1}}})
+	require.Error(t, err)
+}
+
+func TestAdapterReturnsExpiredCachedProfileAfterProviderFailure(t *testing.T) {
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	status := http.StatusOK
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		if status == http.StatusOK {
+			_, _ = w.Write([]byte(gfsPayload()))
+		}
+	}))
+	defer server.Close()
+	adapter := New(Config{BaseURL: server.URL, Now: func() time.Time { return now }, CacheTTL: time.Minute})
+	request := predictor.WindProfileRequest{Samples: []predictor.WindSampleRequest{{At: now.Add(5 * time.Minute)}}}
+	first, err := adapter.WindProfile(context.Background(), request)
+	require.NoError(t, err)
+	now = now.Add(2 * time.Minute)
+	status = http.StatusBadGateway
+	stale, err := adapter.WindProfile(context.Background(), request)
+	require.NoError(t, err)
+	require.Equal(t, first.ExpiresAt, stale.ExpiresAt)
+	require.True(t, stale.ExpiresAt.Before(now))
+}
+
+func TestAdapterRejectsOversizedAndMalformedResponses(t *testing.T) {
+	for _, body := range []string{string(make([]byte, maxResponseBytes+1)), `{"hourly":{}}`} {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(body)) }))
+		adapter := New(Config{BaseURL: server.URL})
+		_, err := adapter.WindProfile(context.Background(), predictor.WindProfileRequest{Samples: []predictor.WindSampleRequest{{At: time.Now().UTC()}}})
+		require.Error(t, err)
+		server.Close()
+	}
+}
+
+func TestAdapterCacheIsSafeForConcurrentCallers(t *testing.T) {
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(gfsPayload())) }))
+	defer server.Close()
+	adapter := New(Config{BaseURL: server.URL, Now: func() time.Time { return now }})
+	request := predictor.WindProfileRequest{Samples: []predictor.WindSampleRequest{{At: now.Add(5 * time.Minute)}}}
+	var group sync.WaitGroup
+	errors := make(chan error, 24)
+	for range 24 {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			profile, err := adapter.WindProfile(context.Background(), request)
+			if err != nil {
+				errors <- err
+				return
+			}
+			if len(profile.Samples) != 1 {
+				errors <- fmt.Errorf("unexpected sample count")
+			}
+		}()
+	}
+	group.Wait()
+	close(errors)
+	for err := range errors {
+		require.NoError(t, err)
+	}
+}
+
+var _ predictor.WindProfileReader = (*Adapter)(nil)
+
+func interpolate(levels []predictor.WindLevel, altitude float64) (float64, float64, bool) {
+	for i := 1; i < len(levels); i++ {
+		if altitude >= levels[i-1].AltitudeFeet && altitude <= levels[i].AltitudeFeet {
+			f := (altitude - levels[i-1].AltitudeFeet) / (levels[i].AltitudeFeet - levels[i-1].AltitudeFeet)
+			return levels[i-1].EastKnots + (levels[i].EastKnots-levels[i-1].EastKnots)*f, 0, true
+		}
+	}
+	return 0, 0, false
+}
+func gfsPayload() string {
+	return `{"hourly":{"time":["2026-07-18T12:00"],"wind_speed_1000hPa":[20],"wind_direction_1000hPa":[270],"geopotential_height_1000hPa":[100],"wind_speed_850hPa":[25],"wind_direction_850hPa":[270],"geopotential_height_850hPa":[1500],"wind_speed_700hPa":[30],"wind_direction_700hPa":[270],"geopotential_height_700hPa":[3000],"wind_speed_500hPa":[40],"wind_direction_500hPa":[270],"geopotential_height_500hPa":[5500],"wind_speed_300hPa":[60],"wind_direction_300hPa":[270],"geopotential_height_300hPa":[9500],"wind_speed_250hPa":[70],"wind_direction_250hPa":[270],"geopotential_height_250hPa":[10500],"wind_speed_200hPa":[80],"wind_direction_200hPa":[270],"geopotential_height_200hPa":[12000],"wind_speed_150hPa":[90],"wind_direction_150hPa":[270],"geopotential_height_150hPa":[14000]}}`
+}

--- a/backend/internal/aman/predictor/performance_wind.go
+++ b/backend/internal/aman/predictor/performance_wind.go
@@ -1,0 +1,358 @@
+package predictor
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+	"strings"
+	"time"
+
+	"FlightStrips/internal/aman"
+)
+
+const (
+	defaultMinimumGroundspeedKnots = 120.0
+	defaultMaximumGroundspeedKnots = 600.0
+	defaultMaxWindCorrection       = 0.20
+	defaultPerformanceVersion      = "aman-performance-defaults-v1"
+)
+
+// AircraftPerformanceRepository supplies versioned, provider-neutral profile
+// data. The predictor performs deterministic ICAO/WTC selection itself.
+type AircraftPerformanceRepository interface {
+	PerformanceProfiles(context.Context, time.Time) ([]PerformanceProfile, error)
+}
+
+// WindProfileReader supplies spatial and temporal upper-wind profiles. Wind
+// components are knots towards east (U) and north (V); altitude is feet.
+type WindProfileReader interface {
+	WindProfile(context.Context, WindProfileRequest) (WindProfile, error)
+}
+
+type PerformanceProfile struct {
+	ID, Version             string
+	AircraftICAOTypes       []string
+	WakeTurbulenceCategory  AircraftCategory
+	CruiseTrueAirspeedKnots float64
+	ValidFrom, ValidUntil   time.Time
+}
+
+type WindCoordinate struct{ LatitudeDegrees, LongitudeDegrees float64 }
+
+type WindProfileRequest struct{ Samples []WindSampleRequest }
+type WindSampleRequest struct {
+	Position     WindCoordinate
+	At           time.Time
+	AltitudeFeet float64
+}
+
+// WindProfile is metadata plus one vertical profile per requested sample, in
+// request order. ExpiresAt is an inclusive upper bound for prediction use.
+type WindProfile struct {
+	SourceID, SourceRevision string
+	ObservedAt, ExpiresAt    time.Time
+	Samples                  []WindSample
+}
+type WindSample struct {
+	Position WindCoordinate
+	At       time.Time
+	Levels   []WindLevel
+}
+type WindLevel struct {
+	AltitudeFeet, EastKnots, NorthKnots float64
+}
+
+// RouteLeg is the small trajectory seam consumed by the raw predictor.
+// Course is true degrees, distance is NM, and WGS84 coordinates bound the leg.
+type RouteLeg struct {
+	ID                            string
+	DistanceNM, CourseTrueDegrees float64
+	Start, End                    WindCoordinate
+}
+
+type PerformanceWindConfig struct {
+	MinimumGroundspeedKnots, MaximumGroundspeedKnots float64
+	// MaxWindCorrectionPercent caps the total duration change around no-wind
+	// geometry. 0 selects 20 percent; values must otherwise be in (0, 1).
+	MaxWindCorrectionPercent float64
+}
+
+func (c PerformanceWindConfig) normalized() (PerformanceWindConfig, error) {
+	if c.MinimumGroundspeedKnots == 0 {
+		c.MinimumGroundspeedKnots = defaultMinimumGroundspeedKnots
+	}
+	if c.MaximumGroundspeedKnots == 0 {
+		c.MaximumGroundspeedKnots = defaultMaximumGroundspeedKnots
+	}
+	if c.MaxWindCorrectionPercent == 0 {
+		c.MaxWindCorrectionPercent = defaultMaxWindCorrection
+	}
+	if !finite(c.MinimumGroundspeedKnots) || !finite(c.MaximumGroundspeedKnots) || !finite(c.MaxWindCorrectionPercent) || c.MinimumGroundspeedKnots <= 0 || c.MaximumGroundspeedKnots < c.MinimumGroundspeedKnots || c.MaxWindCorrectionPercent <= 0 || c.MaxWindCorrectionPercent >= 1 {
+		return c, errPerformanceWindConfig
+	}
+	return c, nil
+}
+
+type PerformanceWindInput struct {
+	PredictionAt           time.Time
+	AircraftICAO           string
+	WakeTurbulenceCategory AircraftCategory
+	AltitudeFeet           float64
+	Remaining              []RouteLeg
+}
+
+type PerformanceWindResult struct {
+	RawTETA                                         time.Time
+	NoWindDuration, Duration                        time.Duration
+	Confidence                                      aman.Confidence
+	PerformanceProfileID, PerformanceProfileVersion *string
+	WeatherSource, WeatherSourceRevision            *string
+	DegradationReasons                              []string
+}
+
+// EstimatePerformanceWind calculates only the latest physical/raw route
+// arrival. It intentionally does not persist, smooth, freeze, or project an
+// operational TETA; those behaviors belong to #314.
+func EstimatePerformanceWind(ctx context.Context, performance AircraftPerformanceRepository, wind WindProfileReader, input PerformanceWindInput, config PerformanceWindConfig) (PerformanceWindResult, error) {
+	config, err := config.normalized()
+	if err != nil {
+		return PerformanceWindResult{}, err
+	}
+	if !validPredictionInstant(input.PredictionAt) || !finite(input.AltitudeFeet) || input.AltitudeFeet < 0 || len(input.Remaining) == 0 {
+		return PerformanceWindResult{}, errPerformanceWindInput
+	}
+	for _, leg := range input.Remaining {
+		if !validRouteLeg(leg) {
+			return PerformanceWindResult{}, errPerformanceWindInput
+		}
+	}
+
+	result := PerformanceWindResult{Confidence: aman.ConfidenceHigh}
+	profile, exact, unavailable := selectProfile(ctx, performance, input)
+	if unavailable {
+		result.DegradationReasons = append(result.DegradationReasons, "PERFORMANCE_PROFILE_UNAVAILABLE")
+		result.Confidence = aman.ConfidenceMedium
+	} else if !exact {
+		result.DegradationReasons = append(result.DegradationReasons, "PERFORMANCE_PROFILE_FALLBACK")
+		result.Confidence = aman.ConfidenceMedium
+	}
+	result.PerformanceProfileID, result.PerformanceProfileVersion = pointerString(profile.ID), pointerString(profile.Version)
+	base := durationFor(input.Remaining, profile.CruiseTrueAirspeedKnots, config)
+	result.NoWindDuration, result.Duration = base, base
+
+	if wind == nil {
+		result = degradeWind(result, "WEATHER_UNAVAILABLE")
+		result.RawTETA = input.PredictionAt.Add(result.Duration)
+		return result, nil
+	}
+	requests := windRequests(input, profile.CruiseTrueAirspeedKnots, config)
+	weather, err := wind.WindProfile(ctx, WindProfileRequest{Samples: requests})
+	if err != nil || !validWindProfile(weather, requests, input.PredictionAt) {
+		result = degradeWind(result, "WEATHER_UNAVAILABLE")
+		result.RawTETA = input.PredictionAt.Add(result.Duration)
+		return result, nil
+	}
+	result.WeatherSource = pointerString(weather.SourceID)
+	result.WeatherSourceRevision = pointerString(weather.SourceRevision)
+	windDuration, ok := durationWithWind(input.Remaining, profile.CruiseTrueAirspeedKnots, weather, input.AltitudeFeet, config)
+	if !ok {
+		result = degradeWind(result, "WEATHER_INCOMPLETE")
+		result.RawTETA = input.PredictionAt.Add(result.Duration)
+		return result, nil
+	}
+	low, high := durationBounds(base, config.MaxWindCorrectionPercent)
+	result.Duration = maxDuration(low, minDuration(high, windDuration))
+	result.RawTETA = input.PredictionAt.Add(result.Duration)
+	return result, nil
+}
+
+func degradeWind(result PerformanceWindResult, reason string) PerformanceWindResult {
+	result.DegradationReasons = append(result.DegradationReasons, reason)
+	if result.Confidence == aman.ConfidenceHigh {
+		result.Confidence = aman.ConfidenceMedium
+	}
+	result.RawTETA = time.Time{} // assigned by caller after known prediction instant
+	return result
+}
+
+func selectProfile(ctx context.Context, repository AircraftPerformanceRepository, input PerformanceWindInput) (PerformanceProfile, bool, bool) {
+	profiles := defaultPerformanceProfiles()
+	unavailable := repository == nil
+	if repository != nil {
+		if supplied, err := repository.PerformanceProfiles(ctx, input.PredictionAt); err == nil {
+			profiles = supplied
+		} else {
+			unavailable = true
+		}
+	}
+	valid := make([]PerformanceProfile, 0, len(profiles))
+	for _, profile := range profiles {
+		if validPerformanceProfile(profile, input.PredictionAt) {
+			valid = append(valid, cloneProfile(profile))
+		}
+	}
+	if len(valid) == 0 {
+		valid = defaultPerformanceProfiles()
+		unavailable = true
+	}
+	slices.SortFunc(valid, func(a, b PerformanceProfile) int {
+		if a.ID != b.ID {
+			return strings.Compare(a.ID, b.ID)
+		}
+		return strings.Compare(a.Version, b.Version)
+	})
+	icao := strings.ToUpper(strings.TrimSpace(input.AircraftICAO))
+	for _, profile := range valid {
+		for _, candidate := range profile.AircraftICAOTypes {
+			if icao != "" && icao == strings.ToUpper(strings.TrimSpace(candidate)) {
+				return profile, true, unavailable
+			}
+		}
+	}
+	for _, profile := range valid {
+		if len(profile.AircraftICAOTypes) == 0 && profile.WakeTurbulenceCategory == input.WakeTurbulenceCategory {
+			return profile, false, unavailable
+		}
+	}
+	// Medium is the deterministic final fallback for missing/unknown WTC.
+	for _, profile := range valid {
+		if len(profile.AircraftICAOTypes) == 0 && profile.WakeTurbulenceCategory == CategoryMedium {
+			return profile, false, unavailable
+		}
+	}
+	return defaultPerformanceProfiles()[1], false, true
+}
+
+func defaultPerformanceProfiles() []PerformanceProfile {
+	return []PerformanceProfile{
+		{ID: "fallback-light", Version: defaultPerformanceVersion, WakeTurbulenceCategory: CategoryLight, CruiseTrueAirspeedKnots: 180},
+		{ID: "fallback-medium", Version: defaultPerformanceVersion, WakeTurbulenceCategory: CategoryMedium, CruiseTrueAirspeedKnots: 420},
+		{ID: "fallback-heavy", Version: defaultPerformanceVersion, WakeTurbulenceCategory: CategoryHeavy, CruiseTrueAirspeedKnots: 440},
+		{ID: "fallback-super", Version: defaultPerformanceVersion, WakeTurbulenceCategory: CategorySuper, CruiseTrueAirspeedKnots: 460},
+	}
+}
+
+func windRequests(input PerformanceWindInput, tas float64, config PerformanceWindConfig) []WindSampleRequest {
+	requests := make([]WindSampleRequest, len(input.Remaining))
+	elapsed := time.Duration(0)
+	for i, leg := range input.Remaining {
+		half := durationFor([]RouteLeg{leg}, tas, config) / 2
+		requests[i] = WindSampleRequest{Position: midpoint(leg.Start, leg.End), At: input.PredictionAt.Add(elapsed + half), AltitudeFeet: input.AltitudeFeet}
+		elapsed += half * 2
+	}
+	return requests
+}
+
+func durationWithWind(legs []RouteLeg, tas float64, profile WindProfile, altitude float64, config PerformanceWindConfig) (time.Duration, bool) {
+	total := time.Duration(0)
+	for i, leg := range legs {
+		east, north, ok := interpolateWind(profile.Samples[i].Levels, altitude)
+		if !ok {
+			return 0, false
+		}
+		radians := leg.CourseTrueDegrees * math.Pi / 180
+		tailwind := east*math.Sin(radians) + north*math.Cos(radians)
+		groundspeed := clamp(tas+tailwind, config.MinimumGroundspeedKnots, config.MaximumGroundspeedKnots)
+		total += durationFor([]RouteLeg{leg}, groundspeed, config)
+	}
+	return total, true
+}
+
+// interpolateWind linearly interpolates U/V components at the requested
+// altitude. Values outside the provider's vertical coverage are unusable.
+func interpolateWind(levels []WindLevel, altitude float64) (float64, float64, bool) {
+	if len(levels) == 0 || !finite(altitude) {
+		return 0, 0, false
+	}
+	values := slices.Clone(levels)
+	slices.SortFunc(values, func(a, b WindLevel) int { return cmp.Compare(a.AltitudeFeet, b.AltitudeFeet) })
+	for _, level := range values {
+		if !finite(level.AltitudeFeet) || !finite(level.EastKnots) || !finite(level.NorthKnots) {
+			return 0, 0, false
+		}
+		if level.AltitudeFeet == altitude {
+			return level.EastKnots, level.NorthKnots, true
+		}
+	}
+	for i := 1; i < len(values); i++ {
+		if values[i].AltitudeFeet <= values[i-1].AltitudeFeet {
+			return 0, 0, false
+		}
+	}
+	if altitude < values[0].AltitudeFeet || altitude > values[len(values)-1].AltitudeFeet {
+		return 0, 0, false
+	}
+	for i := 1; i < len(values); i++ {
+		if altitude < values[i].AltitudeFeet {
+			low, high := values[i-1], values[i]
+			fraction := (altitude - low.AltitudeFeet) / (high.AltitudeFeet - low.AltitudeFeet)
+			return low.EastKnots + (high.EastKnots-low.EastKnots)*fraction, low.NorthKnots + (high.NorthKnots-low.NorthKnots)*fraction, true
+		}
+	}
+	return 0, 0, false
+}
+
+func validWindProfile(profile WindProfile, requests []WindSampleRequest, at time.Time) bool {
+	if strings.TrimSpace(profile.SourceID) == "" || strings.TrimSpace(profile.SourceRevision) == "" || !validPredictionInstant(profile.ObservedAt) || !validPredictionInstant(profile.ExpiresAt) || profile.ObservedAt.After(at) || profile.ExpiresAt.Before(profile.ObservedAt) || profile.ExpiresAt.Before(at) || len(profile.Samples) != len(requests) {
+		return false
+	}
+	for i, sample := range profile.Samples {
+		if !validPredictionInstant(sample.At) || !sample.At.Equal(requests[i].At) || math.Abs(sample.Position.LatitudeDegrees-requests[i].Position.LatitudeDegrees) > .000001 || math.Abs(sample.Position.LongitudeDegrees-requests[i].Position.LongitudeDegrees) > .000001 {
+			return false
+		}
+	}
+	return true
+}
+func validPerformanceProfile(p PerformanceProfile, at time.Time) bool {
+	return strings.TrimSpace(p.ID) != "" && strings.TrimSpace(p.Version) != "" && finite(p.CruiseTrueAirspeedKnots) && p.CruiseTrueAirspeedKnots > 0 && (p.ValidFrom.IsZero() || !at.Before(p.ValidFrom)) && (p.ValidUntil.IsZero() || !at.After(p.ValidUntil))
+}
+func validRouteLeg(leg RouteLeg) bool {
+	return strings.TrimSpace(leg.ID) != "" && finite(leg.DistanceNM) && leg.DistanceNM > 0 && finite(leg.CourseTrueDegrees) && leg.CourseTrueDegrees >= 0 && leg.CourseTrueDegrees < 360 && validWindCoordinate(leg.Start) && validWindCoordinate(leg.End)
+}
+func validPredictionInstant(v time.Time) bool { return !v.IsZero() && v.Location() == time.UTC }
+func durationFor(legs []RouteLeg, speed float64, config PerformanceWindConfig) time.Duration {
+	distance := 0.0
+	for _, leg := range legs {
+		distance += leg.DistanceNM
+	}
+	return time.Duration(float64(time.Hour) * distance / clamp(speed, config.MinimumGroundspeedKnots, config.MaximumGroundspeedKnots))
+}
+func durationBounds(base time.Duration, percent float64) (time.Duration, time.Duration) {
+	return time.Duration(float64(base) * (1 - percent)), time.Duration(float64(base) * (1 + percent))
+}
+func minDuration(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
+}
+func maxDuration(a, b time.Duration) time.Duration {
+	if a > b {
+		return a
+	}
+	return b
+}
+func clamp(v, low, high float64) float64 { return math.Max(low, math.Min(high, v)) }
+func validWindCoordinate(value WindCoordinate) bool {
+	return finite(value.LatitudeDegrees) && finite(value.LongitudeDegrees) && value.LatitudeDegrees >= -90 && value.LatitudeDegrees <= 90 && value.LongitudeDegrees >= -180 && value.LongitudeDegrees <= 180
+}
+func midpoint(a, b WindCoordinate) WindCoordinate {
+	latA, lonA := a.LatitudeDegrees*math.Pi/180, a.LongitudeDegrees*math.Pi/180
+	latB, lonB := b.LatitudeDegrees*math.Pi/180, b.LongitudeDegrees*math.Pi/180
+	x, y, z := math.Cos(latA)*math.Cos(lonA)+math.Cos(latB)*math.Cos(lonB), math.Cos(latA)*math.Sin(lonA)+math.Cos(latB)*math.Sin(lonB), math.Sin(latA)+math.Sin(latB)
+	return WindCoordinate{LatitudeDegrees: math.Atan2(z, math.Hypot(x, y)) * 180 / math.Pi, LongitudeDegrees: math.Atan2(y, x) * 180 / math.Pi}
+}
+func cloneProfile(p PerformanceProfile) PerformanceProfile {
+	p.AircraftICAOTypes = slices.Clone(p.AircraftICAOTypes)
+	return p
+}
+func pointerString(value string) *string { copy := value; return &copy }
+func finite(value float64) bool          { return !math.IsNaN(value) && !math.IsInf(value, 0) }
+
+var (
+	errPerformanceWindConfig = errors.New("performance/wind predictor configuration is invalid")
+	errPerformanceWindInput  = fmt.Errorf("performance/wind predictor input is invalid")
+)

--- a/backend/internal/aman/predictor/performance_wind_test.go
+++ b/backend/internal/aman/predictor/performance_wind_test.go
@@ -1,0 +1,222 @@
+package predictor
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectProfileMapsICAOAndFallsBackDeterministically(t *testing.T) {
+	now := performanceNow()
+	repo := profilesRepository{profiles: []PerformanceProfile{
+		{ID: "medium-z", Version: "v1", WakeTurbulenceCategory: CategoryMedium, CruiseTrueAirspeedKnots: 400},
+		{ID: "a320", Version: "v2", AircraftICAOTypes: []string{"A320"}, WakeTurbulenceCategory: CategoryMedium, CruiseTrueAirspeedKnots: 430},
+		{ID: "heavy", Version: "v1", WakeTurbulenceCategory: CategoryHeavy, CruiseTrueAirspeedKnots: 450},
+		{ID: "medium-a", Version: "v1", WakeTurbulenceCategory: CategoryMedium, CruiseTrueAirspeedKnots: 410},
+	}}
+	for _, test := range []struct {
+		name, icao string
+		category   AircraftCategory
+		want       string
+	}{
+		{"known ICAO", "a320", CategoryHeavy, "a320"},
+		{"known WTC", "unknown", CategoryHeavy, "heavy"},
+		{"unknown uses stable medium fallback", "unknown", "unknown", "medium-a"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, _, _ := selectProfile(context.Background(), repo, PerformanceWindInput{PredictionAt: now, AircraftICAO: test.icao, WakeTurbulenceCategory: test.category})
+			require.Equal(t, test.want, got.ID)
+		})
+	}
+}
+
+func TestEstimatePerformanceWindProjectsInterpolatedWindAndBoundsCorrection(t *testing.T) {
+	now, input := performanceNow(), performanceInput()
+	profile := profilesRepository{profiles: []PerformanceProfile{{ID: "A320", Version: "v1", AircraftICAOTypes: []string{"A320"}, WakeTurbulenceCategory: CategoryMedium, CruiseTrueAirspeedKnots: 400}}}
+	for _, test := range []struct {
+		name    string
+		east    float64
+		config  PerformanceWindConfig
+		compare func(*testing.T, PerformanceWindResult)
+	}{
+		{"tailwind decreases arrival", 40, PerformanceWindConfig{}, func(t *testing.T, got PerformanceWindResult) {
+			require.Less(t, got.Duration, got.NoWindDuration)
+			require.Equal(t, aman.ConfidenceHigh, got.Confidence)
+		}},
+		{"headwind increases arrival", -40, PerformanceWindConfig{}, func(t *testing.T, got PerformanceWindResult) { require.Greater(t, got.Duration, got.NoWindDuration) }},
+		{"cap limits extreme headwind", -1000, PerformanceWindConfig{MinimumGroundspeedKnots: 20, MaximumGroundspeedKnots: 900, MaxWindCorrectionPercent: .1}, func(t *testing.T, got PerformanceWindResult) {
+			require.Equal(t, time.Duration(float64(got.NoWindDuration)*1.1), got.Duration)
+		}},
+		{"groundspeed clamp limits extreme tailwind", 1000, PerformanceWindConfig{MinimumGroundspeedKnots: 120, MaximumGroundspeedKnots: 500, MaxWindCorrectionPercent: .9}, func(t *testing.T, got PerformanceWindResult) {
+			require.Equal(t, time.Duration(float64(time.Hour)*100/500), got.Duration)
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			wind := fixedWind{east: test.east, now: now}
+			got, err := EstimatePerformanceWind(context.Background(), profile, wind, input, test.config)
+			require.NoError(t, err)
+			require.Equal(t, now.Add(got.Duration), got.RawTETA)
+			test.compare(t, got)
+		})
+	}
+}
+
+func TestEstimatePerformanceWindPreservesGeometryForRepositoryAndWeatherDegradation(t *testing.T) {
+	now, input := performanceNow(), performanceInput()
+	for _, test := range []struct {
+		name        string
+		performance AircraftPerformanceRepository
+		wind        WindProfileReader
+		want        string
+	}{
+		{"performance repository failure", failingProfiles{}, fixedWind{now: now}, "PERFORMANCE_PROFILE_UNAVAILABLE"},
+		{"missing weather", nil, nil, "WEATHER_UNAVAILABLE"},
+		{"provider failure", profilesRepository{}, failingWind{}, "WEATHER_UNAVAILABLE"},
+		{"stale cached weather", profilesRepository{}, fixedWind{now: now.Add(-2 * time.Hour), expires: now.Add(-time.Minute)}, "WEATHER_UNAVAILABLE"},
+		{"incomplete weather", profilesRepository{}, incompleteWind{now: now}, "WEATHER_INCOMPLETE"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := EstimatePerformanceWind(context.Background(), test.performance, test.wind, input, PerformanceWindConfig{})
+			require.NoError(t, err)
+			require.False(t, got.RawTETA.IsZero())
+			require.Equal(t, now.Add(got.NoWindDuration), got.RawTETA)
+			require.Equal(t, aman.ConfidenceMedium, got.Confidence)
+			require.Contains(t, got.DegradationReasons, test.want)
+			require.NotNil(t, got.PerformanceProfileID)
+		})
+	}
+}
+
+func TestInterpolateWind(t *testing.T) {
+	east, north, ok := interpolateWind([]WindLevel{{AltitudeFeet: 10000, EastKnots: 40, NorthKnots: 20}, {AltitudeFeet: 0, EastKnots: 0, NorthKnots: 10}}, 5000)
+	require.True(t, ok)
+	require.InDelta(t, 20, east, .001)
+	require.InDelta(t, 15, north, .001)
+	_, _, ok = interpolateWind([]WindLevel{{AltitudeFeet: 0}}, 5000)
+	require.False(t, ok)
+}
+
+func TestWindRequestsUseLegMidpointsAndEstimatedTraversalTimes(t *testing.T) {
+	now := performanceNow()
+	input := PerformanceWindInput{PredictionAt: now, AltitudeFeet: 10000, Remaining: []RouteLeg{
+		{ID: "one", DistanceNM: 100, CourseTrueDegrees: 90, Start: WindCoordinate{LatitudeDegrees: 55, LongitudeDegrees: 10}, End: WindCoordinate{LatitudeDegrees: 55, LongitudeDegrees: 12}},
+		{ID: "two", DistanceNM: 100, CourseTrueDegrees: 90, Start: WindCoordinate{LatitudeDegrees: 55, LongitudeDegrees: 12}, End: WindCoordinate{LatitudeDegrees: 55, LongitudeDegrees: 14}},
+	}}
+	requests := windRequests(input, 400, PerformanceWindConfig{MinimumGroundspeedKnots: 120, MaximumGroundspeedKnots: 600})
+	require.Len(t, requests, 2)
+	require.InDelta(t, 11, requests[0].Position.LongitudeDegrees, .01)
+	require.InDelta(t, 13, requests[1].Position.LongitudeDegrees, .01)
+	require.Equal(t, now.Add(7*time.Minute+30*time.Second), requests[0].At)
+	require.Equal(t, now.Add(22*time.Minute+30*time.Second), requests[1].At)
+}
+
+func TestEstimatePerformanceWindClampsNoWindTAS(t *testing.T) {
+	now, input := performanceNow(), performanceInput()
+	for _, test := range []struct {
+		name          string
+		tas, min, max float64
+		want          time.Duration
+	}{
+		{"minimum", 20, 120, 600, time.Duration(float64(time.Hour) * 100 / 120)},
+		{"maximum", 900, 120, 600, time.Duration(float64(time.Hour) * 100 / 600)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			repository := profilesRepository{profiles: []PerformanceProfile{{ID: "profile", Version: "v1", AircraftICAOTypes: []string{"A320"}, CruiseTrueAirspeedKnots: test.tas}}}
+			got, err := EstimatePerformanceWind(context.Background(), repository, nil, input, PerformanceWindConfig{MinimumGroundspeedKnots: test.min, MaximumGroundspeedKnots: test.max, MaxWindCorrectionPercent: .2})
+			require.NoError(t, err)
+			require.Equal(t, test.want, got.NoWindDuration)
+			require.Equal(t, now.Add(test.want), got.RawTETA)
+		})
+	}
+}
+
+func TestEstimatePerformanceWindAllowsFutureRouteSamplesWhileWeatherIsFreshAtPrediction(t *testing.T) {
+	now, input := performanceNow(), performanceInput()
+	input.Remaining[0].DistanceNM = 500 // midpoint traversal is 37m30s ahead at 400 kt.
+	repository := profilesRepository{profiles: []PerformanceProfile{{ID: "profile", Version: "v1", AircraftICAOTypes: []string{"A320"}, CruiseTrueAirspeedKnots: 400}}}
+	weather := fixedWind{now: now, expires: now.Add(30 * time.Minute)}
+	got, err := EstimatePerformanceWind(context.Background(), repository, weather, input, PerformanceWindConfig{})
+	require.NoError(t, err)
+	require.NotContains(t, got.DegradationReasons, "WEATHER_UNAVAILABLE")
+	require.NotNil(t, got.WeatherSource)
+	require.Equal(t, "test-v1", *got.WeatherSourceRevision)
+}
+
+func TestEstimatePerformanceWindLabelsDeterministicProfileFallback(t *testing.T) {
+	input := performanceInput()
+	input.AircraftICAO = "UNKNOWN"
+	input.WakeTurbulenceCategory = CategoryHeavy
+	repository := profilesRepository{profiles: []PerformanceProfile{{ID: "heavy-default", Version: "v1", WakeTurbulenceCategory: CategoryHeavy, CruiseTrueAirspeedKnots: 440}}}
+	got, err := EstimatePerformanceWind(context.Background(), repository, nil, input, PerformanceWindConfig{})
+	require.NoError(t, err)
+	require.Contains(t, got.DegradationReasons, "PERFORMANCE_PROFILE_FALLBACK")
+	require.NotContains(t, got.DegradationReasons, "PERFORMANCE_PROFILE_UNAVAILABLE")
+}
+
+func TestValidWindProfileFreshnessBoundaries(t *testing.T) {
+	now := performanceNow()
+	requests := []WindSampleRequest{{Position: WindCoordinate{LatitudeDegrees: 55, LongitudeDegrees: 12}, At: now, AltitudeFeet: 10000}}
+	profile, err := (fixedWind{now: now}).WindProfile(context.Background(), WindProfileRequest{Samples: requests})
+	require.NoError(t, err)
+	require.True(t, validWindProfile(profile, requests, now), "observation at the prediction instant is valid")
+	profile.ObservedAt = now.Add(time.Second)
+	require.False(t, validWindProfile(profile, requests, now), "future observation is not valid for this prediction")
+	profile.ObservedAt, profile.ExpiresAt = now, now.Add(-time.Second)
+	require.False(t, validWindProfile(profile, requests, now), "expiry must not precede observation")
+}
+
+type profilesRepository struct {
+	profiles []PerformanceProfile
+	err      error
+}
+
+func (p profilesRepository) PerformanceProfiles(context.Context, time.Time) ([]PerformanceProfile, error) {
+	return p.profiles, p.err
+}
+
+type failingProfiles struct{}
+
+func (failingProfiles) PerformanceProfiles(context.Context, time.Time) ([]PerformanceProfile, error) {
+	return nil, errors.New("down")
+}
+
+type failingWind struct{}
+
+func (failingWind) WindProfile(context.Context, WindProfileRequest) (WindProfile, error) {
+	return WindProfile{}, errors.New("down")
+}
+
+type incompleteWind struct{ now time.Time }
+
+func (w incompleteWind) WindProfile(_ context.Context, request WindProfileRequest) (WindProfile, error) {
+	samples := make([]WindSample, len(request.Samples))
+	for i, sample := range request.Samples {
+		samples[i] = WindSample{Position: sample.Position, At: sample.At}
+	}
+	return WindProfile{SourceID: "fixture", SourceRevision: "test-v1", ObservedAt: w.now, ExpiresAt: w.now.Add(time.Hour), Samples: samples}, nil
+}
+
+type fixedWind struct {
+	east         float64
+	now, expires time.Time
+}
+
+func (w fixedWind) WindProfile(_ context.Context, request WindProfileRequest) (WindProfile, error) {
+	expires := w.expires
+	if expires.IsZero() {
+		expires = w.now.Add(2 * time.Hour)
+	}
+	samples := make([]WindSample, len(request.Samples))
+	for i, sample := range request.Samples {
+		samples[i] = WindSample{Position: sample.Position, At: sample.At, Levels: []WindLevel{{AltitudeFeet: 0, EastKnots: w.east}, {AltitudeFeet: 20000, EastKnots: w.east}}}
+	}
+	return WindProfile{SourceID: "fixture", SourceRevision: "test-v1", ObservedAt: w.now, ExpiresAt: expires, Samples: samples}, nil
+}
+func performanceNow() time.Time { return time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC) }
+func performanceInput() PerformanceWindInput {
+	return PerformanceWindInput{PredictionAt: performanceNow(), AircraftICAO: "A320", WakeTurbulenceCategory: CategoryMedium, AltitudeFeet: 10000, Remaining: []RouteLeg{{ID: "EAST", DistanceNM: 100, CourseTrueDegrees: 90, Start: WindCoordinate{LatitudeDegrees: 55, LongitudeDegrees: 12}, End: WindCoordinate{LatitudeDegrees: 55, LongitudeDegrees: 14}}}}
+}

--- a/backend/internal/aman/trajectory/trajectory.go
+++ b/backend/internal/aman/trajectory/trajectory.go
@@ -65,9 +65,12 @@ type Input struct {
 }
 
 type RemainingLeg struct {
-	ID         string
-	From, To   navdata.FixID
-	DistanceNM float64
+	ID                string
+	From, To          navdata.FixID
+	DistanceNM        float64
+	CourseTrueDegrees float64
+	Start             navdata.Coordinate
+	End               navdata.Coordinate
 }
 type Result struct {
 	Remaining       []RemainingLeg
@@ -387,10 +390,14 @@ func remaining(legs []leg, index int, along float64) []RemainingLeg {
 	out := make([]RemainingLeg, 0, len(legs)-index)
 	for i := index; i < len(legs); i++ {
 		d := legs[i].distance
+		start := legs[i].a
 		if i == index {
 			d -= along
+			_, bearing := wgs84Inverse(legs[i].a, legs[i].b)
+			start = wgs84Direct(legs[i].a, bearing, along)
 		}
-		out = append(out, RemainingLeg{legs[i].id, legs[i].from, legs[i].to, math.Max(0, d)})
+		_, course := wgs84Inverse(start, legs[i].b)
+		out = append(out, RemainingLeg{ID: legs[i].id, From: legs[i].from, To: legs[i].to, DistanceNM: math.Max(0, d), CourseTrueDegrees: course * 180 / math.Pi, Start: start, End: legs[i].b})
 	}
 	return out
 }

--- a/backend/internal/aman/trajectory/trajectory_test.go
+++ b/backend/internal/aman/trajectory/trajectory_test.go
@@ -110,6 +110,18 @@ func TestReduceProjectsLongLegAndPositionsBeforeAndAfterPath(t *testing.T) {
 	require.InDelta(t, 0, *after.DistanceToGoNM, .1)
 }
 
+func TestRemainingPartialLegStartsAtProjectedPositionForWindSampling(t *testing.T) {
+	snapshot, route, input := fixtureInput(t)
+	input.Observation.LongitudeDegrees = .5
+	result := Reduce(snapshot, route, input, Config{})
+	require.NotEmpty(t, result.Remaining)
+	first := result.Remaining[0]
+	require.InDelta(t, .5, first.Start.LongitudeDeg, .01)
+	require.InDelta(t, 1, first.End.LongitudeDeg, .01)
+	require.InDelta(t, 90, first.CourseTrueDegrees, .1)
+	require.InDelta(t, routeDistance(snapshot, "A", "B")/2, first.DistanceNM, .1)
+}
+
 func TestReduceRepeatedFixAndCrossingChoosePlausibleForwardLeg(t *testing.T) {
 	snapshot, route, input := fixtureInput(t)
 	a, b, c, d := navdata.FixID("A"), navdata.FixID("B"), navdata.FixID("C"), navdata.FixID("D")


### PR DESCRIPTION
## Summary

- Adds provider-neutral, versioned aircraft-performance selection with deterministic ICAO/WTC/default fallback.
- Calculates bounded raw route-TETA wind corrections from midpoint forecast samples and records profile/weather provenance.
- Adds the Open-Meteo GFS adapter with geopotential-height interpolation, cache safety, and bounded HTTP handling.

## Stack

Base: `codex/aman-316-route-trajectory` at corrected #316 head `ae7dd891ee49d2b3a2854834f2397dc0f9d22d3e`.

## Validation

- `go test -race ./internal/aman/predictor ./internal/aman/predictor/openmeteo ./internal/aman/trajectory`
- `go test ./...`
- `git diff --check ae7dd891ee49d2b3a2854834f2397dc0f9d22d3e..HEAD`
- `git range-diff` confirms the restacked #313 patch is equivalent to the original commit.

Closes #313
