### PR TITLE
fix(strip): update concerned SI and departure border colors

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -18,7 +18,7 @@
   --color-bay-est:         #767676; /* EST view lighter panel */
 
   /* ── Strip background colors ───────────────────────── */
-  --color-strip-frame:       #85b4af; /* strip frame / border (teal) */
+  --color-strip-frame:       #18BCBC; /* departure strip frame / border (cyan) */
   --color-strip-dep-bg:      #bef5ef; /* departure strip background */
   --color-strip-arr-bg:      #fff28e; /* arrival strip background */
   --color-strip-unconcerned: #cccccc; /* unconcerned strip background */
@@ -44,7 +44,7 @@
   /* ── SI (position ownership) indicator colors ────────── */
   --color-si-assumed:        #F0F0F0; /* strip assumed by current controller */
   --color-si-unconcerned:    #DD6A12; /* strip not relevant to position */
-  --color-si-concerned:      #E082E7; /* strip in next position's list */
+  --color-si-concerned:      #FA02FC; /* concerned strip in next position's list */
 
   /* ── Half-strip variant colors ───────────────────────── */
   --color-half-mem-aid:      #004FD6; /* memory aid half-strip */


### PR DESCRIPTION
## Summary

- update the concerned SI color to `#FA02FC`
- update the departure strip border color to `#18BCBC`
- keep both colors centralized in the shared frontend palette

## Why

The shared palette still contained the previous concerned SI and departure border values, so all strip consumers rendered outdated colors.

## Impact

Concerned SI indicators and departure strip borders now match the requested operational color scheme.

Closes #381
Closes #382

## Validation

- `npm run build`
- `npm test` (103 tests passed)
- `git diff --check`

`npm run lint` remains blocked by an unrelated pre-existing `react-hooks/set-state-in-effect` error in `frontend/src/components/commandbar/VACSBTN.tsx:79`.
