### PR TITLE
feat(handover): resolve EKCH transfers from radio coverage

### DIFF
--- a/backend/config/ekch.yaml
+++ b/backend/config/ekch.yaml
@@ -153,13 +153,16 @@ positions:
   - name: "EKCH_C_GND"
     frequency: "121.730"
     section: "GND"
+  - name: "EKCH_GE_TWR"
+    frequency: "121.830"
+    section: "TWR"
   - name: "EKCH_D_TWR"
     frequency: "119.355"
     section: "TWR"
   - name: "EKCH_A_TWR"
     frequency: "118.105"
     section: "TWR"
-  - name: "EKCH_C_TWR"
+  - name: "EKCH_GW_TWR"
     frequency: "118.580"
     section: "TWR"
   - name: "EKCH_FMH"
@@ -326,10 +329,12 @@ sectors:
       - "EKCH_A_GND"
       - "EKCH_B_GND"
       - "EKCH_C_GND"
-      - "EKCH_C_TWR"
+      - "EKCH_GW_TWR"
+      - "EKCH_GE_TWR"
       - "EKCH_D_TWR"
       - "EKCH_A_TWR"
   - name: SQ
+    display_name: "SEQ PLN"
     name_priority: 0
     active: [ ]
     owner:
@@ -337,7 +342,8 @@ sectors:
       - "EKCH_DEL"
       - "EKCH_A_GND"
       - "EKCH_C_GND"
-      - "EKCH_C_TWR"
+      - "EKCH_GW_TWR"
+      - "EKCH_GE_TWR"
       - "EKCH_D_TWR"
       - "EKCH_A_TWR"
 
@@ -353,7 +359,8 @@ sectors:
       - "EKCH_A_GND"
       - "EKCH_B_GND"
       - "EKCH_C_GND"
-      - "EKCH_C_TWR"
+      - "EKCH_GW_TWR"
+      - "EKCH_GE_TWR"
       - "EKCH_D_TWR"
       - "EKCH_A_TWR"
   - name: AD
@@ -367,7 +374,18 @@ sectors:
       - "EKCH_C_GND"
       - "EKCH_B_GND"
       - "EKCH_A_GND"
-      - "EKCH_C_TWR"
+      - "EKCH_GW_TWR"
+      - "EKCH_GE_TWR"
+      - "EKCH_D_TWR"
+      - "EKCH_A_TWR"
+
+  - name: GE
+    name_priority: 40
+    active: [ ]
+    region: [GROUND_EAST]
+    owner:
+      - "EKCH_GE_TWR"
+      - "EKCH_GW_TWR"
       - "EKCH_D_TWR"
       - "EKCH_A_TWR"
 
@@ -375,11 +393,12 @@ sectors:
   - name: TE
     name_priority: 50
     active: ["22L", "22R"]
-    region: [TOWER_EAST, GROUND_EAST]
+    region: [TOWER_EAST]
     owner:
       - "EKCH_A_TWR"
       - "EKCH_D_TWR"
-      - "EKCH_C_TWR"
+      - "EKCH_GW_TWR"
+      - "EKCH_GE_TWR"
   - name: TW
     name_priority: 50
     active: ["22L", "22R"]
@@ -387,17 +406,30 @@ sectors:
     owner:
       - "EKCH_D_TWR"
       - "EKCH_A_TWR"
-      - "EKCH_C_TWR"
+      - "EKCH_GW_TWR"
+      - "EKCH_GE_TWR"
+
+  # Tower West for runway 12
+  - name: TW
+    name_priority: 50
+    active: ["12"]
+    region: [TOWER_WEST]
+    owner:
+      - "EKCH_D_TWR"
+      - "EKCH_A_TWR"
+      - "EKCH_GW_TWR"
+      - "EKCH_GE_TWR"
 
   # Towers 04s
   - name: TE
     name_priority: 50
     active: ["04L", "04R"]
-    region: [TOWER_EAST, GROUND_EAST]
+    region: [TOWER_EAST]
     owner:
       - "EKCH_D_TWR"
       - "EKCH_A_TWR"
-      - "EKCH_C_TWR"
+      - "EKCH_GW_TWR"
+      - "EKCH_GE_TWR"
   - name: TW
     name_priority: 50
     active: ["04L", "04R"]
@@ -405,7 +437,8 @@ sectors:
     owner:
       - "EKCH_A_TWR"
       - "EKCH_D_TWR"
-      - "EKCH_C_TWR"
+      - "EKCH_GW_TWR"
+      - "EKCH_GE_TWR"
 
   # Towers 30
   - name: TE
@@ -415,7 +448,8 @@ sectors:
     owner:
       - "EKCH_A_TWR"
       - "EKCH_D_TWR"
-      - "EKCH_C_TWR"
+      - "EKCH_GW_TWR"
+      - "EKCH_GE_TWR"
   - name: GW
     key: GWD
     name_priority: 40
@@ -425,7 +459,8 @@ sectors:
       departure: true
       arrival: false
     owner:
-      - "EKCH_C_TWR"
+      - "EKCH_GW_TWR"
+      - "EKCH_GE_TWR"
       - "EKCH_D_TWR"
       - "EKCH_A_TWR"
   - name: GW
@@ -437,7 +472,8 @@ sectors:
       departure: false
       arrival: true
     owner:
-      - "EKCH_C_TWR"
+      - "EKCH_GW_TWR"
+      - "EKCH_GE_TWR"
       - "EKCH_D_TWR"
       - "EKCH_A_TWR"
 
@@ -450,7 +486,8 @@ sectors:
     owner:
       - "EKCH_A_TWR"
       - "EKCH_D_TWR"
-      - "EKCH_C_TWR"
+      - "EKCH_GW_TWR"
+      - "EKCH_GE_TWR"
   - name: TW
     name_priority: 50
     active: ["30", "22R"]
@@ -459,7 +496,8 @@ sectors:
     owner:
       - "EKCH_D_TWR"
       - "EKCH_A_TWR"
-      - "EKCH_C_TWR"
+      - "EKCH_GW_TWR"
+      - "EKCH_GE_TWR"
   - name: GW
     key: GWD
     name_priority: 40
@@ -470,7 +508,8 @@ sectors:
       departure: true
       arrival: false
     owner:
-      - "EKCH_C_TWR"
+      - "EKCH_GW_TWR"
+      - "EKCH_GE_TWR"
       - "EKCH_D_TWR"
       - "EKCH_A_TWR"
   - name: GW
@@ -483,7 +522,8 @@ sectors:
       departure: false
       arrival: true
     owner:
-      - "EKCH_C_TWR"
+      - "EKCH_GW_TWR"
+      - "EKCH_GE_TWR"
       - "EKCH_D_TWR"
       - "EKCH_A_TWR"
 
@@ -497,7 +537,8 @@ sectors:
       departure: true
       arrival: false
     owner:
-      - "EKCH_C_TWR"
+      - "EKCH_GW_TWR"
+      - "EKCH_GE_TWR"
       - "EKCH_D_TWR"
       - "EKCH_A_TWR"
   - name: GW
@@ -509,7 +550,8 @@ sectors:
       departure: false
       arrival: true
     owner:
-      - "EKCH_C_TWR"
+      - "EKCH_GW_TWR"
+      - "EKCH_GE_TWR"
       - "EKCH_A_TWR"
       - "EKCH_D_TWR"
 
@@ -547,36 +589,114 @@ sectors:
       - EKDK_UN_CTR
 
 routes:
-  - name: Stands to Runway 22R
+  # Complete departure paths. Logical sectors stay fixed; live radio coverage
+  # determines which primary position carries each step.
+  - name: North stands to runway 22R
     forRunway: 22R
+    forStandRanges: &north_stands
+      - A1-A34
+      - B3-B19
+      - C10-C39
+      - D1-D4
+      - E20-E90
+      - F1-F99
+      - H101-H107
     active: [22R]
-    path: [AD, GWD, TW]
-  - name: Stands to Runway 04R
+    path: [SQ, AD, GW, TW]
+  - name: North stands to runway 04L
+    forRunway: 04L
+    forStandRanges: *north_stands
+    active: [04L]
+    path: [SQ, AD, GW, TW]
+  - name: North stands to runway 04R
     forRunway: 04R
+    forStandRanges: *north_stands
     active: [04R]
-    path: [AD, GWD, TE]
-  - name: Stands to Runway 22R cargo
+    path: [SQ, AD, GW, TE]
+  - name: North stands to runway 30
+    forRunway: "30"
+    forStandRanges: *north_stands
+    active: ["30"]
+    path: [SQ, AD, GW, TE]
+  - name: North stands to runway 22L
+    forRunway: 22L
+    forStandRanges: *north_stands
+    active: [22L]
+    path: [SQ, AD, TE]
+  - name: North stands to runway 12
+    forRunway: "12"
+    forStandRanges: *north_stands
+    active: ["12"]
+    path: [SQ, AD, TW]
+
+  - name: East and South stands to runway 22R
     forRunway: 22R
+    forStandRanges: &east_south_stands [G110-G137]
     active: [22R]
-    path: [TE, GWD, TW]
-  - name: Stands to Runway 04R cargo
+    path: [GE, TW]
+  - name: East and South stands to runway 04L
+    forRunway: 04L
+    forStandRanges: *east_south_stands
+    active: [04L]
+    path: [GE, TW]
+  - name: East and South stands to runway 04R
     forRunway: 04R
+    forStandRanges: *east_south_stands
     active: [04R]
-    path: [TW]
-  - name: Stands to Runway 30
+    path: [GE, TE]
+  - name: East and South stands to runway 30
     forRunway: "30"
+    forStandRanges: *east_south_stands
     active: ["30"]
-    path: [AD, GWD, TE]
-  - name: Stands to Runway 22R cargo
+    path: [GE, TE]
+  - name: East and South stands to runway 22L
+    forRunway: 22L
+    forStandRanges: *east_south_stands
+    active: [22L]
+    path: [GE, TE]
+  - name: East and South stands to runway 12
+    forRunway: "12"
+    forStandRanges: *east_south_stands
+    active: ["12"]
+    path: [GE, TW]
+
+  - name: West stand to runway 22R
+    forRunway: 22R
+    forStandRanges: &west_stands [W1]
+    active: [22R]
+    path: [GW, TW]
+  - name: West stand to runway 04L
+    forRunway: 04L
+    forStandRanges: *west_stands
+    active: [04L]
+    path: [GW, TW]
+  - name: West stand to runway 04R
+    forRunway: 04R
+    forStandRanges: *west_stands
+    active: [04R]
+    path: [GW, TE]
+  - name: West stand to runway 30
     forRunway: "30"
+    forStandRanges: *west_stands
     active: ["30"]
-    path: [GWD, TE]
-  # TODO rest of the runways
+    path: [GW, TE]
+  - name: West stand to runway 22L
+    forRunway: 22L
+    forStandRanges: *west_stands
+    active: [22L]
+    path: [GW, TE]
+  - name: West stand to runway 12
+    forRunway: "12"
+    forStandRanges: *west_stands
+    active: ["12"]
+    path: [GW, TW]
+
+  # Arrival paths are selected from destination stand and arrival runway.
   - name: Runway 30 to cargo
     forStandRanges:
       - G110-G137
     active: ["30"]
-    path: [TE, AA, GWA]
+    path: [TE, AA, GWA, GE]
   - name: Runway 30 to rest
     forStandRanges:
       - A1-A33
@@ -585,7 +705,7 @@ routes:
       - D1-D4
       - E20-E90
       - F1-F99
-      - H101-H106
+      - H101-H107
     active: ["30"]
     path: [TE, GWA, AA]
     owner_overrides:
@@ -611,12 +731,12 @@ routes:
     forStandRanges:
       - G110-G137
     active: [22L, 04R]
-    path: [AA, TE]
+    path: [AA, GE]
   - name: Runway 22L/04R to cargo
     forStandRanges:
       - G110-G137
     active: [22L, 04R]
-    path: [TE, TW, GWA, TE]
+    path: [TE, TW, GWA, GE]
     owner_overrides:
       TW: TE
       GWA: TE
@@ -636,7 +756,7 @@ routes:
       - D1-D4
       - E20-E90
       - F1-F99
-      - H101-H106
+      - H101-H107
     active: [22L, 04R]
     path: [TE, TW, GWA, AA]
     owner_overrides:
@@ -656,12 +776,12 @@ routes:
     forStandRanges:
       - G110-G137
     active: [04L, 22R]
-    path: [AA, TE]
+    path: [AA, GE]
   - name: Runway 04L/22R to cargo
     forStandRanges:
       - G110-G137
     active: [04L, 22R]
-    path: [TW, GWA, TE]
+    path: [TW, GWA, GE]
   - name: Runway 04L/22R to W1
     forStandRanges:
       - W1
@@ -678,7 +798,7 @@ routes:
       - D1-D4
       - E20-E90
       - F1-F99
-      - H101-H106
+      - H101-H107
     active: [04L, 22R]
     path: [TW, TE, GWA, AA]
     owner_overrides:
@@ -689,8 +809,8 @@ message_areas:
   CLR-DEL:   [EKCH_DEL, EKCH_A_GND]
   APRON ARR: [EKCH_A_GND, EKCH_B_GND]
   APRON DEP: [EKCH_C_GND, EKCH_B_GND]
-  GND WEST:  [EKCH_C_TWR, EKCH_A_TWR, EKCH_D_TWR]
-  GND EAST:  [EKCH_D_TWR, EKCH_A_TWR]
+  GND WEST:  [EKCH_GW_TWR, EKCH_A_TWR, EKCH_D_TWR]
+  GND EAST:  [EKCH_GE_TWR, EKCH_D_TWR, EKCH_A_TWR]
   TWR-ARR:   [EKCH_A_TWR, EKCH_D_TWR]
   TWR-DEP:   [EKCH_D_TWR, EKCH_A_TWR]
   SEQ PLN:   [EKCH_B_GND, EKCH_A_GND]
@@ -748,7 +868,12 @@ layouts:
       offline: [EKCH_A_GND, EKCH_B_GND]
       layout: AAAD
 
-  EKCH_C_TWR:
+  EKCH_GE_TWR:
+    - online: []
+      offline: []
+      layout: GEGW
+
+  EKCH_GW_TWR:
     - online: [EKCH_A_TWR, EKCH_D_TWR, _GND]
       offline: []
       layout: GEGW

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -259,8 +259,8 @@ func loadRoutes(cfg Config) error {
 		hasRunway := runway != ""
 		hasStands := len(rt.ForStandRanges) > 0
 
-		if hasRunway == hasStands {
-			return fmt.Errorf("route %d (%q): must specify exactly one of forRunway or forStandRanges", i, rt.Name)
+		if !hasRunway && !hasStands {
+			return fmt.Errorf("route %d (%q): must specify forRunway, forStandRanges, or both", i, rt.Name)
 		}
 		if len(rt.Path) == 0 {
 			return fmt.Errorf("route %d (%q): path must not be empty", i, rt.Name)
@@ -280,23 +280,37 @@ func loadRoutes(cfg Config) error {
 			}
 			rt.OwnerOverrides = normalizedOverrides
 		}
+		for _, reference := range rt.Path {
+			if !configuredSectorExists(cfg.Sectors, reference) {
+				return fmt.Errorf("route %d (%q): route references unknown sector %q", i, rt.Name, reference)
+			}
+		}
 
 		if hasRunway {
 			key := normalizeRunway(runway)
 			rt.ForRunway = key
 			newRunway[key] = append(newRunway[key], rt)
-		} else {
+		}
+		if hasStands {
 			// normalize prefixes in stand ranges
 			for j := range rt.ForStandRanges {
 				rt.ForStandRanges[j].Prefix = strings.ToUpper(strings.TrimSpace(rt.ForStandRanges[j].Prefix))
 			}
-			newStands = append(newStands, rt)
+			if !hasRunway {
+				newStands = append(newStands, rt)
+			}
 		}
 	}
 
 	runwayRoutes = newRunway
 	standRoutes = newStands
 	return nil
+}
+
+func configuredSectorExists(configured []Sector, reference string) bool {
+	return slices.ContainsFunc(configured, func(sector Sector) bool {
+		return strings.EqualFold(sector.Name, reference) || strings.EqualFold(sector.KeyOrName(), reference)
+	})
 }
 
 func InitConfig() error {

--- a/backend/internal/config/layouts_test.go
+++ b/backend/internal/config/layouts_test.go
@@ -164,7 +164,7 @@ func TestGetLayouts_NoMutationAcrossCalls(t *testing.T) {
 
 func ekchTowerLayouts() map[string][]LayoutVariant {
 	return map[string][]LayoutVariant{
-		"EKCH_C_TWR": {
+		"EKCH_GW_TWR": {
 			{Online: []string{"EKCH_A_TWR", "EKCH_D_TWR", "_GND"}, Offline: []string{}, Layout: "GEGW"},
 			{Online: []string{"EKCH_A_TWR", "_GND"}, Offline: []string{"EKCH_D_TWR"}, Layout: "GEGW"},
 			{Online: []string{"EKCH_D_TWR", "_GND"}, Offline: []string{"EKCH_A_TWR"}, Layout: "GEGW"},
@@ -226,7 +226,7 @@ func TestGetLayouts_SingleTopdown_GetsTwrGndWhenGroundOffline(t *testing.T) {
 	setupTowerLayouts(t)
 
 	controllers := []*Position{
-		makePos("EKCH_C_TWR", "118.580", "TWR"),
+		makePos("EKCH_GW_TWR", "118.580", "TWR"),
 	}
 
 	result := GetLayouts(controllers, []string{"22L", "22R"})
@@ -238,7 +238,7 @@ func TestGetLayouts_SingleTopdown_WithGroundOnlineKeepsTwte(t *testing.T) {
 	setupTowerLayouts(t)
 
 	controllers := []*Position{
-		makePos("EKCH_C_TWR", "118.580", "TWR"),
+		makePos("EKCH_GW_TWR", "118.580", "TWR"),
 		makePos("EKCH_A_GND", "121.630", "GND"),
 	}
 

--- a/backend/internal/config/positions_test.go
+++ b/backend/internal/config/positions_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestGetPositionBasedOnFrequency_NormalizesTrailingZeros(t *testing.T) {
 	t.Cleanup(SetPositionsForTest([]Position{
 		{Name: "EKCH_A_GND", Frequency: "121.600", Section: "GND"},
-		{Name: "EKCH_C_TWR", Frequency: "118.580", Section: "TWR"},
+		{Name: "EKCH_GW_TWR", Frequency: "118.580", Section: "TWR"},
 	}))
 
 	tests := []struct {
@@ -14,8 +14,8 @@ func TestGetPositionBasedOnFrequency_NormalizesTrailingZeros(t *testing.T) {
 		wantName  string
 	}{
 		{name: "ground short decimal", frequency: "121.6", wantName: "EKCH_A_GND"},
-		{name: "tower short decimal", frequency: "118.58", wantName: "EKCH_C_TWR"},
-		{name: "already normalized", frequency: "118.580", wantName: "EKCH_C_TWR"},
+		{name: "tower short decimal", frequency: "118.58", wantName: "EKCH_GW_TWR"},
+		{name: "already normalized", frequency: "118.580", wantName: "EKCH_GW_TWR"},
 	}
 
 	for _, tt := range tests {

--- a/backend/internal/config/routes.go
+++ b/backend/internal/config/routes.go
@@ -148,14 +148,12 @@ func SingleStandRange(prefix string, number int) StandRange {
 	return StandRange{Prefix: strings.ToUpper(prefix), From: number, To: number}
 }
 
-// Route is a simple, hard-coded taxi route defined by either a destination runway
-// or a destination set of stands/stand ranges. Exactly one of ForRunway or ForStandRanges must be set.
-// Note: A single stand is represented as a range with From == To (e.g., W1 -> {Prefix: "W", From: 1, To: 1}).
+// Route is an ordered logical route qualified by runway, stand, or both.
 type Route struct {
 	Name           string            `yaml:"name"`
 	ForRunway      string            `yaml:"forRunway"`       // e.g., "RWY27" or "27" (case-insensitive)
 	ForStandRanges []StandRange      `yaml:"forStandRanges"`  // e.g., A10-A20, B5-B10, or single stands like W1 (From=To=1)
-	Path           []string          `yaml:"path"`            // ordered Sector names from general origin area to destination
+	Path           []string          `yaml:"path"`            // ordered logical sector identifiers
 	Active         []string          `yaml:"active"`          // runways that must be active for this route to match
 	RequireAll     bool              `yaml:"require_all"`     // if true, all Active runways must be present (default: any)
 	OwnerOverrides map[string]string `yaml:"owner_overrides"` // matched sector -> sector whose owner should be used
@@ -173,22 +171,51 @@ type ResolvedRoute struct {
 // empty active list is a catch-all (score 0) and loses to any specific match.
 // Returns the subsequence of path from the current Sector to the end together with
 // any route-scoped owner overrides that should apply while constructing next owners.
-func ComputeToRunway(active []string, currentSector string, runway string) (ResolvedRoute, bool) {
+func ComputeToRunway(active []string, currentSector string, runway string, stand ...string) (ResolvedRoute, bool) {
+	return selectRunwayRoute(active, currentSector, runway, firstString(stand), true)
+}
+
+// ComputeDepartureRoute selects the complete outbound route for a stand and
+// runway. The caller resolves the first currently carried logical stage.
+func ComputeDepartureRoute(active []string, stand string, runway string) (ResolvedRoute, bool) {
+	return selectRunwayRoute(active, "", runway, stand, false)
+}
+
+func selectRunwayRoute(active []string, currentSector string, runway string, stand string, requireCurrentSector bool) (ResolvedRoute, bool) {
 	candidates := runwayRoutes[normalizeRunway(runway)]
 	if len(candidates) == 0 {
 		return ResolvedRoute{}, false
 	}
+
+	parsedStand, standErr := ParseStand(stand)
 	bestScore := -1
+	bestStandSpecificity := -1
 	var bestRoute ResolvedRoute
 	for _, r := range candidates {
+		standSpecificity := 0
+		if len(r.ForStandRanges) > 0 {
+			if standErr != nil || !slices.ContainsFunc(r.ForStandRanges, func(standRange StandRange) bool {
+				return standRange.Contains(parsedStand)
+			}) {
+				continue
+			}
+			standSpecificity = 1
+		}
+
 		score := scoreActive(r.Active, active, r.RequireAll)
-		if score < 0 || score <= bestScore {
+		if score < 0 || standSpecificity < bestStandSpecificity || (standSpecificity == bestStandSpecificity && score <= bestScore) {
 			continue
 		}
-		startIdx := indexOfSector(r.Path, currentSector)
-		if startIdx < 0 {
-			continue
+
+		startIdx := 0
+		if requireCurrentSector {
+			startIdx = indexOfSector(r.Path, currentSector)
+			if startIdx < 0 {
+				continue
+			}
 		}
+
+		bestStandSpecificity = standSpecificity
 		bestScore = score
 		bestRoute = resolveRouteSelection(r, startIdx)
 	}
@@ -196,6 +223,13 @@ func ComputeToRunway(active []string, currentSector string, runway string) (Reso
 		return ResolvedRoute{}, false
 	}
 	return bestRoute, true
+}
+
+func firstString(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
 }
 
 // ComputeToStand selects a route to the given destination stand that is valid under
@@ -248,7 +282,8 @@ func normalizeRunway(rwy string) string {
 
 func indexOfSector(path []string, sector string) int {
 	for i, s := range path {
-		if strings.EqualFold(s, sector) {
+		if strings.EqualFold(s, sector) ||
+			strings.EqualFold(GetSectorDisplayName(s), GetSectorDisplayName(sector)) {
 			return i
 		}
 	}

--- a/backend/internal/config/routes_test.go
+++ b/backend/internal/config/routes_test.go
@@ -1,6 +1,9 @@
 package config
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestGetArrivalTowerSector_ReturnsFirstSectorOfMatchingRoute(t *testing.T) {
 	original := standRoutes
@@ -383,5 +386,65 @@ func TestGetDefaultAirborneControllerPriorityReturnsErrorWithoutDefaultRoute(t *
 
 	if _, err := GetDefaultAirborneControllerPriority(); err == nil {
 		t.Fatal("expected error without default airborne route")
+	}
+}
+
+func TestLoadRoutesSupportsCompleteDepartureRoutesQualifiedByStandAndRunway(t *testing.T) {
+	originalRunway := runwayRoutes
+	originalStands := standRoutes
+	t.Cleanup(func() {
+		runwayRoutes = originalRunway
+		standRoutes = originalStands
+	})
+
+	err := loadRoutes(Config{
+		Sectors: []Sector{
+			{Name: "AD"},
+			{Name: "GW"},
+			{Name: "TW"},
+		},
+		Routes: []Route{
+			{
+				Name:           "complete departure route",
+				ForRunway:      "22R",
+				ForStandRanges: []StandRange{{Prefix: "A", From: 1, To: 34}},
+				Path:           []string{"AD", "GW", "TW"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("loadRoutes returned error: %v", err)
+	}
+
+	route, ok := ComputeDepartureRoute(nil, "A12", "22R")
+	if !ok || len(route.Path) != 3 {
+		t.Fatalf("expected complete departure route, got %#v", route)
+	}
+	if got := strings.Join(route.Path, ","); got != "AD,GW,TW" {
+		t.Fatalf("expected logical path AD,GW,TW, got %s", got)
+	}
+	if _, ok := ComputeDepartureRoute(nil, "G120", "22R"); ok {
+		t.Fatal("route must not match a stand outside its configured ranges")
+	}
+}
+
+func TestLoadRoutesRejectsUnknownRouteSector(t *testing.T) {
+	originalRunway := runwayRoutes
+	originalStands := standRoutes
+	t.Cleanup(func() {
+		runwayRoutes = originalRunway
+		standRoutes = originalStands
+	})
+
+	err := loadRoutes(Config{
+		Sectors: []Sector{{Name: "AD"}},
+		Routes: []Route{{
+			Name:      "invalid route",
+			ForRunway: "22R",
+			Path:      []string{"AD", "MISSING"},
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), `unknown sector "MISSING"`) {
+		t.Fatalf("expected unknown route sector error, got %v", err)
 	}
 }

--- a/backend/internal/config/sectors.go
+++ b/backend/internal/config/sectors.go
@@ -15,6 +15,7 @@ type constraints struct {
 type Sector struct {
 	Name         string       `yaml:"name"`
 	Key          string       `yaml:"key"`
+	DisplayName  string       `yaml:"display_name"`
 	NamePriority int          `yaml:"name_priority"`
 	Region       []string     `yaml:"region"`
 	Constraints  *constraints `yaml:"constraints"`
@@ -78,6 +79,7 @@ func GetControllerSectorsWithCoverage(controllers []ControllerCoverage, active [
 		result[primaryFrequency] = make([]Sector, 0)
 		directLookup[c.Name] = primaryFrequency
 		primaryNameByFrequency[primaryFrequency] = c.Name
+		coverageByFrequency[primaryFrequency] = appendUniqueFrequency(coverageByFrequency[primaryFrequency], primaryFrequency)
 		for _, coveredFrequency := range c.CoveredFrequencies {
 			normalizedCoveredFrequency := vatsim.NormalizeFrequency(coveredFrequency)
 			if normalizedCoveredFrequency == "" {
@@ -124,12 +126,6 @@ func GetControllerSectorsWithCoverage(controllers []ControllerCoverage, active [
 
 func resolveSectorOwnerFrequency(owners []string, directLookup map[string]string, primaryNameByFrequency map[string]string, coverageByFrequency map[string][]string) (string, bool) {
 	for _, owner := range owners {
-		if frequency, ok := directLookup[owner]; ok {
-			return frequency, true
-		}
-	}
-
-	for _, owner := range owners {
 		position, err := GetPositionByName(owner)
 		if err != nil {
 			continue
@@ -141,6 +137,12 @@ func resolveSectorOwnerFrequency(owners []string, directLookup map[string]string
 				return frequency, true
 			}
 			return frequencies[0], true
+		}
+	}
+
+	for _, owner := range owners {
+		if frequency, ok := directLookup[owner]; ok {
+			return frequency, true
 		}
 	}
 
@@ -179,6 +181,9 @@ func matchScore(sector Sector, active []string) int {
 func GetSectorDisplayName(sectorRef string) string {
 	for _, sector := range sectors {
 		if sectorMatchesIdentifier(sector, sectorRef) {
+			if strings.TrimSpace(sector.DisplayName) != "" {
+				return sector.DisplayName
+			}
 			return sector.Name
 		}
 	}
@@ -202,6 +207,48 @@ func GetSectorDisplayFrequency(active []string, sectorRef string, isArrival bool
 	}
 
 	return "", false
+}
+
+// GetSectorIdentifier resolves a public or internal sector reference to the
+// runway- and direction-specific configured sector identifier.
+func GetSectorIdentifier(active []string, sectorRef string, isArrival bool) (string, bool) {
+	sector, ok := getSectorByIdentifier(active, sectorRef, isArrival)
+	if !ok {
+		return "", false
+	}
+	return sector.KeyOrName(), true
+}
+
+// GetPositionLogicalIdentifier returns the logical sector that represents a
+// controller's configured operational role. Only sectors for which the position
+// is the primary configured owner are considered; fallback sectors do not change
+// the controller's displayed identity.
+func GetPositionLogicalIdentifier(active []string, positionName string, isArrival bool) (string, bool) {
+	bestPriority := -1
+	bestScore := -1
+	identifier := ""
+
+	for _, sector := range sectors {
+		if sector.Constraints != nil && (sector.Constraints.Arrival != isArrival || sector.Constraints.Departure != !isArrival) {
+			continue
+		}
+		if len(sector.Owner) == 0 || !strings.EqualFold(sector.Owner[0], positionName) {
+			continue
+		}
+		score := matchScore(sector, active)
+		if score < 0 {
+			continue
+		}
+		if sector.NamePriority < bestPriority || (sector.NamePriority == bestPriority && score <= bestScore) {
+			continue
+		}
+
+		bestPriority = sector.NamePriority
+		bestScore = score
+		identifier = sector.KeyOrName()
+	}
+
+	return identifier, identifier != ""
 }
 
 func IsArrivalTowerOwner(owner string, active []string) bool {

--- a/backend/internal/config/sectors_arrival_owner_test.go
+++ b/backend/internal/config/sectors_arrival_owner_test.go
@@ -8,7 +8,7 @@ func TestIsArrivalTowerOwner_MatchesApplicableTwTeOwners(t *testing.T) {
 		{Name: "TW", Active: []string{"22L", "22R"}, Owner: []string{"EKCH_D_TWR", "EKCH_A_TWR"}},
 		{Name: "TE", Active: []string{"04L", "04R"}, Owner: []string{"EKCH_D_TWR", "EKCH_A_TWR"}},
 		{Name: "TW", Active: []string{"04L", "04R"}, Owner: []string{"EKCH_A_TWR", "EKCH_D_TWR"}},
-		{Name: "GW", Active: []string{"22L", "22R"}, Owner: []string{"EKCH_C_TWR"}},
+		{Name: "GW", Active: []string{"22L", "22R"}, Owner: []string{"EKCH_GW_TWR"}},
 	}))
 
 	if !IsArrivalTowerOwner("EKCH_A_TWR", []string{"22L", "22R"}) {
@@ -17,7 +17,51 @@ func TestIsArrivalTowerOwner_MatchesApplicableTwTeOwners(t *testing.T) {
 	if !IsArrivalTowerOwner("EKCH_D_TWR", []string{"22L", "22R"}) {
 		t.Fatal("expected EKCH_D_TWR to match applicable TE/TW owners")
 	}
-	if IsArrivalTowerOwner("EKCH_C_TWR", []string{"22L", "22R"}) {
-		t.Fatal("did not expect EKCH_C_TWR to match TE/TW owners")
+	if IsArrivalTowerOwner("EKCH_GW_TWR", []string{"22L", "22R"}) {
+		t.Fatal("did not expect EKCH_GW_TWR to match TE/TW owners")
+	}
+}
+
+func TestGetPositionLogicalIdentifier_UsesPrimaryConfiguredRole(t *testing.T) {
+	t.Cleanup(SetSectorsForTest([]Sector{
+		{Name: "SQ", NamePriority: 0, Owner: []string{"EKCH_B_GND", "EKCH_C_GND"}},
+		{
+			Name:         "AD",
+			NamePriority: 20,
+			Constraints:  &constraints{Departure: true},
+			Owner:        []string{"EKCH_C_GND", "EKCH_B_GND"},
+		},
+		{Name: "GE", NamePriority: 40, Owner: []string{"EKCH_GE_TWR", "EKCH_GW_TWR"}},
+		{Name: "GW", Key: "GWD", NamePriority: 40, Owner: []string{"EKCH_GW_TWR", "EKCH_GE_TWR"}},
+		{Name: "TE", NamePriority: 50, Active: []string{"22R"}, Owner: []string{"EKCH_A_TWR", "EKCH_D_TWR"}},
+		{Name: "TW", NamePriority: 50, Active: []string{"22R"}, Owner: []string{"EKCH_D_TWR", "EKCH_A_TWR"}},
+	}))
+
+	tests := []struct {
+		name       string
+		active     []string
+		position   string
+		isArrival  bool
+		identifier string
+	}{
+		{name: "sequence", position: "EKCH_B_GND", identifier: "SQ"},
+		{name: "apron departure", position: "EKCH_C_GND", identifier: "AD"},
+		{name: "ground east", position: "EKCH_GE_TWR", identifier: "GE"},
+		{name: "ground west", position: "EKCH_GW_TWR", identifier: "GWD"},
+		{name: "tower east", active: []string{"22R"}, position: "EKCH_A_TWR", identifier: "TE"},
+		{name: "tower west", active: []string{"22R"}, position: "EKCH_D_TWR", identifier: "TW"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			identifier, ok := GetPositionLogicalIdentifier(test.active, test.position, test.isArrival)
+
+			if !ok {
+				t.Fatal("expected configured primary role")
+			}
+			if identifier != test.identifier {
+				t.Fatalf("expected %s, got %s", test.identifier, identifier)
+			}
+		})
 	}
 }

--- a/backend/internal/config/sectors_test.go
+++ b/backend/internal/config/sectors_test.go
@@ -425,6 +425,73 @@ func TestGetControllerSectorsWithCoverage_PrefersDirectOwnerOverIndirectCoverage
 	}
 }
 
+func TestGetControllerSectorsWithCoverage_TransmittingControllerPrecedesNonTransmittingFallbackOwner(t *testing.T) {
+	originalSectors := sectors
+	t.Cleanup(func() { sectors = originalSectors })
+	t.Cleanup(SetPositionsForTest([]Position{
+		{Name: "EKCH_GW_TWR", Frequency: "118.580"},
+		{Name: "EKCH_GE_TWR", Frequency: "121.830"},
+		{Name: "EKCH_D_TWR", Frequency: "119.355"},
+	}))
+
+	sectors = []Sector{
+		{Name: "GW", Key: "GWD", Owner: []string{"EKCH_GW_TWR", "EKCH_GE_TWR", "EKCH_D_TWR"}},
+	}
+
+	result := GetControllerSectorsWithCoverage([]ControllerCoverage{
+		{
+			Name:      "EKCH_GE_TWR",
+			Frequency: "121.830",
+		},
+		{
+			Name:               "EKCH_D_TWR",
+			Frequency:          "119.355",
+			CoveredFrequencies: []string{"118.580"},
+		},
+	}, []string{"04L"})
+
+	if len(result["119.355"]) != 1 {
+		t.Fatalf("expected transmitting D_TWR to claim GW, got %d sectors", len(result["119.355"]))
+	}
+	if len(result["121.830"]) != 0 {
+		t.Fatalf("expected non-transmitting GE fallback owner to stay idle, got %d sectors", len(result["121.830"]))
+	}
+}
+
+func TestGetControllerSectorsWithCoverage_UsesOwnerPriorityWhenTwoControllersTransmitSameFrequency(t *testing.T) {
+	originalSectors := sectors
+	t.Cleanup(func() { sectors = originalSectors })
+	t.Cleanup(SetPositionsForTest([]Position{
+		{Name: "EKCH_GW_TWR", Frequency: "118.580"},
+		{Name: "EKCH_GE_TWR", Frequency: "121.830"},
+		{Name: "EKCH_D_TWR", Frequency: "119.355"},
+	}))
+
+	sectors = []Sector{
+		{Name: "GW", Key: "GWD", Owner: []string{"EKCH_GW_TWR", "EKCH_GE_TWR", "EKCH_D_TWR"}},
+	}
+
+	result := GetControllerSectorsWithCoverage([]ControllerCoverage{
+		{
+			Name:               "EKCH_GE_TWR",
+			Frequency:          "121.830",
+			CoveredFrequencies: []string{"118.580"},
+		},
+		{
+			Name:               "EKCH_D_TWR",
+			Frequency:          "119.355",
+			CoveredFrequencies: []string{"118.580"},
+		},
+	}, []string{"04L"})
+
+	if len(result["121.830"]) != 1 {
+		t.Fatalf("expected higher-priority GE owner to win transmitter tie, got %d sectors", len(result["121.830"]))
+	}
+	if len(result["119.355"]) != 0 {
+		t.Fatalf("expected lower-priority D_TWR owner to lose transmitter tie, got %d sectors", len(result["119.355"]))
+	}
+}
+
 func TestGetControllerSectorsWithCoverage_UsesOwnerPriorityForIndirectMatches(t *testing.T) {
 	originalSectors := sectors
 	t.Cleanup(func() { sectors = originalSectors })

--- a/backend/internal/config/testing.go
+++ b/backend/internal/config/testing.go
@@ -108,5 +108,3 @@ func SetMissedApproachHandoverForTest(m map[string]string) func() {
 	missedApproachHandover = m
 	return func() { missedApproachHandover = old }
 }
-
-

--- a/backend/internal/server/handover.go
+++ b/backend/internal/server/handover.go
@@ -1,0 +1,165 @@
+package server
+
+import (
+	"FlightStrips/internal/config"
+	"FlightStrips/internal/models"
+	"FlightStrips/internal/vatsim"
+	"context"
+	"strings"
+)
+
+type resolvedHandover struct {
+	Identifier     string
+	Owner          string
+	Display        *models.NextDisplay
+	LogicalCarried bool
+}
+
+func (s *Server) ResolveClearedStripOwnerContext(ctx context.Context, strip *models.Strip, sessionID int32) (string, bool, error) {
+	if strip == nil {
+		return "", false, nil
+	}
+
+	session, err := routeSessionByID(ctx, s.sessionRepo, sessionID)
+	if err != nil {
+		return "", false, err
+	}
+	owners, err := routeSectorOwners(ctx, s.sectorRepo, sessionID)
+	if err != nil {
+		return "", false, err
+	}
+	radio, err := routeRadioStateForSession(ctx, s.controllerRepo, sessionID, s.frequencyProviders)
+	if err != nil {
+		return "", false, err
+	}
+
+	route, ok := config.ComputeDepartureRoute(
+		session.ActiveRunways.GetAllActiveRunways(),
+		sharedValue(strip.Stand),
+		sharedValue(strip.Runway),
+	)
+	if !ok {
+		return "", false, nil
+	}
+	resolution := resolveClearedRouteTarget(route.Path, strip, session, buildRouteOwnership(owners), radio)
+	if resolution == nil {
+		return "", false, nil
+	}
+	return resolution.Owner, true, nil
+}
+
+func resolveClearedRouteTarget(path []string, strip *models.Strip, session *models.Session, ownership routeOwnership, radio routeRadioState) *resolvedHandover {
+	if len(path) >= 2 && strings.EqualFold(path[0], "SQ") && strings.EqualFold(path[1], "AD") {
+		sequence := resolveOwnedHandoverTarget(path[0], strip, session, ownership, radio)
+		apronDeparture := resolveOwnedHandoverTarget(path[1], strip, session, ownership, radio)
+		if sequence != nil && apronDeparture != nil &&
+			sequence.LogicalCarried && apronDeparture.LogicalCarried &&
+			vatsim.NormalizeFrequency(sequence.Owner) == vatsim.NormalizeFrequency(apronDeparture.Owner) {
+			sequence.Identifier = "AD"
+			sequence.Display.Label = config.GetSectorDisplayName("AD")
+			return sequence
+		}
+	}
+
+	for _, identifier := range path {
+		if resolution := resolveOwnedHandoverTarget(identifier, strip, session, ownership, radio); resolution != nil {
+			return resolution
+		}
+	}
+	return nil
+}
+
+func resolveOwnedHandoverTarget(identifier string, strip *models.Strip, session *models.Session, ownership routeOwnership, radio routeRadioState) *resolvedHandover {
+	ownerSector := resolveConfiguredRouteSector(identifier, strip, session)
+	owner, ok := resolveRouteSectorOwner(ownerSector, ownership.sectorToOwner, nil)
+	if !ok {
+		return nil
+	}
+	return resolveHandoverTargetForOwner(identifier, owner, strip, session, ownership, radio)
+}
+
+func resolveHandoverTargetForOwner(identifier string, owner string, strip *models.Strip, session *models.Session, ownership routeOwnership, radio routeRadioState) *resolvedHandover {
+	frequency, ok := resolveLogicalSectorFrequency(identifier, strip, session)
+	if ok && ownerCarriesFrequency(owner, frequency, radio.coverage) {
+		return &resolvedHandover{
+			Identifier:     strings.ToUpper(strings.TrimSpace(identifier)),
+			Owner:          owner,
+			LogicalCarried: true,
+			Display: &models.NextDisplay{
+				Label:     config.GetSectorDisplayName(identifier),
+				Frequency: frequency,
+			},
+		}
+	}
+
+	return &resolvedHandover{
+		Identifier: ownership.ownerIdentifier[vatsim.NormalizeFrequency(owner)],
+		Owner:      owner,
+		Display:    buildConfiguredOwnerDisplay(strip, session, owner, ownership, radio),
+	}
+}
+
+func resolveLogicalSectorFrequency(identifier string, strip *models.Strip, session *models.Session) (string, bool) {
+	isArrival := strip.Destination == session.Airport
+	active := session.ActiveRunways.DepartureRunways
+	if isArrival {
+		active = session.ActiveRunways.ArrivalRunways
+	}
+	return config.GetSectorDisplayFrequency(active, identifier, isArrival)
+}
+
+func resolveConfiguredRouteSector(identifier string, strip *models.Strip, session *models.Session) string {
+	isArrival := strip.Destination == session.Airport
+	active := session.ActiveRunways.DepartureRunways
+	if isArrival {
+		active = session.ActiveRunways.ArrivalRunways
+	}
+	if resolved, ok := config.GetSectorIdentifier(active, identifier, isArrival); ok {
+		return resolved
+	}
+	return identifier
+}
+
+func ownerCarriesFrequency(owner string, frequency string, coverage map[string]map[string]struct{}) bool {
+	normalizedOwner := vatsim.NormalizeFrequency(owner)
+	normalizedFrequency := vatsim.NormalizeFrequency(frequency)
+	if normalizedOwner == "" || normalizedFrequency == "" {
+		return false
+	}
+	if normalizedOwner == normalizedFrequency {
+		return true
+	}
+	_, ok := coverage[normalizedOwner][normalizedFrequency]
+	return ok
+}
+
+func buildRouteOwnership(owners []*models.SectorOwner) routeOwnership {
+	ownership := routeOwnership{
+		sectorToOwner:   make(map[string]string),
+		ownerIdentifier: make(map[string]string),
+	}
+	for _, owner := range owners {
+		if owner == nil {
+			continue
+		}
+		normalizedOwner := vatsim.NormalizeFrequency(owner.Position)
+		identifier := strings.TrimSpace(owner.Identifier)
+		if identifier == "" && len(owner.Sector) > 0 {
+			identifier = config.GetSectorDisplayName(owner.Sector[0])
+		}
+		if _, exists := ownership.ownerIdentifier[normalizedOwner]; !exists || strings.TrimSpace(ownership.ownerIdentifier[normalizedOwner]) == "" {
+			ownership.ownerIdentifier[normalizedOwner] = identifier
+		}
+		for _, sector := range owner.Sector {
+			ownership.sectorToOwner[normalizeRouteSectorRef(sector)] = owner.Position
+		}
+	}
+	return ownership
+}
+
+func sharedValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}

--- a/backend/internal/server/handover_test.go
+++ b/backend/internal/server/handover_test.go
@@ -1,0 +1,562 @@
+package server
+
+import (
+	"FlightStrips/internal/config"
+	"FlightStrips/internal/models"
+	pkgModels "FlightStrips/pkg/models"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveClearedRouteTargetUsesCompleteDeparturePath(t *testing.T) {
+	session := handoverSession()
+
+	tests := []struct {
+		name      string
+		stand     string
+		runway    string
+		coverage  map[string]map[string]struct{}
+		wantOwner string
+		wantLabel string
+		wantFreq  string
+		wantRoute bool
+		ownership routeOwnership
+	}{
+		{
+			name:      "east route starts at GE",
+			stand:     "G110",
+			runway:    "22R",
+			coverage:  handoverCoverage("121.830", "119.355"),
+			wantOwner: "121.830",
+			wantLabel: "GE",
+			wantFreq:  "121.830",
+			wantRoute: true,
+			ownership: handoverOwnership(
+				map[string]string{"GE": "121.830", "TW": "119.355"},
+				map[string]string{"121.830": "GE", "119.355": "TW"},
+			),
+		},
+		{
+			name:      "east logical GE uses its configured GW owner when not carried",
+			stand:     "G137",
+			runway:    "22R",
+			coverage:  handoverCoverage("118.580", "119.355"),
+			wantOwner: "118.580",
+			wantLabel: "GW",
+			wantFreq:  "118.580",
+			wantRoute: true,
+			ownership: handoverOwnership(
+				map[string]string{"GE": "118.580", "TW": "119.355"},
+				map[string]string{"118.580": "GW", "119.355": "TW"},
+			),
+		},
+		{
+			name:   "west route resolves logical GW on carrying TW primary",
+			stand:  "W1",
+			runway: "22R",
+			coverage: map[string]map[string]struct{}{
+				"119.355": {"118.580": {}},
+			},
+			wantOwner: "119.355",
+			wantLabel: "GW",
+			wantFreq:  "118.580",
+			wantRoute: true,
+			ownership: handoverOwnership(
+				map[string]string{"GWD": "119.355", "TW": "119.355"},
+				map[string]string{"119.355": "TW"},
+			),
+		},
+		{
+			name:      "north route starts at separately primed sequence",
+			stand:     "A12",
+			runway:    "22R",
+			coverage:  handoverCoverage("121.905", "121.730"),
+			wantOwner: "121.905",
+			wantLabel: "SEQ PLN",
+			wantFreq:  "121.905",
+			wantRoute: true,
+			ownership: handoverOwnership(
+				map[string]string{"SQ": "121.905", "AD": "121.730"},
+				map[string]string{"121.905": "SQ", "121.730": "AD"},
+			),
+		},
+		{
+			name:   "unknown stand is inert",
+			stand:  "Z999",
+			runway: "22R",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			session.ActiveRunways.DepartureRunways = []string{test.runway}
+			route, ok := config.ComputeDepartureRoute(
+				session.ActiveRunways.GetAllActiveRunways(),
+				test.stand,
+				test.runway,
+			)
+			assert.Equal(t, test.wantRoute, ok)
+			if !ok {
+				return
+			}
+
+			strip := &models.Strip{
+				Stand:  handoverStringPtr(test.stand),
+				Runway: handoverStringPtr(test.runway),
+				Origin: "EKCH",
+			}
+			got := resolveClearedRouteTarget(route.Path, strip, session, test.ownership, handoverRadio(test.coverage))
+			require.NotNil(t, got)
+			assert.Equal(t, test.wantOwner, got.Owner)
+			require.NotNil(t, got.Display)
+			assert.Equal(t, test.wantLabel, got.Display.Label)
+			assert.Equal(t, test.wantFreq, got.Display.Frequency)
+		})
+	}
+}
+
+func TestEkchCompleteDeparturePaths(t *testing.T) {
+	tests := []struct {
+		stand  string
+		runway string
+		path   []string
+	}{
+		{"A12", "22R", []string{"SQ", "AD", "GW", "TW"}},
+		{"H107", "22R", []string{"SQ", "AD", "GW", "TW"}},
+		{"A12", "04L", []string{"SQ", "AD", "GW", "TW"}},
+		{"A12", "04R", []string{"SQ", "AD", "GW", "TE"}},
+		{"A12", "30", []string{"SQ", "AD", "GW", "TE"}},
+		{"A12", "22L", []string{"SQ", "AD", "TE"}},
+		{"A12", "12", []string{"SQ", "AD", "TW"}},
+		{"G120", "22R", []string{"GE", "TW"}},
+		{"G120", "04L", []string{"GE", "TW"}},
+		{"G120", "04R", []string{"GE", "TE"}},
+		{"G120", "30", []string{"GE", "TE"}},
+		{"G120", "22L", []string{"GE", "TE"}},
+		{"G120", "12", []string{"GE", "TW"}},
+		{"W1", "22R", []string{"GW", "TW"}},
+		{"W1", "04L", []string{"GW", "TW"}},
+		{"W1", "04R", []string{"GW", "TE"}},
+		{"W1", "30", []string{"GW", "TE"}},
+		{"W1", "22L", []string{"GW", "TE"}},
+		{"W1", "12", []string{"GW", "TW"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.stand+" "+test.runway, func(t *testing.T) {
+			route, ok := config.ComputeDepartureRoute([]string{test.runway}, test.stand, test.runway)
+			require.True(t, ok)
+			assert.Equal(t, test.path, route.Path)
+		})
+	}
+}
+
+func TestResolveClearedRouteTargetCombinedNorthPrimaryUsesADOnSequenceFrequency(t *testing.T) {
+	session := handoverSession()
+	strip := &models.Strip{
+		Stand:  handoverStringPtr("B7"),
+		Runway: handoverStringPtr("22R"),
+		Origin: "EKCH",
+	}
+	coverage := map[string]map[string]struct{}{
+		"121.905": {
+			"121.730": {},
+			"121.905": {},
+		},
+	}
+
+	route, ok := config.ComputeDepartureRoute(
+		session.ActiveRunways.GetAllActiveRunways(),
+		"B7",
+		"22R",
+	)
+	require.True(t, ok)
+
+	ownership := handoverOwnership(
+		map[string]string{"SQ": "121.905", "AD": "121.905"},
+		map[string]string{"121.905": "AD"},
+	)
+	got := resolveClearedRouteTarget(route.Path, strip, session, ownership, handoverRadio(coverage))
+
+	require.NotNil(t, got)
+	assert.Equal(t, "121.905", got.Owner)
+	require.NotNil(t, got.Display)
+	assert.Equal(t, "AD", got.Display.Label)
+	assert.Equal(t, "121.905", got.Display.Frequency)
+}
+
+func TestResolveOwnedHandoverTargetUsesConfiguredOwnerWhenLogicalFrequencyIsNotCarried(t *testing.T) {
+	session := handoverSession()
+	strip := &models.Strip{
+		Stand:  handoverStringPtr("A12"),
+		Runway: handoverStringPtr("22R"),
+		Origin: "EKCH",
+	}
+	ownership := routeOwnership{
+		sectorToOwner:   map[string]string{"GWD": "121.830", "GWA": "118.105"},
+		ownerIdentifier: map[string]string{"121.830": "GE"},
+	}
+
+	got := resolveOwnedHandoverTarget(
+		"GW",
+		strip,
+		session,
+		ownership,
+		handoverRadio(handoverCoverage("121.830")),
+	)
+
+	require.NotNil(t, got)
+	assert.Equal(t, "121.830", got.Owner)
+	require.NotNil(t, got.Display)
+	assert.Equal(t, "GE", got.Display.Label)
+	assert.Equal(t, "121.830", got.Display.Frequency)
+}
+
+func TestResolveOwnedHandoverTargetSelectsDirectionalGWOwner(t *testing.T) {
+	session := handoverSession()
+	ownership := handoverOwnership(
+		map[string]string{"GWD": "119.355", "GWA": "118.105"},
+		map[string]string{"119.355": "TW", "118.105": "TE"},
+	)
+	radio := handoverRadio(handoverCoverage("119.355", "118.105"))
+
+	departure := &models.Strip{
+		Stand:  handoverStringPtr("A12"),
+		Runway: handoverStringPtr("22R"),
+		Origin: "EKCH",
+	}
+	departureTarget := resolveOwnedHandoverTarget("GW", departure, session, ownership, radio)
+	require.NotNil(t, departureTarget)
+	assert.Equal(t, "119.355", departureTarget.Owner)
+
+	arrival := &models.Strip{
+		Stand:       handoverStringPtr("A12"),
+		Runway:      handoverStringPtr("22L"),
+		Destination: "EKCH",
+	}
+	arrivalTarget := resolveOwnedHandoverTarget("GW", arrival, session, ownership, radio)
+	require.NotNil(t, arrivalTarget)
+	assert.Equal(t, "118.105", arrivalTarget.Owner)
+}
+
+func TestResolveOwnedHandoverTargetDoesNotBypassConfiguredOwnerForAnotherCarrier(t *testing.T) {
+	session := handoverSession()
+	strip := &models.Strip{
+		Stand:  handoverStringPtr("A12"),
+		Runway: handoverStringPtr("22R"),
+		Origin: "EKCH",
+	}
+	ownership := handoverOwnership(
+		map[string]string{"GWD": "121.830"},
+		map[string]string{"121.830": "GE"},
+	)
+	radio := routeRadioState{
+		coverage: map[string]map[string]struct{}{
+			"121.830": {"121.830": {}},
+			"119.355": {"118.580": {}},
+		},
+		roleByPrimary: map[string]string{},
+	}
+
+	got := resolveOwnedHandoverTarget("GW", strip, session, ownership, radio)
+
+	require.NotNil(t, got)
+	assert.Equal(t, "121.830", got.Owner)
+	require.NotNil(t, got.Display)
+	assert.Equal(t, "GE", got.Display.Label)
+	assert.Equal(t, "121.830", got.Display.Frequency)
+}
+
+func TestResolveOwnedHandoverTargetUsesCallsignRoleForFallbackDisplay(t *testing.T) {
+	session := handoverSession()
+	strip := &models.Strip{
+		Stand:  handoverStringPtr("A12"),
+		Runway: handoverStringPtr("22R"),
+		Origin: "EKCH",
+	}
+	ownership := handoverOwnership(
+		map[string]string{"GWD": "121.830"},
+		map[string]string{"121.830": "TE"},
+	)
+	radio := routeRadioState{
+		coverage: map[string]map[string]struct{}{
+			"121.830": {"121.830": {}},
+		},
+		roleByPrimary: map[string]string{"121.830": "EKCH_GE_TWR"},
+	}
+
+	got := resolveOwnedHandoverTarget("GW", strip, session, ownership, radio)
+
+	require.NotNil(t, got)
+	assert.Equal(t, "121.830", got.Owner)
+	require.NotNil(t, got.Display)
+	assert.Equal(t, "GE", got.Display.Label)
+	assert.Equal(t, "121.830", got.Display.Frequency)
+}
+
+func TestResolveOwnedHandoverTargetDoesNotDisplayUnsensedFallbackFrequency(t *testing.T) {
+	session := handoverSession()
+	session.ActiveRunways.DepartureRunways = []string{"30"}
+	strip := &models.Strip{
+		Stand:  handoverStringPtr("W1"),
+		Runway: handoverStringPtr("30"),
+		Origin: "EKCH",
+	}
+	ownership := handoverOwnership(
+		map[string]string{"GWD": "119.355"},
+		map[string]string{"119.355": "GW"},
+	)
+	radio := routeRadioState{
+		coverage: map[string]map[string]struct{}{
+			"119.355": {},
+		},
+		roleByPrimary: map[string]string{"119.355": "EKCH_D_TWR"},
+	}
+
+	got := resolveOwnedHandoverTarget("GW", strip, session, ownership, radio)
+
+	require.NotNil(t, got)
+	assert.Equal(t, "119.355", got.Owner)
+	assert.Nil(t, got.Display)
+}
+
+func TestComputeRouteStateUsesLogicalPathAndRadioCarrier(t *testing.T) {
+	session := handoverSession()
+	owner := "121.730"
+
+	tests := []struct {
+		name      string
+		coverage  map[string]map[string]struct{}
+		wantOwner string
+		wantLabel string
+		wantFreq  string
+		owners    []*models.SectorOwner
+	}{
+		{
+			name: "TW carries logical GW",
+			coverage: map[string]map[string]struct{}{
+				"121.730": {},
+				"119.355": {"118.580": {}},
+			},
+			wantOwner: "119.355",
+			wantLabel: "GW",
+			wantFreq:  "118.580",
+			owners: []*models.SectorOwner{
+				{Position: "121.730", Sector: []string{"AD"}, Identifier: "AD"},
+				{Position: "119.355", Sector: []string{"GWD", "TW"}, Identifier: "TW"},
+			},
+		},
+		{
+			name: "GE carries logical GW",
+			coverage: map[string]map[string]struct{}{
+				"121.730": {},
+				"121.830": {"118.580": {}},
+				"119.355": {},
+			},
+			wantOwner: "121.830",
+			wantLabel: "GW",
+			wantFreq:  "118.580",
+			owners: []*models.SectorOwner{
+				{Position: "121.730", Sector: []string{"AD"}, Identifier: "AD"},
+				{Position: "121.830", Sector: []string{"GWD"}, Identifier: "GE"},
+				{Position: "119.355", Sector: []string{"TW"}, Identifier: "TW"},
+			},
+		},
+		{
+			name:      "GE owns logical GW when GW is not carried",
+			coverage:  handoverCoverage("121.730", "121.830", "119.355"),
+			wantOwner: "121.830",
+			wantLabel: "GE",
+			wantFreq:  "121.830",
+			owners: []*models.SectorOwner{
+				{Position: "121.730", Sector: []string{"AD"}, Identifier: "AD"},
+				{Position: "121.830", Sector: []string{"GWD"}, Identifier: "GE"},
+				{Position: "119.355", Sector: []string{"TW"}, Identifier: "TW"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			strip := &models.Strip{
+				Bay:    "CLEARED",
+				Stand:  handoverStringPtr("A12"),
+				Runway: handoverStringPtr("22R"),
+				Origin: "EKCH",
+				Owner:  &owner,
+			}
+
+			state, shouldUpdate, err := computeRouteStateForStrip(strip, session, test.owners, handoverRadio(test.coverage))
+
+			require.NoError(t, err)
+			require.True(t, shouldUpdate)
+			require.NotEmpty(t, state.NextOwners)
+			assert.Equal(t, test.wantOwner, state.NextOwners[0])
+			require.NotNil(t, state.NextDisplay)
+			assert.Equal(t, test.wantLabel, state.NextDisplay.Label)
+			assert.Equal(t, test.wantFreq, state.NextDisplay.Frequency)
+		})
+	}
+}
+
+func TestComputeRouteStateUsesHistoryForRepeatedPhysicalOwner(t *testing.T) {
+	session := handoverSession()
+	currentOwner := "121.830"
+	strip := &models.Strip{
+		Stand:          handoverStringPtr("A12"),
+		Runway:         handoverStringPtr("22R"),
+		Origin:         "EKCH",
+		Owner:          &currentOwner,
+		PreviousOwners: []string{"121.830", "121.730"},
+	}
+	owners := []*models.SectorOwner{
+		{Position: "121.830", Sector: []string{"SQ", "GWD"}, Identifier: "GE"},
+		{Position: "121.730", Sector: []string{"AD"}, Identifier: "AD"},
+		{Position: "119.355", Sector: []string{"TW"}, Identifier: "TW"},
+	}
+	radio := routeRadioState{
+		coverage: map[string]map[string]struct{}{
+			"121.830": {"121.905": {}},
+			"121.730": {},
+			"119.355": {},
+		},
+		roleByPrimary: map[string]string{},
+	}
+
+	state, shouldUpdate, err := computeRouteStateForStrip(strip, session, owners, radio)
+
+	require.NoError(t, err)
+	require.True(t, shouldUpdate)
+	assert.Equal(t, []string{"119.355"}, state.NextOwners)
+	require.NotNil(t, state.NextDisplay)
+	assert.Equal(t, "TW", state.NextDisplay.Label)
+}
+
+func TestComputeRouteStateDisplaysADOnSharedNorthPrimary(t *testing.T) {
+	session := handoverSession()
+	strip := &models.Strip{
+		Stand:  handoverStringPtr("A12"),
+		Runway: handoverStringPtr("22R"),
+		Origin: "EKCH",
+	}
+	owners := []*models.SectorOwner{
+		{Position: "121.905", Sector: []string{"SQ", "AD"}, Identifier: "AD"},
+		{Position: "118.580", Sector: []string{"GWD"}, Identifier: "GW"},
+		{Position: "119.355", Sector: []string{"TW"}, Identifier: "TW"},
+	}
+	radio := routeRadioState{
+		coverage: map[string]map[string]struct{}{
+			"121.905": {"121.730": {}, "121.905": {}},
+			"118.580": {},
+			"119.355": {},
+		},
+		roleByPrimary: map[string]string{},
+	}
+
+	state, shouldUpdate, err := computeRouteStateForStrip(strip, session, owners, radio)
+
+	require.NoError(t, err)
+	require.True(t, shouldUpdate)
+	require.NotNil(t, state.NextDisplay)
+	assert.Equal(t, "AD", state.NextDisplay.Label)
+	assert.Equal(t, "121.905", state.NextDisplay.Frequency)
+}
+
+func TestComputeRouteStateCollapsesLogicalStagesCarriedByCurrentPrimary(t *testing.T) {
+	session := handoverSession()
+	owner := "121.730"
+	strip := &models.Strip{
+		Stand:  handoverStringPtr("A12"),
+		Runway: handoverStringPtr("22R"),
+		Origin: "EKCH",
+		Owner:  &owner,
+	}
+	coverage := map[string]map[string]struct{}{
+		"121.730": {
+			"121.730": {},
+			"121.905": {},
+			"118.580": {},
+		},
+		"119.355": {},
+	}
+
+	owners := []*models.SectorOwner{
+		{Position: "121.730", Sector: []string{"SQ", "AD", "GWD"}, Identifier: "AD"},
+		{Position: "119.355", Sector: []string{"TW"}, Identifier: "TW"},
+	}
+	state, shouldUpdate, err := computeRouteStateForStrip(strip, session, owners, handoverRadio(coverage))
+
+	require.NoError(t, err)
+	require.True(t, shouldUpdate)
+	assert.Equal(t, []string{"119.355"}, state.NextOwners)
+	require.NotNil(t, state.NextDisplay)
+	assert.Equal(t, "TW", state.NextDisplay.Label)
+}
+
+func TestCompleteRouteDoesNotDependOnBay(t *testing.T) {
+	session := handoverSession()
+	owner := "121.730"
+	coverage := handoverCoverage("121.730", "118.580", "119.355")
+
+	var expected computedRouteState
+	for index, bay := range []string{"CLEARED", "TAXI_LWR", "TWY_ARR", ""} {
+		strip := &models.Strip{
+			Bay:    bay,
+			Stand:  handoverStringPtr("A12"),
+			Runway: handoverStringPtr("22R"),
+			Origin: "EKCH",
+			Owner:  &owner,
+		}
+		owners := []*models.SectorOwner{
+			{Position: "121.730", Sector: []string{"SQ", "AD"}, Identifier: "AD"},
+			{Position: "118.580", Sector: []string{"GWD"}, Identifier: "GW"},
+			{Position: "119.355", Sector: []string{"TW"}, Identifier: "TW"},
+		}
+		state, shouldUpdate, err := computeRouteStateForStrip(strip, session, owners, handoverRadio(coverage))
+		require.NoError(t, err)
+		require.True(t, shouldUpdate)
+		if index == 0 {
+			expected = state
+			continue
+		}
+		assert.Equal(t, expected, state)
+	}
+}
+
+func handoverSession() *models.Session {
+	return &models.Session{
+		Airport: "EKCH",
+		ActiveRunways: pkgModels.ActiveRunways{
+			ArrivalRunways:   []string{"22L"},
+			DepartureRunways: []string{"22R"},
+		},
+	}
+}
+
+func handoverCoverage(frequencies ...string) map[string]map[string]struct{} {
+	result := make(map[string]map[string]struct{}, len(frequencies))
+	for _, frequency := range frequencies {
+		result[frequency] = map[string]struct{}{frequency: {}}
+	}
+	return result
+}
+
+func handoverRadio(coverage map[string]map[string]struct{}) routeRadioState {
+	return routeRadioState{
+		coverage:      coverage,
+		roleByPrimary: map[string]string{},
+	}
+}
+
+func handoverOwnership(sectors map[string]string, identifiers map[string]string) routeOwnership {
+	return routeOwnership{
+		sectorToOwner:   sectors,
+		ownerIdentifier: identifiers,
+	}
+}
+
+func handoverStringPtr(value string) *string {
+	return &value
+}

--- a/backend/internal/server/layouts_test.go
+++ b/backend/internal/server/layouts_test.go
@@ -55,7 +55,7 @@ func TestUpdateLayoutsContext_UsesSyncStateWithoutReloadingSessionOrControllers(
 	assert.Equal(t, map[string]string{"118.100": "TWR"}, layouts)
 }
 
-func TestUpdateLayoutsContext_PrefersCallsignPositionOverCrossCoupledFrequency(t *testing.T) {
+func TestUpdateLayoutsContext_UsesCallsignRoleAtActualPrimedFrequency(t *testing.T) {
 	t.Cleanup(config.SetPositionsForTest([]config.Position{
 		{Name: "EKCH_A_TWR", Frequency: "118.100"},
 		{Name: "EKCH_W_APP", Frequency: "119.805"},
@@ -98,5 +98,5 @@ func TestUpdateLayoutsContext_PrefersCallsignPositionOverCrossCoupledFrequency(t
 
 	err := server.UpdateLayoutsContext(ctx, 1)
 	require.NoError(t, err)
-	assert.Equal(t, map[string]string{"118.100": "TWR"}, layouts)
+	assert.Equal(t, map[string]string{"119.805": "TWR"}, layouts)
 }

--- a/backend/internal/server/route.go
+++ b/backend/internal/server/route.go
@@ -12,6 +12,8 @@ import (
 	"log/slog"
 	"slices"
 	"strings"
+
+	"github.com/jackc/pgx/v5"
 )
 
 // This is dumb please optimize
@@ -19,6 +21,23 @@ import (
 type computedRouteState struct {
 	NextOwners  []string
 	NextDisplay *models.NextDisplay
+}
+
+type resolvedRouteStage struct {
+	Identifier     string
+	Owner          string
+	Display        *models.NextDisplay
+	LogicalCarried bool
+}
+
+type routeOwnership struct {
+	sectorToOwner   map[string]string
+	ownerIdentifier map[string]string
+}
+
+type routeRadioState struct {
+	coverage      map[string]map[string]struct{}
+	roleByPrimary map[string]string
 }
 
 func (s *Server) UpdateRouteForStrip(callsign string, sessionId int32, sendUpdate bool) error {
@@ -38,6 +57,15 @@ func (s *Server) UpdateRouteForStripContext(ctx context.Context, callsign string
 	if err != nil {
 		return err
 	}
+	if s.coordRepo != nil {
+		_, err := s.coordRepo.GetByStripID(ctx, sessionId, strip.ID)
+		switch {
+		case err == nil:
+			return nil
+		case !errors.Is(err, pgx.ErrNoRows):
+			return err
+		}
+	}
 
 	session, err := routeSessionByID(ctx, sessionRepo, sessionId)
 	if err != nil {
@@ -49,12 +77,12 @@ func (s *Server) UpdateRouteForStripContext(ctx context.Context, callsign string
 		return err
 	}
 
-	coverage, err := routeDisplayCoverage(ctx, s.controllerRepo, sessionId, s.frequencyProviders)
+	radio, err := routeRadioStateForSession(ctx, s.controllerRepo, sessionId, s.frequencyProviders)
 	if err != nil {
 		return err
 	}
 
-	err = s.updateRouteForStripHelper(ctx, strip, session, owners, coverage, sendUpdate)
+	err = s.updateRouteForStripHelper(ctx, strip, session, owners, radio, sendUpdate)
 	if err == nil {
 		slog.Debug("Route recalculation finished for strip",
 			slog.Int("session", int(sessionId)),
@@ -75,7 +103,12 @@ func (s *Server) ComputeNextOwnersForStripContext(ctx context.Context, strip *mo
 		return nil, false, err
 	}
 
-	result, shouldUpdate, err := computeRouteStateForStrip(strip, session, owners, nil)
+	radio, err := routeRadioStateForSession(ctx, s.controllerRepo, sessionId, s.frequencyProviders)
+	if err != nil {
+		return nil, false, err
+	}
+
+	result, shouldUpdate, err := computeRouteStateForStrip(strip, session, owners, radio)
 	if err != nil {
 		return nil, false, err
 	}
@@ -84,6 +117,19 @@ func (s *Server) ComputeNextOwnersForStripContext(ctx context.Context, strip *mo
 }
 
 func (s *Server) ComputeNextDisplayForStripContext(ctx context.Context, strip *models.Strip, sessionId int32) (*models.NextDisplay, error) {
+	if strip == nil {
+		return nil, nil
+	}
+	if s.coordRepo != nil {
+		_, err := s.coordRepo.GetByStripID(ctx, sessionId, strip.ID)
+		switch {
+		case err == nil:
+			return cloneNextDisplay(strip.NextDisplay), nil
+		case !errors.Is(err, pgx.ErrNoRows):
+			return nil, err
+		}
+	}
+
 	session, err := routeSessionByID(ctx, s.sessionRepo, sessionId)
 	if err != nil {
 		return nil, err
@@ -94,12 +140,12 @@ func (s *Server) ComputeNextDisplayForStripContext(ctx context.Context, strip *m
 		return nil, err
 	}
 
-	coverage, err := routeDisplayCoverage(ctx, s.controllerRepo, sessionId, s.frequencyProviders)
+	radio, err := routeRadioStateForSession(ctx, s.controllerRepo, sessionId, s.frequencyProviders)
 	if err != nil {
 		return nil, err
 	}
 
-	result, _, err := computeRouteStateForStrip(strip, session, owners, coverage)
+	result, _, err := computeRouteStateForStrip(strip, session, owners, radio)
 	if err != nil {
 		return nil, err
 	}
@@ -109,6 +155,33 @@ func (s *Server) ComputeNextDisplayForStripContext(ctx context.Context, strip *m
 
 func (s *Server) ComputeNextDisplaysForStripsContext(ctx context.Context, strips []*models.Strip, sessionId int32) error {
 	if len(strips) == 0 {
+		return nil
+	}
+
+	pendingStripIDs := make(map[int32]struct{})
+	if s.coordRepo != nil {
+		coordinations, err := s.coordRepo.ListBySession(ctx, sessionId)
+		if err != nil {
+			return err
+		}
+		for _, coordination := range coordinations {
+			if coordination != nil {
+				pendingStripIDs[coordination.StripID] = struct{}{}
+			}
+		}
+	}
+
+	hasUncoordinatedStrip := false
+	for _, strip := range strips {
+		if strip == nil {
+			continue
+		}
+		if _, pending := pendingStripIDs[strip.ID]; !pending {
+			hasUncoordinatedStrip = true
+			break
+		}
+	}
+	if !hasUncoordinatedStrip {
 		return nil
 	}
 
@@ -122,7 +195,7 @@ func (s *Server) ComputeNextDisplaysForStripsContext(ctx context.Context, strips
 		return err
 	}
 
-	coverage, err := routeDisplayCoverage(ctx, s.controllerRepo, sessionId, s.frequencyProviders)
+	radio, err := routeRadioStateForSession(ctx, s.controllerRepo, sessionId, s.frequencyProviders)
 	if err != nil {
 		return err
 	}
@@ -131,8 +204,11 @@ func (s *Server) ComputeNextDisplaysForStripsContext(ctx context.Context, strips
 		if strip == nil {
 			continue
 		}
+		if _, pending := pendingStripIDs[strip.ID]; pending {
+			continue
+		}
 
-		result, _, err := computeRouteStateForStrip(strip, session, owners, coverage)
+		result, _, err := computeRouteStateForStrip(strip, session, owners, radio)
 		if err != nil {
 			return err
 		}
@@ -175,9 +251,22 @@ func (s *Server) updateRoutesForSessionContextUnlocked(ctx context.Context, sess
 		return err
 	}
 
-	coverage, err := routeDisplayCoverage(ctx, s.controllerRepo, sessionId, s.frequencyProviders)
+	radio, err := routeRadioStateForSession(ctx, s.controllerRepo, sessionId, s.frequencyProviders)
 	if err != nil {
 		return err
+	}
+
+	pendingStripIDs := make(map[int32]struct{})
+	if s.coordRepo != nil {
+		coordinations, err := s.coordRepo.ListBySession(ctx, sessionId)
+		if err != nil {
+			return err
+		}
+		for _, coordination := range coordinations {
+			if coordination != nil {
+				pendingStripIDs[coordination.StripID] = struct{}{}
+			}
+		}
 	}
 
 	slog.Debug("Route recalculation loaded strips for session",
@@ -186,7 +275,10 @@ func (s *Server) updateRoutesForSessionContextUnlocked(ctx context.Context, sess
 		slog.Bool("send_update", sendUpdate))
 
 	for _, strip := range strips {
-		err := s.updateRouteForStripHelper(ctx, strip, session, owners, coverage, sendUpdate)
+		if _, pending := pendingStripIDs[strip.ID]; pending {
+			continue
+		}
+		err := s.updateRouteForStripHelper(ctx, strip, session, owners, radio, sendUpdate)
 		if err != nil {
 			return err
 		}
@@ -200,8 +292,8 @@ func (s *Server) updateRoutesForSessionContextUnlocked(ctx context.Context, sess
 	return nil
 }
 
-func (s *Server) updateRouteForStripHelper(ctx context.Context, strip *models.Strip, session *models.Session, owners []*models.SectorOwner, coverage map[string]map[string]struct{}, sendUpdate bool) error {
-	result, shouldUpdate, err := computeRouteStateForStrip(strip, session, owners, coverage)
+func (s *Server) updateRouteForStripHelper(ctx context.Context, strip *models.Strip, session *models.Session, owners []*models.SectorOwner, radio routeRadioState, sendUpdate bool) error {
+	result, shouldUpdate, err := computeRouteStateForStrip(strip, session, owners, radio)
 	if err != nil {
 		return err
 	}
@@ -266,7 +358,7 @@ func (s *Server) updateRouteForStripHelper(ctx context.Context, strip *models.St
 }
 
 func computeNextOwnersForStrip(strip *models.Strip, session *models.Session, owners []*models.SectorOwner) ([]string, bool, error) {
-	result, shouldUpdate, err := computeRouteStateForStrip(strip, session, owners, nil)
+	result, shouldUpdate, err := computeRouteStateForStrip(strip, session, owners, routeRadioState{})
 	if err != nil {
 		return nil, false, err
 	}
@@ -274,7 +366,7 @@ func computeNextOwnersForStrip(strip *models.Strip, session *models.Session, own
 	return result.NextOwners, shouldUpdate, nil
 }
 
-func computeRouteStateForStrip(strip *models.Strip, session *models.Session, owners []*models.SectorOwner, coverage map[string]map[string]struct{}) (computedRouteState, bool, error) {
+func computeRouteStateForStrip(strip *models.Strip, session *models.Session, owners []*models.SectorOwner, radio routeRadioState) (computedRouteState, bool, error) {
 	isArrival := strip.Destination == session.Airport
 	currentOwner := helpers.ValueOrDefault(strip.Owner)
 	currentStand := helpers.ValueOrDefault(strip.Stand)
@@ -299,7 +391,21 @@ func computeRouteStateForStrip(strip *models.Strip, session *models.Session, own
 
 	var route config.ResolvedRoute
 
-	if isArrival && (strip.Stand == nil || *strip.Stand == "") {
+	if !isArrival {
+		var success bool
+		route, success = config.ComputeDepartureRoute(
+			session.ActiveRunways.GetAllActiveRunways(),
+			currentStand,
+			currentRunway,
+		)
+		if !success {
+			slog.Warn("Could not compute complete departure route for strip",
+				slog.String("callsign", strip.Callsign),
+				slog.String("runway", currentRunway),
+				slog.String("stand", currentStand))
+			return computedRouteState{}, false, nil
+		}
+	} else if strip.Stand == nil || *strip.Stand == "" {
 		// No stand yet: use the receiving tower sector so the strip always has
 		// at least the tower controller as its next owner.
 		towerSector, ok := config.GetArrivalTowerSector(session.ActiveRunways.ArrivalRunways)
@@ -316,12 +422,6 @@ func computeRouteStateForStrip(strip *models.Strip, session *models.Session, own
 	} else {
 		region, err := config.GetRegionForPosition(helpers.ValueOrDefault(strip.PositionLatitude), helpers.ValueOrDefault(strip.PositionLongitude))
 		if errors.Is(err, config.ErrUnsupportedRegion) {
-			if !isArrival {
-				slog.Debug("Skipping departure route recalculation because aircraft position is outside supported regions",
-					slog.Int("session", int(session.ID)),
-					slog.String("callsign", strip.Callsign))
-				return computedRouteState{}, false, nil
-			}
 			// Arrival is still airborne (outside known ground regions) but already has
 			// a stand assigned. Use the receiving tower sector as the start of the
 			// stand route so the route can still continue onward to apron/ground.
@@ -359,16 +459,10 @@ func computeRouteStateForStrip(strip *models.Strip, session *models.Session, own
 				return computedRouteState{}, false, nil
 			}
 
-			allRunways := session.ActiveRunways.GetAllActiveRunways()
-
+			// Use only arrival runways to select the correct arrival route.
+			// Mixing in departure runways can cause the wrong cargo route to match.
 			var success bool
-			if isArrival {
-				// Use only arrival runways to select the correct arrival route.
-				// Mixing in departure runways can cause the wrong cargo route to match.
-				route, success = config.ComputeToStand(session.ActiveRunways.ArrivalRunways, sector, helpers.ValueOrDefault(strip.Stand))
-			} else {
-				route, success = config.ComputeToRunway(allRunways, sector, helpers.ValueOrDefault(strip.Runway))
-			}
+			route, success = config.ComputeToStand(session.ActiveRunways.ArrivalRunways, sector, helpers.ValueOrDefault(strip.Stand))
 
 			if !success {
 				runway := helpers.ValueOrDefault(strip.Runway)
@@ -380,14 +474,10 @@ func computeRouteStateForStrip(strip *models.Strip, session *models.Session, own
 					slog.String("runway", runway),
 					slog.String("stand", stand))
 
-				if isArrival {
-					// Fall back to the tower sector so arrivals always have at least
-					// the receiving tower controller, even when the full route fails.
-					if towerSector, ok := config.GetArrivalTowerSector(session.ActiveRunways.ArrivalRunways); ok {
-						route = config.ResolvedRoute{Path: []string{towerSector}}
-					} else {
-						return computedRouteState{}, false, nil
-					}
+				// Fall back to the tower sector so arrivals always have at least
+				// the receiving tower controller, even when the full route fails.
+				if towerSector, ok := config.GetArrivalTowerSector(session.ActiveRunways.ArrivalRunways); ok {
+					route = config.ResolvedRoute{Path: []string{towerSector}}
 				} else {
 					return computedRouteState{}, false, nil
 				}
@@ -395,59 +485,182 @@ func computeRouteStateForStrip(strip *models.Strip, session *models.Session, own
 		}
 	}
 
-	sectorToOnwer := make(map[string]string)
-	for _, owner := range owners {
-		for _, s := range owner.Sector {
-			sectorToOnwer[normalizeRouteSectorRef(s)] = owner.Position
-		}
-	}
+	ownership := buildRouteOwnership(owners)
 
-	actualRoute := make([]string, 0)
-	var nextDisplay *models.NextDisplay
-	nextDisplayResolved := false
-	for _, s := range route.Path {
-		owner, ok := resolveRouteSectorOwner(s, sectorToOnwer, route.OwnerOverrides)
+	stages := make([]resolvedRouteStage, 0, len(route.Path)+1)
+	for _, sector := range route.Path {
+		stage, ok := resolveRouteStage(strip, session, sector, ownership, route.OwnerOverrides, radio, isArrival)
 		if !ok {
 			continue
 		}
-		if !nextDisplayResolved && (currentOwner == "" || owner != currentOwner) {
-			nextDisplay = buildRouteNextDisplay(session, s, owner, coverage[vatsim.NormalizeFrequency(owner)], isArrival)
-			nextDisplayResolved = true
+		if len(stages) > 0 && vatsim.NormalizeFrequency(stages[len(stages)-1].Owner) == vatsim.NormalizeFrequency(stage.Owner) {
+			previous := &stages[len(stages)-1]
+			if strings.EqualFold(previous.Identifier, "SQ") &&
+				strings.EqualFold(stage.Identifier, "AD") &&
+				previous.LogicalCarried &&
+				stage.LogicalCarried &&
+				previous.Display != nil {
+				previous.Identifier = "AD"
+				previous.Display.Label = config.GetSectorDisplayName("AD")
+			}
+			continue
 		}
-		if len(actualRoute) == 0 || actualRoute[len(actualRoute)-1] != owner {
-			actualRoute = append(actualRoute, owner)
-		}
+		stages = append(stages, stage)
 	}
 
 	if !isArrival && strip.Sid != nil && *strip.Sid != "" {
 		as, err := config.GetAirborneSector(*strip.Sid)
 		if err != nil {
 			slog.Debug("Error getting airborne frequency", slog.String("sid", *strip.Sid), slog.Any("error", err))
-		} else if owner, ok := sectorToOnwer[normalizeRouteSectorRef(as)]; ok {
-			if !nextDisplayResolved && (currentOwner == "" || owner != currentOwner) {
-				nextDisplay = buildRouteNextDisplay(session, as, owner, coverage[vatsim.NormalizeFrequency(owner)], isArrival)
-				nextDisplayResolved = true
-			}
-			if !slices.Contains(actualRoute, owner) {
-				actualRoute = append(actualRoute, owner)
+		} else if owner, ok := ownership.sectorToOwner[normalizeRouteSectorRef(as)]; ok {
+			if !slices.ContainsFunc(stages, func(stage resolvedRouteStage) bool {
+				return vatsim.NormalizeFrequency(stage.Owner) == vatsim.NormalizeFrequency(owner)
+			}) {
+				stages = append(stages, resolvedRouteStage{
+					Owner:   owner,
+					Display: buildRouteNextDisplay(session, as, owner, radio.coverage[vatsim.NormalizeFrequency(owner)], isArrival),
+				})
 			}
 		}
 	}
 
-	if strip.Owner != nil && *strip.Owner != "" {
-		index := slices.Index(actualRoute, *strip.Owner)
+	if currentOwner != "" {
+		index := resolveCurrentRouteStageIndex(stages, currentOwner, strip.PreviousOwners)
 		if index != -1 {
 			// Trim everything up to and including the current owner.
 			// The owner already holds the strip, so neither the owner nor any earlier
 			// position in the route should appear in next_owners.
-			actualRoute = actualRoute[index+1:]
+			stages = stages[index+1:]
 		}
+	}
+
+	actualRoute := make([]string, 0, len(stages))
+	for _, stage := range stages {
+		actualRoute = append(actualRoute, stage.Owner)
+	}
+	var nextDisplay *models.NextDisplay
+	if len(stages) > 0 {
+		nextDisplay = stages[0].Display
 	}
 
 	return computedRouteState{
 		NextOwners:  actualRoute,
 		NextDisplay: cloneNextDisplay(nextDisplay),
 	}, true, nil
+}
+
+func resolveRouteStage(
+	strip *models.Strip,
+	session *models.Session,
+	sector string,
+	ownership routeOwnership,
+	ownerOverrides map[string]string,
+	radio routeRadioState,
+	isArrival bool,
+) (resolvedRouteStage, bool) {
+	normalizedSector := normalizeRouteSectorRef(sector)
+	if normalizedSector == "" {
+		return resolvedRouteStage{}, false
+	}
+
+	if overrideTarget, ok := ownerOverrides[normalizedSector]; ok {
+		owner, ok := ownership.sectorToOwner[normalizeRouteSectorRef(overrideTarget)]
+		if !ok {
+			return resolvedRouteStage{}, false
+		}
+		return resolvedRouteStage{
+			Identifier: sector,
+			Owner:      owner,
+			Display:    buildRouteNextDisplay(session, sector, owner, radio.coverage[vatsim.NormalizeFrequency(owner)], isArrival),
+		}, true
+	}
+
+	ownerSector := resolveConfiguredRouteSector(sector, strip, session)
+	owner, ok := resolveRouteSectorOwner(ownerSector, ownership.sectorToOwner, nil)
+	if !ok {
+		return resolvedRouteStage{}, false
+	}
+	resolution := resolveHandoverTargetForOwner(sector, owner, strip, session, ownership, radio)
+	return resolvedRouteStage{
+		Identifier:     resolution.Identifier,
+		Owner:          resolution.Owner,
+		Display:        cloneNextDisplay(resolution.Display),
+		LogicalCarried: resolution.LogicalCarried,
+	}, true
+}
+
+func buildConfiguredOwnerDisplay(strip *models.Strip, session *models.Session, owner string, ownership routeOwnership, radio routeRadioState) *models.NextDisplay {
+	normalizedOwner := vatsim.NormalizeFrequency(owner)
+	identifier := ""
+	if role := strings.TrimSpace(radio.roleByPrimary[normalizedOwner]); role != "" {
+		active := session.ActiveRunways.DepartureRunways
+		isArrival := strip.Destination == session.Airport
+		if isArrival {
+			active = session.ActiveRunways.ArrivalRunways
+		}
+		if resolved, ok := config.GetPositionLogicalIdentifier(active, role, isArrival); ok {
+			identifier = resolved
+		}
+	}
+	if identifier == "" {
+		identifier = strings.TrimSpace(ownership.ownerIdentifier[normalizedOwner])
+	}
+	if identifier == "" {
+		return nil
+	}
+
+	frequency, ok := resolveLogicalSectorFrequency(identifier, strip, session)
+	if !ok {
+		return nil
+	}
+	if !ownerCarriesFrequency(owner, frequency, radio.coverage) {
+		return nil
+	}
+	return &models.NextDisplay{
+		Label:     config.GetSectorDisplayName(identifier),
+		Frequency: frequency,
+	}
+}
+
+func resolveCurrentRouteStageIndex(stages []resolvedRouteStage, currentOwner string, previousOwners []string) int {
+	normalizedCurrent := vatsim.NormalizeFrequency(currentOwner)
+	if normalizedCurrent == "" {
+		return -1
+	}
+
+	history := make([]string, 0, len(previousOwners)+1)
+	for _, owner := range previousOwners {
+		normalized := vatsim.NormalizeFrequency(owner)
+		if normalized != "" {
+			history = append(history, normalized)
+		}
+	}
+	history = append(history, normalizedCurrent)
+
+	bestIndex := -1
+	bestMatched := -1
+	for candidate, stage := range stages {
+		if vatsim.NormalizeFrequency(stage.Owner) != normalizedCurrent {
+			continue
+		}
+
+		matched := 1
+		stageIndex := candidate - 1
+		for historyIndex := len(history) - 2; historyIndex >= 0 && stageIndex >= 0; historyIndex-- {
+			for stageIndex >= 0 && vatsim.NormalizeFrequency(stages[stageIndex].Owner) != history[historyIndex] {
+				stageIndex--
+			}
+			if stageIndex >= 0 {
+				matched++
+				stageIndex--
+			}
+		}
+		if matched > bestMatched {
+			bestMatched = matched
+			bestIndex = candidate
+		}
+	}
+	return bestIndex
 }
 
 func resolveRouteSectorOwner(sector string, sectorToOwner map[string]string, ownerOverrides map[string]string) (string, bool) {
@@ -497,17 +710,23 @@ func buildRouteNextDisplay(session *models.Session, sectorRef string, owner stri
 	return nil
 }
 
-func routeDisplayCoverage(ctx context.Context, controllerRepo repository.ControllerRepository, sessionId int32, frequencyProviders []TransceiverLookup) (map[string]map[string]struct{}, error) {
+func routeRadioStateForSession(ctx context.Context, controllerRepo repository.ControllerRepository, sessionId int32, frequencyProviders []TransceiverLookup) (routeRadioState, error) {
 	if controllerRepo == nil {
-		return map[string]map[string]struct{}{}, nil
+		return routeRadioState{
+			coverage:      map[string]map[string]struct{}{},
+			roleByPrimary: map[string]string{},
+		}, nil
 	}
 
 	controllerCoverage, err := getCurrentControllerCoverage(ctx, controllerRepo, sessionId, frequencyProviders)
 	if err != nil {
-		return nil, err
+		return routeRadioState{}, err
 	}
 
-	result := make(map[string]map[string]struct{}, len(controllerCoverage))
+	result := routeRadioState{
+		coverage:      make(map[string]map[string]struct{}, len(controllerCoverage)),
+		roleByPrimary: make(map[string]string, len(controllerCoverage)),
+	}
 	for _, controller := range controllerCoverage {
 		primaryFrequency := vatsim.NormalizeFrequency(controller.Frequency)
 		if primaryFrequency == "" {
@@ -522,7 +741,8 @@ func routeDisplayCoverage(ctx context.Context, controllerRepo repository.Control
 			}
 			covered[normalizedCoveredFrequency] = struct{}{}
 		}
-		result[primaryFrequency] = covered
+		result.coverage[primaryFrequency] = covered
+		result.roleByPrimary[primaryFrequency] = controller.Name
 	}
 
 	return result, nil

--- a/backend/internal/server/route_test.go
+++ b/backend/internal/server/route_test.go
@@ -280,7 +280,7 @@ func TestUpdateRouteForStrip_ArrivalKeepsGWAOwnerWhenControllersAreSplit(t *test
 	require.Equal(t, "GROUND_WEST", region.Name)
 
 	aTowerPosition := frequencyForPosition(t, "EKCH_A_TWR")
-	cTowerPosition := frequencyForPosition(t, "EKCH_C_TWR")
+	gwTowerPosition := frequencyForPosition(t, "EKCH_GW_TWR")
 	apronPosition := frequencyForPosition(t, "EKCH_A_GND")
 
 	strip := &models.Strip{
@@ -330,7 +330,7 @@ func TestUpdateRouteForStrip_ArrivalKeepsGWAOwnerWhenControllersAreSplit(t *test
 			{
 				Session:  92,
 				Sector:   []string{"GWA"},
-				Position: cTowerPosition,
+				Position: gwTowerPosition,
 			},
 			{
 				Session:  92,
@@ -350,12 +350,12 @@ func TestUpdateRouteForStrip_ArrivalKeepsGWAOwnerWhenControllersAreSplit(t *test
 	err = srv.UpdateRouteForStrip("SAS790", 92, true)
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{cTowerPosition, apronPosition}, updatedNextOwners)
+	assert.Equal(t, []string{gwTowerPosition, apronPosition}, updatedNextOwners)
 	require.Len(t, frontendHub.OwnersUpdates, 1)
-	assert.Equal(t, []string{cTowerPosition, apronPosition}, frontendHub.OwnersUpdates[0].NextOwners)
+	assert.Equal(t, []string{gwTowerPosition, apronPosition}, frontendHub.OwnersUpdates[0].NextOwners)
 	require.NotNil(t, frontendHub.OwnersUpdates[0].NextDisplay)
 	assert.Equal(t, "GW", frontendHub.OwnersUpdates[0].NextDisplay.Label)
-	assert.Equal(t, cTowerPosition, frontendHub.OwnersUpdates[0].NextDisplay.Frequency)
+	assert.Equal(t, gwTowerPosition, frontendHub.OwnersUpdates[0].NextDisplay.Frequency)
 	assert.Equal(t, "SAS790", frontendHub.OwnersUpdates[0].Callsign)
 }
 
@@ -365,7 +365,7 @@ func TestResolveRouteSectorOwner_UsesOverrideTargetFirst(t *testing.T) {
 		"GWA",
 		map[string]string{
 			"TE":  "EKCH_A_TWR",
-			"GWA": "EKCH_C_TWR",
+			"GWA": "EKCH_GW_TWR",
 		},
 		map[string]string{"GWA": "TE"},
 	)
@@ -379,13 +379,13 @@ func TestResolveRouteSectorOwner_FallsBackToOriginalSector(t *testing.T) {
 	owner, ok := resolveRouteSectorOwner(
 		"GWA",
 		map[string]string{
-			"GWA": "EKCH_C_TWR",
+			"GWA": "EKCH_GW_TWR",
 		},
 		map[string]string{"GWA": "TE"},
 	)
 
 	require.True(t, ok)
-	assert.Equal(t, "EKCH_C_TWR", owner)
+	assert.Equal(t, "EKCH_GW_TWR", owner)
 }
 
 func TestResolveRouteDisplayFrequency_UsesSectorFrequencyForCrossCoupledAirborneSector(t *testing.T) {
@@ -457,9 +457,11 @@ func TestEKCHArrivalRoute_22LCargoFromTWUsesTEOwnedTransitSectors(t *testing.T) 
 
 	route, ok := config.ComputeToStand([]string{"22L"}, "TW", "G120")
 	require.True(t, ok)
-	assert.Equal(t, []string{"TW", "GWA", "TE"}, route.Path)
+	assert.Equal(t, []string{"TW", "GWA", "GE"}, route.Path)
 	assert.Equal(t, "TE", route.OwnerOverrides["TW"])
 	assert.Equal(t, "TE", route.OwnerOverrides["GWA"])
+	_, hasGEOverride := route.OwnerOverrides["GE"]
+	assert.False(t, hasGEOverride)
 }
 
 func TestEKCHArrivalRoute_04LHighAFromTEOnlyOverridesEntryTower(t *testing.T) {
@@ -496,8 +498,35 @@ func TestEKCHArrivalRoute_CargoFromAAUsesDirectEndpointRoute(t *testing.T) {
 
 			route, ok := config.ComputeToStand(tc.active, "AA", tc.stand)
 			require.True(t, ok)
-			assert.Equal(t, []string{"AA", "TE"}, route.Path)
+			assert.Equal(t, []string{"AA", "GE"}, route.Path)
 			assert.Empty(t, route.OwnerOverrides)
+		})
+	}
+}
+
+func TestEKCHArrivalRoute_04LCargoUsesTWThenGWAThenGE(t *testing.T) {
+	route, ok := config.ComputeToStand([]string{"04L"}, "TW", "G120")
+	require.True(t, ok)
+	assert.Equal(t, []string{"TW", "GWA", "GE"}, route.Path)
+}
+
+func TestEKCHArrivalRoute_CargoAtGroundEastHasNoFollowingHandover(t *testing.T) {
+	testCases := []struct {
+		name   string
+		active []string
+	}{
+		{name: "22L group", active: []string{"22L"}},
+		{name: "04L group", active: []string{"04L"}},
+		{name: "runway 30 group", active: []string{"30"}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			route, ok := config.ComputeToStand(tc.active, "GE", "G120")
+			require.True(t, ok)
+			assert.Equal(t, []string{"GE"}, route.Path)
+			_, hasGEOverride := route.OwnerOverrides["GE"]
+			assert.False(t, hasGEOverride)
 		})
 	}
 }
@@ -590,6 +619,145 @@ func TestUpdateRoutesForSession_RecalculatesEachStrip(t *testing.T) {
 
 	assert.Equal(t, []string{"SAS123", "KLM456"}, updatedCallsigns)
 	assert.Empty(t, frontendHub.OwnersUpdates)
+}
+
+func TestUpdateRoutesForSession_DoesNotRetargetPendingCoordination(t *testing.T) {
+	arrivalRunway, towerSector := mustArrivalRunwayAndTowerSector(t)
+	frontendHub := &testutil.MockFrontendHub{}
+	stripRepo := &testutil.MockStripRepository{}
+	sessionRepo := &testutil.MockSessionRepository{}
+	sectorRepo := &testutil.MockSectorOwnerRepository{}
+	coordRepo := &testutil.MockCoordinationRepository{}
+
+	strips := []*models.Strip{
+		{ID: 1, Callsign: "SAS123", Session: 42, Destination: "EKCH"},
+		{ID: 2, Callsign: "KLM456", Session: 42, Destination: "EKCH"},
+	}
+	var updatedCallsigns []string
+
+	stripRepo.ListFn = func(_ context.Context, _ int32) ([]*models.Strip, error) {
+		return strips, nil
+	}
+	stripRepo.SetNextOwnersFn = func(_ context.Context, _ int32, callsign string, _ []string) error {
+		updatedCallsigns = append(updatedCallsigns, callsign)
+		return nil
+	}
+	sessionRepo.GetByIDFn = func(_ context.Context, _ int32) (*models.Session, error) {
+		return &models.Session{
+			ID:      42,
+			Airport: "EKCH",
+			ActiveRunways: pkgModels.ActiveRunways{
+				ArrivalRunways: []string{arrivalRunway},
+			},
+		}, nil
+	}
+	sectorRepo.ListBySessionFn = func(_ context.Context, _ int32) ([]*models.SectorOwner, error) {
+		return []*models.SectorOwner{{
+			Session:  42,
+			Sector:   []string{towerSector},
+			Position: "EKCH_TWR",
+		}}, nil
+	}
+	coordRepo.ListBySessionFn = func(_ context.Context, _ int32) ([]*models.Coordination, error) {
+		return []*models.Coordination{{Session: 42, StripID: 2}}, nil
+	}
+
+	srv := &Server{
+		frontendHub: frontendHub,
+		stripRepo:   stripRepo,
+		sessionRepo: sessionRepo,
+		sectorRepo:  sectorRepo,
+		coordRepo:   coordRepo,
+	}
+
+	err := srv.UpdateRoutesForSession(42, true)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"SAS123"}, updatedCallsigns)
+	require.Len(t, frontendHub.OwnersUpdates, 1)
+	assert.Equal(t, "SAS123", frontendHub.OwnersUpdates[0].Callsign)
+}
+
+func TestUpdateRouteForStrip_DoesNotRetargetPendingCoordination(t *testing.T) {
+	stripRepo := &testutil.MockStripRepository{}
+	coordRepo := &testutil.MockCoordinationRepository{}
+
+	stripRepo.GetByCallsignFn = func(_ context.Context, session int32, callsign string) (*models.Strip, error) {
+		require.Equal(t, int32(42), session)
+		require.Equal(t, "SAS123", callsign)
+		return &models.Strip{
+			ID:       7,
+			Session:  42,
+			Callsign: "SAS123",
+		}, nil
+	}
+	coordRepo.GetByStripIDFn = func(_ context.Context, session int32, stripID int32) (*models.Coordination, error) {
+		require.Equal(t, int32(42), session)
+		require.Equal(t, int32(7), stripID)
+		return &models.Coordination{
+			Session: 42,
+			StripID: 7,
+		}, nil
+	}
+
+	srv := &Server{
+		stripRepo: stripRepo,
+		coordRepo: coordRepo,
+	}
+
+	err := srv.UpdateRouteForStripContext(context.Background(), "SAS123", 42, true)
+
+	require.NoError(t, err)
+}
+
+func TestComputeNextDisplayForStrip_PreservesDisplayDuringPendingCoordination(t *testing.T) {
+	coordRepo := &testutil.MockCoordinationRepository{}
+	strip := &models.Strip{
+		ID:      7,
+		Session: 42,
+		NextDisplay: &models.NextDisplay{
+			Label:     "GW",
+			Frequency: "118.580",
+		},
+	}
+	coordRepo.GetByStripIDFn = func(_ context.Context, session int32, stripID int32) (*models.Coordination, error) {
+		require.Equal(t, int32(42), session)
+		require.Equal(t, int32(7), stripID)
+		return &models.Coordination{Session: 42, StripID: 7}, nil
+	}
+
+	srv := &Server{coordRepo: coordRepo}
+	display, err := srv.ComputeNextDisplayForStripContext(context.Background(), strip, 42)
+
+	require.NoError(t, err)
+	require.NotNil(t, display)
+	assert.Equal(t, "GW", display.Label)
+	assert.Equal(t, "118.580", display.Frequency)
+	assert.NotSame(t, strip.NextDisplay, display)
+}
+
+func TestComputeNextDisplaysForStrips_PreservesDisplaysDuringPendingCoordination(t *testing.T) {
+	coordRepo := &testutil.MockCoordinationRepository{}
+	strip := &models.Strip{
+		ID:      7,
+		Session: 42,
+		NextDisplay: &models.NextDisplay{
+			Label:     "GW",
+			Frequency: "118.580",
+		},
+	}
+	coordRepo.ListBySessionFn = func(_ context.Context, session int32) ([]*models.Coordination, error) {
+		require.Equal(t, int32(42), session)
+		return []*models.Coordination{{Session: 42, StripID: 7}}, nil
+	}
+
+	srv := &Server{coordRepo: coordRepo}
+	err := srv.ComputeNextDisplaysForStripsContext(context.Background(), []*models.Strip{strip}, 42)
+
+	require.NoError(t, err)
+	require.NotNil(t, strip.NextDisplay)
+	assert.Equal(t, "GW", strip.NextDisplay.Label)
+	assert.Equal(t, "118.580", strip.NextDisplay.Frequency)
 }
 
 func TestUpdateRoutesForSession_ReturnsFirstStripError(t *testing.T) {

--- a/backend/internal/server/sectors.go
+++ b/backend/internal/server/sectors.go
@@ -5,6 +5,7 @@ import (
 	"FlightStrips/internal/models"
 	"FlightStrips/internal/repository"
 	"FlightStrips/internal/shared"
+	"FlightStrips/internal/vatsim"
 	"cmp"
 	"context"
 	"log/slog"
@@ -115,8 +116,10 @@ func (s *Server) updateSectorsContextUnlocked(ctx context.Context, sessionId int
 
 func (s *Server) RefreshAllSectors(ctx context.Context) error {
 	return refreshSessionSectors(ctx, s.sessionRepo, func(sessionID int32) error {
-		_, err := s.UpdateSectors(sessionID)
-		return err
+		if _, err := s.UpdateSectorsContext(ctx, sessionID); err != nil {
+			return err
+		}
+		return s.UpdateRoutesForSession(sessionID, true)
 	})
 }
 
@@ -215,7 +218,7 @@ func getCurrentControllerCoverage(ctx context.Context, controllerRepo repository
 
 		controllerCoverage := config.ControllerCoverage{
 			Name:      position.Name,
-			Frequency: position.Frequency,
+			Frequency: controllerPrimaryFrequency(controller, position),
 		}
 		for _, provider := range frequencyProviders {
 			controllerCoverage.CoveredFrequencies = append(controllerCoverage.CoveredFrequencies, provider.GetFrequencies(controller.Callsign)...)
@@ -238,10 +241,24 @@ func getCurrentPositions(ctx context.Context, controllerRepo repository.Controll
 		if !ok || !shared.IsOperationalControllerForPosition(controller, position) {
 			continue
 		}
-		positions = append(positions, position)
+		actualPosition := *position
+		actualPosition.Frequency = controllerPrimaryFrequency(controller, position)
+		positions = append(positions, &actualPosition)
 	}
 
 	return positions, nil
+}
+
+func controllerPrimaryFrequency(controller *models.Controller, role *config.Position) string {
+	if controller != nil {
+		if frequency := vatsim.NormalizeFrequency(controller.Position); frequency != "" {
+			return frequency
+		}
+	}
+	if role == nil {
+		return ""
+	}
+	return vatsim.NormalizeFrequency(role.Frequency)
 }
 
 func refreshSessionSectors(ctx context.Context, sessionRepo repository.SessionRepository, update func(sessionID int32) error) error {
@@ -279,7 +296,7 @@ func (s *Server) sendControllerUpdates(sessionId int32, owners []*models.SectorO
 		ownedSectors := []string{}
 		position, ok := resolveOperationalPosition(controller)
 		if ok && shared.IsOperationalControllerForPosition(controller, position) {
-			if sector, ok := ownerMap[position.Frequency]; ok {
+			if sector, ok := ownerMap[controllerPrimaryFrequency(controller, position)]; ok {
 				identifier = sector.Identifier
 				ownedSectors = slices.Clone(sector.Sector)
 			}

--- a/backend/internal/server/sectors_test.go
+++ b/backend/internal/server/sectors_test.go
@@ -42,7 +42,7 @@ func TestComputeSectorChanges_ReportsBothGWVariantsWithPublicName(t *testing.T) 
 			},
 			{
 				Sector:   []string{"GWD"},
-				Position: frequencyForPosition(t, "EKCH_C_TWR"),
+				Position: frequencyForPosition(t, "EKCH_GW_TWR"),
 			},
 		},
 		[]*models.SectorOwner{
@@ -60,7 +60,7 @@ func TestComputeSectorChanges_ReportsBothGWVariantsWithPublicName(t *testing.T) 
 	require.Len(t, changes, 2)
 	assert.ElementsMatch(t, []string{"GW", "GW"}, []string{changes[0].SectorName, changes[1].SectorName})
 	assert.ElementsMatch(t,
-		[]string{"EKCH_A_TWR", "EKCH_C_TWR"},
+		[]string{"EKCH_A_TWR", "EKCH_GW_TWR"},
 		[]string{changes[0].FromPosition, changes[1].FromPosition},
 	)
 	assert.ElementsMatch(t,
@@ -101,6 +101,45 @@ func TestEkchGwDepartureVariantAlwaysAssignsToDTower(t *testing.T) {
 	assertEkchGwOwner(t, []string{"04L", "04R"}, "GWD", "EKCH_D_TWR")
 	assertEkchGwOwner(t, []string{"30"}, "GWD", "EKCH_D_TWR")
 	assertEkchGwOwner(t, []string{"30", "22R"}, "GWD", "EKCH_D_TWR")
+}
+
+func TestEkchGeCanCoverAllTerminalSectors(t *testing.T) {
+	t.Parallel()
+
+	geTower, err := config.GetPositionByName("EKCH_GE_TWR")
+	require.NoError(t, err)
+
+	controllerSectors := config.GetControllerSectors([]*config.Position{geTower}, []string{"22L", "22R"})
+
+	assert.ElementsMatch(t,
+		[]string{"DEL", "SQ", "AA", "AD", "GE", "TE", "TW", "GWA", "GWD"},
+		sectorKeys(controllerSectors[geTower.Frequency]),
+	)
+}
+
+func TestEkchGwRetainsFallbackPriorityOverGe(t *testing.T) {
+	t.Parallel()
+
+	gwTower, err := config.GetPositionByName("EKCH_GW_TWR")
+	require.NoError(t, err)
+	geTower, err := config.GetPositionByName("EKCH_GE_TWR")
+	require.NoError(t, err)
+
+	controllerSectors := config.GetControllerSectors(
+		[]*config.Position{geTower, gwTower},
+		[]string{"22L", "22R"},
+	)
+
+	assert.Contains(t, sectorKeys(controllerSectors[gwTower.Frequency]), "DEL")
+	assert.NotContains(t, sectorKeys(controllerSectors[geTower.Frequency]), "DEL")
+}
+
+func sectorKeys(sectors []config.Sector) []string {
+	keys := make([]string, 0, len(sectors))
+	for _, sector := range sectors {
+		keys = append(keys, sector.KeyOrName())
+	}
+	return keys
 }
 
 func assertEkchGwOwner(t *testing.T, active []string, sectorKey string, expectedPositionName string) {
@@ -235,7 +274,7 @@ func TestGetCurrentControllerCoverage_UsesSyncStateControllers(t *testing.T) {
 	}, coverage)
 }
 
-func TestGetCurrentControllerCoverage_PrefersCallsignPositionOverCrossCoupledFrequency(t *testing.T) {
+func TestGetCurrentControllerCoverage_UsesCallsignRoleAtActualPrimedFrequency(t *testing.T) {
 	t.Cleanup(config.SetPositionsForTest([]config.Position{
 		{Name: "EKCH_A_TWR", Frequency: "118.100"},
 		{Name: "EKCH_W_APP", Frequency: "119.805"},
@@ -253,14 +292,14 @@ func TestGetCurrentControllerCoverage_PrefersCallsignPositionOverCrossCoupledFre
 	coverage, err := getCurrentControllerCoverage(context.Background(), controllerRepo, 1, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []config.ControllerCoverage{
-		{Name: "EKCH_A_TWR", Frequency: "118.100"},
+		{Name: "EKCH_A_TWR", Frequency: "119.805"},
 	}, coverage)
 }
 
 func TestGetCurrentControllerCoverage_UsesNormalizedFrequencyForGenericControllers(t *testing.T) {
 	t.Cleanup(config.SetPositionsForTest([]config.Position{
 		{Name: "EKCH_A_GND", Frequency: "121.600"},
-		{Name: "EKCH_C_TWR", Frequency: "118.580"},
+		{Name: "EKCH_GW_TWR", Frequency: "118.580"},
 	}))
 	t.Cleanup(config.SetOwnerCallsignPrefixesForTest([]string{"EKCH"}))
 
@@ -277,7 +316,7 @@ func TestGetCurrentControllerCoverage_UsesNormalizedFrequencyForGenericControlle
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []config.ControllerCoverage{
 		{Name: "EKCH_A_GND", Frequency: "121.600"},
-		{Name: "EKCH_C_TWR", Frequency: "118.580"},
+		{Name: "EKCH_GW_TWR", Frequency: "118.580"},
 	}, coverage)
 }
 
@@ -340,7 +379,7 @@ func TestSendControllerUpdates_UsesCallsignResolvedPositionForOwnedSectors(t *te
 	server := &Server{frontendHub: frontendHub}
 	err := server.sendControllerUpdates(1, []*models.SectorOwner{{
 		Session:    1,
-		Position:   "118.100",
+		Position:   "119.805",
 		Sector:     []string{"TW"},
 		Identifier: "EKCH_A_TWR",
 	}}, controllerRepo)

--- a/backend/internal/services/dependencies.go
+++ b/backend/internal/services/dependencies.go
@@ -87,8 +87,16 @@ type RouteRecalculator interface {
 	UpdateRouteForStripContext(ctx context.Context, callsign string, sessionID int32, sendUpdate bool) error
 }
 
+type ClearedStripOwnerResolver interface {
+	ResolveClearedStripOwnerContext(ctx context.Context, strip *internalModels.Strip, sessionID int32) (string, bool, error)
+}
+
 type StripRouteComputer interface {
 	ComputeNextOwnersForStripContext(ctx context.Context, strip *internalModels.Strip, sessionID int32) ([]string, bool, error)
+}
+
+type StripRouteDisplayComputer interface {
+	ComputeNextDisplayForStripContext(ctx context.Context, strip *internalModels.Strip, sessionID int32) (*internalModels.NextDisplay, error)
 }
 
 type SessionReader interface {

--- a/backend/internal/services/strip.go
+++ b/backend/internal/services/strip.go
@@ -17,26 +17,28 @@ const (
 )
 
 type StripService struct {
-	stripReader       StripReader
-	lifecycleStore    StripLifecycleStore
-	orderingStore     StripOrderingStore
-	fieldStore        StripFieldStore
-	ownerStore        StripOwnerStore
-	cdmStore          StripCdmStore
-	validationStore   StripValidationStatusStore
-	manualFplStore    StripManualFplStore
-	tacticalRepo      repository.TacticalStripRepository
-	sectorOwnerRepo   repository.SectorOwnerRepository
-	publisher         shared.StripEventPublisher
-	esCommander       StripEuroscopeCommander
-	coordRepo         CoordinationStore
-	controllerRepo    ControllerReader
-	sessionRepo       SessionReader
-	routeRecalculator RouteRecalculator
-	routeComputer     StripRouteComputer
-	pdcService        shared.PdcService
-	cdmService        StripCdmService
-	departureObserver departurePositionObserver
+	stripReader          StripReader
+	lifecycleStore       StripLifecycleStore
+	orderingStore        StripOrderingStore
+	fieldStore           StripFieldStore
+	ownerStore           StripOwnerStore
+	cdmStore             StripCdmStore
+	validationStore      StripValidationStatusStore
+	manualFplStore       StripManualFplStore
+	tacticalRepo         repository.TacticalStripRepository
+	sectorOwnerRepo      repository.SectorOwnerRepository
+	publisher            shared.StripEventPublisher
+	esCommander          StripEuroscopeCommander
+	coordRepo            CoordinationStore
+	controllerRepo       ControllerReader
+	sessionRepo          SessionReader
+	routeRecalculator    RouteRecalculator
+	routeComputer        StripRouteComputer
+	routeDisplayComputer StripRouteDisplayComputer
+	clearedOwnerResolver ClearedStripOwnerResolver
+	pdcService           shared.PdcService
+	cdmService           StripCdmService
+	departureObserver    departurePositionObserver
 }
 
 type departurePositionObserver interface {
@@ -111,6 +113,12 @@ func (s *StripService) SetRouteRecalculator(routeRecalculator RouteRecalculator)
 	s.routeRecalculator = routeRecalculator
 	if routeComputer, ok := routeRecalculator.(StripRouteComputer); ok {
 		s.routeComputer = routeComputer
+	}
+	if displayComputer, ok := routeRecalculator.(StripRouteDisplayComputer); ok {
+		s.routeDisplayComputer = displayComputer
+	}
+	if resolver, ok := routeRecalculator.(ClearedStripOwnerResolver); ok {
+		s.clearedOwnerResolver = resolver
 	}
 }
 

--- a/backend/internal/services/strip_auto_assume.go
+++ b/backend/internal/services/strip_auto_assume.go
@@ -12,10 +12,10 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-// AutoAssumeForClearedStrip finds the SQ (or fallback DEL) sector owner for a
-// cleared departure strip and assigns them as the strip owner. It sends an owners
-// update broadcast to all frontend clients. If no SQ/DEL owner is found, the strip
-// is left unowned.
+// AutoAssumeForClearedStrip resolves the configured clearance handover target for a
+// cleared departure strip and assigns it directly as the strip owner. It sends an
+// owners update broadcast to all frontend clients. If no target is sensed, the
+// strip is left unchanged.
 func (s *StripService) AutoAssumeForClearedStrip(ctx context.Context, session int32, callsign string) error {
 	return s.autoAssumeForClearedStrip(ctx, session, callsign, "")
 }
@@ -30,7 +30,7 @@ func (s *StripService) AutoAssumeForClearedStripByCid(ctx context.Context, sessi
 }
 
 func (s *StripService) autoAssumeForClearedStrip(ctx context.Context, session int32, callsign string, actingPosition string) error {
-	if s.sectorOwnerRepo == nil {
+	if s.sectorOwnerRepo == nil && s.clearedOwnerResolver == nil {
 		return nil
 	}
 
@@ -48,58 +48,78 @@ func (s *StripService) autoAssumeForClearedStrip(ctx context.Context, session in
 		return nil
 	}
 
-	owners, err := s.syncSectorOwners(ctx, session)
+	targetPosition, resolved, err := s.resolveClearedStripOwner(ctx, session, strip)
 	if err != nil {
 		return err
 	}
-
-	sqPosition := ""
-	for _, owner := range owners {
-		if slices.Contains(owner.Sector, "SQ") {
-			sqPosition = owner.Position
-			break
-		}
-	}
-	if sqPosition == "" {
-		for _, owner := range owners {
-			if slices.Contains(owner.Sector, "DEL") {
-				sqPosition = owner.Position
-				break
-			}
-		}
-	}
-
-	if sqPosition == "" {
-		slog.DebugContext(ctx, "No SQ/DEL owner found for auto-assume", slog.String("callsign", callsign))
+	if !resolved {
+		slog.DebugContext(ctx, "No clearance handover target sensed for auto-assume", slog.String("callsign", callsign))
 		return nil
 	}
 
-	slog.DebugContext(ctx, "Auto-assuming cleared departure strip", slog.String("callsign", callsign), slog.String("position", sqPosition))
+	slog.DebugContext(ctx, "Auto-assuming cleared departure strip", slog.String("callsign", callsign), slog.String("position", targetPosition))
 
-	nextOwners, previousOwners := prepareOwnersForAutomaticTransfer(strip, sqPosition, actingPosition)
+	nextOwners, previousOwners := prepareOwnersForAutomaticTransfer(strip, targetPosition, actingPosition)
 
 	if err := s.ownerStore.SetNextAndPreviousOwners(ctx, session, callsign, nextOwners, previousOwners); err != nil {
 		return err
 	}
 
-	count, err := s.setOwnerAndReevaluateDuplicateSquawkValidation(ctx, session, callsign, &sqPosition, strip.Version)
+	count, err := s.setOwnerAndReevaluateDuplicateSquawkValidation(ctx, session, callsign, &targetPosition, strip.Version)
 	if err != nil {
 		return err
 	}
 
 	if count == 1 {
+		resolvedOwner := targetPosition
+		strip.Owner = &resolvedOwner
+		strip.NextOwners = slices.Clone(nextOwners)
+		strip.PreviousOwners = slices.Clone(previousOwners)
+
+		var nextDisplay *models.NextDisplay
 		if routeRecalculator := s.getRouteRecalculator(); routeRecalculator != nil {
 			if err := routeRecalculator.UpdateRouteForStripContext(ctx, callsign, session, false); err != nil {
 				slog.ErrorContext(ctx, "Error updating route after auto-assume", slog.String("callsign", callsign), slog.Any("error", err))
 			}
 			if refreshed, err := s.syncStripByCallsign(ctx, session, callsign); err == nil {
 				nextOwners = refreshed.NextOwners
+				nextDisplay = refreshed.NextDisplay
+				if s.routeDisplayComputer != nil {
+					if computed, err := s.routeDisplayComputer.ComputeNextDisplayForStripContext(ctx, refreshed, session); err == nil {
+						nextDisplay = computed
+					} else {
+						slog.ErrorContext(ctx, "Error computing route display after auto-assume",
+							slog.String("callsign", callsign),
+							slog.Any("error", err))
+					}
+				}
 			}
 		}
-		s.publisher.SendOwnersUpdate(session, callsign, sqPosition, nextOwners, previousOwners, nil)
+		s.publisher.SendOwnersUpdate(session, callsign, targetPosition, nextOwners, previousOwners, nextDisplay)
 	}
 
 	return nil
+}
+
+func (s *StripService) resolveClearedStripOwner(ctx context.Context, session int32, strip *models.Strip) (string, bool, error) {
+	if s.clearedOwnerResolver != nil {
+		return s.clearedOwnerResolver.ResolveClearedStripOwnerContext(ctx, strip, session)
+	}
+
+	// Preserve the legacy fallback for isolated service users that do not wire the
+	// server resolver (primarily narrow unit tests and test tools).
+	owners, err := s.syncSectorOwners(ctx, session)
+	if err != nil {
+		return "", false, err
+	}
+	for _, sector := range []string{"SQ", "DEL"} {
+		for _, owner := range owners {
+			if slices.Contains(owner.Sector, sector) {
+				return owner.Position, true, nil
+			}
+		}
+	}
+	return "", false, nil
 }
 
 func (s *StripService) resolveControllerPositionByCid(ctx context.Context, cid string) (string, error) {

--- a/backend/internal/services/strip_auto_assume_handover_test.go
+++ b/backend/internal/services/strip_auto_assume_handover_test.go
@@ -1,0 +1,104 @@
+package services
+
+import (
+	"FlightStrips/internal/models"
+	"FlightStrips/internal/testutil"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type clearedHandoverRouteStub struct {
+	target             string
+	resolvedStrip      *models.Strip
+	ownerAtRouteUpdate string
+}
+
+func (s *clearedHandoverRouteStub) ResolveClearedStripOwnerContext(_ context.Context, strip *models.Strip, _ int32) (string, bool, error) {
+	s.resolvedStrip = strip
+	return s.target, true, nil
+}
+
+func (s *clearedHandoverRouteStub) UpdateRouteForStrip(string, int32, bool) error {
+	return nil
+}
+
+func (s *clearedHandoverRouteStub) UpdateRouteForStripContext(context.Context, string, int32, bool) error {
+	if s.resolvedStrip != nil && s.resolvedStrip.Owner != nil {
+		s.ownerAtRouteUpdate = *s.resolvedStrip.Owner
+	}
+	return nil
+}
+
+func (s *clearedHandoverRouteStub) ComputeNextDisplayForStripContext(context.Context, *models.Strip, int32) (*models.NextDisplay, error) {
+	return &models.NextDisplay{Label: "AD", Frequency: "121.905"}, nil
+}
+
+func TestWithRouteRecalculatorWiresHandoverAndDisplayCapabilities(t *testing.T) {
+	route := &clearedHandoverRouteStub{}
+
+	service := NewStripService(&testutil.MockStripRepository{}, WithRouteRecalculator(route))
+
+	assert.Same(t, route, service.routeRecalculator)
+	assert.Same(t, route, service.routeDisplayComputer)
+	assert.Same(t, route, service.clearedOwnerResolver)
+}
+
+func TestAutoAssumeForClearedStrip_UsesRadioHandoverResolverWithoutCoordination(t *testing.T) {
+	const (
+		session  = int32(42)
+		callsign = "SAS380"
+		target   = "121.905"
+	)
+	ownerSet := false
+	stripRepo := &testutil.MockStripRepository{
+		GetByCallsignFn: func(context.Context, int32, string) (*models.Strip, error) {
+			if !ownerSet {
+				return &models.Strip{
+					Callsign:    callsign,
+					Origin:      "EKCH",
+					Destination: "EKBI",
+					Bay:         "CLEARED",
+					Version:     7,
+					NextOwners:  []string{target},
+				}, nil
+			}
+			owner := target
+			return &models.Strip{
+				Callsign:   callsign,
+				Owner:      &owner,
+				NextOwners: []string{"121.730"},
+			}, nil
+		},
+		SetNextAndPreviousOwnersFn: func(_ context.Context, _ int32, _ string, nextOwners, previousOwners []string) error {
+			assert.Empty(t, nextOwners)
+			assert.Empty(t, previousOwners)
+			return nil
+		},
+		SetOwnerFn: func(_ context.Context, _ int32, _ string, owner *string, version int32) (int64, error) {
+			require.NotNil(t, owner)
+			assert.Equal(t, target, *owner)
+			assert.Equal(t, int32(7), version)
+			ownerSet = true
+			return 1, nil
+		},
+	}
+	hub := &testutil.MockFrontendHub{}
+	service := NewStripService(stripRepo)
+	service.SetFrontendHub(hub)
+	route := &clearedHandoverRouteStub{target: target}
+	service.SetRouteRecalculator(route)
+
+	err := service.AutoAssumeForClearedStrip(context.Background(), session, callsign)
+
+	require.NoError(t, err)
+	assert.Equal(t, target, route.ownerAtRouteUpdate)
+	require.Len(t, hub.OwnersUpdates, 1)
+	assert.Equal(t, target, hub.OwnersUpdates[0].Owner)
+	assert.Equal(t, []string{"121.730"}, hub.OwnersUpdates[0].NextOwners)
+	require.NotNil(t, hub.OwnersUpdates[0].NextDisplay)
+	assert.Equal(t, "AD", hub.OwnersUpdates[0].NextDisplay.Label)
+	assert.Equal(t, "121.905", hub.OwnersUpdates[0].NextDisplay.Frequency)
+}

--- a/backend/internal/services/strip_coordination.go
+++ b/backend/internal/services/strip_coordination.go
@@ -201,10 +201,40 @@ func (s *StripService) AcceptCoordination(ctx context.Context, session int32, ca
 	if count != 1 {
 		return errors.New("failed to set strip owner after accepting coordination")
 	}
+	resolvedOwner := assumingPosition
+	strip.Owner = &resolvedOwner
+	strip.NextOwners = slices.Clone(nextOwners)
+	strip.PreviousOwners = slices.Clone(previousOwners)
+
+	var nextDisplay *internalModels.NextDisplay
+	if routeRecalculator := s.getRouteRecalculator(); routeRecalculator != nil && shouldRefreshRouteAfterCoordinationAssume(strip.Bay) {
+		if err := routeRecalculator.UpdateRouteForStripContext(ctx, callsign, session, false); err != nil {
+			slog.ErrorContext(ctx, "Error updating route after coordination acceptance",
+				slog.String("callsign", callsign),
+				slog.Any("error", err))
+		} else if refreshed, err := s.syncStripByCallsign(ctx, session, callsign); err == nil {
+			nextOwners = refreshed.NextOwners
+			nextDisplay = refreshed.NextDisplay
+			if s.routeDisplayComputer != nil {
+				if computed, err := s.routeDisplayComputer.ComputeNextDisplayForStripContext(ctx, refreshed, session); err == nil {
+					nextDisplay = computed
+				}
+			}
+		}
+	}
 
 	s.publisher.SendCoordinationAssume(session, callsign, assumingPosition)
-	s.publisher.SendOwnersUpdate(session, callsign, assumingPosition, nextOwners, previousOwners, nil)
+	s.publisher.SendOwnersUpdate(session, callsign, assumingPosition, nextOwners, previousOwners, nextDisplay)
 	return nil
+}
+
+func shouldRefreshRouteAfterCoordinationAssume(bay string) bool {
+	switch bay {
+	case shared.BAY_CLEARED, shared.BAY_TAXI_LWR, shared.BAY_TWY_ARR:
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *StripService) AutoTransferAirborneStrip(ctx context.Context, session int32, callsign string) error {
@@ -511,8 +541,28 @@ func (s *StripService) AssumeStripCoordination(ctx context.Context, session int3
 				if count != 1 {
 					return errors.New("failed to set strip owner")
 				}
+				resolvedOwner := position
+				strip.Owner = &resolvedOwner
+				strip.NextOwners = slices.Clone(nextOwners)
+
+				var nextDisplay *internalModels.NextDisplay
+				if routeRecalculator := s.getRouteRecalculator(); routeRecalculator != nil {
+					if err := routeRecalculator.UpdateRouteForStripContext(ctx, callsign, session, false); err != nil {
+						slog.ErrorContext(ctx, "Error updating route after stale coordination assumption",
+							slog.String("callsign", callsign),
+							slog.Any("error", err))
+					} else if refreshed, err := s.syncStripByCallsign(ctx, session, callsign); err == nil {
+						nextOwners = refreshed.NextOwners
+						nextDisplay = refreshed.NextDisplay
+						if s.routeDisplayComputer != nil {
+							if computed, err := s.routeDisplayComputer.ComputeNextDisplayForStripContext(ctx, refreshed, session); err == nil {
+								nextDisplay = computed
+							}
+						}
+					}
+				}
 				s.publisher.SendCoordinationAssume(session, callsign, position)
-				s.publisher.SendOwnersUpdate(session, callsign, position, nextOwners, strip.PreviousOwners, nil)
+				s.publisher.SendOwnersUpdate(session, callsign, position, nextOwners, strip.PreviousOwners, nextDisplay)
 				return nil
 			}
 			return errors.New("cannot assume strip which is not transferred to you")
@@ -559,19 +609,29 @@ func (s *StripService) AssumeStripCoordination(ctx context.Context, session int3
 		if count != 1 {
 			return errors.New("failed to set strip owner")
 		}
+		resolvedOwner := position
+		strip.Owner = &resolvedOwner
+		strip.NextOwners = slices.Clone(nextOwners)
 
 		s.publisher.SendCoordinationAssume(session, callsign, position)
 
+		var nextDisplay *internalModels.NextDisplay
 		if routeRecalculator := s.getRouteRecalculator(); routeRecalculator != nil {
-			if err := routeRecalculator.UpdateRouteForStrip(callsign, session, false); err != nil {
+			if err := routeRecalculator.UpdateRouteForStripContext(ctx, callsign, session, false); err != nil {
 				slog.ErrorContext(ctx, "Error updating route after direct assume", slog.String("callsign", callsign), slog.Any("error", err))
 			}
-			if refreshed, err := s.stripReader.GetByCallsign(ctx, session, callsign); err == nil {
+			if refreshed, err := s.syncStripByCallsign(ctx, session, callsign); err == nil {
 				nextOwners = refreshed.NextOwners
+				nextDisplay = refreshed.NextDisplay
+				if s.routeDisplayComputer != nil {
+					if computed, err := s.routeDisplayComputer.ComputeNextDisplayForStripContext(ctx, refreshed, session); err == nil {
+						nextDisplay = computed
+					}
+				}
 			}
 		}
 
-		s.publisher.SendOwnersUpdate(session, callsign, position, nextOwners, strip.PreviousOwners, nil)
+		s.publisher.SendOwnersUpdate(session, callsign, position, nextOwners, strip.PreviousOwners, nextDisplay)
 		return nil
 	}
 

--- a/backend/internal/services/strip_ctot_validation_test.go
+++ b/backend/internal/services/strip_ctot_validation_test.go
@@ -133,7 +133,7 @@ func TestApplyCtotValidation_ReactivatesOnOwnerChange(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2024, time.January, 1, 10, 0, 0, 0, time.UTC)
-	oldOwner := "EKCH_C_TWR"
+	oldOwner := "EKCH_GW_TWR"
 	newOwner := "EKCH_A_TWR"
 	ctot := "1015"
 	var persisted *models.ValidationStatus

--- a/backend/internal/services/strip_landing_clearance_validation_test.go
+++ b/backend/internal/services/strip_landing_clearance_validation_test.go
@@ -20,7 +20,7 @@ func setupLandingClearanceValidationConfig(t *testing.T) {
 	t.Cleanup(config.SetPositionsForTest([]config.Position{
 		{Name: "EKCH_A_TWR", Frequency: "118.105", Section: "TWR"},
 		{Name: "EKCH_D_TWR", Frequency: "119.355", Section: "TWR"},
-		{Name: "EKCH_C_TWR", Frequency: "118.580", Section: "TWR"},
+		{Name: "EKCH_GW_TWR", Frequency: "118.580", Section: "TWR"},
 	}))
 	t.Cleanup(config.SetSectorsForTest([]config.Sector{
 		{Name: "TE", Active: []string{"22L", "22R"}, Owner: []string{"EKCH_A_TWR", "EKCH_D_TWR"}},

--- a/backend/internal/services/strip_no_stand_validation_test.go
+++ b/backend/internal/services/strip_no_stand_validation_test.go
@@ -85,7 +85,7 @@ func newDuplicateNoStandPrecedenceFixture() *precedenceValidationFixture {
 }
 
 func TestApplyNoStandValidation_ActivatesForRelevantOwnerAndBay(t *testing.T) {
-	owner := "EKCH_C_TWR"
+	owner := "EKCH_GW_TWR"
 	var persisted *models.ValidationStatus
 
 	svc := NewStripService(&testutil.MockStripRepository{
@@ -175,7 +175,7 @@ func TestApplyNoStandValidation_ClearsForNonApplicableOwner(t *testing.T) {
 
 func TestReevaluateNoStandValidation_ReactivatesOnOwnerChange(t *testing.T) {
 	oldOwner := "EKCH_A_GND"
-	newOwner := "EKCH_C_TWR"
+	newOwner := "EKCH_GW_TWR"
 	var persisted *models.ValidationStatus
 
 	repo := &testutil.MockStripRepository{
@@ -252,7 +252,7 @@ func TestUpdateStand_ReevaluatesNoStandValidation(t *testing.T) {
 }
 
 func TestMoveToBay_ReevaluatesNoStandValidationOnActivationEdge(t *testing.T) {
-	owner := "EKCH_C_TWR"
+	owner := "EKCH_GW_TWR"
 	var persisted *models.ValidationStatus
 
 	repo := &testutil.MockStripRepository{

--- a/backend/internal/services/strip_options.go
+++ b/backend/internal/services/strip_options.go
@@ -55,6 +55,12 @@ func WithRouteRecalculator(routeRecalculator RouteRecalculator) StripServiceOpti
 		if routeComputer, ok := routeRecalculator.(StripRouteComputer); ok {
 			s.routeComputer = routeComputer
 		}
+		if displayComputer, ok := routeRecalculator.(StripRouteDisplayComputer); ok {
+			s.routeDisplayComputer = displayComputer
+		}
+		if resolver, ok := routeRecalculator.(ClearedStripOwnerResolver); ok {
+			s.clearedOwnerResolver = resolver
+		}
 	}
 }
 

--- a/backend/internal/services/strip_taxiway_type_validation_test.go
+++ b/backend/internal/services/strip_taxiway_type_validation_test.go
@@ -21,14 +21,14 @@ func setupTaxiwayTypeValidationTestConfig(t *testing.T) {
 		{Name: "EKCH_DEL", Section: "DEL"},
 		{Name: "EKCH_A_GND", Section: "GND"},
 		{Name: "EKCH_A_TWR", Section: "TWR"},
-		{Name: "EKCH_C_TWR", Section: "TWR"},
+		{Name: "EKCH_GW_TWR", Section: "TWR"},
 		{Name: "TEST_GW_GND", Section: "GND"},
 	}))
 
 	t.Cleanup(config.SetLayoutsForTest(map[string][]config.LayoutVariant{
 		"EKCH_A_GND":  {{Layout: "AA"}},
 		"EKCH_A_TWR":  {{Layout: "TWTE"}},
-		"EKCH_C_TWR":  {{Layout: "GEGW"}},
+		"EKCH_GW_TWR": {{Layout: "GEGW"}},
 		"TEST_GW_GND": {{Layout: "GEGW"}},
 	}))
 

--- a/docs/src/content/docs/ekch/aa-ad.md
+++ b/docs/src/content/docs/ekch/aa-ad.md
@@ -42,7 +42,12 @@ Strips are organised into **bays**. A bay is either **ACTIVE** or **LOCKED**. St
 ## REQ and transfers
 
 - Bays marked **Can be REQ** allow requesting a strip you do not own.
-- **APN-TAXI-DEP** strips in **TWY DEP** qualify for **SI** transfer to the next controller (e.g. GW) per system rules.
+- **TWY DEP-LWR** SI creates normal pending coordination to the next carried step in the configured route:
+  - 22R/04L: AD → GW → TW
+  - 04R/30: AD → GW → TE
+  - 22L: AD → TE
+  - 12: AD → TW
+- Cross-coupled targets use the carrying primary while displaying the logical identifier frequency. For example, when TW or GE carries GW, AD transfers to that primary but the strip shows **GW 118.580**. When GW is not carried and GE is the configured owner of the GW sector, AD transfers to GE and the strip shows **GE 121.830**.
 - Manual moves are allowed between **ACTIVE** bays.
 
 For clearance dialogue, PDC strip colours, and delivery workflow, see [CLR DEL](/ekch/clr-del/) and [Pre-departure clearance](/concepts/pre-departure-clearance/).

--- a/docs/src/content/docs/ekch/clr-del.mdx
+++ b/docs/src/content/docs/ekch/clr-del.mdx
@@ -30,14 +30,13 @@ Uncleared strips cannot be manually moved to another bay — only issuing a clea
 
 ## Cleared strips
 
-**SI from Cleared** is disabled in standard CLR DEL; enabled when **DEL+SEQ** is active.
+Completing the clearance directly assigns the strip to the first carried step in its complete departure route. This is an ownership change, not pending coordination. A logical step is carried when its frequency is primed or cross-coupled:
 
-Automatic SI handoff from Cleared depends on staffing:
+- **East/South stands (G110–G137):** GE 121.830 → the applicable tower.
+- **West stand (W1):** GW 118.580 → the applicable tower.
+- **North stands:** SEQ PLN 121.905 → AD 121.730 → the configured ground/tower route. If AD and SEQ PLN are carried by the same primary, the strip is assigned as **AD** and the displayed frequency is **121.905**.
 
-- Two or fewer apron positions online → SI hands off to **Apron Departure**.
-- Three apron positions online → SI hands off to **[SEQ PLN](/ekch/seq-pln/)**.
-
-When **DEL+SEQ** is active, strips stay with **EKCH_DEL** in Cleared; the SI indicator changes (white vs orange) and delivery coordinates the handoff to apron at startup time.
+When a logical frequency is carried, cross-coupling changes the primary position that receives the strip while the SI label continues to show the logical identifier frequency. Otherwise, the sector's configured fallback owner receives the strip with that controller's identifier and frequency. A step is skipped only when neither radio carriage nor configured sector ownership resolves it.
 
 ## Issue a clearance
 
@@ -79,5 +78,5 @@ See [Pre-departure clearance](/concepts/pre-departure-clearance/) and [Validatio
 ## Related
 
 - [AA + AD](/ekch/aa-ad/) — combined apron after handoff
-- [SEQ PLN](/ekch/seq-pln/) — when three apron positions are online
+- [SEQ PLN](/ekch/seq-pln/) — startup sequencing for North stands
 - [Apron Departure](/ekch/apn-dep/) — B/C_GND split layout

--- a/docs/src/content/docs/ekch/ge-gw.md
+++ b/docs/src/content/docs/ekch/ge-gw.md
@@ -7,7 +7,7 @@ sidebar:
 
 ![Kastrup Ground East + West](../../../assets/ekch/ge-gw.jpg)
 
-**GE + GW** is the tower ground scope for **EKCH_C_TWR** (118.580), using the **TWR aspect** layout. It covers runway and taxi logic while coordinating with apron and delivery.
+**GE + GW** is the tower ground scope for **EKCH_GW_TWR** (118.580) and **EKCH_GE_TWR** (121.830), using the **TWR aspect** layout. It covers runway and taxi logic while coordinating with apron and delivery.
 
 Strips live in **bays** that are **ACTIVE** or **LOCKED**. Use **REQ** where the bay allows; fully locked strip types cannot be requested.
 
@@ -30,11 +30,13 @@ Strips live in **bays** that are **ACTIVE** or **LOCKED**. Use **REQ** where the
 
 ## Departures
 
-Startup → Push back (TWR) via pushback map → TWY DEP (TWR) / De-ice A as needed. TWY DEP (TWR) and apron TWY DEP-LWR stay in sync; use SI and handoff rules per spec. RWY DEP and Airborne behaviour (including auto-move and SI) aligns with [TE + TW](/ekch/te-tw/).
+Startup → Push back (TWR) via pushback map → TWY DEP (TWR) / De-ice A as needed. TWY DEP (TWR) and apron TWY DEP-LWR stay in sync.
+
+The complete departure route contains GE or GW followed by **TW** for 22R/04L/12 and **TE** for 04R/22L/30. TWY DEP SI creates pending coordination to that next logical step. The actionable target is the primary carrying its frequency.
 
 ## Arrivals
 
-TWY ARR strips match other TWR scopes; SI splits follow system logic. Final and RWY ARR (`TWR-ARR`) landing workflow and runway colour rules are documented in [TE + TW](/ekch/te-tw/).
+For North stands, TWY ARR SI targets **AA 121.630**. East/South and West arrivals have no GE/GW handover target. Final and RWY ARR (`TWR-ARR`) landing workflow and runway colour rules are documented in [TE + TW](/ekch/te-tw/).
 
 ## Uncleared strips
 

--- a/docs/src/content/docs/ekch/seq-pln.mdx
+++ b/docs/src/content/docs/ekch/seq-pln.mdx
@@ -9,7 +9,7 @@ import { Aside } from '@astrojs/starlight/components';
 
 ![Kastrup Sequence Planner](../../../assets/ekch/est.jpg)
 
-**SEQ PLN** is used by **EKCH_B_GND** only when **EKCH_C_GND** (121.730) is online — B-GND takes the planner role while C-GND covers the other ground sector. The layout uses the **GND aspect** (same family as [AA + AD](/ekch/aa-ad/) and [CLR DEL](/ekch/clr-del/)).
+**SEQ PLN** uses logical frequency **121.905**. The controller carrying that frequency may be primed on it or carry it through cross-coupling. The layout uses the **GND aspect** (same family as [AA + AD](/ekch/aa-ad/) and [CLR DEL](/ekch/clr-del/)).
 
 ## Bay overview
 
@@ -35,17 +35,16 @@ import { Aside } from '@astrojs/starlight/components';
 All cleared departures sit in **Startup (SEQ)**. Clickspots match Cleared strips in CLR DEL.
 
 <Aside>
-The SI box shows white (strip is owned by SEQ PLN). SI always targets **Apron Departure (AD)** — click SI to split and send. Manual **TRF** SI is also available. Manual moves within this scope are limited to **Startup (SEQ)** ↔ **Push back**.
+The SI box shows white when the strip is owned by SEQ PLN. **START+TRF** and manual SI create normal pending coordination to the resolved primary. Manual moves within this scope are limited to **Startup (SEQ)** ↔ **Push back**.
 </Aside>
 
-## How SEQ PLN fits into staffing
+The next logical route steps are:
 
-From **CLR DEL Cleared**, automatic SI handoff depends on how many apron controllers are online:
+- **East/South:** GE 121.830 → the applicable tower.
+- **West:** GW 118.580 → the applicable tower.
+- **North:** AD 121.730 → the configured ground/tower route.
 
-- **Two or fewer** → SI to **Apron Departure**.
-- **Three** → SI to **SEQ PLN** (this scope).
-
-When **DEL+SEQ** is active on delivery, strips stay with **EKCH_DEL** in Cleared; the SI indicator changes (white vs orange) and delivery handles the handoff to apron at startup time.
+Unavailable steps are skipped. When consecutive steps are carried by the same primary, no self-transfer is created.
 
 ## Related
 

--- a/docs/src/content/docs/ekch/te-tw.mdx
+++ b/docs/src/content/docs/ekch/te-tw.mdx
@@ -38,12 +38,14 @@ Cleared departure strips are **not listed as normal strips** in this scope. Use 
 - **Callsign** opens the ARR dialogue; **FORCE ASSUME** assumes the strip and prioritises it.
 - Click the arrival runway to move a strip from **Final** to **RWY ARR**. Runway colour reflects clearance state (green / red) based on other traffic in the bay.
 - The strip moves to **TWY ARR** automatically when the aircraft leaves the runway area; manual moves are also available.
+- TE/TW handovers from **TWY ARR** retain the existing arrival-route target.
 
 ## Departures — TWY DEP-TWR, RWY DEP, Airborne
 
 - Click the departure runway to move a strip from **TWY DEP-TWR** to **RWY DEP**. Same green / red clearance logic applies.
 - The strip moves to **Airborne** automatically when the aircraft is airborne; **SI** then targets the departure frequency.
 - Manual move from **RWY DEP** to **Airborne** is possible; SI still drives the downstream handoff.
+- TE and TW display the active RIU/runway frequency; cross-coupling routes the action to the carrying primary.
 
 ## Control zone
 

--- a/frontend/src/components/est/transferState.test.ts
+++ b/frontend/src/components/est/transferState.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isEstDepartureTransferActive } from "./transferState";
+import { getEstDepartureTransferTarget, isEstDepartureTransferActive } from "./transferState";
 
 describe("isEstDepartureTransferActive", () => {
   it("recognizes the active START REQ transfer to APRON", () => {
@@ -38,5 +38,22 @@ describe("isEstDepartureTransferActive", () => {
         "EKCH_A_GND",
       ),
     ).toBe(false);
+  });
+});
+
+describe("getEstDepartureTransferTarget", () => {
+  it("uses the strip's first next controller instead of a hard-coded sector owner", () => {
+    expect(
+      getEstDepartureTransferTarget(
+        { next_controllers: ["121.905", "121.730", "118.580"] },
+        "121.905",
+      ),
+    ).toBe("121.730");
+  });
+
+  it("returns no target when the route only contains the current primary", () => {
+    expect(
+      getEstDepartureTransferTarget({ next_controllers: ["121.905"] }, "121.905"),
+    ).toBe("");
   });
 });

--- a/frontend/src/components/est/transferState.ts
+++ b/frontend/src/components/est/transferState.ts
@@ -4,6 +4,13 @@ interface CoordinationTransferState {
   isTagRequest: boolean;
 }
 
+export function getEstDepartureTransferTarget(
+  strip: { next_controllers: string[] } | undefined,
+  sourcePosition: string,
+): string {
+  return strip?.next_controllers.find((position) => position !== sourcePosition) ?? "";
+}
+
 export function isEstDepartureTransferActive(
   transfer: CoordinationTransferState | undefined,
   sourcePosition: string,

--- a/frontend/src/routes/ekch/EST.tsx
+++ b/frontend/src/routes/ekch/EST.tsx
@@ -7,7 +7,7 @@ import EstStandCell from "@/components/est/EstStandCell";
 import EstStandMenu, { type EstMenuAnchor } from "@/components/est/EstStandMenu";
 import EstStandStatusDialog from "@/components/est/EstStandStatusDialog";
 import EstViewButtons from "@/components/est/EstViewButtons";
-import { isEstDepartureTransferActive } from "@/components/est/transferState";
+import { getEstDepartureTransferTarget, isEstDepartureTransferActive } from "@/components/est/transferState";
 import { isTsatWithinStartRequestWindow } from "@/lib/cdmColors";
 import { deriveEstStandBlocking } from "@/components/est/standBlocking";
 import { deriveEstStandDisplay } from "@/components/est/standDisplay";
@@ -20,11 +20,10 @@ import {
   type EstView,
 } from "@/components/est/metadata";
 import { useNonClearedStrips } from "@/store/airports/ekch.ts";
-import { useControllers, useMarkArmed, useMyPosition, useSelectStrip, useSelectedCallsign, useWebSocketStore, useSatEnabled, useStandAssignments, useStandBlocks, useOccupyStand, useVacateStand, useRequestManualStand, useStripTransfers } from "@/store/store-hooks.ts";
+import { useMarkArmed, useMyPosition, useSelectStrip, useSelectedCallsign, useWebSocketStore, useSatEnabled, useStandAssignments, useStandBlocks, useOccupyStand, useVacateStand, useRequestManualStand, useStripTransfers } from "@/store/store-hooks.ts";
 
 const PAGE_BG = "bg-bay-est";
 const COLOR_LABEL_DEFAULT = "#202020";
-const APRON_DEPARTURE_SECTOR = "AD";
 
 type ActionOverride = {
   callsign: string;
@@ -112,7 +111,6 @@ export default function EST() {
   const transferStrip = useWebSocketStore((state) => state.transferStrip);
   const setStartReq = useWebSocketStore((state) => state.setStartReq);
   const toggleMarked = useWebSocketStore((state) => state.toggleMarked);
-  const controllers = useControllers();
   const myPosition = useMyPosition();
   const nonClearedStrips = useNonClearedStrips();
   const markArmed = useMarkArmed();
@@ -207,13 +205,8 @@ export default function EST() {
   const statusStrip = statusStand ? stripByStand.get(statusStand) : undefined;
   const visibleStands = useMemo(() => getEstStandsForView(boardView), [boardView]);
   const apronDepartureTransferTarget = useMemo(
-    () =>
-      controllers.find(
-        (controller) =>
-          controller.position !== myPosition &&
-          controller.owned_sectors.includes(APRON_DEPARTURE_SECTOR),
-      )?.position ?? "",
-    [controllers, myPosition],
+    () => getEstDepartureTransferTarget(menuStrip, myPosition),
+    [menuStrip, myPosition],
   );
 
   function closeMenu() {
@@ -503,7 +496,7 @@ export default function EST() {
                   departureTransferActive={isEstDepartureTransferActive(
                     strip ? stripTransfers[strip.callsign] : undefined,
                     myPosition,
-                    apronDepartureTransferTarget,
+                    getEstDepartureTransferTarget(strip, myPosition),
                   )}
                   ctotImproved={strip ? !!ctotState.flags[strip.callsign] : false}
                   nowMs={nowMs}


### PR DESCRIPTION
## Summary

- model EKCH handovers as complete arrival and departure routes with runway- and apron-aware stages
- resolve each logical stage to the controller whose primary or cross-coupled radios cover its frequency, using current ownership as the tie-breaker
- keep logical strip labels and frequencies separate from the actionable primary controller, and never display a frequency the target is not listening to
- retain direct CLR DEL auto-assume while keeping controller-initiated SEQ and SI transfers as normal pending coordination
- make `START+TRF` use the dynamically resolved target and document the updated EKCH procedures

## Why

The previous routing treated availability and displayed frequency as static position properties. That could target the wrong primary controller when a logical position was cross-coupled, omit valid intermediate sectors, or display a logical frequency that the receiving controller was not actually monitoring.

This change uses the existing route configuration as the operational path and resolves radio coverage at runtime. The receiving controller is always an actionable primary position, while the strip label represents the logical sector only when that frequency is actually carried.

## Operational impact

- cross-coupled frequencies take ownership of their logical route stage
- current sector ownership breaks ties when multiple primaries transmit the same cross-coupled frequency
- GE/GW retain their logical labels and prescribed frequencies when carried by another primary
- the 04L cargo arrival route remains `TW -> GWA -> GE`
- unresolved, unknown, and same-primary stages remain inert

## Validation

- full backend suite: `go test -count=1 ./...` in Linux/Docker
- frontend tests: `npm test` (105 passed)
- frontend production build: `npm run build`
- whitespace validation: `git diff --check`

Closes #380
