### PR TITLE
fix(cdm): update tower departure CTOT display

### DIFF
--- a/frontend/src/components/strip/TwyDepStrip.tsx
+++ b/frontend/src/components/strip/TwyDepStrip.tsx
@@ -14,6 +14,7 @@ import { TAXI_MAP_POINTS } from "@/config/ekch";
 import { Bay } from "@/api/models";
 import { ValidationStatusDialog } from "./ValidationStatusDialog";
 import { getGroundStopRestriction, isFlightLevelViolated } from "@/lib/ecfmp";
+import { computeTwyDepCTOTColors } from "@/lib/cdmColors";
 import { DepartureAwareFlightPlanDialog } from "./DepartureAwareFlightPlanDialog";
 
 // Heights— 4.72dvh total (51px at 1080p), 2/3 top / 1/3 bottom (used by callsign and SID/dest)
@@ -21,15 +22,15 @@ const TOP_H      = "3.15dvh";  // 2/3 of 4.72dvh
 const BOT_H      = "1.57dvh";  // 1/3 of 4.72dvh
 const TOP_HALF_H = "1.575dvh"; // half of TOP_H — used by SID/dest two-line split
 
-// Equal halves — used by type/squawk, stand/ctot, TWY, runway/HP, FL/heading
+// Equal halves — used by type/squawk, stand/empty, TWY, runway/HP, FL/heading
 const HALF_H = "2.36dvh"; // 1/2 of 4.72dvh
 
 // Flex-grow proportions (flex-basis: 0 so space is shared proportionally).
-// Values match the original pixel widths: SI=40, Callsign=120, Type/Squawk=60, Stand/CTOT=60, Small×3=53, SID/Dest=80
+// Values match the original pixel widths: SI=40, Callsign=120, Type/Squawk=60, Stand=60, Small×3=53, SID/Dest/CTOT=80
 const F_SI         = 40;
 const F_CALLSIGN   = 120;
 const F_TYPE_SQ    = 60;
-const F_STAND_CTOT = 60;
+const F_STAND      = 60;
 const F_SMALL      = 53;
 const F_SID_DEST   = 80;
 
@@ -38,8 +39,8 @@ const F_SID_DEST   = 80;
 //
 // 4.72dvh height (51px at 1080p), scales to 95% of bay width. Cells left → right:
 //   [SI] | [callsign + :freq] | [type / squawk] |
-//   [stand / ctot] | [TWY label] |
-//   [runway / HP] | [FL / heading] | [SID / dest]
+//   [stand / empty] | [TWY label] |
+//   [runway / HP] | [FL / heading] | [SID / dest / ctot]
 //
 // Background: cyan (var(--color-strip-dep-bg)).
 // -----------------------------------------------------------------------------
@@ -76,7 +77,7 @@ export function TwyDepStrip({
 }: StripProps) {
   const { isSelected, isValidationActive, handleClick, handleContextMenu, guardValidationAction, validationDialogOpen, setValidationDialogOpen, validationStatus } = useStripCallsignInteraction({ callsign, selectable, bay, owner, myPosition });
   const stripTransfers = useStripTransfers();
-  const { ctotBg, ctotColor, showCtot } = useCTOTColor(ctot ?? "");
+  const { ctotBg, ctotColor, showCtot } = useCTOTColor(ctot ?? "", computeTwyDepCTOTColors);
   const isTagRequest = !!stripTransfers[callsign]?.isTagRequest;
   const cellBorderColor = getCellBorderColor(marked);
   const { isUnconcerned, isAssumed } = getStripOwnership(myPosition, owner, nextControllers, previousControllers);
@@ -190,25 +191,21 @@ export function TwyDepStrip({
         </div>
       </div>
 
-      {/* Stand / CTOT; bold stand, light ctot */}
+      {/* Stand / empty; the lower half is intentionally reserved */}
       <div
         className="flex flex-col border-r-2 min-w-0"
-        style={{ flexGrow: F_STAND_CTOT, flexBasis: 0, height: "100%", borderRightColor: cellBorderColor }}
+        style={{ flexGrow: F_STAND, flexBasis: 0, height: "100%", borderRightColor: cellBorderColor }}
       >
         <div
-          className="flex items-center justify-center border-b-2 overflow-hidden"
-          style={{ height: HALF_H, borderBottomColor: showCtot ? cellBorderColor : "transparent", backgroundColor: standYellow ? COLOR_UNEXPECTED_YELLOW : undefined, cursor: standYellow ? getValidationBlockedCursor(isValidationActive) : undefined }}
+          className="flex items-center justify-center overflow-hidden"
+          style={{ height: HALF_H, backgroundColor: standYellow ? COLOR_UNEXPECTED_YELLOW : undefined, cursor: standYellow ? getValidationBlockedCursor(isValidationActive) : undefined }}
           onClick={standYellow ? (e) => guardValidationAction(e, () => acknowledgeUnexpectedChange(callsign, "stand")) : undefined}
         >
           <span className="truncate px-[0.21vw]" style={{ fontFamily: FONT, fontWeight: "bold", fontSize: "0.68vw", color: getCellTextColor("stand", controllerModifiedFields) }}>
             {stand}
           </span>
         </div>
-        <div className="flex items-center justify-center overflow-hidden" style={{ height: HALF_H, backgroundColor: ctotBg || undefined, color: ctotColor }}>
-          <span className="truncate px-[0.21vw]" style={{ fontFamily: FONT, fontWeight: 300, fontSize: "0.68vw" }}>
-            {showCtot ? ctot : ""}
-          </span>
-        </div>
+        <div style={{ height: HALF_H }} />
       </div>
 
       {/* TWY label; whole cell clickable → taxi map */}
@@ -273,7 +270,7 @@ export function TwyDepStrip({
         </div>
       </div>
 
-      {/* SID / Destination; two lines in top 2/3, bottom 1/3 empty */}
+      {/* SID / Destination in the top 2/3; CTOT in the bottom 1/3 */}
       <div
         className="flex flex-col overflow-hidden min-w-0 cursor-pointer hover:brightness-95"
         style={{ flexGrow: F_SID_DEST, flexBasis: 0, height: "100%", cursor: "pointer" }}
@@ -289,7 +286,14 @@ export function TwyDepStrip({
             {destination}
           </span>
         </div>
-        <div style={{ height: BOT_H }} />
+        <div
+          className="flex items-center justify-center overflow-hidden"
+          style={{ height: BOT_H, backgroundColor: ctotBg || undefined, color: ctotColor }}
+        >
+          <span className="truncate px-[0.21vw]" style={{ fontFamily: FONT, fontWeight: "normal", fontSize: "0.63vw" }}>
+            {showCtot ? `CTOT: ${ctot}` : ""}
+          </span>
+        </div>
       </div>
     </div>
 

--- a/frontend/src/hooks/useCTOTColor.ts
+++ b/frontend/src/hooks/useCTOTColor.ts
@@ -1,7 +1,9 @@
 import { useState, useEffect } from "react";
 import { computeCTOTColors, type CTOTColors } from "@/lib/cdmColors";
 
-export function useCTOTColor(ctot: string): CTOTColors {
+type ComputeCTOTColors = (ctot: string, nowMs: number) => CTOTColors;
+
+export function useCTOTColor(ctot: string, computeColors: ComputeCTOTColors = computeCTOTColors): CTOTColors {
   const [nowMs, setNowMs] = useState(Date.now);
 
   useEffect(() => {
@@ -9,5 +11,5 @@ export function useCTOTColor(ctot: string): CTOTColors {
     return () => clearInterval(interval);
   }, []);
 
-  return computeCTOTColors(ctot, nowMs);
+  return computeColors(ctot, nowMs);
 }

--- a/frontend/src/lib/cdmColors.test.ts
+++ b/frontend/src/lib/cdmColors.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, it } from "vitest";
 
 import { Bay } from "@/api/models";
-import { CDM_GREEN, CDM_YELLOW, computeCDMColors, hasManualTobtSource, isTsatWithinStartRequestWindow } from "./cdmColors";
+import {
+  CDM_GREEN,
+  CDM_YELLOW,
+  TWY_DEP_CTOT_BLUE,
+  TWY_DEP_CTOT_ORANGE,
+  TWY_DEP_CTOT_RED,
+  TWY_DEP_CTOT_YELLOW,
+  computeCDMColors,
+  computeTwyDepCTOTColors,
+  hasManualTobtSource,
+  isTsatWithinStartRequestWindow,
+} from "./cdmColors";
 
 describe("hasManualTobtSource", () => {
   it("returns true for pilot-filed TOBT requests", () => {
@@ -59,6 +70,39 @@ describe("computeCDMColors", () => {
     expect(computeCDMColors("1000", "0955", now, Bay.Cleared)).toEqual({
       tobtBg: CDM_GREEN,
       tsatBg: CDM_YELLOW,
+    });
+  });
+});
+
+describe("computeTwyDepCTOTColors", () => {
+  const ctot = "1000";
+
+  it("hides an empty CTOT", () => {
+    expect(computeTwyDepCTOTColors("", Date.UTC(2026, 6, 14, 10, 0, 0))).toEqual({
+      ctotBg: "",
+      ctotColor: "black",
+      showCtot: false,
+    });
+  });
+
+  it.each([
+    ["before the CTOT window", Date.UTC(2026, 6, 14, 9, 54, 59), TWY_DEP_CTOT_ORANGE, "black"],
+    ["at CTOT - 5 minutes", Date.UTC(2026, 6, 14, 9, 55, 0), TWY_DEP_CTOT_BLUE, "white"],
+    ["at CTOT + 9 minutes", Date.UTC(2026, 6, 14, 10, 9, 0), TWY_DEP_CTOT_YELLOW, "black"],
+    ["at CTOT + 11 minutes", Date.UTC(2026, 6, 14, 10, 11, 0), TWY_DEP_CTOT_RED, "black"],
+  ])("uses the expected colour %s", (_description, now, ctotBg, ctotColor) => {
+    expect(computeTwyDepCTOTColors(ctot, now)).toEqual({
+      ctotBg,
+      ctotColor,
+      showCtot: true,
+    });
+  });
+
+  it("handles the CTOT window across midnight", () => {
+    expect(computeTwyDepCTOTColors("0002", Date.UTC(2026, 6, 14, 23, 56, 0))).toEqual({
+      ctotBg: TWY_DEP_CTOT_ORANGE,
+      ctotColor: "black",
+      showCtot: true,
     });
   });
 });

--- a/frontend/src/lib/cdmColors.ts
+++ b/frontend/src/lib/cdmColors.ts
@@ -10,6 +10,10 @@ export const CDM_RED    = "#dc2626";
 export const CDM_ORANGE = "#DD6A12";
 export const CTOT_YELLOW = "#F3EA1F";
 export const CTOT_BLUE   = "#00008B";
+export const TWY_DEP_CTOT_ORANGE = "#DD6A12";
+export const TWY_DEP_CTOT_BLUE   = "#131376";
+export const TWY_DEP_CTOT_YELLOW = "#FFF500";
+export const TWY_DEP_CTOT_RED    = "#FF0000";
 
 // ── HHMM parser ────────────────────────────────────────────────────────────
 
@@ -117,4 +121,24 @@ export function computeCTOTColors(ctot: string, nowMs: number): CTOTColors {
   if (diffMs < -5 * MINUTE_MS)  return { ctotBg: CTOT_YELLOW, ctotColor: "black", showCtot: true };
   if (diffMs <= 10 * MINUTE_MS) return { ctotBg: CTOT_BLUE,   ctotColor: "white", showCtot: true };
   return { ctotBg: "", ctotColor: "black", showCtot: false };
+}
+
+/**
+ * Compute the CTOT colours used by the TE/TW departure strips.
+ *
+ * The operational CTOT window opens five minutes before CTOT. It turns yellow
+ * at CTOT + 9 minutes and red at CTOT + 11 minutes.
+ */
+export function computeTwyDepCTOTColors(ctot: string, nowMs: number): CTOTColors {
+  const normalizedCtot = normalizeCdmTime(ctot);
+
+  if (!normalizedCtot) return { ctotBg: "", ctotColor: "black", showCtot: false };
+
+  const ctotMs = parseHHMM(normalizedCtot, nowMs);
+  const diffMs = nowMs - ctotMs;
+
+  if (diffMs < -5 * MINUTE_MS) return { ctotBg: TWY_DEP_CTOT_ORANGE, ctotColor: "black", showCtot: true };
+  if (diffMs < 9 * MINUTE_MS)  return { ctotBg: TWY_DEP_CTOT_BLUE,   ctotColor: "white", showCtot: true };
+  if (diffMs < 11 * MINUTE_MS) return { ctotBg: TWY_DEP_CTOT_YELLOW, ctotColor: "black", showCtot: true };
+  return { ctotBg: TWY_DEP_CTOT_RED, ctotColor: "black", showCtot: true };
 }


### PR DESCRIPTION
## Summary

- move CTOT from the stand column to the bottom third of the flight-plan column on TE/TW departure strips
- leave the former CTOT area below the stand empty
- add the TE/TW-specific orange, blue, yellow, and red timing states from the supplied design
- keep the existing CTOT behavior for other strip types unchanged
- cover the timing boundaries and midnight rollover with unit tests

## Why

TE/TW departure strips still used the previous CTOT position and shared color behavior. This updates their visible layout and operational timing states to match the revised strip design.

## User impact

Controllers using the TE/TW departure view will see `CTOT: HHMM` below the SID and destination. Its color now progresses from orange before the CTOT window, to blue within the window, yellow at CTOT +9 minutes, and red at CTOT +11 minutes.

## Validation

- `npm test` - 109 tests passed
- `npm run build` - passed
- ESLint on all changed files - passed
- repository-wide `npm run lint` - blocked by the pre-existing `react-hooks/set-state-in-effect` error in `frontend/src/components/commandbar/VACSBTN.tsx:79`

Closes #383
