### PR TITLE
feat(strip): add tactical strip ownership

### DIFF
--- a/backend/internal/config/testing.go
+++ b/backend/internal/config/testing.go
@@ -15,6 +15,14 @@ func SetRunwayRegionsForTest(r []Region) func() {
 	return func() { runwayRegions = old }
 }
 
+// SetRunwaysForTest replaces the configured runway identifiers for testing.
+// Returns a cleanup function that restores the original value.
+func SetRunwaysForTest(values []string) func() {
+	old := slices.Clone(runways)
+	runways = slices.Clone(values)
+	return func() { runways = old }
+}
+
 // SetFinalApproachRegionsForTest replaces the package-level finalApproachRegions slice for testing.
 // Returns a cleanup function that restores the original value.
 func SetFinalApproachRegionsForTest(r []Region) func() {

--- a/backend/internal/database/models.go
+++ b/backend/internal/database/models.go
@@ -9,6 +9,15 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+type AiracnetHttpCheckpoint struct {
+	RequestKey   string
+	Etag         string
+	LastModified string
+	NextPage     int32
+	ResponseBody []byte
+	UpdatedAt    pgtype.Timestamptz
+}
+
 type Airport struct {
 	Name string
 }
@@ -324,10 +333,11 @@ type TacticalStrip struct {
 	Aircraft    *string
 	ProducedBy  string
 	Sequence    int32
-	TimerStart  pgtype.Timestamptz
 	Confirmed   bool
 	ConfirmedBy *string
 	CreatedAt   pgtype.Timestamptz
+	Owner       string
+	Marked      bool
 }
 
 type Version struct {

--- a/backend/internal/database/tactical_strips.sql.go
+++ b/backend/internal/database/tactical_strips.sql.go
@@ -13,7 +13,7 @@ const confirmTacticalStrip = `-- name: ConfirmTacticalStrip :one
 UPDATE tactical_strips
 SET confirmed = TRUE, confirmed_by = $3
 WHERE id = $1 AND session_id = $2
-RETURNING id, session_id, type, bay, label, aircraft, produced_by, sequence, timer_start, confirmed, confirmed_by, created_at
+RETURNING id, session_id, type, bay, label, aircraft, produced_by, sequence, confirmed, confirmed_by, created_at, owner, marked
 `
 
 type ConfirmTacticalStripParams struct {
@@ -34,18 +34,19 @@ func (q *Queries) ConfirmTacticalStrip(ctx context.Context, arg ConfirmTacticalS
 		&i.Aircraft,
 		&i.ProducedBy,
 		&i.Sequence,
-		&i.TimerStart,
 		&i.Confirmed,
 		&i.ConfirmedBy,
 		&i.CreatedAt,
+		&i.Owner,
+		&i.Marked,
 	)
 	return i, err
 }
 
 const createTacticalStrip = `-- name: CreateTacticalStrip :one
-INSERT INTO tactical_strips (session_id, type, bay, label, aircraft, produced_by, sequence)
-VALUES ($1, $2, $3, $4, $5, $6, $7)
-RETURNING id, session_id, type, bay, label, aircraft, produced_by, sequence, timer_start, confirmed, confirmed_by, created_at
+INSERT INTO tactical_strips (session_id, type, bay, label, aircraft, produced_by, owner, sequence)
+VALUES ($1, $2, $3, $4, $5, $6, $6, $7)
+RETURNING id, session_id, type, bay, label, aircraft, produced_by, sequence, confirmed, confirmed_by, created_at, owner, marked
 `
 
 type CreateTacticalStripParams struct {
@@ -78,10 +79,11 @@ func (q *Queries) CreateTacticalStrip(ctx context.Context, arg CreateTacticalStr
 		&i.Aircraft,
 		&i.ProducedBy,
 		&i.Sequence,
-		&i.TimerStart,
 		&i.Confirmed,
 		&i.ConfirmedBy,
 		&i.CreatedAt,
+		&i.Owner,
+		&i.Marked,
 	)
 	return i, err
 }
@@ -100,8 +102,43 @@ func (q *Queries) DeleteTacticalStrip(ctx context.Context, arg DeleteTacticalStr
 	return err
 }
 
+const forceAssumeTacticalStrip = `-- name: ForceAssumeTacticalStrip :one
+UPDATE tactical_strips
+SET owner = $3,
+    marked = FALSE
+WHERE id = $1 AND session_id = $2
+RETURNING id, session_id, type, bay, label, aircraft, produced_by, sequence, confirmed, confirmed_by, created_at, owner, marked
+`
+
+type ForceAssumeTacticalStripParams struct {
+	ID        int64
+	SessionID int32
+	Owner     string
+}
+
+func (q *Queries) ForceAssumeTacticalStrip(ctx context.Context, arg ForceAssumeTacticalStripParams) (TacticalStrip, error) {
+	row := q.db.QueryRow(ctx, forceAssumeTacticalStrip, arg.ID, arg.SessionID, arg.Owner)
+	var i TacticalStrip
+	err := row.Scan(
+		&i.ID,
+		&i.SessionID,
+		&i.Type,
+		&i.Bay,
+		&i.Label,
+		&i.Aircraft,
+		&i.ProducedBy,
+		&i.Sequence,
+		&i.Confirmed,
+		&i.ConfirmedBy,
+		&i.CreatedAt,
+		&i.Owner,
+		&i.Marked,
+	)
+	return i, err
+}
+
 const getTacticalStripByID = `-- name: GetTacticalStripByID :one
-SELECT id, session_id, type, bay, label, aircraft, produced_by, sequence, timer_start, confirmed, confirmed_by, created_at FROM tactical_strips
+SELECT id, session_id, type, bay, label, aircraft, produced_by, sequence, confirmed, confirmed_by, created_at, owner, marked FROM tactical_strips
 WHERE id = $1 AND session_id = $2
 `
 
@@ -122,10 +159,11 @@ func (q *Queries) GetTacticalStripByID(ctx context.Context, arg GetTacticalStrip
 		&i.Aircraft,
 		&i.ProducedBy,
 		&i.Sequence,
-		&i.TimerStart,
 		&i.Confirmed,
 		&i.ConfirmedBy,
 		&i.CreatedAt,
+		&i.Owner,
+		&i.Marked,
 	)
 	return i, err
 }
@@ -183,7 +221,7 @@ func (q *Queries) ListTacticalStripBaySequences(ctx context.Context, arg ListTac
 }
 
 const listTacticalStripsByBay = `-- name: ListTacticalStripsByBay :many
-SELECT id, session_id, type, bay, label, aircraft, produced_by, sequence, timer_start, confirmed, confirmed_by, created_at FROM tactical_strips
+SELECT id, session_id, type, bay, label, aircraft, produced_by, sequence, confirmed, confirmed_by, created_at, owner, marked FROM tactical_strips
 WHERE session_id = $1 AND bay = $2
 ORDER BY sequence ASC
 `
@@ -211,10 +249,11 @@ func (q *Queries) ListTacticalStripsByBay(ctx context.Context, arg ListTacticalS
 			&i.Aircraft,
 			&i.ProducedBy,
 			&i.Sequence,
-			&i.TimerStart,
 			&i.Confirmed,
 			&i.ConfirmedBy,
 			&i.CreatedAt,
+			&i.Owner,
+			&i.Marked,
 		); err != nil {
 			return nil, err
 		}
@@ -227,7 +266,7 @@ func (q *Queries) ListTacticalStripsByBay(ctx context.Context, arg ListTacticalS
 }
 
 const listTacticalStripsBySession = `-- name: ListTacticalStripsBySession :many
-SELECT id, session_id, type, bay, label, aircraft, produced_by, sequence, timer_start, confirmed, confirmed_by, created_at FROM tactical_strips
+SELECT id, session_id, type, bay, label, aircraft, produced_by, sequence, confirmed, confirmed_by, created_at, owner, marked FROM tactical_strips
 WHERE session_id = $1
 ORDER BY bay, sequence ASC
 `
@@ -250,10 +289,11 @@ func (q *Queries) ListTacticalStripsBySession(ctx context.Context, sessionID int
 			&i.Aircraft,
 			&i.ProducedBy,
 			&i.Sequence,
-			&i.TimerStart,
 			&i.Confirmed,
 			&i.ConfirmedBy,
 			&i.CreatedAt,
+			&i.Owner,
+			&i.Marked,
 		); err != nil {
 			return nil, err
 		}
@@ -265,44 +305,12 @@ func (q *Queries) ListTacticalStripsBySession(ctx context.Context, sessionID int
 	return items, nil
 }
 
-const startTacticalStripTimer = `-- name: StartTacticalStripTimer :one
-UPDATE tactical_strips
-SET timer_start = NOW()
-WHERE id = $1 AND session_id = $2
-RETURNING id, session_id, type, bay, label, aircraft, produced_by, sequence, timer_start, confirmed, confirmed_by, created_at
-`
-
-type StartTacticalStripTimerParams struct {
-	ID        int64
-	SessionID int32
-}
-
-func (q *Queries) StartTacticalStripTimer(ctx context.Context, arg StartTacticalStripTimerParams) (TacticalStrip, error) {
-	row := q.db.QueryRow(ctx, startTacticalStripTimer, arg.ID, arg.SessionID)
-	var i TacticalStrip
-	err := row.Scan(
-		&i.ID,
-		&i.SessionID,
-		&i.Type,
-		&i.Bay,
-		&i.Label,
-		&i.Aircraft,
-		&i.ProducedBy,
-		&i.Sequence,
-		&i.TimerStart,
-		&i.Confirmed,
-		&i.ConfirmedBy,
-		&i.CreatedAt,
-	)
-	return i, err
-}
-
 const updateTacticalStripBayAndSequence = `-- name: UpdateTacticalStripBayAndSequence :one
 UPDATE tactical_strips
 SET bay = $3::TEXT,
     sequence = $4::INT
 WHERE id = $1 AND session_id = $2
-RETURNING id, session_id, type, bay, label, aircraft, produced_by, sequence, timer_start, confirmed, confirmed_by, created_at
+RETURNING id, session_id, type, bay, label, aircraft, produced_by, sequence, confirmed, confirmed_by, created_at, owner, marked
 `
 
 type UpdateTacticalStripBayAndSequenceParams struct {
@@ -329,10 +337,45 @@ func (q *Queries) UpdateTacticalStripBayAndSequence(ctx context.Context, arg Upd
 		&i.Aircraft,
 		&i.ProducedBy,
 		&i.Sequence,
-		&i.TimerStart,
 		&i.Confirmed,
 		&i.ConfirmedBy,
 		&i.CreatedAt,
+		&i.Owner,
+		&i.Marked,
+	)
+	return i, err
+}
+
+const updateTacticalStripMarked = `-- name: UpdateTacticalStripMarked :one
+UPDATE tactical_strips
+SET marked = $3
+WHERE id = $1 AND session_id = $2
+RETURNING id, session_id, type, bay, label, aircraft, produced_by, sequence, confirmed, confirmed_by, created_at, owner, marked
+`
+
+type UpdateTacticalStripMarkedParams struct {
+	ID        int64
+	SessionID int32
+	Marked    bool
+}
+
+func (q *Queries) UpdateTacticalStripMarked(ctx context.Context, arg UpdateTacticalStripMarkedParams) (TacticalStrip, error) {
+	row := q.db.QueryRow(ctx, updateTacticalStripMarked, arg.ID, arg.SessionID, arg.Marked)
+	var i TacticalStrip
+	err := row.Scan(
+		&i.ID,
+		&i.SessionID,
+		&i.Type,
+		&i.Bay,
+		&i.Label,
+		&i.Aircraft,
+		&i.ProducedBy,
+		&i.Sequence,
+		&i.Confirmed,
+		&i.ConfirmedBy,
+		&i.CreatedAt,
+		&i.Owner,
+		&i.Marked,
 	)
 	return i, err
 }
@@ -341,7 +384,7 @@ const updateTacticalStripSequence = `-- name: UpdateTacticalStripSequence :one
 UPDATE tactical_strips
 SET sequence = $3::INT
 WHERE id = $1 AND session_id = $2
-RETURNING id, session_id, type, bay, label, aircraft, produced_by, sequence, timer_start, confirmed, confirmed_by, created_at
+RETURNING id, session_id, type, bay, label, aircraft, produced_by, sequence, confirmed, confirmed_by, created_at, owner, marked
 `
 
 type UpdateTacticalStripSequenceParams struct {
@@ -362,10 +405,11 @@ func (q *Queries) UpdateTacticalStripSequence(ctx context.Context, arg UpdateTac
 		&i.Aircraft,
 		&i.ProducedBy,
 		&i.Sequence,
-		&i.TimerStart,
 		&i.Confirmed,
 		&i.ConfirmedBy,
 		&i.CreatedAt,
+		&i.Owner,
+		&i.Marked,
 	)
 	return i, err
 }

--- a/backend/internal/frontend/handlers.go
+++ b/backend/internal/frontend/handlers.go
@@ -495,19 +495,28 @@ func handleCreateTacticalStrip(ctx context.Context, client *Client, message Mess
 		return errors.New("label is required for MEMAID strips")
 	}
 	if req.StripType == "START" || req.StripType == "LAND" {
-		if req.Label == "" {
-			return errors.New("runway label is required for START and LAND strips")
-		}
-		validRunways := config.GetRunways()
-		isValid := false
-		for _, rwy := range validRunways {
-			if rwy == req.Label {
-				isValid = true
-				break
+		switch req.Bay {
+		case shared.BAY_TWY_ARR, shared.BAY_TAXI, shared.BAY_TAXI_LWR:
+			if req.Label == "" {
+				return errors.New("runway label is required for START and LAND strips in taxiway bays")
 			}
-		}
-		if !isValid {
-			return errors.New("invalid runway: " + req.Label)
+			validRunways := config.GetRunways()
+			isValid := false
+			for _, rwy := range validRunways {
+				if rwy == req.Label {
+					isValid = true
+					break
+				}
+			}
+			if !isValid {
+				return errors.New("invalid runway: " + req.Label)
+			}
+		case shared.BAY_RWY_ARR, shared.BAY_DEPART:
+			if req.Label != "" {
+				return errors.New("runway label is not allowed for START and LAND strips in this bay")
+			}
+		default:
+			return errors.New("START and LAND strips are not valid in bay: " + req.Bay)
 		}
 	}
 
@@ -549,25 +558,19 @@ func handleDeleteTacticalStrip(ctx context.Context, client *Client, message Mess
 		return errors.New("tactical strip repository not available")
 	}
 
-	// Need the bay for the deleted event
-	// We load it first, then delete
-	strips, err := tacticalRepo.ListBySession(ctx, client.session)
+	ts, err := tacticalRepo.GetByID(ctx, req.ID, client.session)
 	if err != nil {
 		return err
 	}
-	bay := ""
-	for _, s := range strips {
-		if s.ID == req.ID {
-			bay = s.Bay
-			break
-		}
+	if ts.Owner != client.position {
+		return errors.New("only the tactical strip owner can delete it")
 	}
 
 	if err := tacticalRepo.Delete(ctx, req.ID, client.session); err != nil {
 		return err
 	}
 
-	client.hub.SendTacticalStripDeleted(client.session, req.ID, bay)
+	client.hub.SendTacticalStripDeleted(client.session, req.ID, ts.Bay)
 	return nil
 }
 
@@ -587,11 +590,11 @@ func handleConfirmTacticalStrip(ctx context.Context, client *Client, message Mes
 		return err
 	}
 
-	if ts.Type != internalModels.TacticalStripTypeMemaid && ts.Type != internalModels.TacticalStripTypeCrossing {
-		return errors.New("confirm is only valid for MEMAID and CROSSING strips")
+	if ts.Type != internalModels.TacticalStripTypeMemaid {
+		return errors.New("confirm is only valid for MEMAID strips")
 	}
-	if ts.ProducedBy == client.position {
-		return errors.New("producer cannot confirm their own MEMAID strip")
+	if ts.Owner == client.position {
+		return errors.New("owner cannot confirm their own MEMAID strip")
 	}
 
 	ts, err = tacticalRepo.Confirm(ctx, req.ID, client.session, client.position)
@@ -603,8 +606,28 @@ func handleConfirmTacticalStrip(ctx context.Context, client *Client, message Mes
 	return nil
 }
 
-func handleStartTacticalTimer(ctx context.Context, client *Client, message Message) error {
-	var req frontend.StartTacticalTimerAction
+func handleForceAssumeTacticalStrip(ctx context.Context, client *Client, message Message) error {
+	var req frontend.ForceAssumeTacticalStripAction
+	if err := message.JsonUnmarshal(&req); err != nil {
+		return err
+	}
+
+	tacticalRepo := client.hub.server.GetTacticalStripRepository()
+	if tacticalRepo == nil {
+		return errors.New("tactical strip repository not available")
+	}
+
+	ts, err := tacticalRepo.ForceAssume(ctx, req.ID, client.session, client.position)
+	if err != nil {
+		return err
+	}
+
+	client.hub.SendTacticalStripUpdated(client.session, MapTacticalStripToPayload(ts))
+	return nil
+}
+
+func handleMarkTacticalStrip(ctx context.Context, client *Client, message Message) error {
+	var req frontend.MarkTacticalStripAction
 	if err := message.JsonUnmarshal(&req); err != nil {
 		return err
 	}
@@ -618,16 +641,14 @@ func handleStartTacticalTimer(ctx context.Context, client *Client, message Messa
 	if err != nil {
 		return err
 	}
-
-	if ts.Type != internalModels.TacticalStripTypeStart && ts.Type != internalModels.TacticalStripTypeLand {
-		return errors.New("start timer is only valid for START and LAND strips")
+	if ts.Owner != client.position {
+		return errors.New("only the tactical strip owner can mark it")
 	}
 
-	ts, err = tacticalRepo.StartTimer(ctx, req.ID, client.session)
+	ts, err = tacticalRepo.UpdateMarked(ctx, req.ID, client.session, req.Marked)
 	if err != nil {
 		return err
 	}
-
 	client.hub.SendTacticalStripUpdated(client.session, MapTacticalStripToPayload(ts))
 	return nil
 }
@@ -643,6 +664,14 @@ func handleMoveTacticalStrip(ctx context.Context, client *Client, message Messag
 		return errors.New("tactical strip repository not available")
 	}
 
+	ts, err := tacticalRepo.GetByID(ctx, req.ID, client.session)
+	if err != nil {
+		return err
+	}
+	if ts.Owner != client.position {
+		return errors.New("only the tactical strip owner can move it")
+	}
+
 	bay := req.Bay
 	if bay != "" {
 		if !validBays[bay] {
@@ -652,19 +681,7 @@ func handleMoveTacticalStrip(ctx context.Context, client *Client, message Messag
 			return errors.New("invalid bay: " + bay)
 		}
 	} else {
-		strips, err := tacticalRepo.ListBySession(ctx, client.session)
-		if err != nil {
-			return err
-		}
-		for _, s := range strips {
-			if s.ID == req.ID {
-				bay = s.Bay
-				break
-			}
-		}
-		if bay == "" {
-			return errors.New("tactical strip not found")
-		}
+		bay = ts.Bay
 	}
 
 	return client.hub.stripService.MoveTacticalStripBetween(ctx, client.session, req.ID, req.InsertAfter, bay)

--- a/backend/internal/frontend/handlers_tactical_test.go
+++ b/backend/internal/frontend/handlers_tactical_test.go
@@ -1,6 +1,7 @@
 package frontend
 
 import (
+	"FlightStrips/internal/config"
 	"FlightStrips/internal/models"
 	"FlightStrips/internal/shared"
 	"FlightStrips/internal/testutil"
@@ -28,6 +29,7 @@ func buildTacticalRepoHub(repo *testutil.MockTacticalStripRepository) *Hub {
 			TacticalStripRepoVal: repo,
 		},
 		stripService: &noOpStripService{},
+		send:         make(chan internalMessage, 10),
 	}
 }
 
@@ -96,15 +98,15 @@ func TestHandleConfirmTacticalStrip_InvalidTypeRejectedBeforeMutation(t *testing
 	assert.False(t, confirmCalled, "Confirm must not be called when the tactical strip type is invalid")
 }
 
-func TestHandleConfirmTacticalStrip_ProducerRejectedBeforeMutation(t *testing.T) {
+func TestHandleConfirmTacticalStrip_OwnerRejectedBeforeMutation(t *testing.T) {
 	confirmCalled := false
 	hub := buildTacticalRepoHub(&testutil.MockTacticalStripRepository{
 		GetByIDFn: func(_ context.Context, id int64, sessionID int32) (*models.TacticalStrip, error) {
 			return &models.TacticalStrip{
-				ID:         id,
-				SessionID:  sessionID,
-				Type:       models.TacticalStripTypeCrossing,
-				ProducedBy: "EKCH_TWR",
+				ID:        id,
+				SessionID: sessionID,
+				Type:      models.TacticalStripTypeMemaid,
+				Owner:     "EKCH_TWR",
 			}, nil
 		},
 		ConfirmFn: func(_ context.Context, _ int64, _ int32, _ string) (*models.TacticalStrip, error) {
@@ -119,31 +121,158 @@ func TestHandleConfirmTacticalStrip_ProducerRejectedBeforeMutation(t *testing.T)
 
 	err := handleConfirmTacticalStrip(context.Background(), client, msg)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "producer cannot confirm")
-	assert.False(t, confirmCalled, "Confirm must not be called when the producer is not allowed to confirm")
+	assert.Contains(t, err.Error(), "owner cannot confirm")
+	assert.False(t, confirmCalled)
 }
 
-func TestHandleStartTacticalTimer_InvalidTypeRejectedBeforeMutation(t *testing.T) {
-	startTimerCalled := false
+func TestHandleCreateTacticalStrip_RunwayRules(t *testing.T) {
+	t.Cleanup(config.SetRunwaysForTest([]string{"04R", "04L", "12", "22R", "22L", "30"}))
+
+	tests := []struct {
+		name    string
+		bay     string
+		label   string
+		wantErr string
+	}{
+		{name: "taxi requires runway", bay: shared.BAY_TAXI, wantErr: "runway label is required"},
+		{name: "twy arr requires valid runway", bay: shared.BAY_TWY_ARR, label: "99", wantErr: "invalid runway"},
+		{name: "rwy arr rejects runway", bay: shared.BAY_RWY_ARR, label: "22L", wantErr: "runway label is not allowed"},
+		{name: "rwy dep accepts no runway", bay: shared.BAY_DEPART},
+		{name: "taxi lower requires runway", bay: shared.BAY_TAXI_LWR, wantErr: "runway label is required"},
+		{name: "taxi lower accepts valid runway", bay: shared.BAY_TAXI_LWR, label: "22L"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			created := false
+			repo := &testutil.MockTacticalStripRepository{
+				GetMaxSequenceInBayFn: func(_ context.Context, _ int32, _ string) (int32, error) {
+					return 0, nil
+				},
+				CreateFn: func(_ context.Context, sessionID int32, stripType, bay, label string, _ *string, producedBy string, sequence int32) (*models.TacticalStrip, error) {
+					created = true
+					assert.Equal(t, "EKCH_TWR", producedBy)
+					return &models.TacticalStrip{
+						ID:         1,
+						SessionID:  sessionID,
+						Type:       stripType,
+						Bay:        bay,
+						Label:      label,
+						ProducedBy: producedBy,
+						Owner:      producedBy,
+						Sequence:   sequence,
+					}, nil
+				},
+			}
+			hub := buildTacticalRepoHub(repo)
+			client := buildFrontendTestClient(hub, 1, "EKCH")
+			client.position = "EKCH_TWR"
+
+			err := handleCreateTacticalStrip(context.Background(), client, marshalMessage(t, frontend.CreateTacticalStripAction{
+				StripType: models.TacticalStripTypeStart,
+				Bay:       tt.bay,
+				Label:     tt.label,
+			}))
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.False(t, created)
+				return
+			}
+			require.NoError(t, err)
+			assert.True(t, created)
+		})
+	}
+}
+
+func TestHandleForceAssumeTacticalStrip_TransfersOwnership(t *testing.T) {
+	var assumedBy string
 	hub := buildTacticalRepoHub(&testutil.MockTacticalStripRepository{
-		GetByIDFn: func(_ context.Context, id int64, sessionID int32) (*models.TacticalStrip, error) {
+		ForceAssumeFn: func(_ context.Context, id int64, sessionID int32, owner string) (*models.TacticalStrip, error) {
+			assumedBy = owner
 			return &models.TacticalStrip{
 				ID:        id,
 				SessionID: sessionID,
-				Type:      models.TacticalStripTypeMemaid,
+				Type:      models.TacticalStripTypeCrossing,
+				Owner:     owner,
+				Marked:    false,
 			}, nil
 		},
-		StartTimerFn: func(_ context.Context, _ int64, _ int32) (*models.TacticalStrip, error) {
-			startTimerCalled = true
+	})
+	client := buildFrontendTestClient(hub, 1, "EKCH")
+	client.position = "EKCH_TWR"
+
+	err := handleForceAssumeTacticalStrip(context.Background(), client, marshalMessage(t, frontend.ForceAssumeTacticalStripAction{ID: 99}))
+	require.NoError(t, err)
+	assert.Equal(t, "EKCH_TWR", assumedBy)
+}
+
+func TestHandleMarkTacticalStrip_NonOwnerRejected(t *testing.T) {
+	updated := false
+	hub := buildTacticalRepoHub(&testutil.MockTacticalStripRepository{
+		GetByIDFn: func(_ context.Context, id int64, sessionID int32) (*models.TacticalStrip, error) {
+			return &models.TacticalStrip{ID: id, SessionID: sessionID, Owner: "EKCH_GND"}, nil
+		},
+		UpdateMarkedFn: func(_ context.Context, _ int64, _ int32, _ bool) (*models.TacticalStrip, error) {
+			updated = true
 			return nil, nil
 		},
 	})
 	client := buildFrontendTestClient(hub, 1, "EKCH")
+	client.position = "EKCH_TWR"
 
-	msg := marshalMessage(t, frontend.StartTacticalTimerAction{ID: 99})
-
-	err := handleStartTacticalTimer(context.Background(), client, msg)
+	err := handleMarkTacticalStrip(context.Background(), client, marshalMessage(t, frontend.MarkTacticalStripAction{ID: 42, Marked: true}))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "start timer is only valid")
-	assert.False(t, startTimerCalled, "StartTimer must not be called when the tactical strip type is invalid")
+	assert.Contains(t, err.Error(), "only the tactical strip owner")
+	assert.False(t, updated)
+}
+
+func TestHandleDeleteTacticalStrip_NonOwnerRejected(t *testing.T) {
+	deleted := false
+	hub := buildTacticalRepoHub(&testutil.MockTacticalStripRepository{
+		GetByIDFn: func(_ context.Context, id int64, sessionID int32) (*models.TacticalStrip, error) {
+			return &models.TacticalStrip{ID: id, SessionID: sessionID, Owner: "EKCH_GND"}, nil
+		},
+		DeleteFn: func(_ context.Context, _ int64, _ int32) error {
+			deleted = true
+			return nil
+		},
+	})
+	client := buildFrontendTestClient(hub, 1, "EKCH")
+	client.position = "EKCH_TWR"
+
+	err := handleDeleteTacticalStrip(context.Background(), client, marshalMessage(t, frontend.DeleteTacticalStripAction{ID: 42}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the tactical strip owner")
+	assert.False(t, deleted)
+}
+
+func TestHandleMoveTacticalStrip_NonOwnerRejected(t *testing.T) {
+	hub := buildTacticalRepoHub(&testutil.MockTacticalStripRepository{
+		GetByIDFn: func(_ context.Context, id int64, sessionID int32) (*models.TacticalStrip, error) {
+			return &models.TacticalStrip{ID: id, SessionID: sessionID, Owner: "EKCH_GND"}, nil
+		},
+	})
+	client := buildFrontendTestClient(hub, 1, "EKCH")
+	client.position = "EKCH_TWR"
+
+	err := handleMoveTacticalStrip(context.Background(), client, marshalMessage(t, frontend.MoveTacticalStripAction{ID: 42}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only the tactical strip owner")
+}
+
+func TestMapTacticalStripToPayload_IncludesOwnershipState(t *testing.T) {
+	payload := MapTacticalStripToPayload(&models.TacticalStrip{
+		ID:         42,
+		SessionID:  1,
+		Type:       models.TacticalStripTypeCrossing,
+		ProducedBy: "EKCH_GND",
+		Owner:      "EKCH_TWR",
+		Marked:     true,
+	})
+
+	assert.Equal(t, "EKCH_GND", payload.ProducedBy)
+	assert.Equal(t, "EKCH_TWR", payload.Owner)
+	assert.True(t, payload.Marked)
 }

--- a/backend/internal/frontend/hub.go
+++ b/backend/internal/frontend/hub.go
@@ -140,7 +140,8 @@ func NewHub(deps HubDependencies) (*Hub, error) {
 	handlers.Add(frontend.ActionCreateTacticalStrip, handleCreateTacticalStrip)
 	handlers.Add(frontend.ActionDeleteTacticalStrip, handleDeleteTacticalStrip)
 	handlers.Add(frontend.ActionConfirmTacticalStrip, handleConfirmTacticalStrip)
-	handlers.Add(frontend.ActionStartTacticalTimer, handleStartTacticalTimer)
+	handlers.Add(frontend.ActionForceAssumeTacticalStrip, handleForceAssumeTacticalStrip)
+	handlers.Add(frontend.ActionMarkTacticalStrip, handleMarkTacticalStrip)
 	handlers.Add(frontend.ActionMoveTacticalStrip, handleMoveTacticalStrip)
 	handlers.Add(frontend.MissedApproachRequestType, handleMissedApproach)
 	handlers.Add(frontend.ActionCreateManualFPL, handleCreateManualFPL)
@@ -391,8 +392,9 @@ func MapTacticalStripToPayload(ts *internalModels.TacticalStrip) frontend.Tactic
 		Label:       ts.Label,
 		Aircraft:    aircraft,
 		ProducedBy:  ts.ProducedBy,
+		Owner:       ts.Owner,
+		Marked:      ts.Marked,
 		Sequence:    ts.Sequence,
-		TimerStart:  ts.TimerStart,
 		Confirmed:   ts.Confirmed,
 		ConfirmedBy: confirmedBy,
 		CreatedAt:   ts.CreatedAt,

--- a/backend/internal/models/tactical_strip.go
+++ b/backend/internal/models/tactical_strip.go
@@ -20,8 +20,9 @@ type TacticalStrip struct {
 	Label       string
 	Aircraft    *string
 	ProducedBy  string
+	Owner       string
+	Marked      bool
 	Sequence    int32
-	TimerStart  *time.Time
 	Confirmed   bool
 	ConfirmedBy *string
 	CreatedAt   time.Time

--- a/backend/internal/repository/postgres/tactical_strip.go
+++ b/backend/internal/repository/postgres/tactical_strip.go
@@ -30,13 +30,11 @@ func tacticalStripToModel(db database.TacticalStrip) *models.TacticalStrip {
 		Label:       db.Label,
 		Aircraft:    db.Aircraft,
 		ProducedBy:  db.ProducedBy,
+		Owner:       db.Owner,
+		Marked:      db.Marked,
 		Sequence:    db.Sequence,
 		Confirmed:   db.Confirmed,
 		ConfirmedBy: db.ConfirmedBy,
-	}
-	if db.TimerStart.Valid {
-		t := db.TimerStart.Time
-		m.TimerStart = &t
 	}
 	if db.CreatedAt.Valid {
 		m.CreatedAt = db.CreatedAt.Time
@@ -102,10 +100,23 @@ func (r *tacticalStripRepository) Confirm(ctx context.Context, id int64, session
 	return tacticalStripToModel(result), nil
 }
 
-func (r *tacticalStripRepository) StartTimer(ctx context.Context, id int64, sessionID int32) (*models.TacticalStrip, error) {
-	result, err := r.queries.StartTacticalStripTimer(ctx, database.StartTacticalStripTimerParams{
+func (r *tacticalStripRepository) ForceAssume(ctx context.Context, id int64, sessionID int32, owner string) (*models.TacticalStrip, error) {
+	result, err := r.queries.ForceAssumeTacticalStrip(ctx, database.ForceAssumeTacticalStripParams{
 		ID:        id,
 		SessionID: sessionID,
+		Owner:     owner,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return tacticalStripToModel(result), nil
+}
+
+func (r *tacticalStripRepository) UpdateMarked(ctx context.Context, id int64, sessionID int32, marked bool) (*models.TacticalStrip, error) {
+	result, err := r.queries.UpdateTacticalStripMarked(ctx, database.UpdateTacticalStripMarkedParams{
+		ID:        id,
+		SessionID: sessionID,
+		Marked:    marked,
 	})
 	if err != nil {
 		return nil, err

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -171,7 +171,8 @@ type TacticalStripRepository interface {
 	GetByID(ctx context.Context, id int64, sessionID int32) (*models.TacticalStrip, error)
 	Delete(ctx context.Context, id int64, sessionID int32) error
 	Confirm(ctx context.Context, id int64, sessionID int32, confirmedBy string) (*models.TacticalStrip, error)
-	StartTimer(ctx context.Context, id int64, sessionID int32) (*models.TacticalStrip, error)
+	ForceAssume(ctx context.Context, id int64, sessionID int32, owner string) (*models.TacticalStrip, error)
+	UpdateMarked(ctx context.Context, id int64, sessionID int32, marked bool) (*models.TacticalStrip, error)
 	UpdateBayAndSequence(ctx context.Context, id int64, sessionID int32, bay string, sequence int32) (*models.TacticalStrip, error)
 	UpdateSequence(ctx context.Context, id int64, sessionID int32, sequence int32) (*models.TacticalStrip, error)
 	GetSequenceByID(ctx context.Context, id int64, sessionID int32) (int32, error)

--- a/backend/internal/testutil/mock_tactical_strip_repository.go
+++ b/backend/internal/testutil/mock_tactical_strip_repository.go
@@ -11,7 +11,8 @@ type MockTacticalStripRepository struct {
 	GetByIDFn                func(ctx context.Context, id int64, sessionID int32) (*models.TacticalStrip, error)
 	DeleteFn                 func(ctx context.Context, id int64, sessionID int32) error
 	ConfirmFn                func(ctx context.Context, id int64, sessionID int32, confirmedBy string) (*models.TacticalStrip, error)
-	StartTimerFn             func(ctx context.Context, id int64, sessionID int32) (*models.TacticalStrip, error)
+	ForceAssumeFn            func(ctx context.Context, id int64, sessionID int32, owner string) (*models.TacticalStrip, error)
+	UpdateMarkedFn           func(ctx context.Context, id int64, sessionID int32, marked bool) (*models.TacticalStrip, error)
 	UpdateBayAndSequenceFn   func(ctx context.Context, id int64, sessionID int32, bay string, sequence int32) (*models.TacticalStrip, error)
 	UpdateSequenceFn         func(ctx context.Context, id int64, sessionID int32, sequence int32) (*models.TacticalStrip, error)
 	GetSequenceByIDFn        func(ctx context.Context, id int64, sessionID int32) (int32, error)
@@ -56,11 +57,18 @@ func (m *MockTacticalStripRepository) Confirm(ctx context.Context, id int64, ses
 	return m.ConfirmFn(ctx, id, sessionID, confirmedBy)
 }
 
-func (m *MockTacticalStripRepository) StartTimer(ctx context.Context, id int64, sessionID int32) (*models.TacticalStrip, error) {
-	if m.StartTimerFn == nil {
-		panic("unexpected call to MockTacticalStripRepository.StartTimer")
+func (m *MockTacticalStripRepository) ForceAssume(ctx context.Context, id int64, sessionID int32, owner string) (*models.TacticalStrip, error) {
+	if m.ForceAssumeFn == nil {
+		panic("unexpected call to MockTacticalStripRepository.ForceAssume")
 	}
-	return m.StartTimerFn(ctx, id, sessionID)
+	return m.ForceAssumeFn(ctx, id, sessionID, owner)
+}
+
+func (m *MockTacticalStripRepository) UpdateMarked(ctx context.Context, id int64, sessionID int32, marked bool) (*models.TacticalStrip, error) {
+	if m.UpdateMarkedFn == nil {
+		panic("unexpected call to MockTacticalStripRepository.UpdateMarked")
+	}
+	return m.UpdateMarkedFn(ctx, id, sessionID, marked)
 }
 
 func (m *MockTacticalStripRepository) UpdateBayAndSequence(ctx context.Context, id int64, sessionID int32, bay string, sequence int32) (*models.TacticalStrip, error) {

--- a/backend/migrations/0038-add-tactical-strip-ownership.sql
+++ b/backend/migrations/0038-add-tactical-strip-ownership.sql
@@ -1,0 +1,11 @@
+ALTER TABLE tactical_strips
+    ADD COLUMN owner TEXT,
+    ADD COLUMN marked BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE tactical_strips
+SET owner = produced_by
+WHERE owner IS NULL;
+
+ALTER TABLE tactical_strips
+    ALTER COLUMN owner SET NOT NULL,
+    DROP COLUMN timer_start;

--- a/backend/pkg/events/frontend/actions.go
+++ b/backend/pkg/events/frontend/actions.go
@@ -7,7 +7,8 @@ const (
 	ActionCreateTacticalStrip  EventType = "create_tactical_strip"
 	ActionDeleteTacticalStrip  EventType = "delete_tactical_strip"
 	ActionConfirmTacticalStrip EventType = "confirm_tactical_strip"
-	ActionStartTacticalTimer   EventType = "start_tactical_timer"
+	ActionForceAssumeTacticalStrip EventType = "force_assume_tactical_strip"
+	ActionMarkTacticalStrip    EventType = "mark_tactical_strip"
 	ActionMoveTacticalStrip    EventType = "move_tactical_strip"
 )
 
@@ -60,9 +61,15 @@ type ConfirmTacticalStripAction struct {
 	ID   int64     `json:"id"`
 }
 
-type StartTacticalTimerAction struct {
+type ForceAssumeTacticalStripAction struct {
 	Type EventType `json:"type"`
 	ID   int64     `json:"id"`
+}
+
+type MarkTacticalStripAction struct {
+	Type   EventType `json:"type"`
+	ID     int64     `json:"id"`
+	Marked bool      `json:"marked"`
 }
 
 // MoveTacticalStripAction moves a tactical strip within or between bays.

--- a/backend/pkg/events/frontend/events.go
+++ b/backend/pkg/events/frontend/events.go
@@ -946,8 +946,9 @@ type TacticalStripPayload struct {
 	Label       string     `json:"label"`
 	Aircraft    string     `json:"aircraft"`
 	ProducedBy  string     `json:"produced_by"`
+	Owner       string     `json:"owner"`
+	Marked      bool       `json:"marked"`
 	Sequence    int32      `json:"sequence"`
-	TimerStart  *time.Time `json:"timer_start,omitempty"`
 	Confirmed   bool       `json:"confirmed"`
 	ConfirmedBy string     `json:"confirmed_by"`
 	CreatedAt   time.Time  `json:"created_at"`

--- a/backend/queries/tactical_strips.sql
+++ b/backend/queries/tactical_strips.sql
@@ -1,6 +1,6 @@
 -- name: CreateTacticalStrip :one
-INSERT INTO tactical_strips (session_id, type, bay, label, aircraft, produced_by, sequence)
-VALUES ($1, $2, $3, $4, $5, $6, $7)
+INSERT INTO tactical_strips (session_id, type, bay, label, aircraft, produced_by, owner, sequence)
+VALUES ($1, $2, $3, $4, $5, $6, $6, $7)
 RETURNING *;
 
 -- name: ListTacticalStripsByBay :many
@@ -26,9 +26,16 @@ SET confirmed = TRUE, confirmed_by = $3
 WHERE id = $1 AND session_id = $2
 RETURNING *;
 
--- name: StartTacticalStripTimer :one
+-- name: ForceAssumeTacticalStrip :one
 UPDATE tactical_strips
-SET timer_start = NOW()
+SET owner = $3,
+    marked = FALSE
+WHERE id = $1 AND session_id = $2
+RETURNING *;
+
+-- name: UpdateTacticalStripMarked :one
+UPDATE tactical_strips
+SET marked = $3
 WHERE id = $1 AND session_id = $2
 RETURNING *;
 

--- a/frontend/public/runway-selector-lines.svg
+++ b/frontend/public/runway-selector-lines.svg
@@ -1,0 +1,3 @@
+<svg preserveAspectRatio="none" width="100%" height="100%" overflow="visible" style="display: block;" viewBox="0 0 457.348 368.379" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path id="Vector 338" d="M218.012 256.747L433.012 10.747M455.012 173.747L218.012 3.24705M3.01182 365.747L218.012 119.747" stroke="black" stroke-width="8"/>
+</svg>

--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -69,7 +69,8 @@ export enum ActionType {
   FrontendCreateTacticalStrip = "create_tactical_strip",
   FrontendDeleteTacticalStrip = "delete_tactical_strip",
   FrontendConfirmTacticalStrip = "confirm_tactical_strip",
-  FrontendStartTacticalTimer = "start_tactical_timer",
+  FrontendForceAssumeTacticalStrip = "force_assume_tactical_strip",
+  FrontendMarkTacticalStrip = "mark_tactical_strip",
   FrontendMoveTacticalStrip = "move_tactical_strip",
   FrontendAcknowledgeUnexpectedChange = "acknowledge_unexpected_change",
   FrontendCoordinationTagRequest = "coordination_tag_request",
@@ -109,8 +110,9 @@ export interface TacticalStrip {
   label: string;
   aircraft: string;
   produced_by: string;
+  owner: string;
+  marked: boolean;
   sequence: number;
-  timer_start: string | null;
   confirmed: boolean;
   confirmed_by: string;
   created_at: string;
@@ -915,9 +917,15 @@ export interface FrontendConfirmTacticalStripAction {
   id: number;
 }
 
-export interface FrontendStartTacticalTimerAction {
-  type: ActionType.FrontendStartTacticalTimer;
+export interface FrontendForceAssumeTacticalStripAction {
+  type: ActionType.FrontendForceAssumeTacticalStrip;
   id: number;
+}
+
+export interface FrontendMarkTacticalStripAction {
+  type: ActionType.FrontendMarkTacticalStrip;
+  id: number;
+  marked: boolean;
 }
 
 export interface FrontendMoveTacticalStripAction {
@@ -987,7 +995,7 @@ export interface FrontendClxUpdateTobtEvent {
 }
 
 // Union type for all events that can be sent
-export type FrontendSendEvent = FrontendUpdateRunwayStatusEvent | FrontendMissedApproachEvent |FrontendCreateManualFPLAction | FrontendCreateVFRFPLAction |FrontendAuthenticationEvent | FrontendMoveEvent | FrontendGenerateSquawkEvent | FrontendUpdateStripDataEvent | FrontendUpdateOrder | FrontendSendMessageEvent | FrontendSendPrivateMessageEvent | FrontendCdmReadyEvent | FrontendSendReleasePointEvent | FrontendSetStartReqAction | FrontendSendMarkedEvent | FrontendSendRunwayClearanceEvent | FrontendSendRunwayConfirmationEvent | FrontendIssuePdcClearanceRequest | FrontendRevertToVoiceRequest | FrontendCoordinationTransferRequestEvent | FrontendCoordinationAssumeRequestEvent | FrontendCoordinationForceAssumeRequestEvent | FrontendCoordinationFreeRequestEvent | FrontendCoordinationCancelTransferRequestEvent | FrontendCoordinationTagRequestEvent | FrontendCoordinationAcceptTagRequestEvent | FrontendCreateTacticalStripAction | FrontendDeleteTacticalStripAction | FrontendConfirmTacticalStripAction | FrontendStartTacticalTimerAction | FrontendMoveTacticalStripAction | FrontendAcknowledgeUnexpectedChangeEvent | FrontendAcknowledgeValidationStatusEvent | FrontendClxOverrideValidationEvent | FrontendClxUpdateTobtEvent | FrontendStandOccupyAction | FrontendStandVacateAction | FrontendStandAutomaticRequestAction | FrontendStandManualRequestAction | FrontendStandConfirmedOverrideAction | FrontendStandAcknowledgeAction | FrontendStandBlockCreateAction | FrontendStandBlockRemoveAction;
+export type FrontendSendEvent = FrontendUpdateRunwayStatusEvent | FrontendMissedApproachEvent |FrontendCreateManualFPLAction | FrontendCreateVFRFPLAction |FrontendAuthenticationEvent | FrontendMoveEvent | FrontendGenerateSquawkEvent | FrontendUpdateStripDataEvent | FrontendUpdateOrder | FrontendSendMessageEvent | FrontendSendPrivateMessageEvent | FrontendCdmReadyEvent | FrontendSendReleasePointEvent | FrontendSetStartReqAction | FrontendSendMarkedEvent | FrontendSendRunwayClearanceEvent | FrontendSendRunwayConfirmationEvent | FrontendIssuePdcClearanceRequest | FrontendRevertToVoiceRequest | FrontendCoordinationTransferRequestEvent | FrontendCoordinationAssumeRequestEvent | FrontendCoordinationForceAssumeRequestEvent | FrontendCoordinationFreeRequestEvent | FrontendCoordinationCancelTransferRequestEvent | FrontendCoordinationTagRequestEvent | FrontendCoordinationAcceptTagRequestEvent | FrontendCreateTacticalStripAction | FrontendDeleteTacticalStripAction | FrontendConfirmTacticalStripAction | FrontendForceAssumeTacticalStripAction | FrontendMarkTacticalStripAction | FrontendMoveTacticalStripAction | FrontendAcknowledgeUnexpectedChangeEvent | FrontendAcknowledgeValidationStatusEvent | FrontendClxOverrideValidationEvent | FrontendClxUpdateTobtEvent | FrontendStandOccupyAction | FrontendStandVacateAction | FrontendStandAutomaticRequestAction | FrontendStandManualRequestAction | FrontendStandConfirmedOverrideAction | FrontendStandAcknowledgeAction | FrontendStandBlockCreateAction | FrontendStandBlockRemoveAction;
 
 export type AnyStrip = FrontendStrip | TacticalStrip;
 export const isFlight = (s: AnyStrip): s is FrontendStrip => 'callsign' in s;

--- a/frontend/src/components/bays/SortableBay.tsx
+++ b/frontend/src/components/bays/SortableBay.tsx
@@ -18,7 +18,7 @@ import { Children, useCallback, useLayoutEffect, useRef, useState, type CSSPrope
 import type { AnyStrip, StripRef } from "@/api/models.ts";
 import { stripDndId, isFlight } from "@/api/models.ts";
 import { isValidationBlockingForPosition } from "@/components/strip/shared";
-import { useWebSocketStore } from "@/store/store-hooks";
+import { useMyPosition, useWebSocketStore } from "@/store/store-hooks";
 import { useStripSensors } from "./useStripSensors";
 import { makeBayContainerDropZoneId } from "./dropZoneIds";
 
@@ -155,6 +155,10 @@ export function SortableBay({
 }: SortableBayProps) {
   const { containerRef, containerClassName } = useBottomAlignedBay(className, `${bayId ?? "standalone"}:${strips.length}`);
   const sensors = useStripSensors();
+  const myPosition = useMyPosition();
+
+  const dragDisabled = (strip: AnyStrip) =>
+    (!isFlight(strip) && strip.owner !== myPosition) || isDragDisabled?.(strip) === true;
 
   function handleDragEnd(event: DragEndEvent) {
     const { active, over } = event;
@@ -190,7 +194,7 @@ export function SortableBay({
           <SortableContext items={sortableItems} strategy={verticalListSortingStrategy}>
           <div ref={containerRef} className={containerClassName} data-strip-scroll-container="true">
               {strips.map(s => (
-                <SortableStrip key={stripDndId(s)} callsign={stripDndId(s)} dragDisabled={isDragDisabled?.(s)}>
+                <SortableStrip key={stripDndId(s)} callsign={stripDndId(s)} dragDisabled={dragDisabled(s)}>
                   {children(s)}
               </SortableStrip>
             ))}
@@ -206,7 +210,7 @@ export function SortableBay({
     <SortableContext items={sortableItems} strategy={verticalListSortingStrategy}>
       <DroppableContainer bayId={bayId!} isEmpty={strips.length === 0} className={className}>
         {strips.map(s => (
-          <SortableStrip key={stripDndId(s)} callsign={stripDndId(s)} hideWhenDragging bayId={bayId} dragDisabled={isDragDisabled?.(s)}>
+          <SortableStrip key={stripDndId(s)} callsign={stripDndId(s)} hideWhenDragging bayId={bayId} dragDisabled={dragDisabled(s)}>
             {children(s)}
           </SortableStrip>
         ))}

--- a/frontend/src/components/strip/RunwayDialog.tsx
+++ b/frontend/src/components/strip/RunwayDialog.tsx
@@ -1,30 +1,37 @@
+import type { CSSProperties } from "react";
+
 import {
   Dialog,
   DialogContent,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { scalePx } from "@/lib/viewportScale";
 import { useSelectedCallsign, useWebSocketStore } from "@/store/store-hooks";
 
-const RUNWAYS = ["04R", "04L", "12", "22R", "22L", "30"];
+const RUNWAYS = ["04R", "04L", "12", "22R", "22L", "30"] as const;
 
-// All sizes derived from 1920×1080 base:
-//   horizontal → / 1920 * 100 = vw
-//   vertical   → / 1080 * 100 = dvh
-//
-// Dialog: 167px → 8.7vw
-// Panel mx: 8px → 0.42vw  |  my: 11px → 1.02dvh
-// List gap: 12px → 1.11dvh  |  pt: 14px → 1.3dvh  |  pb: 16px → 1.48dvh
-// Button: 108×70px → 5.63vw × 6.48dvh  |  font: 28px → 1.46vw
-// ESC row pb: 24px → 2.22dvh
+const RUNWAY_POSITIONS: Record<(typeof RUNWAYS)[number], { left: number; top: number }> = {
+  "12": { left: 226.2, top: 76 },
+  "22L": { left: 490.2, top: 84 },
+  "22R": { left: 261.2, top: 189 },
+  "30": { left: 491.2, top: 250 },
+  "04R": { left: 245.2, top: 353 },
+  "04L": { left: 20.2, top: 454 },
+};
 
-// Tailwind class constants (hex must be literal strings for JIT) — styled to match Runways.svg
-const CLS_DIALOG_BG      = "bg-[#B3B3B3] border border-black p-0 w-[8.7vw] max-w-none max-h-none gap-0 overflow-hidden [&>button]:hidden";
-const CLS_PANEL          = "mx-[0.42vw] my-[1.02dvh] border border-black flex flex-col justify-between h-fit";
-const CLS_RWY_LIST       = "flex flex-col items-center gap-[1.11dvh] pt-[1.3dvh] pb-[1.48dvh]";
-const CLS_RWY_BTN        = "w-[5.63vw] h-[6.48dvh] bg-[#CCCCCC] text-black font-semibold text-[1.46vw] shadow-[0_4px_4px_rgba(0,0,0,0.25)] outline-none active:brightness-90";
-const CLS_RWY_BTN_ACTIVE = "w-[5.63vw] h-[6.48dvh] bg-[#1BFF16] text-black font-semibold text-[1.46vw] shadow-[0_4px_4px_rgba(0,0,0,0.25)] outline-none active:brightness-90";
-const CLS_ESC_ROW        = "flex items-center justify-center pb-[2.22dvh]";
-const CLS_ESC_BTN        = "w-[5.63vw] h-[6.48dvh] bg-[#3F3F3F] text-white font-semibold text-[1.46vw] shadow-[0_4px_4px_rgba(0,0,0,0.25)] outline-none active:brightness-75";
+const BUTTON_STYLE: CSSProperties = {
+  position: "absolute",
+  width: scalePx(71),
+  height: scalePx(44.065),
+  background: "#D6D6D6",
+  color: "#000",
+  border: 0,
+  boxShadow: `0 ${scalePx(4)} ${scalePx(4)} rgba(0, 0, 0, 0.25)`,
+  fontFamily: "Rubik, sans-serif",
+  fontSize: scalePx(16),
+  fontWeight: 600,
+  cursor: "pointer",
+};
 
 interface TacticalProps {
   open: boolean;
@@ -55,15 +62,9 @@ type Props = TacticalProps | AssignProps | SelectProps;
 
 export function RunwayDialog(props: Props) {
   const { open, onOpenChange } = props;
-  const createTacticalStrip = useWebSocketStore(s => s.createTacticalStrip);
-  const assignRunway = useWebSocketStore(s => s.assignRunway);
+  const createTacticalStrip = useWebSocketStore((state) => state.createTacticalStrip);
+  const assignRunway = useWebSocketStore((state) => state.assignRunway);
   const selectedAircraft = useSelectedCallsign();
-  //const runwaySetup = useRunwaySetup();
-
-  const runways = /*props.mode === "ASSIGN"
-    ? (props.direction === "departure" ? runwaySetup.departure : runwaySetup.arrival)
-    :*/ RUNWAYS;
-
   const title = props.mode === "ASSIGN" ? "Assign Runway" : props.mode === "SELECT" ? "Select Runway" : props.type;
   const currentRunway = props.mode === "ASSIGN" || props.mode === "SELECT" ? props.currentRunway : undefined;
 
@@ -80,28 +81,72 @@ export function RunwayDialog(props: Props) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className={CLS_DIALOG_BG}>
+      <DialogContent
+        className="fixed block max-w-none max-h-none overflow-hidden rounded-none border border-black bg-[#B3B3B3] p-0 [&>button]:hidden"
+        style={{ width: scalePx(589.924), height: scalePx(532.102) }}
+      >
         <DialogTitle className="sr-only">Select Runway — {title}</DialogTitle>
-        <div className={CLS_PANEL}>
-          <div className={CLS_RWY_LIST}>
-            {runways.map(rwy => (
+
+        <div
+          className="pointer-events-none absolute border border-black"
+          style={{
+            left: scalePx(8.07),
+            top: scalePx(8.79),
+            width: scalePx(571.993),
+            height: scalePx(510.622),
+          }}
+        />
+
+        <img
+          aria-hidden="true"
+          alt=""
+          className="pointer-events-none absolute max-w-none"
+          src="/runway-selector-lines.svg"
+          style={{
+            left: scalePx(68.2),
+            top: scalePx(107.75),
+            width: scalePx(457.348),
+            height: scalePx(368.379),
+          }}
+        />
+
+        <div className="absolute inset-0">
+          {RUNWAYS.map((runway) => {
+            const position = RUNWAY_POSITIONS[runway];
+            return (
               <button
-                key={rwy}
-                className={rwy === currentRunway ? CLS_RWY_BTN_ACTIVE : CLS_RWY_BTN}
-                onClick={() => handleSelect(rwy)}
+                key={runway}
+                className="outline-none active:brightness-90"
+                style={{
+                  ...BUTTON_STYLE,
+                  left: scalePx(position.left),
+                  top: scalePx(position.top),
+                  background: runway === currentRunway ? "#1BFF16" : BUTTON_STYLE.background,
+                }}
+                onClick={() => handleSelect(runway)}
               >
-                {rwy}
+                {runway}
               </button>
-            ))}
-          </div>
-          <div className={CLS_ESC_ROW}>
-            <button
-              className={CLS_ESC_BTN}
-              onClick={() => onOpenChange(false)}
-            >
-              ESC
-            </button>
-          </div>
+            );
+          })}
+
+          <button
+            className="absolute bg-[#3F3F3F] text-white outline-none active:brightness-75"
+            style={{
+              left: scalePx(440.2),
+              top: scalePx(450),
+              width: scalePx(119.792),
+              height: scalePx(49.09),
+              border: 0,
+              boxShadow: `0 ${scalePx(4)} ${scalePx(4)} rgba(0, 0, 0, 0.25)`,
+              fontFamily: "Rubik, sans-serif",
+              fontSize: scalePx(18),
+              fontWeight: 600,
+            }}
+            onClick={() => onOpenChange(false)}
+          >
+            ESC
+          </button>
         </div>
       </DialogContent>
     </Dialog>

--- a/frontend/src/components/strip/StripContextMenu.tsx
+++ b/frontend/src/components/strip/StripContextMenu.tsx
@@ -10,8 +10,8 @@ export interface StripContextMenuProps {
 }
 
 // From design SVG: 167px wide panel
-const MENU_W = 167;
-const MENU_H_APPROX = 420;
+export const STRIP_CONTEXT_MENU_WIDTH = 167;
+export const STRIP_CONTEXT_MENU_HEIGHT = 373;
 
 // Colours from design SVG
 const COLOR_PANEL_BG  = "#B3B3B3"; // outer panel
@@ -84,8 +84,8 @@ export function StripContextMenu({ callsign, position, onClose }: StripContextMe
   );
 
   // Clamp menu to viewport
-  const menuX = Math.min(position.x, window.innerWidth - MENU_W - 8);
-  const menuY = Math.min(position.y, window.innerHeight - MENU_H_APPROX - 8);
+  const menuX = Math.min(position.x, window.innerWidth - STRIP_CONTEXT_MENU_WIDTH - 8);
+  const menuY = Math.min(position.y, window.innerHeight - STRIP_CONTEXT_MENU_HEIGHT - 8);
 
   useEffect(() => {
     function onMouseDown(e: MouseEvent) {
@@ -145,7 +145,9 @@ export function StripContextMenu({ callsign, position, onClose }: StripContextMe
         position: "fixed",
         left: menuX,
         top: menuY,
-        width: MENU_W,
+        width: STRIP_CONTEXT_MENU_WIDTH,
+        height: STRIP_CONTEXT_MENU_HEIGHT,
+        boxSizing: "border-box",
         backgroundColor: COLOR_PANEL_BG,
         border: "1px solid black",
         zIndex: 9999,

--- a/frontend/src/components/strip/TacticalButtons.tsx
+++ b/frontend/src/components/strip/TacticalButtons.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { Bay } from "@/api/models";
+import { Bay } from "@/api/models";
 import { useWebSocketStore } from "@/store/store-hooks";
 import { MemaidDialog } from "./MemaidDialog";
 import { RunwayDialog } from "./RunwayDialog";
@@ -16,20 +16,44 @@ export function MemAidButton({ bay, className }: { bay: Bay; className?: string 
 
 export function StartButton({ bay, className }: { bay: Bay; className?: string }) {
   const [open, setOpen] = useState(false);
+  const createTacticalStrip = useWebSocketStore((state) => state.createTacticalStrip);
+  const selectedAircraft = useWebSocketStore((state) => state.selectedCallsign);
+  const requiresRunway = bay === Bay.TwyArr || bay === Bay.Taxi || bay === Bay.TaxiLwr;
+
+  const handleClick = () => {
+    if (requiresRunway) {
+      setOpen(true);
+      return;
+    }
+    createTacticalStrip("START", bay, "", selectedAircraft ?? "");
+  };
+
   return (
     <>
-      <button className={className} onClick={() => setOpen(true)}>START</button>
-      <RunwayDialog open={open} bay={bay} type="START" onOpenChange={setOpen} />
+      <button className={className} onClick={handleClick}>START</button>
+      {requiresRunway && <RunwayDialog open={open} bay={bay} type="START" onOpenChange={setOpen} />}
     </>
   );
 }
 
 export function LandButton({ bay, className }: { bay: Bay; className?: string }) {
   const [open, setOpen] = useState(false);
+  const createTacticalStrip = useWebSocketStore((state) => state.createTacticalStrip);
+  const selectedAircraft = useWebSocketStore((state) => state.selectedCallsign);
+  const requiresRunway = bay === Bay.TwyArr || bay === Bay.Taxi || bay === Bay.TaxiLwr;
+
+  const handleClick = () => {
+    if (requiresRunway) {
+      setOpen(true);
+      return;
+    }
+    createTacticalStrip("LAND", bay, "", selectedAircraft ?? "");
+  };
+
   return (
     <>
-      <button className={className} onClick={() => setOpen(true)}>LAND</button>
-      <RunwayDialog open={open} bay={bay} type="LAND" onOpenChange={setOpen} />
+      <button className={className} onClick={handleClick}>LAND</button>
+      {requiresRunway && <RunwayDialog open={open} bay={bay} type="LAND" onOpenChange={setOpen} />}
     </>
   );
 }

--- a/frontend/src/components/strip/TacticalCrossingStrip.tsx
+++ b/frontend/src/components/strip/TacticalCrossingStrip.tsx
@@ -1,15 +1,8 @@
 import type { TacticalStrip } from "@/api/models";
-import { useMyPosition, useWebSocketStore } from "@/store/store-hooks";
-import { getFlatStripBorderStyle, FONT } from "./shared";
-
-const HEIGHT = "2.36dvh";
-const W_SI = "1.77vw";
-const W_BTN = "1.25vw";
+import { TacticalStripShell } from "./TacticalStripShell";
 
 const STRIP_BG        = "#fcc800"; // amber/gold crossing strip background
 const CELL_BORDER_CLR = "#b39200"; // darker gold for cell borders / bottom border
-const COLOR_PRODUCER  = "white";   // SI box when strip produced by current position
-const COLOR_OTHER     = "#800080"; // SI box when produced by another position
 
 interface Props {
   strip: TacticalStrip;
@@ -17,65 +10,18 @@ interface Props {
 }
 
 export function TacticalCrossingStrip({ strip, width }: Props) {
-  const myPosition = useMyPosition();
-  const confirmTacticalStrip = useWebSocketStore(s => s.confirmTacticalStrip);
-  const deleteTacticalStrip = useWebSocketStore(s => s.deleteTacticalStrip);
-
-  const isProducer = strip.produced_by === myPosition;
-  const siBackground = isProducer ? COLOR_PRODUCER : COLOR_OTHER;
   const label = strip.aircraft ? `${strip.label} (${strip.aircraft})` : strip.label;
-  const canConfirm = !isProducer && !strip.confirmed;
 
   return (
-    <div
-      className="flex select-none"
-      style={{
-        height: HEIGHT,
-        width: width ?? "100%",
-        backgroundColor: STRIP_BG,
-        ...getFlatStripBorderStyle({ borderBottom: `1px solid ${CELL_BORDER_CLR}` }),
-      }}
+    <TacticalStripShell
+      strip={strip}
+      width={width}
+      backgroundColor={STRIP_BG}
+      borderColor={CELL_BORDER_CLR}
+      textColor="black"
+      deleteHoverClass="hover:bg-yellow-400"
     >
-      {/* SI box */}
-      <div
-        className="flex-shrink-0 border-r-2"
-        style={{ width: W_SI, height: "100%", backgroundColor: siBackground, borderRightColor: CELL_BORDER_CLR }}
-      />
-
-      {/* Label */}
-      <div
-        className="flex-1 flex items-center justify-center pl-[0.42vw] overflow-hidden font-bold"
-        style={{ fontFamily: FONT, color: "black", fontSize: "0.63vw" }}
-      >
-        <span className="truncate">{label}</span>
-      </div>
-
-      {/* Confirm button (hourglass / tickmark) */}
-      <div
-        className="flex-shrink-0 flex items-center justify-center border-l-2"
-        style={{
-          width: W_BTN,
-          height: "100%",
-          borderLeftColor: CELL_BORDER_CLR,
-          color: "black",
-          cursor: canConfirm ? "pointer" : "default",
-          opacity: isProducer && !strip.confirmed ? 0.35 : 1,
-        }}
-        onClick={canConfirm ? (e) => { e.stopPropagation(); confirmTacticalStrip(strip.id); } : undefined}
-      >
-        <span style={{ fontFamily: FONT, fontSize: "0.68vw" }}>
-          {strip.confirmed ? "✓" : "⌛"}
-        </span>
-      </div>
-
-      {/* Delete button (X) */}
-      <div
-        className="flex-shrink-0 flex items-center justify-center border-l-2 cursor-pointer hover:bg-yellow-400"
-        style={{ width: W_BTN, height: "100%", borderLeftColor: CELL_BORDER_CLR, color: "black" }}
-        onClick={(e) => { e.stopPropagation(); deleteTacticalStrip(strip.id); }}
-      >
-        <span style={{ fontFamily: FONT, fontSize: "0.68vw" }}>✕</span>
-      </div>
-    </div>
+      {label}
+    </TacticalStripShell>
   );
 }

--- a/frontend/src/components/strip/TacticalMemaidStrip.tsx
+++ b/frontend/src/components/strip/TacticalMemaidStrip.tsx
@@ -1,14 +1,9 @@
 import type { TacticalStrip } from "@/api/models";
 import { useMyPosition, useWebSocketStore } from "@/store/store-hooks";
-import { getFlatStripBorderStyle, FONT, COLOR_BTN_BLUE } from "./shared";
-
-const HEIGHT = "2.36dvh";
-const W_SI = "1.77vw";
-const W_BTN = "1.25vw";
+import { FONT, COLOR_BTN_BLUE } from "./shared";
+import { TacticalActionCell, TacticalStripShell } from "./TacticalStripShell";
 
 const CELL_BORDER_CLR = "#d9d9d9"; // light grey cell borders on memaid strip
-const COLOR_PRODUCER  = "white";   // SI box when strip produced by current position
-const COLOR_OTHER     = "#800080"; // SI box when produced by another position
 
 interface Props {
   strip: TacticalStrip;
@@ -18,63 +13,35 @@ interface Props {
 export function TacticalMemaidStrip({ strip, width }: Props) {
   const myPosition = useMyPosition();
   const confirmTacticalStrip = useWebSocketStore(s => s.confirmTacticalStrip);
-  const deleteTacticalStrip = useWebSocketStore(s => s.deleteTacticalStrip);
 
-  const isProducer = strip.produced_by === myPosition;
-  const siBackground = isProducer ? COLOR_PRODUCER : COLOR_OTHER;
+  const isOwner = strip.owner === myPosition;
   const label = strip.aircraft ? `${strip.label} (${strip.aircraft})` : strip.label;
 
-  const canConfirm = !isProducer && !strip.confirmed;
+  const canConfirm = !isOwner && !strip.confirmed;
+  const confirmAction = (
+    <TacticalActionCell
+      borderColor={CELL_BORDER_CLR}
+      color="white"
+      clickable={canConfirm}
+      onClick={canConfirm ? () => confirmTacticalStrip(strip.id) : undefined}
+    >
+      <span style={{ fontFamily: FONT, fontSize: "0.68vw", opacity: isOwner && !strip.confirmed ? 0.35 : 1 }}>
+        {strip.confirmed ? "✓" : "⌛"}
+      </span>
+    </TacticalActionCell>
+  );
 
   return (
-    <div
-      className="flex select-none"
-      style={{
-        height: HEIGHT,
-        width: width ?? "100%",
-        backgroundColor: COLOR_BTN_BLUE,
-        ...getFlatStripBorderStyle({ borderBottom: "1px solid white" }),
-      }}
+    <TacticalStripShell
+      strip={strip}
+      width={width}
+      backgroundColor={COLOR_BTN_BLUE}
+      borderColor={CELL_BORDER_CLR}
+      textColor="white"
+      action={confirmAction}
+      deleteHoverClass="hover:bg-primary/80"
     >
-      {/* SI box */}
-      <div
-        className="flex-shrink-0 border-r-2"
-        style={{ width: W_SI, height: "100%", backgroundColor: siBackground, borderRightColor: CELL_BORDER_CLR }}
-      />
-
-      {/* Label */}
-      <div
-        className="flex-1 flex items-center pl-[0.42vw] overflow-hidden text-white font-bold"
-        style={{ fontFamily: FONT, fontSize: "0.63vw" }}
-      >
-        <span className="truncate">{label}</span>
-      </div>
-
-      {/* Confirm button (hourglass / tickmark) */}
-      <div
-        className="flex-shrink-0 flex items-center justify-center border-l-2 text-white"
-        style={{
-          width: W_BTN,
-          height: "100%",
-          borderLeftColor: CELL_BORDER_CLR,
-          cursor: canConfirm ? "pointer" : "default",
-          opacity: isProducer && !strip.confirmed ? 0.35 : 1,
-        }}
-        onClick={canConfirm ? (e) => { e.stopPropagation(); confirmTacticalStrip(strip.id); } : undefined}
-      >
-        <span style={{ fontFamily: FONT, fontSize: "0.68vw" }}>
-          {strip.confirmed ? "✓" : "⌛"}
-        </span>
-      </div>
-
-      {/* Delete button (X) */}
-      <div
-        className="flex-shrink-0 flex items-center justify-center border-l-2 text-white cursor-pointer hover:bg-primary/80"
-        style={{ width: W_BTN, height: "100%", borderLeftColor: CELL_BORDER_CLR }}
-        onClick={(e) => { e.stopPropagation(); deleteTacticalStrip(strip.id); }}
-      >
-        <span style={{ fontFamily: FONT, fontSize: "0.68vw" }}>✕</span>
-      </div>
-    </div>
+      {label}
+    </TacticalStripShell>
   );
 }

--- a/frontend/src/components/strip/TacticalRwyStrip.tsx
+++ b/frontend/src/components/strip/TacticalRwyStrip.tsx
@@ -1,15 +1,8 @@
-import { useState, useEffect } from "react";
 import type { TacticalStrip } from "@/api/models";
-import { useMyPosition, useWebSocketStore } from "@/store/store-hooks";
-import { getFlatStripBorderStyle, FONT, COLOR_BTN_ORANGE } from "./shared";
-
-const HEIGHT = "2.36dvh";
-const W_SI = "1.77vw";
-const W_BTN = "1.25vw";
+import { COLOR_BTN_ORANGE } from "./shared";
+import { TacticalStripShell } from "./TacticalStripShell";
 
 const CELL_BORDER_CLR = "#a04a00"; // dark burnt-orange cell borders on rwy strip
-const COLOR_PRODUCER  = "white";   // SI box when strip produced by current position
-const COLOR_OTHER     = "#800080"; // SI box when produced by another position
 
 interface Props {
   strip: TacticalStrip;
@@ -17,79 +10,20 @@ interface Props {
 }
 
 export function TacticalRwyStrip({ strip, width }: Props) {
-  const myPosition = useMyPosition();
-  const startTacticalTimer = useWebSocketStore(s => s.startTacticalTimer);
-  const deleteTacticalStrip = useWebSocketStore(s => s.deleteTacticalStrip);
-
-  const isProducer = strip.produced_by === myPosition;
-  const siBackground = isProducer ? COLOR_PRODUCER : COLOR_OTHER;
-
   const label = strip.aircraft
-    ? `${strip.type} ${strip.label} (${strip.aircraft})`
-    : `${strip.type} ${strip.label}`;
-
-  const [elapsed, setElapsed] = useState(0);
-  useEffect(() => {
-    if (!strip.timer_start) return;
-    const start = new Date(strip.timer_start).getTime();
-    const interval = setInterval(() => {
-      setElapsed(Math.floor((Date.now() - start) / 1000));
-    }, 1000);
-    return () => clearInterval(interval);
-  }, [strip.timer_start]);
-
-  const timerText = strip.timer_start
-    ? `${String(Math.floor(elapsed / 60)).padStart(2, "0")}:${String(elapsed % 60).padStart(2, "0")}`
-    : null;
+    ? `${strip.type}${strip.label ? ` ${strip.label}` : ""} (${strip.aircraft})`
+    : `${strip.type}${strip.label ? ` ${strip.label}` : ""}`;
 
   return (
-    <div
-      className="flex select-none"
-      style={{
-        height: HEIGHT,
-        width: width ?? "100%",
-        backgroundColor: COLOR_BTN_ORANGE,
-        ...getFlatStripBorderStyle({ borderBottom: `1px solid ${CELL_BORDER_CLR}` }),
-      }}
+    <TacticalStripShell
+      strip={strip}
+      width={width}
+      backgroundColor={COLOR_BTN_ORANGE}
+      borderColor={CELL_BORDER_CLR}
+      textColor="white"
+      deleteHoverClass="hover:bg-orange-600"
     >
-      {/* SI box */}
-      <div
-        className="flex-shrink-0 border-r-2"
-        style={{ width: W_SI, height: "100%", backgroundColor: siBackground, borderRightColor: CELL_BORDER_CLR }}
-      />
-
-      {/* Label */}
-      <div
-        className="flex-1 flex items-center pl-[0.42vw] overflow-hidden text-white font-bold"
-        style={{ fontFamily: FONT, fontSize: "0.63vw" }}
-      >
-        <span className="truncate">{label}</span>
-      </div>
-
-      {/* Timer / hourglass button */}
-      <div
-        className="flex-shrink-0 flex items-center justify-center border-l-2 text-white"
-        style={{
-          width: strip.timer_start ? "2.5vw" : W_BTN,
-          height: "100%",
-          borderLeftColor: CELL_BORDER_CLR,
-          cursor: strip.timer_start ? "default" : "pointer",
-        }}
-        onClick={strip.timer_start ? undefined : (e) => { e.stopPropagation(); startTacticalTimer(strip.id); }}
-      >
-        <span style={{ fontFamily: FONT, fontSize: strip.timer_start ? "0.57vw" : "0.68vw", letterSpacing: 0 }}>
-          {timerText ?? "⌛"}
-        </span>
-      </div>
-
-      {/* Delete button (X) */}
-      <div
-        className="flex-shrink-0 flex items-center justify-center border-l-2 text-white cursor-pointer hover:bg-orange-600"
-        style={{ width: W_BTN, height: "100%", borderLeftColor: CELL_BORDER_CLR }}
-        onClick={(e) => { e.stopPropagation(); deleteTacticalStrip(strip.id); }}
-      >
-        <span style={{ fontFamily: FONT, fontSize: "0.68vw" }}>✕</span>
-      </div>
-    </div>
+      {label}
+    </TacticalStripShell>
   );
 }

--- a/frontend/src/components/strip/TacticalStripShell.tsx
+++ b/frontend/src/components/strip/TacticalStripShell.tsx
@@ -1,0 +1,292 @@
+import { useEffect, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import type { TacticalStrip } from "@/api/models";
+import { useControllers, useMyPosition, useWebSocketStore } from "@/store/store-hooks";
+import { STRIP_CONTEXT_MENU_WIDTH } from "./StripContextMenu";
+import { FONT, SELECTION_COLOR, getFlatStripBorderStyle } from "./shared";
+
+const HEIGHT = "2.36dvh";
+const W_SI = "1.77vw";
+const W_BTN = "1.25vw";
+const TACTICAL_MENU_HEIGHT = 254;
+const MENU_VIEWPORT_MARGIN = 8;
+const MENU_BG = "#B3B3B3";
+const MENU_ITEM_BG = "#D6D6D6";
+const MENU_DISABLED = "#A4A4A4";
+const MENU_FONT = "'Arial', sans-serif";
+const MENU_SHADOW = "0 4px 4px rgba(0,0,0,0.25)";
+
+const menuItemStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  backgroundColor: MENU_ITEM_BG,
+  color: "black",
+  fontFamily: MENU_FONT,
+  fontWeight: 600,
+  fontSize: 16,
+  cursor: "pointer",
+  userSelect: "none",
+  boxShadow: MENU_SHADOW,
+};
+
+interface TacticalStripShellProps {
+  strip: TacticalStrip;
+  width?: string | number;
+  backgroundColor: string;
+  borderColor: string;
+  textColor: string;
+  children: ReactNode;
+  action?: ReactNode;
+  deleteHoverClass: string;
+}
+
+export function TacticalActionCell({
+  borderColor,
+  color,
+  children,
+  onClick,
+  clickable = false,
+}: {
+  borderColor: string;
+  color: string;
+  children: ReactNode;
+  onClick?: () => void;
+  clickable?: boolean;
+}) {
+  const handleClick = (event: ReactMouseEvent<HTMLDivElement>) => {
+    event.stopPropagation();
+    onClick?.();
+  };
+
+  return (
+    <div
+      className="flex-shrink-0 flex items-center justify-center border-l-2"
+      style={{
+        width: W_BTN,
+        height: "100%",
+        borderLeftColor: borderColor,
+        color,
+        cursor: clickable ? "pointer" : "default",
+      }}
+      onClick={handleClick}
+    >
+      {children}
+    </div>
+  );
+}
+
+function TacticalOwnershipMenu({
+  strip,
+  position,
+  onClose,
+}: {
+  strip: TacticalStrip;
+  position: { x: number; y: number };
+  onClose: () => void;
+}) {
+  const controllers = useControllers();
+  const forceAssume = useWebSocketStore((state) => state.forceAssumeTacticalStrip);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const ownerIdentifier = controllers.find((controller) => controller.position === strip.owner)?.identifier || strip.owner;
+  const menuX = Math.min(position.x, window.innerWidth - STRIP_CONTEXT_MENU_WIDTH - MENU_VIEWPORT_MARGIN);
+  const menuY = Math.min(position.y, window.innerHeight - TACTICAL_MENU_HEIGHT - MENU_VIEWPORT_MARGIN);
+
+  useEffect(() => {
+    function handleMouseDown(event: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    }
+
+    document.addEventListener("mousedown", handleMouseDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose]);
+
+  const handleForceAssume = () => {
+    forceAssume(strip.id);
+    onClose();
+  };
+
+  return createPortal(
+    <div
+      ref={menuRef}
+      role="dialog"
+      aria-label="Tactical strip actions"
+      style={{
+        position: "fixed",
+        left: menuX,
+        top: menuY,
+        width: STRIP_CONTEXT_MENU_WIDTH,
+        boxSizing: "border-box",
+        backgroundColor: MENU_BG,
+        border: "1px solid black",
+        zIndex: 9999,
+        display: "flex",
+        flexDirection: "column",
+        padding: "13px 7px",
+        gap: 4,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          height: 25,
+          flexShrink: 0,
+          backgroundColor: "white",
+          color: "#AFAFAF",
+          fontFamily: MENU_FONT,
+          fontWeight: 300,
+          fontSize: 16,
+          userSelect: "none",
+          boxShadow: MENU_SHADOW,
+        }}
+      >
+        {ownerIdentifier || "—"}
+      </div>
+
+      <button
+        style={{ ...menuItemStyle, height: 50, flexShrink: 0, border: 0 }}
+        onClick={handleForceAssume}
+      >
+        FORCE ASSUME
+      </button>
+
+      <button
+        style={{
+          ...menuItemStyle,
+          height: 48,
+          flexShrink: 0,
+          border: 0,
+          color: MENU_DISABLED,
+          cursor: "not-allowed",
+        }}
+        disabled
+      >
+        RECALL
+      </button>
+
+      <button
+        style={{
+          ...menuItemStyle,
+          height: 44,
+          flexShrink: 0,
+          border: 0,
+          color: MENU_DISABLED,
+          cursor: "not-allowed",
+        }}
+        disabled
+      >
+        VIEW FPL
+      </button>
+
+      <button
+        style={{
+          ...menuItemStyle,
+          height: 43,
+          flexShrink: 0,
+          border: 0,
+          backgroundColor: "#3F3F3F",
+          color: "white",
+          fontSize: 18,
+        }}
+        onClick={onClose}
+      >
+        ESC
+      </button>
+    </div>,
+    document.body,
+  );
+}
+
+export function TacticalStripShell({
+  strip,
+  width,
+  backgroundColor,
+  borderColor,
+  textColor,
+  children,
+  action,
+  deleteHoverClass,
+}: TacticalStripShellProps) {
+  const [menuPosition, setMenuPosition] = useState<{ x: number; y: number } | null>(null);
+  const myPosition = useMyPosition();
+  const deleteTacticalStrip = useWebSocketStore((state) => state.deleteTacticalStrip);
+  const markTacticalStrip = useWebSocketStore((state) => state.markTacticalStrip);
+  const isOwner = strip.owner === myPosition;
+
+  const handleStripClick = (event: ReactMouseEvent<HTMLDivElement>) => {
+    event.stopPropagation();
+    if (isOwner) {
+      markTacticalStrip(strip.id, !strip.marked);
+      return;
+    }
+    setMenuPosition({ x: event.clientX, y: event.clientY });
+  };
+
+  return (
+    <>
+      <div
+        className="flex select-none"
+        style={{
+          height: HEIGHT,
+          width: width ?? "100%",
+          backgroundColor,
+          ...getFlatStripBorderStyle({ borderBottom: `1px solid ${borderColor}` }),
+          cursor: "pointer",
+        }}
+        onClick={handleStripClick}
+      >
+        {isOwner && (
+          <div
+            className="flex-shrink-0 border-r-2 bg-white"
+            style={{ width: W_SI, height: "100%", borderRightColor: borderColor }}
+          />
+        )}
+
+        <div
+          className="flex-1 flex items-center justify-center px-[0.42vw] overflow-hidden font-bold"
+          style={{
+            fontFamily: FONT,
+            color: textColor,
+            fontSize: "0.63vw",
+            backgroundColor: strip.marked ? SELECTION_COLOR : undefined,
+          }}
+        >
+          <span className="truncate">{children}</span>
+        </div>
+
+        {action}
+
+        {isOwner && (
+          <div
+            className={`flex-shrink-0 flex items-center justify-center border-l-2 cursor-pointer ${deleteHoverClass}`}
+            style={{ width: W_BTN, height: "100%", borderLeftColor: borderColor, color: textColor }}
+            onClick={(event) => {
+              event.stopPropagation();
+              deleteTacticalStrip(strip.id);
+            }}
+          >
+            <span style={{ fontFamily: FONT, fontSize: "0.68vw" }}>✕</span>
+          </div>
+        )}
+      </div>
+
+      {!isOwner && menuPosition && (
+        <TacticalOwnershipMenu strip={strip} position={menuPosition} onClose={() => setMenuPosition(null)} />
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/strip/TacticalStrips.test.tsx
+++ b/frontend/src/components/strip/TacticalStrips.test.tsx
@@ -1,0 +1,120 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Bay, type TacticalStrip } from "@/api/models";
+import { StartButton } from "./TacticalButtons";
+import { TacticalCrossingStrip } from "./TacticalCrossingStrip";
+import { TacticalMemaidStrip } from "./TacticalMemaidStrip";
+import { TacticalRwyStrip } from "./TacticalRwyStrip";
+
+const actions = {
+  createTacticalStrip: vi.fn(),
+  deleteTacticalStrip: vi.fn(),
+  confirmTacticalStrip: vi.fn(),
+  forceAssumeTacticalStrip: vi.fn(),
+  markTacticalStrip: vi.fn(),
+};
+
+let position = "EKCH_TWR";
+const controllers = [
+  { callsign: "EKCH_TWR", position: "EKCH_TWR", identifier: "TE", section: "TWR", owned_sectors: ["TE"] },
+  { callsign: "EKCH_GND", position: "EKCH_GND", identifier: "GE", section: "GND", owned_sectors: ["GE"] },
+];
+
+vi.mock("@/store/store-hooks", () => ({
+  useWebSocketStore: (selector: (state: unknown) => unknown) => selector({
+    ...actions,
+    selectedCallsign: "SAS123",
+    controllers,
+    position,
+  }),
+  useMyPosition: () => position,
+  useControllers: () => controllers,
+  useSelectedCallsign: () => "SAS123",
+}));
+
+function tactical(overrides: Partial<TacticalStrip> = {}): TacticalStrip {
+  return {
+    id: 42,
+    session_id: 1,
+    type: "START",
+    bay: Bay.Taxi,
+    label: "22L",
+    aircraft: "",
+    produced_by: "EKCH_TWR",
+    owner: "EKCH_TWR",
+    marked: false,
+    sequence: 1000,
+    confirmed: false,
+    confirmed_by: "",
+    created_at: "2026-07-20T12:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  position = "EKCH_TWR";
+  Object.values(actions).forEach((mock) => mock.mockReset());
+});
+
+afterEach(cleanup);
+
+describe("tactical strip ownership interactions", () => {
+  it("lets the owner mark and close a runway strip without a timer control", () => {
+    render(<TacticalRwyStrip strip={tactical()} />);
+
+    fireEvent.click(screen.getByText("START 22L"));
+    expect(actions.markTacticalStrip).toHaveBeenCalledWith(42, true);
+    expect(screen.getByText("✕")).toBeInTheDocument();
+    expect(screen.queryByText("⌛")).not.toBeInTheDocument();
+  });
+
+  it("opens force assume for a non-owner and omits SI/close controls", () => {
+    position = "EKCH_GND";
+    const { container } = render(
+      <TacticalCrossingStrip strip={tactical({ type: "CROSSING", label: "CROSSING TRAFFIC" })} />,
+    );
+
+    expect(screen.queryByText("✕")).not.toBeInTheDocument();
+    expect(container.querySelector(".bg-white")).toBeNull();
+    fireEvent.click(screen.getByText("CROSSING TRAFFIC"), { clientX: 100, clientY: 120 });
+
+    expect(screen.getByRole("dialog", { name: "Tactical strip actions" })).toHaveStyle({ width: "167px" });
+    expect(screen.getByRole("dialog", { name: "Tactical strip actions" }).style.height).toBe("");
+    expect(screen.getByText("TE")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "FORCE ASSUME" }));
+    expect(actions.forceAssumeTacticalStrip).toHaveBeenCalledWith(42);
+  });
+
+  it("keeps the MEMAID acknowledgement separate from force assume", () => {
+    position = "EKCH_GND";
+    render(<TacticalMemaidStrip strip={tactical({ type: "MEMAID", label: "STOP CLIMB" })} />);
+
+    fireEvent.click(screen.getByText("⌛"));
+    expect(actions.confirmTacticalStrip).toHaveBeenCalledWith(42);
+    expect(screen.queryByRole("button", { name: "FORCE ASSUME" })).not.toBeInTheDocument();
+  });
+});
+
+describe("START creation by bay", () => {
+  it("creates immediately without a runway in runway bays", () => {
+    render(<StartButton bay={Bay.RwyArr} />);
+    fireEvent.click(screen.getByRole("button", { name: "START" }));
+    expect(actions.createTacticalStrip).toHaveBeenLastCalledWith("START", Bay.RwyArr, "", "SAS123");
+  });
+
+  it("requires runway selection in TAXI", () => {
+    render(<StartButton bay={Bay.Taxi} />);
+    fireEvent.click(screen.getByRole("button", { name: "START" }));
+    fireEvent.click(screen.getByRole("button", { name: "22L" }));
+
+    expect(actions.createTacticalStrip).toHaveBeenCalledWith("START", Bay.Taxi, "22L", "SAS123");
+  });
+
+  it("requires runway selection in TAXI_LWR", () => {
+    render(<StartButton bay={Bay.TaxiLwr} />);
+    fireEvent.click(screen.getByRole("button", { name: "START" }));
+    fireEvent.click(screen.getByRole("button", { name: "22L" }));
+
+    expect(actions.createTacticalStrip).toHaveBeenCalledWith("START", Bay.TaxiLwr, "22L", "SAS123");
+  });
+});

--- a/frontend/src/routes/ekch/AA.tsx
+++ b/frontend/src/routes/ekch/AA.tsx
@@ -1,5 +1,5 @@
 import { Strip } from "@/components/strip/Strip.tsx";
-import { MemAidButton } from "@/components/strip/TacticalButtons.tsx";
+import { CrossingButton, LandButton, MemAidButton, StartButton } from "@/components/strip/TacticalButtons.tsx";
 import { useMyPosition, useWebSocketStore, useDelOnline } from "@/store/store-hooks.ts";
 import {
   useDeIceStrips,
@@ -24,12 +24,14 @@ import { ViewDndContext } from "@/components/bays/ViewDndContext.tsx";
 import { StripListPopup, type SortMode } from "@/components/StripListPopup.tsx";
 import { useState } from "react";
 import { APN_TAXI_DEP_STRIP_WIDTH } from "@/components/strip/ApnTaxiDepStrip.tsx";
-import { CLS_BTN, CLS_BTN_BLUE, CLS_LABEL } from "@/components/strip/shared";
+import { CLS_BTN, CLS_BTN_BLUE, CLS_BTN_ORANGE, CLS_BTN_YELLOW, CLS_LABEL } from "@/components/strip/shared";
 import { NewIfrDialog } from "@/components/strip/NewIfrDialog";
 import { PlannedDialog } from "@/components/strip/PlannedDialog";
 
 const btn     = CLS_BTN;
 const btnBlue = CLS_BTN_BLUE;
+const btnOrange = CLS_BTN_ORANGE;
+const btnYellow = CLS_BTN_YELLOW;
 
 export default function AA() {
   const myPosition  = useMyPosition();
@@ -145,7 +147,7 @@ export default function AA() {
         <SortableBay
           strips={standStrips}
           bayId="STAND"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="flex-1 bay-scroll-area-bottom"
         >
@@ -180,7 +182,7 @@ export default function AA() {
         <SortableBay
           strips={deIceStrips}
           bayId="DE-ICE"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="h-[20%] bay-scroll-area-bottom"
         >
@@ -196,7 +198,7 @@ export default function AA() {
         <SortableBay
           strips={twyArrStrips}
           bayId="TWY-ARR"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="flex-1 bay-scroll-area-bottom"
         >
@@ -216,7 +218,7 @@ export default function AA() {
         <SortableBay
           strips={pushStrips}
           bayId="PUSHBACK"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="h-[35%] bay-scroll-area-bottom"
         >
@@ -231,13 +233,16 @@ export default function AA() {
             <button className={btn} onClick={() => setNewOpen(true)}>NEW</button>
             <button className={btn} onClick={() => setPlannedOpen(true)}>PLANNED</button>
             <MemAidButton bay={Bay.Taxi} className={btnBlue} />
+            <LandButton bay={Bay.Taxi} className={btnOrange} />
+            <StartButton bay={Bay.Taxi} className={btnOrange} />
+            <CrossingButton bay={Bay.Taxi} className={btnYellow} />
           </span>
         </div>
         {/* TWY DEP-UPR (intermediate hold short, TAXI bay) */}
         <SortableBay
           strips={twyDepUpr}
           bayId="TWY-DEP-UPR"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="h-[25%] bay-scroll-area-bottom"
         >
@@ -262,7 +267,7 @@ export default function AA() {
         <SortableBay
           strips={twyDepLwr}
           bayId="TWY-DEP-LWR"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="flex-1 bay-scroll-area-bottom"
         >

--- a/frontend/src/routes/ekch/AAAD.tsx
+++ b/frontend/src/routes/ekch/AAAD.tsx
@@ -1,5 +1,5 @@
 import { Strip } from "@/components/strip/Strip.tsx";
-import { MemAidButton } from "@/components/strip/TacticalButtons.tsx";
+import { CrossingButton, LandButton, MemAidButton, StartButton } from "@/components/strip/TacticalButtons.tsx";
 import { MessageStrip } from "@/components/strip/MessageStrip.tsx";
 import { MessageComposeDialog } from "@/components/MessageComposeDialog.tsx";
 import { useMyPosition, useMessages, useWebSocketStore, useDelOnline } from "@/store/store-hooks.ts";
@@ -27,7 +27,7 @@ import { ViewDndContext } from "@/components/bays/ViewDndContext.tsx";
 import { StripListPopup, type SortMode } from "@/components/StripListPopup.tsx";
 import { useState } from "react";
 import { APN_TAXI_DEP_STRIP_WIDTH } from "@/components/strip/ApnTaxiDepStrip.tsx";
-import { CLS_BTN, CLS_BTN_BLUE, CLS_LABEL } from "@/components/strip/shared";
+import { CLS_BTN, CLS_BTN_BLUE, CLS_BTN_ORANGE, CLS_BTN_YELLOW, CLS_LABEL } from "@/components/strip/shared";
 import { NewIfrDialog } from "@/components/strip/NewIfrDialog";
 import { PlannedDialog } from "@/components/strip/PlannedDialog";
 
@@ -35,6 +35,8 @@ const primaryHeader = `bg-primary h-10 flex items-center px-2 shrink-0`;
 const primaryLabel  = "text-white font-bold text-lg";
 const btn     = CLS_BTN;
 const btnBlue = CLS_BTN_BLUE;
+const btnOrange = CLS_BTN_ORANGE;
+const btnYellow = CLS_BTN_YELLOW;
 
 export default function AAAD() {
   const myPosition  = useMyPosition();
@@ -167,7 +169,7 @@ export default function AAAD() {
         <SortableBay
           strips={standStrips}
           bayId="STAND"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="flex-1 bay-scroll-area-bottom"
         >
@@ -202,13 +204,16 @@ export default function AAAD() {
             <button className={btn} onClick={() => setNewOpen(true)}>NEW</button>
             <button className={btn} onClick={() => setPlannedOpen(true)}>PLANNED</button>
             <MemAidButton bay={Bay.Taxi} className={btnBlue} />
+            <LandButton bay={Bay.Taxi} className={btnOrange} />
+            <StartButton bay={Bay.Taxi} className={btnOrange} />
+            <CrossingButton bay={Bay.Taxi} className={btnYellow} />
           </span>
         </div>
         {/* TWY DEP-UPR (intermediate hold short, TAXI bay) */}
         <SortableBay
           strips={twyDepUpr}
           bayId="TWY-DEP-UPR"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="h-[30%] bay-scroll-area-bottom"
         >
@@ -233,7 +238,7 @@ export default function AAAD() {
         <SortableBay
           strips={twyDepLwr}
           bayId="TWY-DEP-LWR"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="h-[30%] bay-scroll-area-bottom"
         >
@@ -251,7 +256,7 @@ export default function AAAD() {
         <SortableBay
           strips={twyArrStrips}
           bayId="TWY-ARR"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="flex-1 bay-scroll-area-bottom"
         >
@@ -271,7 +276,7 @@ export default function AAAD() {
         <SortableBay
           strips={startupStrips}
           bayId="STARTUP"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="h-[40%] bay-scroll-area-bottom"
         >
@@ -286,7 +291,7 @@ export default function AAAD() {
         <SortableBay
           strips={pushStrips}
           bayId="PUSHBACK"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="h-[30%] bay-scroll-area-bottom"
         >
@@ -301,7 +306,7 @@ export default function AAAD() {
         <SortableBay
           strips={deIceStrips}
           bayId="DE-ICE"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="flex-1 bay-scroll-area-bottom"
         >

--- a/frontend/src/routes/ekch/AD.tsx
+++ b/frontend/src/routes/ekch/AD.tsx
@@ -1,5 +1,5 @@
 import { Strip } from "@/components/strip/Strip.tsx";
-import { MemAidButton } from "@/components/strip/TacticalButtons.tsx";
+import { CrossingButton, LandButton, MemAidButton, StartButton } from "@/components/strip/TacticalButtons.tsx";
 import { useMyPosition, useMessages, useWebSocketStore, useDelOnline } from "@/store/store-hooks.ts";
 import {
   useClearedStrips,
@@ -24,7 +24,7 @@ import { ViewDndContext } from "@/components/bays/ViewDndContext.tsx";
 import { StripListPopup, type SortMode } from "@/components/StripListPopup.tsx";
 import { useState } from "react";
 import { APN_TAXI_DEP_STRIP_WIDTH } from "@/components/strip/ApnTaxiDepStrip.tsx";
-import { CLS_BTN, CLS_BTN_BLUE, CLS_LABEL } from "@/components/strip/shared";
+import { CLS_BTN, CLS_BTN_BLUE, CLS_BTN_ORANGE, CLS_BTN_YELLOW, CLS_LABEL } from "@/components/strip/shared";
 import { NewIfrDialog } from "@/components/strip/NewIfrDialog";
 import { PlannedDialog } from "@/components/strip/PlannedDialog";
 import { MessageStrip } from "@/components/strip/MessageStrip.tsx";
@@ -34,6 +34,8 @@ const primaryHeader = `bg-primary h-10 flex items-center px-2 shrink-0`;
 const primaryLabel  = "text-white font-bold text-lg";
 const btn     = CLS_BTN;
 const btnBlue = CLS_BTN_BLUE;
+const btnOrange = CLS_BTN_ORANGE;
+const btnYellow = CLS_BTN_YELLOW;
 
 export default function AD() {
   const myPosition  = useMyPosition();
@@ -168,7 +170,7 @@ export default function AD() {
         <SortableBay
           strips={twyArrStrips}
           bayId="TWY-ARR"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="flex-1 bay-scroll-area-bottom"
         >
@@ -203,7 +205,7 @@ export default function AD() {
         <SortableBay
           strips={deIceStrips}
           bayId="DE-ICE-V"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="h-[7.08dvh] bay-scroll-area-bottom"
         >
@@ -233,13 +235,16 @@ export default function AD() {
             <button className={btn} onClick={() => setNewOpen(true)}>NEW</button>
             <button className={btn} onClick={() => setPlannedOpen(true)}>PLANNED</button>
             <MemAidButton bay={Bay.Taxi} className={btnBlue} />
+            <LandButton bay={Bay.Taxi} className={btnOrange} />
+            <StartButton bay={Bay.Taxi} className={btnOrange} />
+            <CrossingButton bay={Bay.Taxi} className={btnYellow} />
           </span>
         </div>
         {/* TWY DEP-UPR (intermediate hold short, TAXI bay) */}
         <SortableBay
           strips={twyDepUpr}
           bayId="TWY-DEP-UPR"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="h-[30%] bay-scroll-area-bottom"
         >
@@ -264,7 +269,7 @@ export default function AD() {
         <SortableBay
           strips={twyDepLwr}
           bayId="TWY-DEP-LWR"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="flex-1 bay-scroll-area-bottom"
         >
@@ -284,7 +289,7 @@ export default function AD() {
         <SortableBay
           strips={startupStrips}
           bayId="STARTUP"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="h-[40%] bay-scroll-area-bottom"
         >
@@ -299,7 +304,7 @@ export default function AD() {
         <SortableBay
           strips={pushStrips}
           bayId="PUSHBACK"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="flex-1 bay-scroll-area-bottom"
         >

--- a/frontend/src/routes/ekch/GEGW.tsx
+++ b/frontend/src/routes/ekch/GEGW.tsx
@@ -136,7 +136,7 @@ export default function GEGW() {
         <SortableBay
           strips={finalStrips.filter(isFlight)}
           bayId="FINAL"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="h-[25%] bay-scroll-area-bottom"
         >
@@ -151,7 +151,7 @@ export default function GEGW() {
         <SortableBay
           strips={rwyArrStrips.filter(isFlight)}
           bayId="RWY-ARR"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="h-[20%] bay-scroll-area-dark"
         >
@@ -172,7 +172,7 @@ export default function GEGW() {
         <SortableBay
           strips={twyArrStrips}
           bayId="TWY-ARR"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="flex-1 bay-scroll-area-bottom"
         >
@@ -205,7 +205,7 @@ export default function GEGW() {
         <SortableBay
           strips={pushStrips}
           bayId="PUSHBACK"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="h-[12%] bay-scroll-area-bottom"
         >
@@ -227,7 +227,7 @@ export default function GEGW() {
         <SortableBay
           strips={twyDepDesc}
           bayId="TWY-DEP"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="h-[35%] bay-scroll-area-bottom"
         >
@@ -242,7 +242,7 @@ export default function GEGW() {
         <SortableBay
           strips={rwyDepStrips}
           bayId="RWY-DEP"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="h-[15%] bay-scroll-area-dark"
         >
@@ -257,7 +257,7 @@ export default function GEGW() {
         <SortableBay
           strips={airborneStrips}
           bayId="AIRBORNE"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="flex-1 bay-scroll-area-dark"
         >
@@ -276,7 +276,7 @@ export default function GEGW() {
         <SortableBay
           strips={startupStrips}
           bayId="STARTUP"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="h-[33%] bay-scroll-area-bottom"
         >
@@ -291,7 +291,7 @@ export default function GEGW() {
         <SortableBay
           strips={deIceStrips}
           bayId="DE-ICE"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="h-[33%] bay-scroll-area-bottom"
         >
@@ -337,7 +337,7 @@ export default function GEGW() {
         <SortableBay
           strips={standStrips}
           bayId="STAND"
-          isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+          isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
           standalone={false}
           className="flex-1 bay-scroll-area-bottom"
         >

--- a/frontend/src/routes/ekch/TowerGroundLayout.tsx
+++ b/frontend/src/routes/ekch/TowerGroundLayout.tsx
@@ -229,7 +229,7 @@ export default function TowerGroundLayout({ variant }: TowerGroundLayoutProps) {
           <SortableBay
             strips={finalStrips}
             bayId="FINAL"
-            isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+            isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
             standalone={false}
             className="h-[35%] bay-scroll-area-bottom"
           >
@@ -256,7 +256,7 @@ export default function TowerGroundLayout({ variant }: TowerGroundLayoutProps) {
           <SortableBay
             strips={rwyArrStrips}
             bayId="RWY-ARR"
-            isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+            isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
             standalone={false}
             className="h-[20%] bay-scroll-area-dark"
           >
@@ -277,7 +277,7 @@ export default function TowerGroundLayout({ variant }: TowerGroundLayoutProps) {
           <SortableBay
             strips={twyArrStrips}
             bayId="TWY-ARR"
-            isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+            isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
             standalone={false}
             className="flex-1 bay-scroll-area-bottom"
           >
@@ -304,7 +304,7 @@ export default function TowerGroundLayout({ variant }: TowerGroundLayoutProps) {
           <SortableBay
             strips={twyDepDesc}
             bayId="TWY-DEP"
-            isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+            isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
             standalone={false}
             className="h-[35%] bay-scroll-area-bottom"
           >
@@ -324,7 +324,7 @@ export default function TowerGroundLayout({ variant }: TowerGroundLayoutProps) {
           <SortableBay
             strips={rwyDepDesc}
             bayId="RWY-DEP"
-            isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+            isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
             standalone={false}
             className="h-[20%] bay-scroll-area-dark"
           >
@@ -339,7 +339,7 @@ export default function TowerGroundLayout({ variant }: TowerGroundLayoutProps) {
           <SortableBay
             strips={airborneDesc}
             bayId="AIRBORNE"
-            isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+            isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
             standalone={false}
             className="flex-1 bay-scroll-area-bottom"
           >
@@ -392,7 +392,7 @@ export default function TowerGroundLayout({ variant }: TowerGroundLayoutProps) {
           <SortableBay
             strips={controlzoneStrips}
             bayId="CONTROLZONE"
-            isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+            isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
             standalone={false}
             className={showStartupBay ? "h-[21.65%] bay-scroll-area-bottom" : "h-[35%] bay-scroll-area-bottom"}
           >
@@ -407,7 +407,7 @@ export default function TowerGroundLayout({ variant }: TowerGroundLayoutProps) {
               <SortableBay
                 strips={pushStrips}
                 bayId="PUSHBACK"
-                isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+                isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
                 standalone={false}
                 className="flex-1 bay-scroll-area-bottom"
               >
@@ -419,7 +419,7 @@ export default function TowerGroundLayout({ variant }: TowerGroundLayoutProps) {
               <SortableBay
                 strips={startupStrips}
                 bayId="STARTUP"
-                isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+                isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
                 standalone={false}
                 className="flex-1 bay-scroll-area-bottom"
               >
@@ -434,7 +434,7 @@ export default function TowerGroundLayout({ variant }: TowerGroundLayoutProps) {
               <SortableBay
                 strips={pushStrips}
                 bayId="PUSHBACK"
-                isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+                isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
                 standalone={false}
                 className="h-[35%] bay-scroll-area-bottom"
               >
@@ -485,7 +485,7 @@ export default function TowerGroundLayout({ variant }: TowerGroundLayoutProps) {
           <SortableBay
             strips={deIceStrips}
             bayId="DE-ICE"
-            isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+            isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
             standalone={false}
             className="h-[25%] bay-scroll-area-bottom"
           >
@@ -498,7 +498,7 @@ export default function TowerGroundLayout({ variant }: TowerGroundLayoutProps) {
           <SortableBay
             strips={standStrips}
             bayId="STAND"
-            isDragDisabled={(strip) => isFlight(strip) && !!strip.owner && strip.owner !== myPosition}
+            isDragDisabled={(strip) => !!strip.owner && strip.owner !== myPosition}
             standalone={false}
             className="flex-1 bay-scroll-area-bottom"
           >

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -224,7 +224,8 @@ export interface WebSocketState {
   createTacticalStrip: (stripType: TacticalStripType, bay: string, label: string, aircraft: string) => void;
   deleteTacticalStrip: (id: number) => void;
   confirmTacticalStrip: (id: number) => void;
-  startTacticalTimer: (id: number) => void;
+  forceAssumeTacticalStrip: (id: number) => void;
+  markTacticalStrip: (id: number, marked: boolean) => void;
   moveTacticalStrip: (id: number, insertAfter: StripRef | null, bay?: Bay) => void;
 
   acknowledgeValidationStatus: (callsign: string, activationKey: string) => void;
@@ -726,10 +727,18 @@ export const createWebSocketStore = (wsClient: WebSocketClient) => {
     confirmTacticalStrip: (id) => {
       sendIfWritable({ type: ActionType.FrontendConfirmTacticalStrip, id });
     },
-    startTacticalTimer: (id) => {
-      sendIfWritable({ type: ActionType.FrontendStartTacticalTimer, id });
+    forceAssumeTacticalStrip: (id) => {
+      sendIfWritable({ type: ActionType.FrontendForceAssumeTacticalStrip, id });
+    },
+    markTacticalStrip: (id, marked) => {
+      sendIfWritable({ type: ActionType.FrontendMarkTacticalStrip, id, marked });
     },
     moveTacticalStrip: (id, insertAfter, bay) => set((state) => {
+      const tacticalStrip = state.tacticalStrips.find((strip) => strip.id === id);
+      if (!tacticalStrip || tacticalStrip.owner !== state.position) {
+        return state;
+      }
+
       if (!sendIfWritable({ type: ActionType.FrontendMoveTacticalStrip, id, insert_after: insertAfter, bay })) {
         return state;
       }


### PR DESCRIPTION
## Summary

- persist tactical-strip `owner` and `marked` state, backfill existing owners, and remove START/LAND timer support
- enforce owner-only delete, move, mark, and drag behavior with force-assume ownership transfer
- align tactical strip rendering, non-owner menus, MEMAID confirmation, and runway selection with the linked designs
- require runway selection in `TWY_ARR`, `TAXI`, and `TAXI_LWR`; keep `RWY_ARR` and `DEPART` immediate

## Migration

The ownership migration is numbered `0038`, after the `0035`–`0037` migrations now present on the latest `main`.

## Validation

- `sqlc generate`
- `go test ./...`
- `npm test -- --run` — 117 tests passed
- `npm run build`
- ESLint on every changed frontend file
- `git diff --check`

Repository-wide `npm run lint` still reports the existing `react-hooks/set-state-in-effect` error in `src/components/commandbar/VACSBTN.tsx`, which is unchanged by this PR.

Closes #385