### PR TITLE
fix(cdm): restore START REQ stand styling

### DIFF
--- a/frontend/src/components/est/EstStandCell.tsx
+++ b/frontend/src/components/est/EstStandCell.tsx
@@ -4,7 +4,7 @@ import { Bay, type FrontendStandAssignmentEntry, type FrontendStrip } from "@/ap
 import { SELECTION_COLOR } from "@/components/strip/shared";
 import { cn, getSimpleAircraftType } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { CDM_GREEN, CTOT_BLUE, computeCDMColors, computeCTOTColors, hasManualTobtSource } from "@/lib/cdmColors";
+import { CDM_GREEN, CDM_ORANGE, CTOT_BLUE, computeCDMColors, computeCTOTColors, hasManualTobtSource } from "@/lib/cdmColors";
 
 import {
   EST_CELL_HEIGHT,
@@ -23,8 +23,8 @@ const DETAILS_ROW_TOP = 50.5;
 const DETAILS_ROW_HEIGHT = 20;
 const READY_ROW_TOP = 72;
 const TOBT_ROW_TOP = 88;
-const TSAT_ROW_TOP = 104;
-const CTOT_ROW_TOP = 120;
+const TSAT_ROW_TOP = 105;
+const CTOT_ROW_TOP = 121;
 const ROW_HEIGHT = 15;
 const LABEL_FONT_SIZE = 20;
 const DETAILS_FONT_SIZE = 14;
@@ -129,6 +129,9 @@ export default function EstStandCell({
   const showMark = isClearedDeparture && !!strip?.marked;
   const showCtotText = ctotLabel !== "";
   const boxShadows: string[] = [];
+  if (startReqActive) {
+    boxShadows.push(`inset 0 0 0 2px ${tobtBarColor === CDM_GREEN ? CDM_GREEN : CDM_ORANGE}`);
+  }
   if (showMark) {
     boxShadows.push(`0 0 0 4px ${SELECTION_COLOR}`);
   }
@@ -157,12 +160,14 @@ export default function EstStandCell({
             {tobtBarColor && (
               <div
                 className="absolute left-0 right-0"
+                data-testid="est-tobt-background"
                 style={{ top: TOBT_ROW_TOP, height: ROW_HEIGHT, backgroundColor: tobtBarColor }}
               />
             )}
             {tsatBarColor && (
               <div
                 className="absolute left-0 right-0"
+                data-testid="est-tsat-background"
                 style={{ top: TSAT_ROW_TOP, height: ROW_HEIGHT, backgroundColor: tsatBarColor }}
               />
             )}
@@ -237,7 +242,7 @@ export default function EstStandCell({
             {showReady && (
               <div
                 className="absolute left-0 right-0 flex items-center justify-center"
-                style={{ top: READY_ROW_TOP, height: ROW_HEIGHT, fontFamily: CONTENT_FONT, fontSize: CONTENT_FONT_SIZE }}
+                style={{ top: READY_ROW_TOP, height: ROW_HEIGHT, fontFamily: CONTENT_FONT, fontSize: CONTENT_FONT_SIZE, color: "#000000" }}
               >
                 READY
               </div>
@@ -274,7 +279,7 @@ export default function EstStandCell({
              {showTobt && (
                 <div
                   className="absolute left-0 right-0 flex items-center justify-center gap-1"
-                  style={{ top: TOBT_ROW_TOP, height: ROW_HEIGHT, fontFamily: CONTENT_FONT, fontSize: CONTENT_FONT_SIZE }}
+                  style={{ top: TOBT_ROW_TOP, height: ROW_HEIGHT, fontFamily: CONTENT_FONT, fontSize: CONTENT_FONT_SIZE, color: tobtBarColor === CDM_GREEN ? "#000000" : undefined }}
                 >
                   <span>TOBT:</span>
                   <span style={{ fontWeight: emphasizeTobtTime ? 700 : undefined }}>
@@ -287,7 +292,7 @@ export default function EstStandCell({
             {showTsat && (
                <div
                  className="absolute left-0 right-0 flex items-center justify-center"
-                 style={{ top: TSAT_ROW_TOP, height: ROW_HEIGHT, fontFamily: CONTENT_FONT, fontSize: CONTENT_FONT_SIZE }}
+                 style={{ top: TSAT_ROW_TOP, height: ROW_HEIGHT, fontFamily: CONTENT_FONT, fontSize: CONTENT_FONT_SIZE, color: tsatBarColor === CDM_GREEN ? "#000000" : undefined }}
                >
                  {`TSAT: ${formatTimeLabel(strip!.tsat).replace(":", "")}`}
                </div>

--- a/frontend/src/components/est/est-stand-cell.test.tsx
+++ b/frontend/src/components/est/est-stand-cell.test.tsx
@@ -104,6 +104,49 @@ describe("EstStandCell", () => {
 
     expect(screen.getByText("READY")).toBeDefined();
     expect(screen.getByTestId("est-ready-background").style.backgroundColor).toBe("rgb(0, 255, 38)");
+    expect(screen.getByText("READY").style.color).toBe("rgb(0, 0, 0)");
+  });
+
+  it("outlines a START REQ stand in orange when TOBT is not active", () => {
+    render(
+      <EstStandCell
+        stand={stand}
+        strip={makeStrip({ start_req: true, tobt: "", tsat: "" })}
+        blocked={false}
+        selected={false}
+        actionActive={false}
+        blinking={false}
+        startReqActive
+        ctotImproved={false}
+        nowMs={Date.now()}
+        onClick={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("button").style.boxShadow).toContain("inset 0 0 0 2px #DD6A12");
+  });
+
+  it("outlines a START REQ stand in green when TOBT is active", () => {
+    render(
+      <EstStandCell
+        stand={stand}
+        strip={makeStrip({ start_req: true, tobt: "1420", tsat: "1425" })}
+        blocked={false}
+        selected={false}
+        actionActive={false}
+        blinking={false}
+        startReqActive
+        ctotImproved={false}
+        nowMs={Date.UTC(2026, 6, 14, 14, 21, 0)}
+        onClick={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("button").style.boxShadow).toContain("inset 0 0 0 2px #00FF26");
+    expect(screen.getByTestId("est-tobt-background").style.top).toBe("88px");
+    expect(screen.getByTestId("est-tsat-background").style.top).toBe("105px");
+    expect(screen.getByText("TOBT:").parentElement?.style.color).toBe("rgb(0, 0, 0)");
+    expect(screen.getByText("TSAT: 1425").style.color).toBe("rgb(0, 0, 0)");
   });
 
   it("hides TOBT and TSAT during transfer to APRON but retains CTOT", () => {


### PR DESCRIPTION
## Summary

- Restore the START REQ stand indicator with a 2px inset border.
- Use orange when TOBT is inactive and green when TOBT is active.
- Add spacing between the TOBT and TSAT rows.
- Use black text on green READY, TOBT, and TSAT backgrounds.

Fixes #391.

## Validation

- `npm test -- --run src/components/est/est-stand-cell.test.tsx`
- `npx eslint src/components/est/EstStandCell.tsx src/components/est/est-stand-cell.test.tsx`
- `git diff --check`
