### PR TITLE
fix(strip): color H and L WTC labels

### DIFF
--- a/frontend/src/components/strip/ApnArrStrip.tsx
+++ b/frontend/src/components/strip/ApnArrStrip.tsx
@@ -1,8 +1,7 @@
 import { useState } from "react";
-import { getAircraftTypeWithWtc } from "@/lib/utils";
 import type { StripProps } from "./types";
 import FlightPlanDialog from "@/components/FlightPlanDialog";
-import { useStripCallsignInteraction, getCellBorderColor, getFlatStripBorderStyle, SELECTION_COLOR, COLOR_ARR_YELLOW, COLOR_UNEXPECTED_YELLOW, COLOR_MANUAL_BLUE, COLOR_TYPE_HEAVY, getStripOwnership, getCellTextColor, useStripBg, getValidationBlinkStyle, getValidationBlockedCursor, useNextFrequencyDisplay } from "./shared";
+import { AircraftTypeLabel, useStripCallsignInteraction, getCellBorderColor, getFlatStripBorderStyle, SELECTION_COLOR, COLOR_ARR_YELLOW, COLOR_UNEXPECTED_YELLOW, COLOR_MANUAL_BLUE, getStripOwnership, getCellTextColor, useStripBg, getValidationBlinkStyle, getValidationBlockedCursor, useNextFrequencyDisplay } from "./shared";
 import { useStripTransfers, useWebSocketStore } from "@/store/store-hooks";
 import { RunwayDialog } from "./RunwayDialog";
 import { ArrStandDialog } from "./ArrStandDialog";
@@ -129,7 +128,7 @@ export function ApnArrStrip({
       {/* A/C type / Registration */}
       <div className="flex flex-col border-r-2 min-w-0" style={{ flexGrow: F_TYPE, flexBasis: 0, height: "100%", borderRightColor: cellBorderColor }}>
         <div className="flex items-center justify-center" style={{ height: TOP_H }}>
-          <span className="truncate px-[0.21vw]" style={{ fontWeight: 600, fontSize: "0.63vw", color: aircraftCategory === "H" ? COLOR_TYPE_HEAVY : undefined }}>{getAircraftTypeWithWtc(aircraftType, aircraftCategory)}</span>
+          <AircraftTypeLabel className="truncate px-[0.21vw]" style={{ fontWeight: 600, fontSize: "0.63vw" }} aircraftType={aircraftType} aircraftCategory={aircraftCategory} />
         </div>
         <div style={{ height: BOT_H }} />
       </div>

--- a/frontend/src/components/strip/ApnPushStrip.tsx
+++ b/frontend/src/components/strip/ApnPushStrip.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { getAircraftTypeWithWtc } from "@/lib/utils";
 import type { StripProps } from "./types";
 import {
   useStripCallsignInteraction,
@@ -9,7 +8,7 @@ import {
   FONT,
   COLOR_UNEXPECTED_YELLOW,
   COLOR_MANUAL_BLUE,
-  COLOR_TYPE_HEAVY,
+  AircraftTypeLabel,
   getStripOwnership,
   getCellTextColor,
   useStripBg,
@@ -167,7 +166,7 @@ export function ApnPushStrip({
           style={{ flex: `${F_TYPE} 0 0%`, height: "100%", paddingBottom: "1.48dvh", minWidth: 0, borderRightColor: cellBorderColor, cursor: "pointer" }}
           onClick={(e) => { e.stopPropagation(); setFplOpen(true); }}
         >
-          <span className="truncate px-[0.21vw] leading-tight w-full text-center" style={{ fontFamily: FONT, fontSize: "0.52vw", color: aircraftCategory === "H" ? COLOR_TYPE_HEAVY : undefined }}>{getAircraftTypeWithWtc(aircraftType, aircraftCategory)}</span>
+          <AircraftTypeLabel className="truncate px-[0.21vw] leading-tight w-full text-center" style={{ fontFamily: FONT, fontSize: "0.52vw" }} aircraftType={aircraftType} aircraftCategory={aircraftCategory} />
           <span className="truncate px-[0.21vw] leading-tight w-full text-center" style={{ fontFamily: FONT, fontSize: "0.52vw" }}>{registration}</span>
         </div>
 

--- a/frontend/src/components/strip/ApnTaxiDepStrip.tsx
+++ b/frontend/src/components/strip/ApnTaxiDepStrip.tsx
@@ -8,7 +8,7 @@ import {
   FONT,
   COLOR_DEP_STRIP_BG,
   COLOR_UNEXPECTED_YELLOW,
-  COLOR_TYPE_HEAVY,
+  AircraftTypeLabel,
   getStripOwnership,
   getCellTextColor,
   useStripBg,
@@ -17,7 +17,6 @@ import {
   useNextFrequencyDisplay,
 } from "./shared";
 import { SIBox } from "./SIBox";
-import { getAircraftTypeWithWtc } from "@/lib/utils";
 import { useStripTransfers, useWebSocketStore } from "@/store/store-hooks";
 import { ApronTaxiMapDialog } from "@/components/map-dialogs/ApronTaxiMapDialog";
 import { useCTOTColor } from "@/hooks/useCTOTColor";
@@ -139,9 +138,7 @@ export function ApnTaxiDepStrip({
           style={{ flex: `${F_TYPE} 0 0%`, height: "100%", paddingBottom: BOT_H, minWidth: 0, borderRightColor: cellBorderColor, cursor: "pointer" }}
           onClick={(e) => { e.stopPropagation(); setFplOpen(true); }}
         >
-          <span className="truncate px-[0.21vw] leading-tight w-full text-center" style={{ fontFamily: FONT, fontSize: "0.52vw", color: aircraftCategory === "H" ? COLOR_TYPE_HEAVY : undefined }}>
-            {getAircraftTypeWithWtc(aircraftType, aircraftCategory)}
-          </span>
+          <AircraftTypeLabel className="truncate px-[0.21vw] leading-tight w-full text-center" style={{ fontFamily: FONT, fontSize: "0.52vw" }} aircraftType={aircraftType} aircraftCategory={aircraftCategory} />
           <span className="truncate px-[0.21vw] leading-tight w-full text-center" style={{ fontFamily: FONT, fontSize: "0.52vw" }}>
             {registration}
           </span>

--- a/frontend/src/components/strip/ClxHalfStrip.tsx
+++ b/frontend/src/components/strip/ClxHalfStrip.tsx
@@ -1,7 +1,6 @@
-import { getAircraftTypeWithWtc } from "@/lib/utils";
 import type { StripProps } from "./types";
 import { getStripBg } from "./types";
-import { FONT, STRIP_FRAME_COLOR, COLOR_SHADOW, COLOR_TYPE_HEAVY, useStripBg } from "./shared";
+import { AircraftTypeLabel, FONT, STRIP_FRAME_COLOR, COLOR_SHADOW, useStripBg } from "./shared";
 
 const CELL_BORDER = "border-r border-[var(--color-strip-frame)]"; // matches STRIP_FRAME_COLOR
 // Flex-grow proportions (flex-basis: 0 so space is shared proportionally)
@@ -70,9 +69,7 @@ export function ClxHalfStrip({
           style={{ flex: `${F_TYPE} 0 0%`, height: "100%", minWidth: 0 }}
         >
           <div className="flex items-center justify-center" style={{ height: "100%" }}>
-            <span className="truncate" style={{ fontFamily: FONT, fontSize: FONT_SIZE, color: aircraftCategory === "H" ? COLOR_TYPE_HEAVY : undefined }}>
-              {getAircraftTypeWithWtc(aircraftType, aircraftCategory)}
-            </span>
+            <AircraftTypeLabel className="truncate" style={{ fontFamily: FONT, fontSize: FONT_SIZE }} aircraftType={aircraftType} aircraftCategory={aircraftCategory} />
           </div>
         </div>
 

--- a/frontend/src/components/strip/FinalArrStrip.tsx
+++ b/frontend/src/components/strip/FinalArrStrip.tsx
@@ -1,10 +1,9 @@
 import { useState } from "react";
-import { getAircraftTypeWithWtc } from "@/lib/utils";
 import { useStripTransfers, useWebSocketStore } from "@/store/store-hooks";
 import FlightPlanDialog from "@/components/FlightPlanDialog";
 import { Bay } from "@/api/models";
 import type { StripProps } from "./types";
-import { useStripCallsignInteraction, getCellBorderColor, getFlatStripBorderStyle, SELECTION_COLOR, FONT, COLOR_ARR_YELLOW, COLOR_TYPE_HEAVY, getStripOwnership, useStripBg, getValidationBlinkStyle, getValidationBlockedCursor, useNextFrequencyDisplay } from "./shared";
+import { AircraftTypeLabel, useStripCallsignInteraction, getCellBorderColor, getFlatStripBorderStyle, SELECTION_COLOR, FONT, COLOR_ARR_YELLOW, getStripOwnership, useStripBg, getValidationBlinkStyle, getValidationBlockedCursor, useNextFrequencyDisplay } from "./shared";
 import { SIBox } from "./SIBox";
 import { ArrStandDialog } from "./ArrStandDialog";
 import { TaxiMapDialog } from "@/components/map-dialogs/TaxiMapDialog";
@@ -140,9 +139,7 @@ export function FinalArrStrip({
         style={{ flexGrow: F_TYPE, flexBasis: 0, height: "100%", borderRightColor: cellBorderColor }}
       >
         <div className="flex items-center justify-center" style={{ height: TOP_H }}>
-          <span className="truncate px-[0.21vw]" style={{ fontFamily: FONT, fontWeight: 600, fontSize: "0.63vw", color: aircraftCategory === "H" ? COLOR_TYPE_HEAVY : undefined }}>
-            {getAircraftTypeWithWtc(aircraftType, aircraftCategory)}
-          </span>
+          <AircraftTypeLabel className="truncate px-[0.21vw]" style={{ fontFamily: FONT, fontWeight: 600, fontSize: "0.63vw" }} aircraftType={aircraftType} aircraftCategory={aircraftCategory} />
         </div>
         <div
           className="flex items-center justify-center"

--- a/frontend/src/components/strip/GroundStrip.tsx
+++ b/frontend/src/components/strip/GroundStrip.tsx
@@ -1,7 +1,6 @@
-import { getAircraftTypeWithWtc } from "@/lib/utils";
 import { getStripBg } from "./types";
 import type { StripProps } from "./types";
-import { useStripCallsignInteraction, getCellBorderColor, getFlatStripBorderStyle, SELECTION_COLOR, COLOR_TYPE_HEAVY, getStripOwnership, useStripBg, getValidationBlinkStyle, getValidationBlockedCursor } from "./shared";
+import { AircraftTypeLabel, useStripCallsignInteraction, getCellBorderColor, getFlatStripBorderStyle, SELECTION_COLOR, getStripOwnership, useStripBg, getValidationBlinkStyle, getValidationBlockedCursor } from "./shared";
 import { useStripTransfers } from "@/store/store-hooks";
 import { SIBox } from "./SIBox";
 import { ValidationStatusDialog } from "./ValidationStatusDialog";
@@ -84,7 +83,7 @@ export function GroundStrip({
       {/* A/C type — 80px split (bottom reserved for registration) */}
       <div className="flex-shrink-0 flex flex-col border-r-2" style={{ width: "4.17vw", height: "100%", borderRightColor: cellBorderColor }}>
         <div className="flex items-center justify-center border-b-2" style={{ height: TOP_H, borderBottomColor: cellBorderColor }}>
-          <span className="truncate px-[0.21vw]" style={{ fontWeight: 600, fontSize: "0.63vw", color: aircraftCategory === "H" ? COLOR_TYPE_HEAVY : undefined }}>{getAircraftTypeWithWtc(aircraftType, aircraftCategory)}</span>
+          <AircraftTypeLabel className="truncate px-[0.21vw]" style={{ fontWeight: 600, fontSize: "0.63vw" }} aircraftType={aircraftType} aircraftCategory={aircraftCategory} />
         </div>
         <div style={{ height: BOT_H }} />
       </div>

--- a/frontend/src/components/strip/HalfStrip.tsx
+++ b/frontend/src/components/strip/HalfStrip.tsx
@@ -1,6 +1,5 @@
-import { getAircraftTypeWithWtc } from "@/lib/utils";
 import type { HalfStripVariant, StripProps } from "./types";
-import { useStripSelection, getCellBorderColor, getFlatStripBorderStyle, SELECTION_COLOR, COLOR_ARR_YELLOW, COLOR_DEP_STRIP_BG, COLOR_BTN_BLUE, COLOR_BTN_ORANGE, COLOR_UNEXPECTED_YELLOW, COLOR_MANUAL_BLUE, COLOR_TYPE_HEAVY, getCellTextColor, useStripBg } from "./shared";
+import { AircraftTypeLabel, useStripSelection, getCellBorderColor, getFlatStripBorderStyle, SELECTION_COLOR, COLOR_ARR_YELLOW, COLOR_DEP_STRIP_BG, COLOR_BTN_BLUE, COLOR_BTN_ORANGE, COLOR_UNEXPECTED_YELLOW, COLOR_MANUAL_BLUE, getCellTextColor, useStripBg } from "./shared";
 import { useStripTransfers, useWebSocketStore } from "@/store/store-hooks";
 
 // Variant-specific background colours
@@ -118,9 +117,7 @@ export function HalfStrip({
             className={`h-full w-[2.92vw] border-r-2 flex items-center justify-center text-[0.63vw] ${textColor}`}
             style={{ borderRightColor: cellBorderColor }}
           >
-            <span style={{ color: aircraftCategory === "H" ? COLOR_TYPE_HEAVY : undefined }}>
-              {getAircraftTypeWithWtc(aircraftType, aircraftCategory)}
-            </span>
+            <AircraftTypeLabel aircraftType={aircraftType} aircraftCategory={aircraftCategory} />
           </div>
           <div
             className={`h-full w-[2.92vw] border-r-2 flex items-center justify-center font-bold ${textColor}`}

--- a/frontend/src/components/strip/TwyDepStrip.tsx
+++ b/frontend/src/components/strip/TwyDepStrip.tsx
@@ -1,9 +1,8 @@
 import { useState } from "react";
-import { getAircraftTypeWithWtc } from "@/lib/utils";
+import { AircraftTypeLabel, COLOR_UNEXPECTED_YELLOW, getValidationBlockedCursor } from "./shared";
 import { useStripTransfers, useTransitionAltitude, useWebSocketStore } from "@/store/store-hooks";
 import { formatAltitude } from "@/lib/utils";
 import { useCTOTColor } from "@/hooks/useCTOTColor";
-import { COLOR_UNEXPECTED_YELLOW, COLOR_TYPE_HEAVY, getValidationBlockedCursor } from "./shared";
 import { getStripBg } from "./types";
 import type { StripProps } from "./types";
 import { useStripCallsignInteraction, getCellBorderColor, getFlatStripBorderStyle, SELECTION_COLOR, FONT, getStripOwnership, getCellTextColor, useStripBg, getValidationBlinkStyle, useNextFrequencyDisplay } from "./shared";
@@ -177,9 +176,7 @@ export function TwyDepStrip({
         style={{ flexGrow: F_TYPE_SQ, flexBasis: 0, height: "100%", borderRightColor: cellBorderColor }}
       >
         <div className="flex items-center justify-center overflow-hidden" style={{ height: HALF_H }}>
-          <span className="truncate px-[0.21vw]" style={{ fontFamily: FONT, fontWeight: "bold", fontSize: "0.68vw", color: aircraftCategory === "H" ? COLOR_TYPE_HEAVY : undefined }}>
-            {getAircraftTypeWithWtc(aircraftType, aircraftCategory)}
-          </span>
+          <AircraftTypeLabel className="truncate px-[0.21vw]" style={{ fontFamily: FONT, fontWeight: "bold", fontSize: "0.68vw" }} aircraftType={aircraftType} aircraftCategory={aircraftCategory} />
         </div>
         <div
           className="flex items-center justify-center overflow-hidden"

--- a/frontend/src/components/strip/shared.tsx
+++ b/frontend/src/components/strip/shared.tsx
@@ -10,6 +10,7 @@ import type { NextDisplay } from "@/api/models";
 import type { PdcStatus } from "@/api/models";
 import type { ValidationStatus } from "@/api/models";
 import { isValidationActiveForPosition, isValidationBlockingForPosition } from "@/lib/validation-status";
+import { getAircraftTypeWithWtc } from "@/lib/utils";
 
 export { isPdcValidationStatus, isValidationActiveForPosition, isValidationBlockingForPosition } from "@/lib/validation-status";
 
@@ -300,8 +301,27 @@ export const COLOR_BTN_DEFAULT   = "#646464";
 export const COLOR_BTN_ORANGE    = "var(--color-si-unconcerned)";
 /** Blue accent button background. */
 export const COLOR_BTN_BLUE      = "var(--color-half-mem-aid)";
-/** Heavy WTC aircraft type text color. */
-export const COLOR_TYPE_HEAVY    = "var(--color-type-heavy)";
+/** WTC/H and WTC/L aircraft type text color. */
+export const COLOR_TYPE_WTC      = "var(--color-type-wtc)";
+
+type AircraftTypeLabelProps = {
+  aircraftType: string | null | undefined;
+  aircraftCategory: string | null | undefined;
+  className?: string;
+  style?: CSSProperties;
+};
+
+/** Renders an aircraft type with its WTC suffix and the shared WTC color. */
+export function AircraftTypeLabel({ aircraftType, aircraftCategory, className, style }: AircraftTypeLabelProps) {
+  const isWtcColored = aircraftCategory === "H" || aircraftCategory === "L";
+
+  return (
+    <span className={className} style={{ ...style, ...(isWtcColored ? { color: COLOR_TYPE_WTC } : {}) }}>
+      {getAircraftTypeWithWtc(aircraftType, aircraftCategory)}
+    </span>
+  );
+}
+
 /** Yellow accent button background. */
 export const COLOR_BTN_YELLOW    = "#F3EA1F";
 /** Cyan background for departure / push strips (ApnPushStrip, ApnTaxiDepStrip, HalfStrip). */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -39,7 +39,7 @@
   /* ── Strip text colors ───────────────────────────────── */
   --color-field-modified:    #2751A3; /* controller-modified field text */
   --color-field-manual:      #21326A; /* manually entered field text */
-  --color-type-heavy:        #DD6A12; /* heavy WTC aircraft type text */
+  --color-type-wtc:          #A00005; /* WTC/H and WTC/L aircraft type text */
 
   /* ── SI (position ownership) indicator colors ────────── */
   --color-si-assumed:        #F0F0F0; /* strip assumed by current controller */


### PR DESCRIPTION
## What changed

- Add the `#A00005` WTC color for both WTC/H and WTC/L aircraft types.
- Centralize aircraft type and WTC label rendering in the shared `AircraftTypeLabel` component.

## Why

Issue #393 requested a dedicated color for WTC/H and WTC/L labels. Centralizing the rendering keeps the color and suffix behavior consistent across all strip variants.

## Validation

- `npm test -- --run` — 117 tests passed
- `npm run build` — passed
- ESLint on all changed TypeScript files — passed with existing Fast Refresh warnings in `shared.tsx`
