### PR TITLE
feat(aman): add technical health and observability

### DIFF
--- a/backend/internal/aman/health.go
+++ b/backend/internal/aman/health.go
@@ -1,0 +1,126 @@
+package aman
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"time"
+)
+
+// HealthStatus describes technical readiness. It deliberately has no
+// provider-approval or transport-delivery states: neither is an AMAN gate.
+type HealthStatus string
+
+const (
+	HealthDisabled    HealthStatus = "disabled"
+	HealthReady       HealthStatus = "ready"
+	HealthDegraded    HealthStatus = "degraded"
+	HealthUnavailable HealthStatus = "unavailable"
+)
+
+// ComponentHealth captures one bounded technical dependency. Reason is a
+// stable, operator-facing reason code; details belong in structured logs.
+type ComponentHealth struct {
+	Status     HealthStatus `json:"status"`
+	Reason     string       `json:"reason,omitempty"`
+	UpdatedAt  *time.Time   `json:"updated_at,omitempty"`
+	AgeSeconds *float64     `json:"age_seconds,omitempty"`
+}
+
+// TechnicalHealth is the complete AMAN readiness snapshot. It exposes the
+// inputs that can technically block authority without making a policy or
+// provider-approval decision itself.
+type TechnicalHealth struct {
+	Enabled          bool            `json:"enabled"`
+	Mode             RolloutMode     `json:"mode"`
+	Ready            bool            `json:"ready"`
+	Status           HealthStatus    `json:"status"`
+	BlockedReasons   []string        `json:"blocked_reasons,omitempty"`
+	VATSIM           ComponentHealth `json:"vatsim"`
+	Navigation       ComponentHealth `json:"navigation"`
+	Weather          ComponentHealth `json:"weather"`
+	Repository       ComponentHealth `json:"repository"`
+	Predictor        ComponentHealth `json:"predictor"`
+	ReplayValidation ComponentHealth `json:"replay_validation"`
+}
+
+// TechnicalHealthReporter is the narrow runtime seam for a concrete health
+// owner. It stays independent of HTTP, WebSocket hubs, and provider approval.
+type TechnicalHealthReporter interface {
+	Component
+	TechnicalHealth(context.Context) TechnicalHealth
+}
+
+// EvaluateTechnicalHealth creates one deterministic snapshot from concrete
+// component checks. Every non-ready component is named in BlockedReasons so
+// operators can identify the technical authority blocker directly.
+func EvaluateTechnicalHealth(mode RolloutMode, vatsim, navigation, weather, repository, predictor, replay ComponentHealth) TechnicalHealth {
+	report := TechnicalHealth{
+		Enabled: mode != ModeDisabled,
+		Mode:    mode,
+		VATSIM:  vatsim, Navigation: navigation, Weather: weather,
+		Repository: repository, Predictor: predictor, ReplayValidation: replay,
+	}
+	if !report.Enabled {
+		report.Status = HealthDisabled
+		return report
+	}
+	checks := []struct {
+		name  string
+		value ComponentHealth
+	}{
+		{"vatsim", vatsim}, {"navigation", navigation}, {"weather", weather},
+		{"repository", repository}, {"predictor", predictor}, {"replay_validation", replay},
+	}
+	for _, check := range checks {
+		if check.value.Status != HealthReady {
+			report.BlockedReasons = append(report.BlockedReasons, check.name+":"+healthReason(check.value))
+		}
+	}
+	report.Ready = len(report.BlockedReasons) == 0
+	if report.Ready {
+		report.Status = HealthReady
+	} else {
+		report.Status = HealthDegraded
+	}
+	return report
+}
+
+// Health returns the injected concrete report, with runtime configuration
+// applied as the effective mode. A missing reporter is visible as a technical
+// blocker rather than being mistaken for a healthy authoritative runtime.
+func (r *Runtime) Health(ctx context.Context) TechnicalHealth {
+	mode := ModeDisabled
+	if r != nil {
+		mode = r.config.Mode
+	}
+	if mode == ModeDisabled {
+		return EvaluateTechnicalHealth(mode, ComponentHealth{}, ComponentHealth{}, ComponentHealth{}, ComponentHealth{}, ComponentHealth{}, ComponentHealth{})
+	}
+	reporter, ok := r.deps.HealthService.(TechnicalHealthReporter)
+	if !ok {
+		unavailable := ComponentHealth{Status: HealthUnavailable, Reason: "health_reporter_unavailable"}
+		return EvaluateTechnicalHealth(mode, unavailable, unavailable, unavailable, unavailable, unavailable, unavailable)
+	}
+	report := reporter.TechnicalHealth(ctx)
+	report.Enabled, report.Mode = true, mode
+	return normalizeTechnicalHealth(report)
+}
+
+func normalizeTechnicalHealth(report TechnicalHealth) TechnicalHealth {
+	report.BlockedReasons = slices.Clone(report.BlockedReasons)
+	if report.Status == "" {
+		report = EvaluateTechnicalHealth(report.Mode, report.VATSIM, report.Navigation, report.Weather, report.Repository, report.Predictor, report.ReplayValidation)
+	}
+	return report
+}
+
+func healthReason(value ComponentHealth) string {
+	if reason := strings.TrimSpace(value.Reason); reason != "" {
+		return reason
+	}
+	if value.Status == "" {
+		return "not_reported"
+	}
+	return string(value.Status)
+}

--- a/backend/internal/aman/health_test.go
+++ b/backend/internal/aman/health_test.go
@@ -1,0 +1,81 @@
+package aman
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type healthTestComponent struct{ report TechnicalHealth }
+
+func (healthTestComponent) Name() string                                      { return "test health" }
+func (c healthTestComponent) TechnicalHealth(context.Context) TechnicalHealth { return c.report }
+
+func TestEvaluateTechnicalHealthNamesTechnicalAuthorityBlockers(t *testing.T) {
+	report := EvaluateTechnicalHealth(ModeAuthoritative,
+		ComponentHealth{Status: HealthReady},
+		ComponentHealth{Status: HealthDegraded, Reason: "terminal_geometry_invalid"},
+		ComponentHealth{Status: HealthReady},
+		ComponentHealth{Status: HealthReady},
+		ComponentHealth{Status: HealthUnavailable, Reason: "model_not_loaded"},
+		ComponentHealth{Status: HealthReady},
+	)
+	if report.Ready || report.Status != HealthDegraded {
+		t.Fatalf("unexpected readiness: %#v", report)
+	}
+	want := []string{"navigation:terminal_geometry_invalid", "predictor:model_not_loaded"}
+	if len(report.BlockedReasons) != len(want) {
+		t.Fatalf("blocked reasons = %#v, want %#v", report.BlockedReasons, want)
+	}
+	for index, reason := range want {
+		if report.BlockedReasons[index] != reason {
+			t.Fatalf("blocked reasons = %#v, want %#v", report.BlockedReasons, want)
+		}
+	}
+}
+
+func TestEvaluateTechnicalHealthRestoresAfterFreshInput(t *testing.T) {
+	stale := EvaluateTechnicalHealth(ModeAuthoritative,
+		ComponentHealth{Status: HealthDegraded, Reason: "snapshot_stale"}, ComponentHealth{Status: HealthReady},
+		ComponentHealth{Status: HealthReady}, ComponentHealth{Status: HealthReady}, ComponentHealth{Status: HealthReady}, ComponentHealth{Status: HealthReady},
+	)
+	fresh := EvaluateTechnicalHealth(ModeAuthoritative,
+		ComponentHealth{Status: HealthReady}, ComponentHealth{Status: HealthReady},
+		ComponentHealth{Status: HealthReady}, ComponentHealth{Status: HealthReady}, ComponentHealth{Status: HealthReady}, ComponentHealth{Status: HealthReady},
+	)
+	if stale.Ready || stale.BlockedReasons[0] != "vatsim:snapshot_stale" {
+		t.Fatalf("stale report = %#v", stale)
+	}
+	if !fresh.Ready || fresh.Status != HealthReady || len(fresh.BlockedReasons) != 0 {
+		t.Fatalf("fresh report = %#v", fresh)
+	}
+}
+
+func TestRuntimeHealthUsesEffectiveModeAndReporter(t *testing.T) {
+	now := time.Date(2026, time.July, 21, 12, 0, 0, 0, time.UTC)
+	reporter := healthTestComponent{report: EvaluateTechnicalHealth(ModeShadow,
+		ComponentHealth{Status: HealthReady, UpdatedAt: &now}, ComponentHealth{Status: HealthReady},
+		ComponentHealth{Status: HealthReady}, ComponentHealth{Status: HealthReady},
+		ComponentHealth{Status: HealthReady}, ComponentHealth{Status: HealthReady},
+	)}
+	runtime, err := NewRuntime(RuntimeConfig{Mode: ModeAuthoritative, EnabledAirports: []string{"EKCH"}, TerminalGeometryPath: "terminal.json", NavigationSourceAdapter: NavigationAdapterAIRACNet}, Dependencies{
+		Repositories: reporter, NavigationMaterializer: reporter, NavigationReader: reporter, Predictor: reporter,
+		StateEngine: reporter, SequenceService: reporter, Publisher: reporter, ValidationService: reporter,
+		HealthService: reporter, ReconciliationWorker: healthTestWorker{}, ObservationSink: healthTestSink{},
+	})
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+	report := runtime.Health(context.Background())
+	if !report.Ready || report.Mode != ModeAuthoritative || !report.Enabled || report.Status != HealthReady {
+		t.Fatalf("unexpected report: %#v", report)
+	}
+}
+
+type healthTestWorker struct{}
+
+func (healthTestWorker) Run(context.Context, time.Duration) {}
+
+type healthTestSink struct{}
+
+func (healthTestSink) Observe(context.Context, FlightObservation) error { return nil }

--- a/backend/internal/aman/materializer/materializer.go
+++ b/backend/internal/aman/materializer/materializer.go
@@ -15,6 +15,7 @@ import (
 	"FlightStrips/internal/aman"
 	"FlightStrips/internal/aman/navdata"
 	"FlightStrips/internal/aman/terminal"
+	"FlightStrips/internal/metrics"
 )
 
 const (
@@ -260,11 +261,18 @@ func (m *Materializer) Refresh(ctx context.Context, request Request) error {
 // MaterializeRoute is called by flight-plan/route-change handling, never by a
 // normal TETA tick. A warm cached key remains usable during a source outage.
 func (m *Materializer) MaterializeRoute(ctx context.Context, query navdata.RouteQuery, resolverVersion string) (navdata.RouteKey, error) {
+	started := time.Now()
 	geometry, err := m.deps.Routes.Resolve(ctx, query)
 	if err != nil {
+		metrics.RecordAMANRouteMaterialization(ctx, time.Since(started), "failure")
 		return "", err
 	}
 	key, err := m.deps.Cache.PutRoute(ctx, navdata.RouteCandidate{Query: query, ResolverVersion: resolverVersion, SchemaVersion: navdata.CanonicalSchemaVersion, Geometry: geometry, CreatedAt: m.deps.Now().UTC()})
+	if err != nil {
+		metrics.RecordAMANRouteMaterialization(ctx, time.Since(started), "failure")
+		return "", err
+	}
+	metrics.RecordAMANRouteMaterialization(ctx, time.Since(started), "success")
 	return key, err
 }
 

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -381,6 +381,7 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 		standAssignmentReadiness: standAssignmentReadiness,
 		amanRuntime:              amanRuntime,
 		handler: buildHandler(buildHandlerConfig{
+			amanRuntime:  amanRuntime,
 			authService:  authService,
 			frontendHub:  frontendHub,
 			euroscopeHub: euroscopeHub,
@@ -839,6 +840,7 @@ func configureCDM(
 }
 
 type buildHandlerConfig struct {
+	amanRuntime                *aman.Runtime
 	authService                shared.AuthenticationService
 	frontendHub                *frontend.Hub
 	euroscopeHub               *euroscope.Hub
@@ -871,7 +873,7 @@ func buildHandler(cfg buildHandlerConfig) http.Handler {
 	frontendUpgrader := websocket.NewConnectionUpgrader[pkgFrontend.EventType, *frontend.Client](cfg.frontendHub, cfg.authService)
 	euroscopeUpgrader := websocket.NewConnectionUpgrader[pkgEuroscope.EventType, *euroscope.Client](cfg.euroscopeHub, cfg.authService)
 
-	mux.HandleFunc("/healthz", satHealthz(cfg.standAssignmentReadiness, cfg.vatsimSource, cfg.standAssignmentStaleAfter))
+	mux.HandleFunc("/healthz", healthz(cfg.amanRuntime, cfg.standAssignmentReadiness, cfg.vatsimSource, cfg.standAssignmentStaleAfter))
 	mux.HandleFunc("/euroscopeEvents", euroscopeUpgrader.Upgrade)
 	mux.HandleFunc("/frontEndEvents", frontendUpgrader.Upgrade)
 	if cfg.enableALB {
@@ -915,8 +917,9 @@ func buildHandler(cfg buildHandlerConfig) http.Handler {
 }
 
 type healthResponse struct {
-	Status          string    `json:"status"`
-	StandAssignment satHealth `json:"stand_assignment"`
+	Status          string               `json:"status"`
+	StandAssignment satHealth            `json:"stand_assignment"`
+	AMAN            aman.TechnicalHealth `json:"aman"`
 }
 
 type satHealth struct {
@@ -927,9 +930,9 @@ type satHealth struct {
 	SnapshotAgeSeconds *float64 `json:"snapshot_age_seconds,omitempty"`
 }
 
-func satHealthz(readiness appconfig.StandAssignmentReadiness, cache vatsim.SnapshotSource, staleAfter time.Duration) http.HandlerFunc {
+func healthz(amanRuntime *aman.Runtime, readiness appconfig.StandAssignmentReadiness, cache vatsim.SnapshotSource, staleAfter time.Duration) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
-		result := healthResponse{Status: "ok", StandAssignment: satHealth{Enabled: readiness.Enabled, Ready: readiness.Ready, Status: "disabled"}}
+		result := healthResponse{Status: "ok", StandAssignment: satHealth{Enabled: readiness.Enabled, Ready: readiness.Ready, Status: "disabled"}, AMAN: evaluateAMANHealth(amanRuntime, cache, staleAfter)}
 		sat := &result.StandAssignment
 		switch {
 		case !readiness.Enabled:
@@ -943,10 +946,52 @@ func satHealthz(readiness appconfig.StandAssignmentReadiness, cache vatsim.Snaps
 				result.Status = "degraded"
 			}
 		}
+		if result.AMAN.Enabled && !result.AMAN.Ready {
+			result.Status = "degraded"
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK) // SAT degradation must not take unrelated features down.
 		_ = json.NewEncoder(w).Encode(result)
 	}
+}
+
+func evaluateAMANHealth(runtime *aman.Runtime, cache vatsim.SnapshotSource, staleAfter time.Duration) aman.TechnicalHealth {
+	report := runtime.Health(context.Background())
+	if !report.Enabled {
+		return report
+	}
+	report.VATSIM = amanVATSIMHealth(cache, staleAfter)
+	return aman.EvaluateTechnicalHealth(report.Mode, report.VATSIM, report.Navigation, report.Weather, report.Repository, report.Predictor, report.ReplayValidation)
+}
+
+func amanVATSIMHealth(cache vatsim.SnapshotSource, staleAfter time.Duration) aman.ComponentHealth {
+	if cache == nil {
+		return aman.ComponentHealth{Status: aman.HealthUnavailable, Reason: "feed_unavailable"}
+	}
+	snapshot := cache.Snapshot()
+	age := time.Since(snapshot.Timestamp)
+	if age < 0 {
+		age = 0
+	}
+	ageSeconds := age.Seconds()
+	result := aman.ComponentHealth{Status: aman.HealthReady, UpdatedAt: optionalHealthTime(snapshot.Timestamp), AgeSeconds: &ageSeconds}
+	switch {
+	case snapshot.Timestamp.IsZero():
+		result.Status, result.Reason = aman.HealthUnavailable, "snapshot_unavailable"
+	case snapshot.LastRefreshError != nil:
+		result.Status, result.Reason = aman.HealthUnavailable, "refresh_failed"
+	case age > staleAfter:
+		result.Status, result.Reason = aman.HealthDegraded, "snapshot_stale"
+	}
+	return result
+}
+
+func optionalHealthTime(value time.Time) *time.Time {
+	if value.IsZero() {
+		return nil
+	}
+	value = value.UTC()
+	return &value
 }
 
 func evaluateSATHealth(readiness appconfig.StandAssignmentReadiness, snapshot vatsim.Snapshot, staleAfter time.Duration) satHealth {

--- a/backend/internal/app/sat_health_test.go
+++ b/backend/internal/app/sat_health_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"FlightStrips/internal/aman"
 	appconfig "FlightStrips/internal/config"
 	"FlightStrips/internal/vatsim"
 	"errors"
@@ -33,3 +34,19 @@ func TestEvaluateSATHealthFeedStates(t *testing.T) {
 		})
 	}
 }
+
+func TestAMANVATSIMHealthReportsStaleReasonAndRestoration(t *testing.T) {
+	now := time.Now().UTC()
+	stale := amanVATSIMHealth(amanHealthSnapshotSource{snapshot: vatsim.Snapshot{Timestamp: now.Add(-2 * time.Minute)}}, time.Minute)
+	fresh := amanVATSIMHealth(amanHealthSnapshotSource{snapshot: vatsim.Snapshot{Timestamp: now}}, time.Minute)
+	if stale.Status != aman.HealthDegraded || stale.Reason != "snapshot_stale" || stale.AgeSeconds == nil {
+		t.Fatalf("stale AMAN VATSIM health = %#v", stale)
+	}
+	if fresh.Status != aman.HealthReady || fresh.Reason != "" || fresh.AgeSeconds == nil {
+		t.Fatalf("fresh AMAN VATSIM health = %#v", fresh)
+	}
+}
+
+type amanHealthSnapshotSource struct{ snapshot vatsim.Snapshot }
+
+func (s amanHealthSnapshotSource) Snapshot() vatsim.Snapshot { return s.snapshot }

--- a/backend/internal/metrics/metrics.go
+++ b/backend/internal/metrics/metrics.go
@@ -43,6 +43,18 @@ type instruments struct {
 	satOutcomes             metric.Int64Counter
 	satConflicts            metric.Int64Counter
 	satExpirations          metric.Int64Counter
+	amanObservationAge      metric.Float64Histogram
+	amanGeometryCache       metric.Int64Counter
+	amanRouteMaterialized   metric.Int64Counter
+	amanRouteDuration       metric.Float64Histogram
+	amanPredictorDuration   metric.Float64Histogram
+	amanPredictionDrift     metric.Float64Histogram
+	amanSequenceRevisions   metric.Int64Counter
+	amanSequenceConflicts   metric.Int64Counter
+	amanCommandOutcomes     metric.Int64Counter
+	amanFlightDegradation   metric.Int64Counter
+	amanSourceRefreshes     metric.Int64Counter
+	amanPublicationFailures metric.Int64Counter
 }
 
 func get() *instruments {
@@ -157,6 +169,18 @@ func get() *instruments {
 		satOutcomes, _ := meter.Int64Counter("sat.allocation.outcomes", metric.WithDescription("SAT allocation outcomes"), metric.WithUnit("{result}"))
 		satConflicts, _ := meter.Int64Counter("sat.allocation.conflicts", metric.WithDescription("SAT allocation database and occupancy conflicts"), metric.WithUnit("{conflict}"))
 		satExpirations, _ := meter.Int64Counter("sat.assignments.expired", metric.WithDescription("SAT assignments expired or released"), metric.WithUnit("{assignment}"))
+		amanObservationAge, _ := meter.Float64Histogram("aman.observation.age", metric.WithDescription("Age of AMAN source observations"), metric.WithUnit("s"), metric.WithExplicitBucketBoundaries(1, 5, 15, 30, 60, 120, 300))
+		amanGeometryCache, _ := meter.Int64Counter("aman.geometry.cache", metric.WithDescription("AMAN geometry cache lookups"), metric.WithUnit("{lookup}"))
+		amanRouteMaterialized, _ := meter.Int64Counter("aman.route.materialization", metric.WithDescription("Explicit AMAN route materialization attempts"), metric.WithUnit("{route}"))
+		amanRouteDuration, _ := meter.Float64Histogram("aman.route.materialization.duration", metric.WithDescription("AMAN route materialization duration"), metric.WithUnit("s"), metric.WithExplicitBucketBoundaries(.01, .05, .1, .25, .5, 1, 2, 5))
+		amanPredictorDuration, _ := meter.Float64Histogram("aman.predictor.duration", metric.WithDescription("AMAN predictor duration"), metric.WithUnit("s"), metric.WithExplicitBucketBoundaries(.001, .005, .01, .05, .1, .5, 1))
+		amanPredictionDrift, _ := meter.Float64Histogram("aman.prediction.drift", metric.WithDescription("AMAN raw, operational, and Superstable prediction drift"), metric.WithUnit("s"), metric.WithExplicitBucketBoundaries(1, 5, 15, 30, 60, 120, 300))
+		amanSequenceRevisions, _ := meter.Int64Counter("aman.sequence.revisions", metric.WithDescription("Committed AMAN sequence revisions"), metric.WithUnit("{revision}"))
+		amanSequenceConflicts, _ := meter.Int64Counter("aman.sequence.conflicts", metric.WithDescription("AMAN sequence revision conflicts"), metric.WithUnit("{conflict}"))
+		amanCommandOutcomes, _ := meter.Int64Counter("aman.commands", metric.WithDescription("AMAN command outcomes"), metric.WithUnit("{command}"))
+		amanFlightDegradation, _ := meter.Int64Counter("aman.flights.degraded", metric.WithDescription("AMAN stale and disconnected flight transitions"), metric.WithUnit("{flight}"))
+		amanSourceRefreshes, _ := meter.Int64Counter("aman.source.refreshes", metric.WithDescription("AMAN source refresh attempts"), metric.WithUnit("{refresh}"))
+		amanPublicationFailures, _ := meter.Int64Counter("aman.publication.failures", metric.WithDescription("Post-commit AMAN replacement publication failures"), metric.WithUnit("{publication}"))
 
 		inst = &instruments{
 			activeConnections:       activeConnections,
@@ -179,12 +203,77 @@ func get() *instruments {
 			trafficTaxiing:          trafficTaxiing,
 			trafficArrivalRate15m:   trafficArrivalRate15m,
 			trafficDepartureRate15m: trafficDepartureRate15m,
-			satSnapshotAge: satSnapshotAge, satFeedRecords: satFeedRecords,
+			satSnapshotAge:          satSnapshotAge, satFeedRecords: satFeedRecords,
 			satAssignments: satAssignments, satOutcomes: satOutcomes,
 			satConflicts: satConflicts, satExpirations: satExpirations,
+			amanObservationAge: amanObservationAge, amanGeometryCache: amanGeometryCache,
+			amanRouteMaterialized: amanRouteMaterialized, amanRouteDuration: amanRouteDuration,
+			amanPredictorDuration: amanPredictorDuration, amanPredictionDrift: amanPredictionDrift,
+			amanSequenceRevisions: amanSequenceRevisions, amanSequenceConflicts: amanSequenceConflicts,
+			amanCommandOutcomes: amanCommandOutcomes, amanFlightDegradation: amanFlightDegradation,
+			amanSourceRefreshes: amanSourceRefreshes, amanPublicationFailures: amanPublicationFailures,
 		}
 	})
 	return inst
+}
+
+// AMAN metrics intentionally accept only fixed vocabulary labels. In
+// particular, callsigns, route text, command IDs, and provider payloads never
+// become metric dimensions.
+func RecordAMANObservation(ctx context.Context, age time.Duration, state string) {
+	get().amanObservationAge.Record(ctx, max(age.Seconds(), 0), metric.WithAttributes(attribute.String("state", amanStateLabel(state))))
+}
+
+func RecordAMANGeometryCache(ctx context.Context, outcome string) {
+	get().amanGeometryCache.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", fixedAMANLabel(outcome, "hit", "miss", "error"))))
+}
+
+func RecordAMANRouteMaterialization(ctx context.Context, duration time.Duration, outcome string) {
+	attrs := metric.WithAttributes(attribute.String("outcome", fixedAMANLabel(outcome, "success", "failure")))
+	i := get()
+	i.amanRouteMaterialized.Add(ctx, 1, attrs)
+	i.amanRouteDuration.Record(ctx, max(duration.Seconds(), 0), attrs)
+}
+
+func RecordAMANPredictor(ctx context.Context, duration time.Duration, confidence, degradation string) {
+	get().amanPredictorDuration.Record(ctx, max(duration.Seconds(), 0), metric.WithAttributes(
+		attribute.String("confidence", fixedAMANLabel(confidence, "unknown", "low", "medium", "high")),
+		attribute.String("degradation", fixedAMANLabel(degradation, "none", "weather", "geometry", "performance", "source")),
+	))
+}
+
+func RecordAMANPredictionDrift(ctx context.Context, kind string, drift time.Duration) {
+	get().amanPredictionDrift.Record(ctx, max(drift.Seconds(), 0), metric.WithAttributes(attribute.String("kind", fixedAMANLabel(kind, "raw_operational", "superstable"))))
+}
+
+func RecordAMANSequenceRevision(ctx context.Context) { get().amanSequenceRevisions.Add(ctx, 1) }
+func RecordAMANSequenceConflict(ctx context.Context, kind string) {
+	get().amanSequenceConflicts.Add(ctx, 1, metric.WithAttributes(attribute.String("kind", fixedAMANLabel(kind, "revision", "command", "policy"))))
+}
+func RecordAMANCommand(ctx context.Context, outcome string) {
+	get().amanCommandOutcomes.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", fixedAMANLabel(outcome, "accepted", "rejected", "duplicate", "failed"))))
+}
+func RecordAMANFlightDegradation(ctx context.Context, state string) {
+	get().amanFlightDegradation.Add(ctx, 1, metric.WithAttributes(attribute.String("state", amanStateLabel(state))))
+}
+func RecordAMANSourceRefresh(ctx context.Context, source, outcome string) {
+	get().amanSourceRefreshes.Add(ctx, 1, metric.WithAttributes(attribute.String("source", fixedAMANLabel(source, "vatsim", "navigation", "weather")), attribute.String("outcome", fixedAMANLabel(outcome, "success", "failure", "stale", "disconnected"))))
+}
+func RecordAMANPublicationFailure(ctx context.Context, destination string) {
+	get().amanPublicationFailures.Add(ctx, 1, metric.WithAttributes(attribute.String("destination", fixedAMANLabel(destination, "frontend", "euroscope"))))
+}
+
+func amanStateLabel(value string) string {
+	return fixedAMANLabel(value, "fresh", "stale", "disconnected")
+}
+func fixedAMANLabel(value string, allowed ...string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	for _, candidate := range allowed {
+		if value == candidate {
+			return value
+		}
+	}
+	return "other"
 }
 
 // RecordSATFeedSnapshot records only operational dimensions. Callsigns, CIDs,
@@ -204,7 +293,9 @@ func RecordSATRelevantFlights(ctx context.Context, sessionName, airport string, 
 
 func RecordSATAssignment(ctx context.Context, stage, source, category string, tier int) {
 	attrs := []attribute.KeyValue{attribute.String("stage", stage), attribute.String("source", source), attribute.String("category", category)}
-	if tier > 0 { attrs = append(attrs, attribute.Int("tier", tier)) }
+	if tier > 0 {
+		attrs = append(attrs, attribute.Int("tier", tier))
+	}
 	get().satAssignments.Add(ctx, 1, metric.WithAttributes(attrs...))
 }
 

--- a/backend/internal/metrics/metrics_test.go
+++ b/backend/internal/metrics/metrics_test.go
@@ -276,8 +276,79 @@ func TestSATMetricsAvoidPersonalDataDimensions(t *testing.T) {
 	RecordSATExpiration(ctx, "DEPARTURE", "RESERVED")
 	rm := collectMetrics(t, reader)
 
-	if got := findInt64MetricValue(t, rm, "sat.assignments", map[string]string{"stage": "ASSIGNED", "source": "AUTOMATIC", "category": "airline_rule"}); got != 1 { t.Fatalf("expected assignment counter 1, got %d", got) }
-	if got := findInt64MetricValue(t, rm, "sat.allocation.outcomes", map[string]string{"outcome": "no_compatible_stand", "category": "ARRIVAL"}); got != 1 { t.Fatalf("expected outcome counter 1, got %d", got) }
-	if got := findInt64MetricValue(t, rm, "sat.allocation.conflicts", map[string]string{"kind": "database_contention"}); got != 1 { t.Fatalf("expected conflict counter 1, got %d", got) }
-	if got := findInt64MetricValue(t, rm, "sat.assignments.expired", map[string]string{"direction": "DEPARTURE", "stage": "RESERVED"}); got != 1 { t.Fatalf("expected expiration counter 1, got %d", got) }
+	if got := findInt64MetricValue(t, rm, "sat.assignments", map[string]string{"stage": "ASSIGNED", "source": "AUTOMATIC", "category": "airline_rule"}); got != 1 {
+		t.Fatalf("expected assignment counter 1, got %d", got)
+	}
+	if got := findInt64MetricValue(t, rm, "sat.allocation.outcomes", map[string]string{"outcome": "no_compatible_stand", "category": "ARRIVAL"}); got != 1 {
+		t.Fatalf("expected outcome counter 1, got %d", got)
+	}
+	if got := findInt64MetricValue(t, rm, "sat.allocation.conflicts", map[string]string{"kind": "database_contention"}); got != 1 {
+		t.Fatalf("expected conflict counter 1, got %d", got)
+	}
+	if got := findInt64MetricValue(t, rm, "sat.assignments.expired", map[string]string{"direction": "DEPARTURE", "stage": "RESERVED"}); got != 1 {
+		t.Fatalf("expected expiration counter 1, got %d", got)
+	}
+}
+
+func TestAMANMetricsBoundLabelsAndExcludeFlightIdentifiers(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	previousProvider := otel.GetMeterProvider()
+	otel.SetMeterProvider(provider)
+	resetInstrumentsForTest()
+	t.Cleanup(func() { otel.SetMeterProvider(previousProvider); resetInstrumentsForTest() })
+
+	ctx := context.Background()
+	RecordAMANObservation(ctx, 3*time.Second, "SAS123")
+	RecordAMANGeometryCache(ctx, "hit")
+	RecordAMANRouteMaterialization(ctx, 20*time.Millisecond, "success")
+	RecordAMANPredictor(ctx, 10*time.Millisecond, "high", "weather")
+	RecordAMANPredictionDrift(ctx, "superstable", 2*time.Second)
+	RecordAMANSequenceRevision(ctx)
+	RecordAMANSequenceConflict(ctx, "revision")
+	RecordAMANCommand(ctx, "accepted")
+	RecordAMANFlightDegradation(ctx, "disconnected")
+	RecordAMANSourceRefresh(ctx, "vatsim", "stale")
+	RecordAMANPublicationFailure(ctx, "frontend")
+	rm := collectMetrics(t, reader)
+
+	if got := findInt64MetricValue(t, rm, "aman.geometry.cache", map[string]string{"outcome": "hit"}); got != 1 {
+		t.Fatalf("geometry cache = %d, want 1", got)
+	}
+	if got := findInt64MetricValue(t, rm, "aman.commands", map[string]string{"outcome": "accepted"}); got != 1 {
+		t.Fatalf("commands = %d, want 1", got)
+	}
+	if got := findFloat64HistogramSum(t, rm, "aman.observation.age", map[string]string{"state": "other"}); got != 3 {
+		t.Fatalf("observation age = %f, want 3", got)
+	}
+
+	for _, scope := range rm.ScopeMetrics {
+		for _, recorded := range scope.Metrics {
+			if len(recorded.Name) < 5 || recorded.Name[:5] != "aman." {
+				continue
+			}
+			for _, attrs := range metricAttributeSets(recorded.Data) {
+				for _, attribute := range attrs.ToSlice() {
+					if attribute.Value.AsString() == "SAS123" || string(attribute.Key) == "callsign" || string(attribute.Key) == "route" || string(attribute.Key) == "command_id" {
+						t.Fatalf("AMAN metric %s contains unbounded attribute %s=%s", recorded.Name, attribute.Key, attribute.Value.AsString())
+					}
+				}
+			}
+		}
+	}
+}
+
+func metricAttributeSets(data metricdata.Aggregation) []attribute.Set {
+	var result []attribute.Set
+	switch values := data.(type) {
+	case metricdata.Sum[int64]:
+		for _, point := range values.DataPoints {
+			result = append(result, point.Attributes)
+		}
+	case metricdata.Histogram[float64]:
+		for _, point := range values.DataPoints {
+			result = append(result, point.Attributes)
+		}
+	}
+	return result
 }

--- a/backend/internal/repository/postgres/aman_test.go
+++ b/backend/internal/repository/postgres/aman_test.go
@@ -85,6 +85,31 @@ func TestAMANRepositoryRoundTripIdempotencyAndRollback(t *testing.T) {
 	require.Equal(t, corrected, loaded, "a failed transaction must leave the complete prior aggregate")
 }
 
+func TestAMANRepositoryRollsBackInvalidAuditAndCommitsStructuredAudit(t *testing.T) {
+	pool, _ := testdata.SetupTestDB(t)
+	repo := NewAMANRepository(pool)
+	ctx := context.Background()
+	state := amanState(1, "CID-AUDIT", "SAS330")
+
+	_, err := repo.Commit(ctx, aman.StateCommit{
+		ExpectedRevision: 0, State: state,
+		AuditRecords: []aman.AuditRecord{{Airport: state.Airport, Revision: state.Revision, Category: "", Payload: []byte(`{"event":"rejected"}`), RecordedAt: amanTestTime}},
+	})
+	require.Error(t, err)
+	_, err = repo.LoadAirportState(ctx, state.Airport)
+	require.Error(t, err, "a rejected audit record must roll back the accompanying state")
+
+	_, err = repo.Commit(ctx, aman.StateCommit{
+		ExpectedRevision: 0, State: state,
+		AuditRecords: []aman.AuditRecord{{Airport: state.Airport, Revision: state.Revision, Category: "command_accepted", Payload: []byte(`{"command_type":"freeze","outcome":"accepted"}`), RecordedAt: amanTestTime}},
+	})
+	require.NoError(t, err)
+	audits, err := repo.ListAuditRecords(ctx, state.Airport)
+	require.NoError(t, err)
+	require.Len(t, audits, 1)
+	require.JSONEq(t, `{"command_type":"freeze","outcome":"accepted"}`, string(audits[0].Payload))
+}
+
 func TestAMANRepositoryRestoresHeldAirborneBaselineForFreshPredictor(t *testing.T) {
 	pool, _ := testdata.SetupTestDB(t)
 	ctx := context.Background()

--- a/backend/internal/vatsim/aman_observations.go
+++ b/backend/internal/vatsim/aman_observations.go
@@ -2,6 +2,7 @@ package vatsim
 
 import (
 	"FlightStrips/internal/aman"
+	"FlightStrips/internal/metrics"
 	"context"
 	"errors"
 	"fmt"
@@ -102,6 +103,8 @@ func (w *ObservationWorker) Publish(ctx context.Context) error {
 	snapshot := w.cache.Snapshot()
 	now := w.now().UTC()
 	status := observationSourceStatus(snapshot, now, w.staleAfter)
+	metrics.RecordAMANObservation(ctx, now.Sub(snapshot.Timestamp), string(status))
+	metrics.RecordAMANSourceRefresh(ctx, "vatsim", string(status))
 	current := make(map[string]aman.FlightObservation)
 	failed := make(map[string]struct{})
 	var publishErrors []error


### PR DESCRIPTION
## Summary

- expose a typed AMAN technical-health report through /healthz, including VATSIM freshness and explicit authority-blocking reasons
- add bounded AMAN OpenTelemetry metrics and instrument VATSIM observations plus route materialization
- verify audit records commit and roll back atomically with their state transition

No provider-approval gate, WebSocket outbox, or durable delivery state is introduced.

Closes #330

## Validation

go test ./internal/app ./internal/aman ./internal/metrics ./internal/vatsim ./internal/aman/materializer

go test ./internal/repository/postgres -run TestAMANRepository -count=1

git diff --check