### PR TITLE
feat(aman): enforce rollout gates

### DIFF
--- a/backend/internal/aman/gate/gate.go
+++ b/backend/internal/aman/gate/gate.go
@@ -1,0 +1,223 @@
+// Package gate applies the technical and replay-validation prerequisites for
+// AMAN operational rollout modes. It consumes the canonical validation report
+// rather than defining a second evidence payload.
+package gate
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/aman/report"
+)
+
+const (
+	ReasonEvidenceUnavailable = "validation_evidence_unavailable"
+	ReasonEvidenceMissing     = "validation_evidence_missing"
+	ReasonEvidenceCorrupt     = "validation_evidence_corrupt"
+	ReasonEvidenceFuture      = "validation_evidence_future"
+	ReasonEvidenceStale       = "validation_evidence_stale"
+	ReasonEvidenceFailed      = "validation_evidence_failed"
+	ReasonDigestMismatch      = "validation_evidence_digest_mismatch"
+)
+
+// Digests are the active inputs that must match a replay result before it can
+// grant operational AMAN authority.
+type Digests struct {
+	Code       string
+	Config     string
+	Policy     string
+	Navigation string
+	Terminal   string
+	Holding    string
+	Weather    string
+}
+
+func (d Digests) validate() error {
+	for _, value := range []string{d.Code, d.Config, d.Policy, d.Navigation, d.Terminal, d.Holding, d.Weather} {
+		if strings.TrimSpace(value) == "" {
+			return errors.New("rollout gate requires every active validation digest")
+		}
+	}
+	return nil
+}
+
+// Config controls validation-result freshness and the active inputs against
+// which report metadata is compared.
+type Config struct {
+	MaximumEvidenceAge time.Duration
+	ExpectedDigests    Digests
+}
+
+func (c Config) validate() error {
+	if c.MaximumEvidenceAge <= 0 {
+		return errors.New("rollout gate maximum evidence age must be greater than 0")
+	}
+	return c.ExpectedDigests.validate()
+}
+
+// Decision exposes desired and effective state separately. Blocked is an
+// effective state only; it never rewrites the configured desired mode.
+type Decision struct {
+	DesiredMode      aman.RolloutMode
+	EffectiveMode    aman.EffectiveRolloutMode
+	AuthorityAllowed bool
+	Ownership        aman.Ownership
+	BlockedReasons   []string
+}
+
+// Apply annotates the health payload consumed by controller-facing health
+// endpoints. A blocked decision is degraded and keeps the complete technical
+// and validation reason list visible.
+func (d Decision) Apply(health aman.TechnicalHealth) aman.TechnicalHealth {
+	health.Mode = d.DesiredMode
+	health.DesiredMode = d.DesiredMode
+	health.EffectiveMode = d.EffectiveMode
+	health.AuthorityAllowed = d.AuthorityAllowed
+	if d.EffectiveMode == aman.EffectiveBlocked {
+		health.Ready = false
+		health.Status = aman.HealthDegraded
+		health.BlockedReasons = appendUnique(health.BlockedReasons, d.BlockedReasons)
+	}
+	return health
+}
+
+// Evaluator reads persisted canonical evidence. Now is injected so stale and
+// future boundaries are deterministic in production and replay tests.
+type Evaluator struct {
+	evidence aman.ValidationEvidenceReader
+	config   Config
+	now      func() time.Time
+}
+
+func New(evidence aman.ValidationEvidenceReader, config Config, now func() time.Time) (*Evaluator, error) {
+	if evidence == nil {
+		return nil, errors.New("rollout gate requires validation evidence reader")
+	}
+	if err := config.validate(); err != nil {
+		return nil, err
+	}
+	if now == nil {
+		return nil, errors.New("rollout gate requires clock")
+	}
+	return &Evaluator{evidence: evidence, config: config, now: now}, nil
+}
+
+// EvaluateAirport is fail-closed for read-only and authoritative desired
+// modes. Disabled and shadow remain deterministic desired modes; shadow
+// continues to collect comparison evidence but never consumes it to grant
+// authority.
+func (e *Evaluator) EvaluateAirport(ctx context.Context, airport string, desired aman.RolloutMode, technical aman.TechnicalHealth) Decision {
+	if !desired.Valid() {
+		return blocked(desired, []string{"invalid_desired_mode"})
+	}
+	if !isOperational(desired) {
+		return allowed(desired)
+	}
+	health := aman.EvaluateTechnicalHealth(desired, technical.VATSIM, technical.Navigation, technical.Weather, technical.Repository, technical.Predictor, technical.ReplayValidation)
+	reasons := slices.Clone(health.BlockedReasons)
+	reasons = append(reasons, e.currentEvidenceReasons(ctx, airport)...)
+	if len(reasons) > 0 {
+		return blocked(desired, reasons)
+	}
+	return allowed(desired)
+}
+
+func (e *Evaluator) currentEvidenceReasons(ctx context.Context, airport string) []string {
+	if strings.TrimSpace(airport) == "" {
+		return []string{ReasonEvidenceMissing}
+	}
+	evidence, err := e.evidence.ListValidationEvidence(ctx, airport)
+	if err != nil {
+		return []string{ReasonEvidenceUnavailable}
+	}
+	latest, ok := newestReport(evidence)
+	if !ok {
+		return []string{ReasonEvidenceMissing}
+	}
+	now := e.now()
+	if now.IsZero() || latest.RecordedAt.IsZero() || latest.RecordedAt.After(now) {
+		return []string{ReasonEvidenceFuture}
+	}
+	reportValue, err := report.Decode(bytes.NewReader(latest.Payload))
+	if err != nil {
+		return []string{ReasonEvidenceCorrupt}
+	}
+	if reportValue.Metadata.Airport != airport {
+		return []string{ReasonEvidenceCorrupt}
+	}
+	if reportValue.Metadata.EvaluatedAt.After(now) {
+		return []string{ReasonEvidenceFuture}
+	}
+	if now.Sub(latest.RecordedAt) > e.config.MaximumEvidenceAge || now.Sub(reportValue.Metadata.EvaluatedAt) > e.config.MaximumEvidenceAge {
+		return []string{ReasonEvidenceStale}
+	}
+	if !reportValue.Passed {
+		return []string{ReasonEvidenceFailed}
+	}
+	if !e.matches(reportValue.Metadata) {
+		return []string{ReasonDigestMismatch}
+	}
+	return nil
+}
+
+func (e *Evaluator) matches(metadata report.Metadata) bool {
+	expected := e.config.ExpectedDigests
+	return metadata.CodeDigest == expected.Code && metadata.ConfigDigest == expected.Config && metadata.PolicyDigest == expected.Policy && metadata.NavigationDigest == expected.Navigation && metadata.TerminalDigest == expected.Terminal && metadata.HoldingDigest == expected.Holding && metadata.WeatherDigest == expected.Weather
+}
+
+func newestReport(values []aman.ValidationEvidence) (aman.ValidationEvidence, bool) {
+	candidates := make([]aman.ValidationEvidence, 0, len(values))
+	for _, value := range values {
+		if value.Kind == report.Version {
+			candidates = append(candidates, value)
+		}
+	}
+	if len(candidates) == 0 {
+		return aman.ValidationEvidence{}, false
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].RecordedAt.Equal(candidates[j].RecordedAt) {
+			return candidates[i].ID > candidates[j].ID
+		}
+		return candidates[i].RecordedAt.After(candidates[j].RecordedAt)
+	})
+	return candidates[0], true
+}
+
+func allowed(desired aman.RolloutMode) Decision {
+	authority := isOperational(desired)
+	return Decision{DesiredMode: desired, EffectiveMode: aman.EffectiveModeFor(desired), AuthorityAllowed: authority, Ownership: aman.OwnershipForRolloutGate(desired, authority)}
+}
+
+func blocked(desired aman.RolloutMode, reasons []string) Decision {
+	reasons = appendUnique(nil, reasons)
+	return Decision{DesiredMode: desired, EffectiveMode: aman.EffectiveBlocked, Ownership: aman.OwnershipForRolloutGate(desired, false), BlockedReasons: reasons}
+}
+
+func isOperational(mode aman.RolloutMode) bool {
+	return mode == aman.ModeReadOnly || mode == aman.ModeAuthoritative
+}
+
+func appendUnique(base []string, values []string) []string {
+	seen := make(map[string]struct{}, len(base)+len(values))
+	for _, value := range base {
+		seen[value] = struct{}{}
+	}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, found := seen[value]; !found {
+			seen[value] = struct{}{}
+			base = append(base, value)
+		}
+	}
+	return base
+}

--- a/backend/internal/aman/gate/gate_test.go
+++ b/backend/internal/aman/gate/gate_test.go
@@ -1,0 +1,182 @@
+package gate
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/aman/report"
+	"github.com/stretchr/testify/require"
+)
+
+var gateNow = time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)
+
+type evidenceReader struct {
+	values []aman.ValidationEvidence
+	err    error
+}
+
+func (r *evidenceReader) ListValidationEvidence(context.Context, string) ([]aman.ValidationEvidence, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.values, nil
+}
+
+func TestEvaluatorModeAndOwnershipMatrix(t *testing.T) {
+	reader := &evidenceReader{values: []aman.ValidationEvidence{validationEvidence(t, gateNow, gateNow, true, "EKCH")}}
+	evaluator := newEvaluator(t, reader)
+	technical := readyTechnical()
+
+	tests := []struct {
+		desired                          aman.RolloutMode
+		effective                        aman.EffectiveRolloutMode
+		authority, legacyWriter, amanETA bool
+	}{
+		{desired: aman.ModeDisabled, effective: aman.EffectiveDisabled, legacyWriter: true},
+		{desired: aman.ModeShadow, effective: aman.EffectiveShadow, legacyWriter: true},
+		{desired: aman.ModeReadOnly, effective: aman.EffectiveReadOnly, authority: true, amanETA: true},
+		{desired: aman.ModeAuthoritative, effective: aman.EffectiveAuthoritative, authority: true, amanETA: true},
+	}
+	for _, test := range tests {
+		t.Run(string(test.desired), func(t *testing.T) {
+			decision := evaluator.EvaluateAirport(context.Background(), "EKCH", test.desired, technical)
+			require.Equal(t, test.desired, decision.DesiredMode)
+			require.Equal(t, test.effective, decision.EffectiveMode)
+			require.Equal(t, test.authority, decision.AuthorityAllowed)
+			require.Equal(t, test.legacyWriter, decision.Ownership.LegacyArrivalETAWriter)
+			require.Equal(t, test.amanETA, decision.Ownership.AMANArrivalETAWriter)
+			require.Empty(t, decision.BlockedReasons)
+		})
+	}
+}
+
+func TestEvaluatorBlocksOperationalModesWithoutLegacyFallback(t *testing.T) {
+	reader := &evidenceReader{values: []aman.ValidationEvidence{validationEvidence(t, gateNow, gateNow, true, "EKCH")}}
+	evaluator := newEvaluator(t, reader)
+	technical := readyTechnical()
+	technical.VATSIM = aman.ComponentHealth{Status: aman.HealthDegraded, Reason: "snapshot_stale"}
+
+	for _, desired := range []aman.RolloutMode{aman.ModeReadOnly, aman.ModeAuthoritative} {
+		t.Run(string(desired), func(t *testing.T) {
+			decision := evaluator.EvaluateAirport(context.Background(), "EKCH", desired, technical)
+			require.Equal(t, aman.EffectiveBlocked, decision.EffectiveMode)
+			require.False(t, decision.AuthorityAllowed)
+			require.False(t, decision.Ownership.LegacyArrivalETAWriter)
+			require.False(t, decision.Ownership.AMANArrivalETAWriter)
+			require.Contains(t, decision.BlockedReasons, "vatsim:snapshot_stale")
+
+			health := decision.Apply(technical)
+			require.Equal(t, desired, health.DesiredMode)
+			require.Equal(t, aman.EffectiveBlocked, health.EffectiveMode)
+			require.False(t, health.AuthorityAllowed)
+			require.Contains(t, health.BlockedReasons, "vatsim:snapshot_stale")
+		})
+	}
+}
+
+func TestEvaluatorRejectsInvalidValidationEvidence(t *testing.T) {
+	tests := []struct {
+		name   string
+		reader *evidenceReader
+		want   string
+	}{
+		{name: "missing", reader: &evidenceReader{}, want: ReasonEvidenceMissing},
+		{name: "unavailable", reader: &evidenceReader{err: errors.New("database unavailable")}, want: ReasonEvidenceUnavailable},
+		{name: "corrupt", reader: &evidenceReader{values: []aman.ValidationEvidence{{ID: "bad", Airport: "EKCH", Kind: report.Version, Payload: []byte("not-json"), RecordedAt: gateNow}}}, want: ReasonEvidenceCorrupt},
+		{name: "future record", reader: &evidenceReader{values: []aman.ValidationEvidence{validationEvidence(t, gateNow.Add(time.Second), gateNow, true, "EKCH")}}, want: ReasonEvidenceFuture},
+		{name: "future evaluation", reader: &evidenceReader{values: []aman.ValidationEvidence{validationEvidence(t, gateNow, gateNow.Add(time.Second), true, "EKCH")}}, want: ReasonEvidenceFuture},
+		{name: "stale", reader: &evidenceReader{values: []aman.ValidationEvidence{validationEvidence(t, gateNow.Add(-16*time.Minute), gateNow.Add(-16*time.Minute), true, "EKCH")}}, want: ReasonEvidenceStale},
+		{name: "failed", reader: &evidenceReader{values: []aman.ValidationEvidence{validationEvidence(t, gateNow, gateNow, false, "EKCH")}}, want: ReasonEvidenceFailed},
+		{name: "digest mismatch", reader: &evidenceReader{values: []aman.ValidationEvidence{validationEvidenceWithConfig(t, gateNow, gateNow, true, "EKCH", Digests{Code: "wrong", Config: "config", Policy: "policy", Navigation: "navigation", Terminal: "terminal", Holding: "holding", Weather: "weather"})}}, want: ReasonDigestMismatch},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			decision := newEvaluator(t, test.reader).EvaluateAirport(context.Background(), "EKCH", aman.ModeAuthoritative, readyTechnical())
+			require.Equal(t, aman.EffectiveBlocked, decision.EffectiveMode)
+			require.Contains(t, decision.BlockedReasons, test.want)
+		})
+	}
+}
+
+func TestEvaluatorUsesNewestReportAndRestoresWhenFreshEvidenceReturns(t *testing.T) {
+	reader := &evidenceReader{values: []aman.ValidationEvidence{
+		validationEvidence(t, gateNow.Add(-time.Minute), gateNow.Add(-time.Minute), true, "EKCH"),
+		{ID: "newest-corrupt", Airport: "EKCH", Kind: report.Version, Payload: []byte("bad"), RecordedAt: gateNow},
+	}}
+	evaluator := newEvaluator(t, reader)
+	blocked := evaluator.EvaluateAirport(context.Background(), "EKCH", aman.ModeReadOnly, readyTechnical())
+	require.Equal(t, aman.EffectiveBlocked, blocked.EffectiveMode)
+	require.Contains(t, blocked.BlockedReasons, ReasonEvidenceCorrupt)
+
+	reader.values = []aman.ValidationEvidence{validationEvidence(t, gateNow, gateNow, true, "EKCH")}
+	restored := evaluator.EvaluateAirport(context.Background(), "EKCH", aman.ModeReadOnly, readyTechnical())
+	require.Equal(t, aman.EffectiveReadOnly, restored.EffectiveMode)
+	require.True(t, restored.AuthorityAllowed)
+}
+
+func TestEvaluatorTreatsMaximumEvidenceAgeAsInclusive(t *testing.T) {
+	recordedAt := gateNow.Add(-15 * time.Minute)
+	reader := &evidenceReader{values: []aman.ValidationEvidence{validationEvidence(t, recordedAt, recordedAt, true, "EKCH")}}
+	decision := newEvaluator(t, reader).EvaluateAirport(context.Background(), "EKCH", aman.ModeReadOnly, readyTechnical())
+	require.Equal(t, aman.EffectiveReadOnly, decision.EffectiveMode)
+}
+
+func TestEvaluatorReconstructsSameDecisionFromPersistedEvidence(t *testing.T) {
+	reader := &evidenceReader{values: []aman.ValidationEvidence{validationEvidence(t, gateNow, gateNow, true, "EKCH")}}
+	first := newEvaluator(t, reader).EvaluateAirport(context.Background(), "EKCH", aman.ModeAuthoritative, readyTechnical())
+	restarted := newEvaluator(t, reader).EvaluateAirport(context.Background(), "EKCH", aman.ModeAuthoritative, readyTechnical())
+	require.Equal(t, first, restarted)
+}
+
+func TestNewRejectsUnsafeConfiguration(t *testing.T) {
+	_, err := New(&evidenceReader{}, Config{}, func() time.Time { return gateNow })
+	require.Error(t, err)
+	_, err = New(nil, validConfig(), func() time.Time { return gateNow })
+	require.Error(t, err)
+	_, err = New(&evidenceReader{}, validConfig(), nil)
+	require.Error(t, err)
+}
+
+func newEvaluator(t *testing.T, reader aman.ValidationEvidenceReader) *Evaluator {
+	t.Helper()
+	evaluator, err := New(reader, validConfig(), func() time.Time { return gateNow })
+	require.NoError(t, err)
+	return evaluator
+}
+
+func validConfig() Config {
+	return Config{MaximumEvidenceAge: 15 * time.Minute, ExpectedDigests: Digests{Code: "code", Config: "config", Policy: "policy", Navigation: "navigation", Terminal: "terminal", Holding: "holding", Weather: "weather"}}
+}
+
+func readyTechnical() aman.TechnicalHealth {
+	ready := aman.ComponentHealth{Status: aman.HealthReady}
+	return aman.EvaluateTechnicalHealth(aman.ModeAuthoritative, ready, ready, ready, ready, ready, ready)
+}
+
+func validationEvidence(t *testing.T, recordedAt, evaluatedAt time.Time, passed bool, airport string) aman.ValidationEvidence {
+	t.Helper()
+	return validationEvidenceWithConfig(t, recordedAt, evaluatedAt, passed, airport, validConfig().ExpectedDigests)
+}
+
+func validationEvidenceWithConfig(t *testing.T, recordedAt, evaluatedAt time.Time, passed bool, airport string, digests Digests) aman.ValidationEvidence {
+	t.Helper()
+	value := report.Report{
+		Version:  report.Version,
+		Metadata: report.Metadata{Airport: airport, DatasetID: "replay-fixture", DatasetDigest: "dataset", ReplayDigest: "replay", CodeDigest: digests.Code, ConfigDigest: digests.Config, PolicyDigest: digests.Policy, NavigationDigest: digests.Navigation, TerminalDigest: digests.Terminal, HoldingDigest: digests.Holding, WeatherDigest: digests.Weather, EvaluatedAt: evaluatedAt},
+		Horizons: []report.HorizonMetrics{{Horizon: "terminal", Passed: passed}},
+		Passed:   passed,
+	}
+	canonical, err := json.Marshal(value)
+	require.NoError(t, err)
+	digest := sha256.Sum256(canonical)
+	value.Digest = hex.EncodeToString(digest[:])
+	evidence, err := value.Evidence(recordedAt)
+	require.NoError(t, err)
+	return evidence
+}

--- a/backend/internal/aman/health.go
+++ b/backend/internal/aman/health.go
@@ -31,17 +31,23 @@ type ComponentHealth struct {
 // inputs that can technically block authority without making a policy or
 // provider-approval decision itself.
 type TechnicalHealth struct {
-	Enabled          bool            `json:"enabled"`
-	Mode             RolloutMode     `json:"mode"`
-	Ready            bool            `json:"ready"`
-	Status           HealthStatus    `json:"status"`
-	BlockedReasons   []string        `json:"blocked_reasons,omitempty"`
-	VATSIM           ComponentHealth `json:"vatsim"`
-	Navigation       ComponentHealth `json:"navigation"`
-	Weather          ComponentHealth `json:"weather"`
-	Repository       ComponentHealth `json:"repository"`
-	Predictor        ComponentHealth `json:"predictor"`
-	ReplayValidation ComponentHealth `json:"replay_validation"`
+	Enabled bool `json:"enabled"`
+	// Mode is retained as the desired-mode compatibility field. New consumers
+	// must use DesiredMode and EffectiveMode so a gate cannot be mistaken for a
+	// configuration change.
+	Mode             RolloutMode          `json:"mode"`
+	DesiredMode      RolloutMode          `json:"desired_mode"`
+	EffectiveMode    EffectiveRolloutMode `json:"effective_mode"`
+	AuthorityAllowed bool                 `json:"authority_allowed"`
+	Ready            bool                 `json:"ready"`
+	Status           HealthStatus         `json:"status"`
+	BlockedReasons   []string             `json:"blocked_reasons,omitempty"`
+	VATSIM           ComponentHealth      `json:"vatsim"`
+	Navigation       ComponentHealth      `json:"navigation"`
+	Weather          ComponentHealth      `json:"weather"`
+	Repository       ComponentHealth      `json:"repository"`
+	Predictor        ComponentHealth      `json:"predictor"`
+	ReplayValidation ComponentHealth      `json:"replay_validation"`
 }
 
 // TechnicalHealthReporter is the narrow runtime seam for a concrete health
@@ -56,9 +62,11 @@ type TechnicalHealthReporter interface {
 // operators can identify the technical authority blocker directly.
 func EvaluateTechnicalHealth(mode RolloutMode, vatsim, navigation, weather, repository, predictor, replay ComponentHealth) TechnicalHealth {
 	report := TechnicalHealth{
-		Enabled: mode != ModeDisabled,
-		Mode:    mode,
-		VATSIM:  vatsim, Navigation: navigation, Weather: weather,
+		Enabled:       mode != ModeDisabled,
+		Mode:          mode,
+		DesiredMode:   mode,
+		EffectiveMode: EffectiveModeFor(mode),
+		VATSIM:        vatsim, Navigation: navigation, Weather: weather,
 		Repository: repository, Predictor: predictor, ReplayValidation: replay,
 	}
 	if !report.Enabled {
@@ -78,6 +86,7 @@ func EvaluateTechnicalHealth(mode RolloutMode, vatsim, navigation, weather, repo
 		}
 	}
 	report.Ready = len(report.BlockedReasons) == 0
+	report.AuthorityAllowed = report.Ready && operationalMode(mode)
 	if report.Ready {
 		report.Status = HealthReady
 	} else {
@@ -86,9 +95,10 @@ func EvaluateTechnicalHealth(mode RolloutMode, vatsim, navigation, weather, repo
 	return report
 }
 
-// Health returns the injected concrete report, with runtime configuration
-// applied as the effective mode. A missing reporter is visible as a technical
-// blocker rather than being mistaken for a healthy authoritative runtime.
+// Health returns the injected concrete report with the configured desired
+// mode. A rollout gate may subsequently replace EffectiveMode with blocked;
+// a missing reporter is visible as a technical blocker rather than being
+// mistaken for a healthy authoritative runtime.
 func (r *Runtime) Health(ctx context.Context) TechnicalHealth {
 	mode := ModeDisabled
 	if r != nil {
@@ -102,9 +112,11 @@ func (r *Runtime) Health(ctx context.Context) TechnicalHealth {
 		unavailable := ComponentHealth{Status: HealthUnavailable, Reason: "health_reporter_unavailable"}
 		return EvaluateTechnicalHealth(mode, unavailable, unavailable, unavailable, unavailable, unavailable, unavailable)
 	}
-	report := reporter.TechnicalHealth(ctx)
-	report.Enabled, report.Mode = true, mode
-	return normalizeTechnicalHealth(report)
+	report := normalizeTechnicalHealth(reporter.TechnicalHealth(ctx))
+	report.Enabled, report.Mode, report.DesiredMode = true, mode, mode
+	report.EffectiveMode = EffectiveModeFor(mode)
+	report.AuthorityAllowed = report.Ready && operationalMode(mode)
+	return report
 }
 
 func normalizeTechnicalHealth(report TechnicalHealth) TechnicalHealth {

--- a/backend/internal/aman/health_test.go
+++ b/backend/internal/aman/health_test.go
@@ -70,6 +70,9 @@ func TestRuntimeHealthUsesEffectiveModeAndReporter(t *testing.T) {
 	if !report.Ready || report.Mode != ModeAuthoritative || !report.Enabled || report.Status != HealthReady {
 		t.Fatalf("unexpected report: %#v", report)
 	}
+	if report.DesiredMode != ModeAuthoritative || report.EffectiveMode != EffectiveAuthoritative || !report.AuthorityAllowed {
+		t.Fatalf("unexpected rollout decision fields: %#v", report)
+	}
 }
 
 type healthTestWorker struct{}

--- a/backend/internal/aman/rollout.go
+++ b/backend/internal/aman/rollout.go
@@ -1,0 +1,34 @@
+package aman
+
+// EffectiveRolloutMode is the runtime result after technical and validation
+// gates have been applied to a desired rollout mode. Blocked is intentionally
+// not a desired configuration value: it makes a failed operational gate
+// visible without silently changing the configured mode to disabled or shadow.
+type EffectiveRolloutMode string
+
+const (
+	EffectiveDisabled      EffectiveRolloutMode = "disabled"
+	EffectiveShadow        EffectiveRolloutMode = "shadow"
+	EffectiveReadOnly      EffectiveRolloutMode = "read_only"
+	EffectiveAuthoritative EffectiveRolloutMode = "authoritative"
+	EffectiveBlocked       EffectiveRolloutMode = "blocked"
+)
+
+func EffectiveModeFor(mode RolloutMode) EffectiveRolloutMode {
+	switch mode {
+	case ModeDisabled:
+		return EffectiveDisabled
+	case ModeShadow:
+		return EffectiveShadow
+	case ModeReadOnly:
+		return EffectiveReadOnly
+	case ModeAuthoritative:
+		return EffectiveAuthoritative
+	default:
+		return EffectiveBlocked
+	}
+}
+
+func operationalMode(mode RolloutMode) bool {
+	return mode == ModeReadOnly || mode == ModeAuthoritative
+}

--- a/backend/internal/aman/runtime.go
+++ b/backend/internal/aman/runtime.go
@@ -236,6 +236,18 @@ func ownershipFor(config RuntimeConfig) Ownership {
 	return ownership
 }
 
+// OwnershipForRolloutGate returns the writer and authority ownership for a
+// gate decision. A blocked operational mode deliberately enables neither ETA
+// writer: falling back to legacy ETA would hide the failed AMAN gate. Disabled
+// and shadow retain their documented legacy ownership because they are desired
+// modes, not a degradation of an operational mode.
+func OwnershipForRolloutGate(desired RolloutMode, authorityAllowed bool) Ownership {
+	if operationalMode(desired) && !authorityAllowed {
+		return Ownership{}
+	}
+	return ownershipFor(RuntimeConfig{Mode: desired})
+}
+
 // Config returns a copy of the normalized configuration.
 func (r *Runtime) Config() RuntimeConfig {
 	if r == nil {


### PR DESCRIPTION
## Summary

- add a fail-closed per-airport rollout evaluator using canonical persisted validation reports
- expose desired and effective modes, including the explicit `blocked` state
- keep both ETA writers disabled when an operational AMAN mode is blocked

## Validation

- `go test ./internal/aman/...`
- `go test ./...`