### PR TITLE
fix(landing): repair public page links

### DIFF
--- a/frontend/src/components/public/PublicFooter.tsx
+++ b/frontend/src/components/public/PublicFooter.tsx
@@ -109,7 +109,7 @@ export function PublicFooter({ tone = "landing" }: { tone?: PublicFooterTone }) 
               </svg>
             </a>
             <a
-              href="#"
+              href="https://discord.gg/vpBk2mpg74"
               aria-label="Discord"
               className="text-[#8a9a9a] hover:text-[#a0dae4] transition-colors inline-flex items-center justify-center w-6 h-6"
             >

--- a/frontend/src/components/public/PublicNavigation.tsx
+++ b/frontend/src/components/public/PublicNavigation.tsx
@@ -36,11 +36,8 @@ export function PublicNavigation({ className, linkTone = "landing" }: PublicNavi
   };
 
   const navLinks = [
-    { label: "Product", href: "#" },
-    { label: "Airports", href: "#" },
     { label: "Docs", href: "https://docs.flightstrips.dk" },
-    { label: "Resources", href: "#" },
-    { label: "Community", href: "#" },
+    { label: "Community", href: "https://discord.gg/vpBk2mpg74" },
   ];
 
   if (linkTone === "industrial") {

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -220,9 +220,9 @@ export default function Home() {
       <div className="hidden md:flex bg-[#254a54] px-[60px] py-3.5 justify-between items-center text-sm relative z-10">
         <div />
         <div className="text-center flex-1">
-          <a href="https://flightstrips.dk/app" className="text-white hover:text-[#a0dae4] transition-colors">
+          <Link to="/app" className="text-white hover:text-[#a0dae4] transition-colors">
             Alpha testing is now open →
-          </a>
+          </Link>
         </div>
         <div className="flex gap-5.5 text-sm">
           <a href="https://docs.flightstrips.dk" className="text-white hover:text-[#a0dae4] transition-colors">
@@ -254,12 +254,28 @@ export default function Home() {
             </p>
 
             <div className="flex gap-3.5 justify-center mb-20">
-              <button className="bg-[#a0dae4] text-[#051415] px-7 py-[11px] rounded-full text-sm font-medium hover:bg-[#b8e3ec] transition-colors">
-                Open the board
-              </button>
-              <button className="bg-transparent text-white px-7 py-[11px] border border-[#3a4a4a] rounded-full text-sm font-medium hover:border-[#a0dae4] hover:text-[#a0dae4] transition-colors">
+              {isAuthenticated ? (
+                <Link
+                  to="/app"
+                  className="bg-[#a0dae4] text-[#051415] px-7 py-[11px] rounded-full text-sm font-medium hover:bg-[#b8e3ec] transition-colors"
+                >
+                  Open the board
+                </Link>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => loginWithRedirect({ appState: { returnTo: "/app" } })}
+                  className="bg-[#a0dae4] text-[#051415] px-7 py-[11px] rounded-full text-sm font-medium hover:bg-[#b8e3ec] transition-colors"
+                >
+                  Open the board
+                </button>
+              )}
+              <a
+                href="https://docs.flightstrips.dk"
+                className="bg-transparent text-white px-7 py-[11px] border border-[#3a4a4a] rounded-full text-sm font-medium hover:border-[#a0dae4] hover:text-[#a0dae4] transition-colors"
+              >
                 Read the docs
-              </button>
+              </a>
             </div>
 
             <p className="text-sm text-[#8a9a9a]">Currently live for EKCH Kastrup. More airports coming soon.</p>
@@ -397,20 +413,12 @@ export default function Home() {
         {/* Resources Section */}
         <section className="bg-[#051415] py-20 px-[60px] border-t border-[#233434]">
           <div className="max-w-5xl mx-auto">
-            <div className="flex justify-between items-center mb-8">
+            <div className="flex items-center mb-8">
               <div className="flex items-center gap-4">
                 <h2 className="text-4xl font-semibold tracking-tight">Documentation</h2>
                 <a href="https://docs.flightstrips.dk" className="text-white text-sm px-4 py-1.5 border border-[#233434] rounded-full hover:border-[#a0dae4] hover:text-[#a0dae4] transition-colors">
                   View all
                 </a>
-              </div>
-              <div className="flex gap-2">
-                <button className="w-8 h-8 border border-[#233434] rounded-full flex items-center justify-center text-white hover:bg-white/10 transition-colors">
-                  ←
-                </button>
-                <button className="w-8 h-8 border border-[#233434] rounded-full flex items-center justify-center bg-[#a0dae4] text-[#051415] font-bold">
-                  →
-                </button>
               </div>
             </div>
 
@@ -499,7 +507,7 @@ export default function Home() {
                 ) : (
                   <button
                     type="button"
-                    onClick={() => loginWithRedirect()}
+                    onClick={() => loginWithRedirect({ appState: { returnTo: "/app" } })}
                     className="bg-[#a0dae4] text-[#051415] px-8 py-[11px] rounded-full text-sm font-medium hover:bg-[#b8e3ec] transition-colors"
                   >
                     Log in


### PR DESCRIPTION
## Summary

- Wire the landing-page board and documentation calls to action to real destinations.
- Remove placeholder navigation and carousel controls that had no behavior.
- Add the FlightStrips Discord invite to the Community navigation item and footer icon.

## Why

The public front page exposed links and buttons that either pointed to `#` or did nothing when clicked.

## Validation

- `npm run build`
- `npm test` (123 tests passed)
- `npm run lint` remains blocked by a pre-existing `react-hooks/set-state-in-effect` error in `frontend/src/components/commandbar/VACSBTN.tsx`.
