### PR TITLE
feat(aman): smooth operational arrival predictions

### DIFF
--- a/backend/internal/aman/compatibility/arrival_eta.go
+++ b/backend/internal/aman/compatibility/arrival_eta.go
@@ -1,0 +1,73 @@
+// Package compatibility contains one-way projections from AMAN-owned state to
+// legacy FlightStrips fields. It never feeds a legacy value back into AMAN.
+package compatibility
+
+import (
+	"context"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/models"
+)
+
+const ArrivalETASource = "aman"
+
+// ArrivalETAStore is the narrow strip persistence capability required by the
+// AMAN compatibility adapter. A nil projection is written as SQL NULL rather
+// than leaving a legacy estimate visible in an operational AMAN mode.
+type ArrivalETAStore interface {
+	UpdateArrivalETA(context.Context, int32, string, models.ArrivalETA) (int64, error)
+	ClearArrivalETA(context.Context, int32, string) (int64, error)
+}
+
+// Writer is the sole adapter permitted to write AMAN's one-way ArrivalETA
+// compatibility projection. It has no prediction or sequencing inputs.
+type Writer struct {
+	mode   aman.RolloutMode
+	maxAge time.Duration
+	store  ArrivalETAStore
+}
+
+func NewWriter(mode aman.RolloutMode, maxAge time.Duration, store ArrivalETAStore) Writer {
+	return Writer{mode: mode, maxAge: maxAge, store: store}
+}
+
+// Apply writes the current operational projection, or explicitly clears it
+// when AMAN is unavailable/expired. Disabled and shadow modes do not mutate
+// the compatibility field because the legacy reconciler owns it there.
+func (w Writer) Apply(ctx context.Context, session int32, callsign string, prediction *aman.Prediction, now time.Time) (bool, error) {
+	eta := ProjectArrivalETA(w.mode, prediction, now, w.maxAge)
+	if w.mode != aman.ModeReadOnly && w.mode != aman.ModeAuthoritative {
+		return false, nil
+	}
+	if eta == nil {
+		updated, err := w.store.ClearArrivalETA(ctx, session, callsign)
+		return updated != 0, err
+	}
+	updated, err := w.store.UpdateArrivalETA(ctx, session, callsign, *eta)
+	return updated != 0, err
+}
+
+// ProjectArrivalETA returns the only legacy-compatible representation of an
+// operational AMAN TETA. A nil result means the compatibility field must be
+// unavailable/null; callers must not substitute the legacy estimator.
+//
+// Only read-only and authoritative modes own this projection. Disabled and
+// shadow modes deliberately return nil because their legacy writer remains
+// operational. A zero maxAge disables expiry checks.
+func ProjectArrivalETA(mode aman.RolloutMode, prediction *aman.Prediction, now time.Time, maxAge time.Duration) *models.ArrivalETA {
+	if mode != aman.ModeReadOnly && mode != aman.ModeAuthoritative {
+		return nil
+	}
+	if prediction == nil || !prediction.Publishable || prediction.OperationalTETA.IsZero() || prediction.GeneratedAt.IsZero() {
+		return nil
+	}
+	if maxAge > 0 && !now.IsZero() && prediction.GeneratedAt.Before(now.Add(-maxAge)) {
+		return nil
+	}
+	return &models.ArrivalETA{
+		Time:         prediction.OperationalTETA,
+		Source:       ArrivalETASource,
+		CalculatedAt: prediction.GeneratedAt,
+	}
+}

--- a/backend/internal/aman/compatibility/arrival_eta_test.go
+++ b/backend/internal/aman/compatibility/arrival_eta_test.go
@@ -1,0 +1,74 @@
+package compatibility
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjectArrivalETAHonoursOwnershipAndAvailability(t *testing.T) {
+	now := time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)
+	prediction := &aman.Prediction{OperationalTETA: now.Add(20 * time.Minute), GeneratedAt: now, Publishable: true}
+
+	for _, mode := range []aman.RolloutMode{aman.ModeDisabled, aman.ModeShadow} {
+		require.Nil(t, ProjectArrivalETA(mode, prediction, now, time.Minute))
+	}
+	for _, mode := range []aman.RolloutMode{aman.ModeReadOnly, aman.ModeAuthoritative} {
+		eta := ProjectArrivalETA(mode, prediction, now, time.Minute)
+		require.NotNil(t, eta)
+		require.Equal(t, prediction.OperationalTETA, eta.Time)
+		require.Equal(t, ArrivalETASource, eta.Source)
+		require.Equal(t, prediction.GeneratedAt, eta.CalculatedAt)
+	}
+
+	prediction.Publishable = false
+	require.Nil(t, ProjectArrivalETA(aman.ModeReadOnly, prediction, now, time.Minute))
+	prediction.Publishable = true
+	require.Nil(t, ProjectArrivalETA(aman.ModeReadOnly, prediction, now.Add(2*time.Minute), time.Minute))
+}
+
+func TestWriterOwnsOperationalModesAndClearsUnavailableOutput(t *testing.T) {
+	now := time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)
+	store := &recordingArrivalETAStore{}
+	writer := NewWriter(aman.ModeReadOnly, time.Minute, store)
+	prediction := &aman.Prediction{OperationalTETA: now.Add(20 * time.Minute), GeneratedAt: now, Publishable: true}
+
+	changed, err := writer.Apply(context.Background(), 7, "SAS123", prediction, now)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, 1, store.updated)
+	require.Equal(t, ArrivalETASource, store.eta.Source)
+
+	prediction.Publishable = false
+	changed, err = writer.Apply(context.Background(), 7, "SAS123", prediction, now)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, 1, store.cleared)
+
+	shadow := NewWriter(aman.ModeShadow, time.Minute, store)
+	changed, err = shadow.Apply(context.Background(), 7, "SAS123", prediction, now)
+	require.NoError(t, err)
+	require.False(t, changed)
+	require.Equal(t, 1, store.cleared)
+}
+
+type recordingArrivalETAStore struct {
+	eta     models.ArrivalETA
+	updated int
+	cleared int
+}
+
+func (s *recordingArrivalETAStore) UpdateArrivalETA(_ context.Context, _ int32, _ string, eta models.ArrivalETA) (int64, error) {
+	s.eta = eta
+	s.updated++
+	return 1, nil
+}
+
+func (s *recordingArrivalETAStore) ClearArrivalETA(context.Context, int32, string) (int64, error) {
+	s.cleared++
+	return 1, nil
+}

--- a/backend/internal/aman/prediction/reducer.go
+++ b/backend/internal/aman/prediction/reducer.go
@@ -1,0 +1,272 @@
+// Package prediction owns the deterministic conversion of physical AMAN
+// predictions into the operational TETA used by lifecycle and sequencing.
+package prediction
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"time"
+
+	"FlightStrips/internal/aman"
+)
+
+const smoothingWindowSize = 3
+
+// Config is the operational smoothing policy for one airport. Durations are
+// absolute TETA movements, not wall-clock intervals. This makes an accepted
+// persisted window replay identically after a restart.
+type Config struct {
+	Deadband           time.Duration
+	MaximumRoutineMove time.Duration
+	SuperstableHorizon time.Duration
+	ExcessiveDrift     time.Duration
+}
+
+// DefaultConfig is deliberately explicit so configuration can persist its
+// version alongside Prediction without inheriting process-local defaults.
+func DefaultConfig() Config {
+	return Config{
+		Deadband:           30 * time.Second,
+		MaximumRoutineMove: time.Minute,
+		SuperstableHorizon: 10 * time.Minute,
+		ExcessiveDrift:     2 * time.Minute,
+	}
+}
+
+func (c Config) Validate() error {
+	if c.Deadband < 0 {
+		return fmt.Errorf("prediction deadband cannot be negative")
+	}
+	if c.MaximumRoutineMove <= 0 {
+		return fmt.Errorf("prediction maximum routine movement must be greater than zero")
+	}
+	if c.SuperstableHorizon <= 0 {
+		return fmt.Errorf("prediction Superstable horizon must be greater than zero")
+	}
+	if c.ExcessiveDrift <= 0 {
+		return fmt.Errorf("prediction excessive drift threshold must be greater than zero")
+	}
+	return nil
+}
+
+// Input records the facts that may legitimately bypass routine smoothing.
+// The state engine is responsible for authorizing manual/release flags before
+// it calls this pure reducer.
+type Input struct {
+	Raw                aman.Prediction
+	State              aman.FlightState
+	RouteRevision      bool
+	RunwayGroupChanged bool
+	ManualOverride     *time.Time
+	ReleaseFreeze      bool
+	ConfirmedGoAround  bool
+	Slot               *aman.Slot
+}
+
+// Result contains the replacement aggregate and the observable drift while a
+// flight is Superstable. Excessive drift never resequences or releases a slot.
+type Result struct {
+	Flight         aman.AMANFlight
+	RawDrift       time.Duration
+	ExcessiveDrift bool
+}
+
+// Reduce accepts one raw prediction and returns a copy of the flight with its
+// persisted three-sample smoothing window and operational TETA updated.
+func Reduce(config Config, flight aman.AMANFlight, input Input) (Result, error) {
+	if err := config.Validate(); err != nil {
+		return Result{}, err
+	}
+	if !input.State.Valid() {
+		return Result{}, fmt.Errorf("prediction state is invalid")
+	}
+	if err := validateRaw(input.Raw); err != nil {
+		return Result{}, err
+	}
+	if input.ManualOverride != nil && (input.ManualOverride.IsZero() || input.ManualOverride.Location() != time.UTC) {
+		return Result{}, fmt.Errorf("manual operational TETA must be UTC")
+	}
+	if staleRaw(flight.RawTETASamples, input.Raw) {
+		// Reconciliation may deliver an already-applied or delayed predictor
+		// result. It must not regress prediction provenance or UpdatedAt.
+		return result(config, flight), nil
+	}
+	if input.Slot != nil && (flight.FreezeReason != aman.FreezeSuperstable || input.ReleaseFreeze || input.ManualOverride != nil || input.ConfirmedGoAround) {
+		copy := cloneSlot(input.Slot)
+		flight.Slot = &copy
+	}
+
+	previousState := flight.State
+	flight.State = input.State
+	flight.RawTETASamples = acceptRaw(flight.RawTETASamples, input.Raw)
+	flight.UpdatedAt = input.Raw.GeneratedAt
+
+	// A confirmed go-around is the only automatic release. It intentionally
+	// bypasses every normal filter and leaves the sequence owner to assign a
+	// new slot later.
+	if input.ConfirmedGoAround {
+		clearFreeze(&flight)
+		flight.Slot = nil
+		setOperational(&flight, input.Raw, input.Raw.RawTETA, aman.OperationalReasonGoAround)
+		return result(config, flight), nil
+	}
+
+	if input.ManualOverride != nil {
+		manual := *input.ManualOverride
+		freezeAt := input.Raw.GeneratedAt
+		flight.FreezeReason = aman.FreezeManual
+		flight.FrozenAt = &freezeAt
+		flight.FrozenOperationalTETA = &manual
+		flight.FrozenSlot = nil
+		setOperational(&flight, input.Raw, manual, aman.OperationalReasonManualOverride)
+		return result(config, flight), nil
+	}
+
+	if input.ReleaseFreeze {
+		clearFreeze(&flight)
+	}
+
+	// Raw TETA continues to update during a freeze so the caller can surface
+	// drift, but normal surveillance, wind, direct-to and route changes cannot
+	// move a Superstable operational value.
+	if flight.FreezeReason == aman.FreezeSuperstable {
+		setOperational(&flight, input.Raw, *flight.FrozenOperationalTETA, aman.OperationalReasonSuperstableFreeze)
+		return result(config, flight), nil
+	}
+	if flight.FreezeReason == aman.FreezeManual {
+		setOperational(&flight, input.Raw, *flight.FrozenOperationalTETA, aman.OperationalReasonManualOverride)
+		return result(config, flight), nil
+	}
+
+	candidate, reason := routineOperational(config, flight, previousState, input)
+	setOperational(&flight, input.Raw, candidate, reason)
+
+	// Superstable happens only at the exact configured holding-fix boundary,
+	// never before/after it and never until a complete slot exists.
+	if atSuperstableBoundary(input.Raw.GeneratedAt, input.Raw.HoldingFixETA, config.SuperstableHorizon) && flight.Slot != nil {
+		freezeAt := input.Raw.GeneratedAt
+		frozenTETA := candidate
+		frozenSlot := cloneSlot(flight.Slot)
+		flight.FreezeReason = aman.FreezeSuperstable
+		flight.FrozenAt = &freezeAt
+		flight.FrozenOperationalTETA = &frozenTETA
+		flight.FrozenSlot = &frozenSlot
+		flight.Prediction.OperationalReason = aman.OperationalReasonSuperstableFreeze
+	}
+	return result(config, flight), nil
+}
+
+func validateRaw(raw aman.Prediction) error {
+	// Prediction.Validate deliberately validates the operational fields too.
+	// The physical predictor supplies only RawTETA; set temporary valid values
+	// here so the shared provenance and confidence validation remains central.
+	copy := raw
+	copy.OperationalTETA = raw.RawTETA
+	copy.OperationalReason = aman.OperationalReasonPredicted
+	if err := copy.Validate(); err != nil {
+		return fmt.Errorf("raw prediction: %w", err)
+	}
+	return nil
+}
+
+func routineOperational(config Config, flight aman.AMANFlight, previousState aman.FlightState, input Input) (time.Time, aman.OperationalReason) {
+	if input.RouteRevision {
+		return input.Raw.RawTETA, aman.OperationalReasonRouteRevision
+	}
+	if input.RunwayGroupChanged {
+		return input.Raw.RawTETA, aman.OperationalReasonRunwayGroupChanged
+	}
+	if input.State == aman.StateUnstable && previousState != aman.StateUnstable {
+		return input.Raw.RawTETA, aman.OperationalReasonFirstUnstable
+	}
+
+	median := median(inputSamples(flight.RawTETASamples))
+	if flight.Prediction == nil {
+		return median, aman.OperationalReasonPredicted
+	}
+	previous := flight.Prediction.OperationalTETA
+	delta := median.Sub(previous)
+	if absolute(delta) <= config.Deadband {
+		return previous, aman.OperationalReasonDeadband
+	}
+	if absolute(delta) > config.MaximumRoutineMove {
+		if delta < 0 {
+			return previous.Add(-config.MaximumRoutineMove), aman.OperationalReasonRateLimited
+		}
+		return previous.Add(config.MaximumRoutineMove), aman.OperationalReasonRateLimited
+	}
+	return median, aman.OperationalReasonSmoothed
+}
+
+func result(config Config, flight aman.AMANFlight) Result {
+	result := Result{Flight: flight}
+	if flight.Prediction == nil || flight.FreezeReason != aman.FreezeSuperstable || flight.FrozenOperationalTETA == nil {
+		return result
+	}
+	result.RawDrift = absolute(flight.Prediction.RawTETA.Sub(*flight.FrozenOperationalTETA))
+	result.ExcessiveDrift = result.RawDrift > config.ExcessiveDrift
+	return result
+}
+
+func setOperational(flight *aman.AMANFlight, raw aman.Prediction, operational time.Time, reason aman.OperationalReason) {
+	raw.OperationalTETA = operational
+	raw.OperationalReason = reason
+	flight.Prediction = &raw
+}
+
+func acceptRaw(history []aman.RawTETASample, raw aman.Prediction) []aman.RawTETASample {
+	accepted := slices.Clone(history)
+	if staleRaw(accepted, raw) {
+		return accepted
+	}
+	accepted = append(accepted, aman.RawTETASample{TETA: raw.RawTETA, GeneratedAt: raw.GeneratedAt})
+	if len(accepted) > smoothingWindowSize {
+		accepted = accepted[len(accepted)-smoothingWindowSize:]
+	}
+	return accepted
+}
+
+func staleRaw(history []aman.RawTETASample, raw aman.Prediction) bool {
+	return len(history) != 0 && !raw.GeneratedAt.After(history[len(history)-1].GeneratedAt)
+}
+
+func inputSamples(history []aman.RawTETASample) []time.Time {
+	values := make([]time.Time, len(history))
+	for index, sample := range history {
+		values[index] = sample.TETA
+	}
+	return values
+}
+
+func median(values []time.Time) time.Time {
+	values = slices.Clone(values)
+	sort.Slice(values, func(i, j int) bool { return values[i].Before(values[j]) })
+	middle := len(values) / 2
+	if len(values)%2 != 0 {
+		return values[middle]
+	}
+	return values[middle-1].Add(values[middle].Sub(values[middle-1]) / 2)
+}
+
+func atSuperstableBoundary(now time.Time, holdingFixETA *time.Time, horizon time.Duration) bool {
+	return holdingFixETA != nil && now.Add(horizon).Equal(*holdingFixETA)
+}
+
+func clearFreeze(flight *aman.AMANFlight) {
+	flight.FreezeReason = aman.FreezeNone
+	flight.FrozenAt = nil
+	flight.FrozenOperationalTETA = nil
+	flight.FrozenSlot = nil
+}
+
+func cloneSlot(slot *aman.Slot) aman.Slot {
+	return *slot
+}
+
+func absolute(value time.Duration) time.Duration {
+	if value < 0 {
+		return -value
+	}
+	return value
+}

--- a/backend/internal/aman/prediction/reducer_test.go
+++ b/backend/internal/aman/prediction/reducer_test.go
@@ -1,0 +1,160 @@
+package prediction
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReducePersistsMedianDeadbandRateLimitAndBypasses(t *testing.T) {
+	now := predictionTime()
+	config := DefaultConfig()
+	config.Deadband = 30 * time.Second
+	config.MaximumRoutineMove = 2 * time.Minute
+	flight := predictionFlight(now)
+
+	first, err := Reduce(config, flight, Input{Raw: rawPrediction(now, now.Add(20*time.Minute)), State: aman.StateStable})
+	require.NoError(t, err)
+	require.Equal(t, now.Add(20*time.Minute), first.Flight.Prediction.OperationalTETA)
+
+	second, err := Reduce(config, first.Flight, Input{Raw: rawPrediction(now.Add(time.Minute), now.Add(20*time.Minute+10*time.Second)), State: aman.StateStable})
+	require.NoError(t, err)
+	require.Equal(t, now.Add(20*time.Minute), second.Flight.Prediction.OperationalTETA)
+	require.Equal(t, aman.OperationalReasonDeadband, second.Flight.Prediction.OperationalReason)
+
+	third, err := Reduce(config, second.Flight, Input{Raw: rawPrediction(now.Add(2*time.Minute), now.Add(30*time.Minute)), State: aman.StateStable})
+	require.NoError(t, err)
+	require.Len(t, third.Flight.RawTETASamples, 3)
+	require.Equal(t, now.Add(20*time.Minute), third.Flight.Prediction.OperationalTETA)
+
+	fourth, err := Reduce(config, third.Flight, Input{Raw: rawPrediction(now.Add(3*time.Minute), now.Add(30*time.Minute)), State: aman.StateStable})
+	require.NoError(t, err)
+	require.Len(t, fourth.Flight.RawTETASamples, 3)
+	require.Equal(t, now.Add(22*time.Minute), fourth.Flight.Prediction.OperationalTETA)
+	require.Equal(t, aman.OperationalReasonRateLimited, fourth.Flight.Prediction.OperationalReason)
+
+	persisted, err := json.Marshal(third.Flight)
+	require.NoError(t, err)
+	var restored aman.AMANFlight
+	require.NoError(t, json.Unmarshal(persisted, &restored))
+	restarted, err := Reduce(config, restored, Input{Raw: rawPrediction(now.Add(3*time.Minute), now.Add(30*time.Minute)), State: aman.StateStable})
+	require.NoError(t, err)
+	require.Equal(t, fourth.Flight.RawTETASamples, restarted.Flight.RawTETASamples)
+	require.Equal(t, fourth.Flight.Prediction.OperationalTETA, restarted.Flight.Prediction.OperationalTETA)
+
+	route, err := Reduce(config, fourth.Flight, Input{Raw: rawPrediction(now.Add(4*time.Minute), now.Add(35*time.Minute)), State: aman.StateStable, RouteRevision: true})
+	require.NoError(t, err)
+	require.Equal(t, now.Add(35*time.Minute), route.Flight.Prediction.OperationalTETA)
+	require.Equal(t, aman.OperationalReasonRouteRevision, route.Flight.Prediction.OperationalReason)
+
+	unstable, err := Reduce(config, route.Flight, Input{Raw: rawPrediction(now.Add(5*time.Minute), now.Add(40*time.Minute)), State: aman.StateUnstable})
+	require.NoError(t, err)
+	require.Equal(t, now.Add(40*time.Minute), unstable.Flight.Prediction.OperationalTETA)
+	require.Equal(t, aman.OperationalReasonFirstUnstable, unstable.Flight.Prediction.OperationalReason)
+}
+
+func TestReduceRestoresWindowAndSuperstableFreezeDeterministically(t *testing.T) {
+	now := predictionTime()
+	config := DefaultConfig()
+	config.ExcessiveDrift = time.Minute
+	slot := aman.Slot{Time: now.Add(25 * time.Minute), RunwayGroupID: "north", Sequence: 3, Reason: "spacing"}
+	freezeRaw := rawPrediction(now, now.Add(20*time.Minute))
+	holdingFix := now.Add(config.SuperstableHorizon)
+	freezeRaw.HoldingFixETA = &holdingFix
+
+	frozen, err := Reduce(config, predictionFlight(now), Input{Raw: freezeRaw, State: aman.StateStable, Slot: &slot})
+	require.NoError(t, err)
+	require.Equal(t, aman.FreezeSuperstable, frozen.Flight.FreezeReason)
+	require.Equal(t, aman.OperationalReasonSuperstableFreeze, frozen.Flight.Prediction.OperationalReason)
+	require.NotNil(t, frozen.Flight.FrozenSlot)
+	require.Equal(t, slot, *frozen.Flight.FrozenSlot)
+
+	persisted, err := json.Marshal(frozen.Flight)
+	require.NoError(t, err)
+	var restored aman.AMANFlight
+	require.NoError(t, json.Unmarshal(persisted, &restored))
+	require.NoError(t, restored.Validate())
+
+	drifted, err := Reduce(config, restored, Input{Raw: rawPrediction(now.Add(time.Minute), now.Add(24*time.Minute)), State: aman.StateStable, RouteRevision: true})
+	require.NoError(t, err)
+	require.Equal(t, now.Add(20*time.Minute), drifted.Flight.Prediction.OperationalTETA)
+	require.True(t, drifted.ExcessiveDrift)
+	require.Equal(t, 4*time.Minute, drifted.RawDrift)
+
+	manual := now.Add(22 * time.Minute)
+	overridden, err := Reduce(config, drifted.Flight, Input{Raw: rawPrediction(now.Add(2*time.Minute), now.Add(23*time.Minute)), State: aman.StateStable, ManualOverride: &manual})
+	require.NoError(t, err)
+	require.Equal(t, aman.FreezeManual, overridden.Flight.FreezeReason)
+	require.Equal(t, manual, overridden.Flight.Prediction.OperationalTETA)
+
+	released, err := Reduce(config, overridden.Flight, Input{Raw: rawPrediction(now.Add(3*time.Minute), now.Add(23*time.Minute)), State: aman.StateStable, ReleaseFreeze: true})
+	require.NoError(t, err)
+	require.Equal(t, aman.FreezeNone, released.Flight.FreezeReason)
+	require.NotEqual(t, aman.OperationalReasonManualOverride, released.Flight.Prediction.OperationalReason)
+
+	goAround, err := Reduce(config, released.Flight, Input{Raw: rawPrediction(now.Add(4*time.Minute), now.Add(30*time.Minute)), State: aman.StateGoAround, ConfirmedGoAround: true})
+	require.NoError(t, err)
+	require.Equal(t, aman.FreezeNone, goAround.Flight.FreezeReason)
+	require.Nil(t, goAround.Flight.Slot)
+	require.Equal(t, now.Add(30*time.Minute), goAround.Flight.Prediction.OperationalTETA)
+}
+
+func TestReduceDoesNotFreezeWithoutSlotOrOutsideExactBoundary(t *testing.T) {
+	now := predictionTime()
+	config := DefaultConfig()
+	raw := rawPrediction(now, now.Add(20*time.Minute))
+	holdingFix := now.Add(config.SuperstableHorizon + time.Second)
+	raw.HoldingFixETA = &holdingFix
+	slot := aman.Slot{Time: now.Add(25 * time.Minute), RunwayGroupID: "north", Sequence: 1, Reason: "spacing"}
+
+	result, err := Reduce(config, predictionFlight(now), Input{Raw: raw, State: aman.StateStable, Slot: &slot})
+	require.NoError(t, err)
+	require.Equal(t, aman.FreezeNone, result.Flight.FreezeReason)
+
+	holdingFix = now.Add(config.SuperstableHorizon)
+	raw = rawPrediction(now.Add(time.Minute), now.Add(20*time.Minute))
+	holdingFix = raw.GeneratedAt.Add(config.SuperstableHorizon)
+	raw.HoldingFixETA = &holdingFix
+	result, err = Reduce(config, predictionFlight(now), Input{Raw: raw, State: aman.StateStable})
+	require.NoError(t, err)
+	require.Equal(t, aman.FreezeNone, result.Flight.FreezeReason)
+}
+
+func TestReduceIgnoresStaleRawAndFrozenSlotUpdates(t *testing.T) {
+	now := predictionTime()
+	config := DefaultConfig()
+	slot := aman.Slot{Time: now.Add(25 * time.Minute), RunwayGroupID: "north", Sequence: 1, Reason: "spacing"}
+	raw := rawPrediction(now, now.Add(20*time.Minute))
+	holdingFix := now.Add(config.SuperstableHorizon)
+	raw.HoldingFixETA = &holdingFix
+
+	frozen, err := Reduce(config, predictionFlight(now), Input{Raw: raw, State: aman.StateStable, Slot: &slot})
+	require.NoError(t, err)
+	require.Equal(t, aman.FreezeSuperstable, frozen.Flight.FreezeReason)
+
+	changedSlot := slot
+	changedSlot.Time = changedSlot.Time.Add(time.Minute)
+	current, err := Reduce(config, frozen.Flight, Input{Raw: rawPrediction(now.Add(time.Minute), now.Add(24*time.Minute)), State: aman.StateStable, Slot: &changedSlot})
+	require.NoError(t, err)
+	require.Equal(t, slot, *current.Flight.Slot)
+	require.Equal(t, slot, *current.Flight.FrozenSlot)
+
+	stale, err := Reduce(config, current.Flight, Input{Raw: rawPrediction(now, now.Add(40*time.Minute)), State: aman.StateStable})
+	require.NoError(t, err)
+	require.Equal(t, current.Flight, stale.Flight)
+}
+
+func predictionTime() time.Time {
+	return time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)
+}
+
+func predictionFlight(now time.Time) aman.AMANFlight {
+	return aman.AMANFlight{ID: "flight-1", VATSIMCID: "1234567", CurrentCallsign: "SAS123", State: aman.StateStable, DataStatus: aman.DataFresh, FreezeReason: aman.FreezeNone, UpdatedAt: now}
+}
+
+func rawPrediction(generatedAt, rawTETA time.Time) aman.Prediction {
+	return aman.Prediction{RawTETA: rawTETA, GeneratedAt: generatedAt, InputObservedAt: generatedAt, Confidence: aman.ConfidenceHigh, Publishable: true, DatasetVersion: "2607", GeometryDigest: "geometry", ModelVersion: "performance-wind-v1", ConfigVersion: "ekch-v1", Sources: []string{"vatsim", "airacnet"}}
+}

--- a/backend/internal/aman/types.go
+++ b/backend/internal/aman/types.go
@@ -87,6 +87,42 @@ func (c Confidence) Valid() bool {
 	}
 }
 
+// OperationalReason explains why OperationalTETA differs from, or follows,
+// the latest physical prediction. Consumers must use OperationalTETA rather
+// than inferring policy from RawTETA or the flight state.
+type OperationalReason string
+
+const (
+	OperationalReasonPredicted          OperationalReason = "predicted"
+	OperationalReasonSmoothed           OperationalReason = "smoothed"
+	OperationalReasonDeadband           OperationalReason = "deadband"
+	OperationalReasonRateLimited        OperationalReason = "rate_limited"
+	OperationalReasonRouteRevision      OperationalReason = "route_revision"
+	OperationalReasonRunwayGroupChanged OperationalReason = "runway_group_changed"
+	OperationalReasonFirstUnstable      OperationalReason = "first_unstable"
+	OperationalReasonManualOverride     OperationalReason = "manual_override"
+	OperationalReasonSuperstableFreeze  OperationalReason = "superstable_freeze"
+	OperationalReasonGoAround           OperationalReason = "go_around"
+)
+
+func (r OperationalReason) Valid() bool {
+	switch r {
+	case OperationalReasonPredicted,
+		OperationalReasonSmoothed,
+		OperationalReasonDeadband,
+		OperationalReasonRateLimited,
+		OperationalReasonRouteRevision,
+		OperationalReasonRunwayGroupChanged,
+		OperationalReasonFirstUnstable,
+		OperationalReasonManualOverride,
+		OperationalReasonSuperstableFreeze,
+		OperationalReasonGoAround:
+		return true
+	default:
+		return false
+	}
+}
+
 // BaselineSource identifies the deterministic input used before the
 // route-aware predictor can calculate a replacement raw prediction.
 //
@@ -208,7 +244,7 @@ type SurveillanceFact struct {
 type Prediction struct {
 	RawTETA           time.Time
 	OperationalTETA   time.Time
-	OperationalReason string
+	OperationalReason OperationalReason
 
 	GeneratedAt       time.Time
 	InputObservedAt   time.Time
@@ -226,6 +262,15 @@ type Prediction struct {
 	PerformanceProfileID *string
 	WeatherSource        *string
 	Sources              []string
+}
+
+// RawTETASample is one accepted physical/model output in the persisted
+// smoothing window. The window is deliberately small and complete: retaining
+// the TETA together with its generation time makes a restart produce the same
+// median and rate-limited result without re-reading an external source.
+type RawTETASample struct {
+	TETA        time.Time
+	GeneratedAt time.Time
 }
 
 // BaselineState is the narrow persisted result of the first normal airborne
@@ -319,6 +364,7 @@ type AMANFlight struct {
 	State                 FlightState
 	DataStatus            DataStatus
 	Prediction            *Prediction
+	RawTETASamples        []RawTETASample
 	ArrivalBaseline       *BaselineState
 	SelectedRunwayGroup   *RunwayGroupID
 	SelectedFeeder        *string
@@ -328,6 +374,7 @@ type AMANFlight struct {
 	FreezeReason          FreezeReason
 	FrozenAt              *time.Time
 	FrozenOperationalTETA *time.Time
+	FrozenSlot            *Slot
 	Slot                  *Slot
 	Order                 *int
 	ETAReview             *ETAReview
@@ -451,8 +498,8 @@ func (p Prediction) Validate() error {
 	if err := requireUTCTime("operational TETA", p.OperationalTETA); err != nil {
 		return err
 	}
-	if strings.TrimSpace(p.OperationalReason) == "" {
-		return invalid("operational reason is required")
+	if !p.OperationalReason.Valid() {
+		return invalid("operational reason is invalid")
 	}
 	if err := requireUTCTime("generated at", p.GeneratedAt); err != nil {
 		return err
@@ -538,6 +585,17 @@ func (f AMANFlight) Validate() error {
 			return err
 		}
 	}
+	if len(f.RawTETASamples) > 3 {
+		return invalid("raw TETA smoothing window exceeds three samples")
+	}
+	for index, sample := range f.RawTETASamples {
+		if err := sample.Validate(); err != nil {
+			return err
+		}
+		if index > 0 && !sample.GeneratedAt.After(f.RawTETASamples[index-1].GeneratedAt) {
+			return invalid("raw TETA smoothing samples must be ordered by generation time")
+		}
+	}
 	if f.ArrivalBaseline != nil {
 		if err := f.ArrivalBaseline.Validate(); err != nil {
 			return err
@@ -564,7 +622,7 @@ func (f AMANFlight) Validate() error {
 
 func (f AMANFlight) validateFreeze() error {
 	if f.FreezeReason == FreezeNone {
-		if f.FrozenAt != nil || f.FrozenOperationalTETA != nil {
+		if f.FrozenAt != nil || f.FrozenOperationalTETA != nil || f.FrozenSlot != nil {
 			return invalid("unfrozen flight cannot retain freeze values")
 		}
 		return nil
@@ -575,7 +633,25 @@ func (f AMANFlight) validateFreeze() error {
 	if err := requireUTCTime("frozen at", *f.FrozenAt); err != nil {
 		return err
 	}
-	return requireUTCTime("frozen operational TETA", *f.FrozenOperationalTETA)
+	if err := requireUTCTime("frozen operational TETA", *f.FrozenOperationalTETA); err != nil {
+		return err
+	}
+	if f.FreezeReason == FreezeSuperstable {
+		if f.Slot == nil || f.FrozenSlot == nil {
+			return invalid("Superstable freeze requires a captured slot")
+		}
+		if err := f.FrozenSlot.validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s RawTETASample) Validate() error {
+	if err := requireUTCTime("raw TETA sample", s.TETA); err != nil {
+		return err
+	}
+	return requireUTCTime("raw TETA sample generated at", s.GeneratedAt)
 }
 
 func (s Slot) validate() error {

--- a/backend/internal/aman/types_test.go
+++ b/backend/internal/aman/types_test.go
@@ -47,6 +47,7 @@ func TestDomainTypesDoNotDeclareWireJSONTags(t *testing.T) {
 		reflect.TypeFor[FlightPlanFact](),
 		reflect.TypeFor[SurveillanceFact](),
 		reflect.TypeFor[Prediction](),
+		reflect.TypeFor[RawTETASample](),
 		reflect.TypeFor[BaselineState](),
 		reflect.TypeFor[Slot](),
 		reflect.TypeFor[RouteFact](),
@@ -94,6 +95,10 @@ func TestFlightFreezeHasOneCanonicalRepresentation(t *testing.T) {
 	flight.FrozenAt = &now
 	freezeTETA := now.Add(10 * time.Minute)
 	flight.FrozenOperationalTETA = &freezeTETA
+	slot := Slot{Time: now.Add(11 * time.Minute), RunwayGroupID: "north", Sequence: 1, Reason: "spacing"}
+	flight.Slot = &slot
+	frozenSlot := slot
+	flight.FrozenSlot = &frozenSlot
 	if err := flight.Validate(); err != nil {
 		t.Fatalf("validate frozen flight: %v", err)
 	}
@@ -227,7 +232,7 @@ func validPrediction() Prediction {
 	return Prediction{
 		RawTETA:           now.Add(15 * time.Minute),
 		OperationalTETA:   now.Add(15 * time.Minute),
-		OperationalReason: "raw",
+		OperationalReason: OperationalReasonPredicted,
 		GeneratedAt:       now,
 		InputObservedAt:   now,
 		Confidence:        ConfidenceMedium,

--- a/backend/internal/database/strips.sql.go
+++ b/backend/internal/database/strips.sql.go
@@ -1326,6 +1326,27 @@ func (q *Queries) UpdateStripArrivalETA(ctx context.Context, arg UpdateStripArri
 	return result.RowsAffected(), nil
 }
 
+const clearStripArrivalETA = `-- name: ClearStripArrivalETA :execrows
+UPDATE strips
+SET
+    version = version + 1,
+    arrival_eta = NULL
+WHERE callsign = $1 AND session = $2
+`
+
+type ClearStripArrivalETAParams struct {
+	Callsign string
+	Session  int32
+}
+
+func (q *Queries) ClearStripArrivalETA(ctx context.Context, arg ClearStripArrivalETAParams) (int64, error) {
+	result, err := q.db.Exec(ctx, clearStripArrivalETA, arg.Callsign, arg.Session)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const updateStripAssignedSquawkByID = `-- name: UpdateStripAssignedSquawkByID :execrows
 UPDATE strips
 SET assigned_squawk = $1,

--- a/backend/internal/repository/postgres/strip.go
+++ b/backend/internal/repository/postgres/strip.go
@@ -938,6 +938,15 @@ func (r *stripRepository) UpdateArrivalETA(ctx context.Context, session int32, c
 	})
 }
 
+// ClearArrivalETA explicitly makes the compatibility estimate unavailable.
+// Operational AMAN modes must never reactivate a legacy ETA as a fallback.
+func (r *stripRepository) ClearArrivalETA(ctx context.Context, session int32, callsign string) (int64, error) {
+	return r.queries.ClearStripArrivalETA(ctx, database.ClearStripArrivalETAParams{
+		Callsign: callsign,
+		Session:  session,
+	})
+}
+
 func (r *stripRepository) UpdateVatsimSource(ctx context.Context, session int32, callsign string, source models.VatsimStripSource) (int64, error) {
 	cid := source.CID
 	revision := source.Revision

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -69,6 +69,7 @@ type StripRepository interface {
 
 	// Arrival ETA
 	UpdateArrivalETA(ctx context.Context, session int32, callsign string, eta models.ArrivalETA) (int64, error)
+	ClearArrivalETA(ctx context.Context, session int32, callsign string) (int64, error)
 
 	// Release point
 	UpdateReleasePoint(ctx context.Context, session int32, callsign string, releasePoint *string) (int64, error)

--- a/backend/internal/testutil/mock_strip_repository.go
+++ b/backend/internal/testutil/mock_strip_repository.go
@@ -57,6 +57,7 @@ type MockStripRepository struct {
 	GetCdmDataForCallsignFn         func(ctx context.Context, session int32, callsign string) (*models.CdmData, error)
 	SetCdmDataFn                    func(ctx context.Context, session int32, callsign string, data *models.CdmData) (int64, error)
 	UpdateArrivalETAFn              func(ctx context.Context, session int32, callsign string, eta models.ArrivalETA) (int64, error)
+	ClearArrivalETAFn               func(ctx context.Context, session int32, callsign string) (int64, error)
 	UpdateReleasePointFn            func(ctx context.Context, session int32, callsign string, releasePoint *string) (int64, error)
 	AppendUnexpectedChangeFieldFn   func(ctx context.Context, session int32, callsign string, fieldName string) error
 	RemoveUnexpectedChangeFieldFn   func(ctx context.Context, session int32, callsign string, fieldName string) error
@@ -435,6 +436,13 @@ func (m *MockStripRepository) UpdateArrivalETA(ctx context.Context, session int3
 		panic("unexpected call to MockStripRepository.UpdateArrivalETA")
 	}
 	return m.UpdateArrivalETAFn(ctx, session, callsign, eta)
+}
+
+func (m *MockStripRepository) ClearArrivalETA(ctx context.Context, session int32, callsign string) (int64, error) {
+	if m.ClearArrivalETAFn == nil {
+		panic("unexpected call to MockStripRepository.ClearArrivalETA")
+	}
+	return m.ClearArrivalETAFn(ctx, session, callsign)
 }
 
 func (m *MockStripRepository) UpdateReleasePoint(ctx context.Context, session int32, callsign string, releasePoint *string) (int64, error) {

--- a/backend/queries/strips.sql
+++ b/backend/queries/strips.sql
@@ -123,6 +123,13 @@ SET
     arrival_eta = sqlc.arg(arrival_eta)
 WHERE callsign = sqlc.arg(callsign) AND session = sqlc.arg(session);
 
+-- name: ClearStripArrivalETA :execrows
+UPDATE strips
+SET
+    version = version + 1,
+    arrival_eta = NULL
+WHERE callsign = sqlc.arg(callsign) AND session = sqlc.arg(session);
+
 -- name: UpdateStripVatsimSource :execrows
 UPDATE strips
 SET


### PR DESCRIPTION
## Summary

Implements AMAN #314 prediction smoothing and the one-way `ArrivalETA` compatibility adapter.

- Persists a three-sample raw-TETA window and applies median, deadband, and rate-limit policy.
- Records typed operational reasons, Superstable slot captures, drift, manual release, and go-around behavior.
- Adds a compatibility writer that projects AMAN ETA values or explicitly clears unavailable output.
- Adds persistence and test-double support for clearing `arrival_eta`.

## Why

Operational AMAN ETA needs stable controller-facing values while retaining raw model output for monitoring. In read-only and authoritative modes, unavailable AMAN output maps to null instead of retaining or restoring a legacy estimate.

## Validation

- `go test ./internal/aman ./internal/aman/prediction ./internal/aman/compatibility ./internal/repository/postgres ./internal/vatsim`