### PR TITLE
fix(traffic-board): link EFB tile to flight board

### DIFF
--- a/frontend/src/pages/efb.test.tsx
+++ b/frontend/src/pages/efb.test.tsx
@@ -92,7 +92,7 @@ describe('EFB page interactions', () => {
     expect(screen.queryByText('CTOT')).not.toBeInTheDocument();
     expect(screen.queryByText('CONTACT PASSING')).not.toBeInTheDocument();
     expect(screen.getByText('Follow controller instructions')).toBeInTheDocument();
-    expect(screen.getByAltText('Traffic Board')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Traffic Board' })).toHaveAttribute('href', 'https://flightboard.simfixr.com/?icao=EKCH');
 
     fireEvent.click(screen.getByRole('button', { name: 'Downloads' }));
     expect(screen.getByRole('dialog', { name: 'Downloads' })).toBeInTheDocument();

--- a/frontend/src/pages/efb.tsx
+++ b/frontend/src/pages/efb.tsx
@@ -586,9 +586,9 @@ useEffect(() => {
         )}
 
         {showFlightplanElements && (
-          <div className="absolute top-0 left-[66.66%] flex h-[86.66%] w-[30.83%] items-center justify-center border-0 bg-white text-xs text-[#999]">
+          <a href="https://flightboard.simfixr.com/?icao=EKCH" target="_blank" rel="noreferrer" className="absolute top-0 left-[66.66%] flex h-[86.66%] w-[30.83%] items-center justify-center border-0 bg-white text-xs text-[#999]">
             <img src={TRAFFICBOARD} alt="Traffic Board" className="h-full w-full object-cover" />
-          </div>
+          </a>
         )}
       </div>
 


### PR DESCRIPTION
## Summary

- Make the EFB traffic board tile link to the EKCH Flight Board.
- Add a regression assertion for the destination URL.

## Impact

Users can open the traffic board directly from the operational EFB view.

## Validation

- `npm test -- --run src/pages/efb.test.tsx`
- `npm run build`
- `git diff --check`