### PR TITLE
feat(aman): implement flight lifecycle state machine

### DIFF
--- a/backend/internal/aman/lifecycle/reducer.go
+++ b/backend/internal/aman/lifecycle/reducer.go
@@ -1,0 +1,283 @@
+// Package lifecycle owns deterministic AMAN flight-state transitions.
+// Source freshness remains orthogonal to the lifecycle state, and prediction
+// and freeze mechanics remain owned by the prediction reducer.
+package lifecycle
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"FlightStrips/internal/aman"
+)
+
+// Config contains the clock boundaries used by the lifecycle reducer.
+// Callers persist the selected policy version with AirportState.
+type Config struct {
+	UnstableHorizon      time.Duration
+	StableHorizon        time.Duration
+	MinimumUnstableDwell time.Duration
+}
+
+func DefaultConfig() Config {
+	return Config{
+		UnstableHorizon:      45 * time.Minute,
+		StableHorizon:        20 * time.Minute,
+		MinimumUnstableDwell: 5 * time.Minute,
+	}
+}
+
+func (c Config) Validate() error {
+	if c.UnstableHorizon <= 0 {
+		return invalidArgument("Unstable horizon must be greater than zero")
+	}
+	if c.StableHorizon <= 0 || c.StableHorizon >= c.UnstableHorizon {
+		return invalidArgument("Stable horizon must be positive and shorter than the Unstable horizon")
+	}
+	if c.MinimumUnstableDwell < 0 {
+		return invalidArgument("minimum Unstable dwell cannot be negative")
+	}
+	return nil
+}
+
+// EventKind identifies accepted lifecycle evidence. Each kind carries only
+// the data it owns; prediction values are already-accepted operational TETA
+// snapshots and never raw physical estimates.
+type EventKind string
+
+const (
+	EventAirborneDetected    EventKind = "airborne_detected"
+	EventPredictionAccepted  EventKind = "prediction_accepted"
+	EventDataStatusChanged   EventKind = "data_status_changed"
+	EventGoAroundConfirmed   EventKind = "go_around_confirmed"
+	EventLandingConfirmed    EventKind = "landing_confirmed"
+	EventManualRemoval       EventKind = "manual_removal"
+	EventLandedTimeout       EventKind = "landed_timeout"
+	EventPlannedCancellation EventKind = "planned_cancellation"
+)
+
+func (k EventKind) Valid() bool {
+	switch k {
+	case EventAirborneDetected,
+		EventPredictionAccepted,
+		EventDataStatusChanged,
+		EventGoAroundConfirmed,
+		EventLandingConfirmed,
+		EventManualRemoval,
+		EventLandedTimeout,
+		EventPlannedCancellation:
+		return true
+	default:
+		return false
+	}
+}
+
+// Event is a clock-injected fact presented to the reducer. DataStatus is used
+// only by EventDataStatusChanged. OperationalTETA is used only by
+// EventPredictionAccepted.
+type Event struct {
+	ID              string
+	Kind            EventKind
+	OccurredAt      time.Time
+	DataStatus      aman.DataStatus
+	OperationalTETA *time.Time
+}
+
+// Transition is emitted once for a real state change. It can be recorded in
+// the same StateCommit as the replacement aggregate.
+type Transition struct {
+	EventID string
+	From    aman.FlightState
+	To      aman.FlightState
+	Reason  aman.LifecycleReason
+	At      time.Time
+}
+
+type Result struct {
+	Flight     aman.AMANFlight
+	Transition *Transition
+	Duplicate  bool
+}
+
+// Reduce applies one accepted event to a copy of flight. Exact retries are
+// idempotent. A different event at or before the persisted cursor is rejected
+// explicitly so delayed input cannot regress lifecycle or freshness.
+func Reduce(config Config, flight aman.AMANFlight, event Event) (Result, error) {
+	if err := config.Validate(); err != nil {
+		return Result{}, err
+	}
+	if err := validateEvent(event); err != nil {
+		return Result{}, err
+	}
+	if !flight.State.Valid() || !flight.DataStatus.Valid() {
+		return Result{}, invalidArgument("flight lifecycle state is invalid")
+	}
+
+	if flight.Lifecycle != nil {
+		if event.ID == flight.Lifecycle.LastEventID {
+			if fingerprint(event) == flight.Lifecycle.LastEventFingerprint {
+				return Result{Flight: flight, Duplicate: true}, nil
+			}
+			return Result{}, invalidTransition(flight.State, event.Kind, "event ID was reused with different content")
+		}
+		if !event.OccurredAt.After(flight.Lifecycle.LastEventAt) {
+			return Result{}, invalidTransition(flight.State, event.Kind, "event is out of order")
+		}
+	} else if event.OccurredAt.Before(flight.UpdatedAt) {
+		return Result{}, invalidTransition(flight.State, event.Kind, "event predates the aggregate")
+	}
+
+	enteredAt := flight.UpdatedAt
+	reason := aman.LifecycleReasonInitial
+	if flight.Lifecycle != nil {
+		enteredAt = flight.Lifecycle.EnteredAt
+		reason = flight.Lifecycle.Reason
+	}
+
+	from := flight.State
+	to, transitionReason, err := nextState(config, flight, enteredAt, event)
+	if err != nil {
+		return Result{}, err
+	}
+	if to != from {
+		enteredAt = event.OccurredAt
+		reason = transitionReason
+	}
+	if event.Kind == EventDataStatusChanged {
+		flight.DataStatus = event.DataStatus
+	}
+
+	flight.State = to
+	flight.UpdatedAt = event.OccurredAt
+	flight.Lifecycle = &aman.LifecycleState{
+		EnteredAt:            enteredAt,
+		Reason:               reason,
+		LastEventID:          event.ID,
+		LastEventFingerprint: fingerprint(event),
+		LastEventAt:          event.OccurredAt,
+	}
+
+	result := Result{Flight: flight}
+	if to != from {
+		result.Transition = &Transition{EventID: event.ID, From: from, To: to, Reason: transitionReason, At: event.OccurredAt}
+	}
+	return result, nil
+}
+
+func fingerprint(event Event) string {
+	operationalTETA := ""
+	if event.OperationalTETA != nil {
+		operationalTETA = event.OperationalTETA.Format(time.RFC3339Nano)
+	}
+	return fmt.Sprintf("%s|%s|%s|%s", event.Kind, event.OccurredAt.Format(time.RFC3339Nano), event.DataStatus, operationalTETA)
+}
+
+func nextState(config Config, flight aman.AMANFlight, enteredAt time.Time, event Event) (aman.FlightState, aman.LifecycleReason, error) {
+	switch event.Kind {
+	case EventDataStatusChanged:
+		if flight.State == aman.StateRemoved {
+			return "", "", invalidTransition(flight.State, event.Kind, "Removed is terminal")
+		}
+		return flight.State, "", nil
+	case EventAirborneDetected:
+		switch flight.State {
+		case aman.StatePlanned:
+			return aman.StateAirborne, aman.LifecycleReasonAirborneDetected, nil
+		case aman.StateAirborne:
+			return flight.State, "", nil
+		default:
+			return "", "", invalidTransition(flight.State, event.Kind, "airborne evidence cannot enter this state")
+		}
+	case EventPredictionAccepted:
+		if flight.DataStatus != aman.DataFresh {
+			return flight.State, "", nil
+		}
+		untilArrival := event.OperationalTETA.Sub(event.OccurredAt)
+		switch flight.State {
+		case aman.StateAirborne, aman.StateGoAround:
+			if untilArrival <= config.UnstableHorizon {
+				return aman.StateUnstable, aman.LifecycleReasonUnstableHorizon, nil
+			}
+		case aman.StateUnstable:
+			if untilArrival <= config.StableHorizon && event.OccurredAt.Sub(enteredAt) >= config.MinimumUnstableDwell {
+				return aman.StateStable, aman.LifecycleReasonStableHorizon, nil
+			}
+		case aman.StateStable:
+			return flight.State, "", nil
+		default:
+			return "", "", invalidTransition(flight.State, event.Kind, "prediction cannot advance this state")
+		}
+		return flight.State, "", nil
+	case EventGoAroundConfirmed:
+		if flight.State != aman.StateUnstable && flight.State != aman.StateStable {
+			return "", "", invalidTransition(flight.State, event.Kind, "go-around requires an arriving flight")
+		}
+		return aman.StateGoAround, aman.LifecycleReasonGoAroundConfirmed, nil
+	case EventLandingConfirmed:
+		switch flight.State {
+		case aman.StateAirborne, aman.StateUnstable, aman.StateStable, aman.StateGoAround:
+			return aman.StateLanded, aman.LifecycleReasonLandingConfirmed, nil
+		default:
+			return "", "", invalidTransition(flight.State, event.Kind, "landing requires an airborne flight")
+		}
+	case EventManualRemoval:
+		if flight.State == aman.StateRemoved {
+			return "", "", invalidTransition(flight.State, event.Kind, "Removed is terminal")
+		}
+		return aman.StateRemoved, aman.LifecycleReasonManualRemoval, nil
+	case EventLandedTimeout:
+		if flight.State != aman.StateLanded {
+			return "", "", invalidTransition(flight.State, event.Kind, "landing timeout requires Landed")
+		}
+		return aman.StateRemoved, aman.LifecycleReasonLandedTimeout, nil
+	case EventPlannedCancellation:
+		if flight.State != aman.StatePlanned {
+			return "", "", invalidTransition(flight.State, event.Kind, "planned cancellation requires Planned")
+		}
+		return aman.StateRemoved, aman.LifecycleReasonPlannedCancellation, nil
+	default:
+		return "", "", invalidArgument("lifecycle event kind is invalid")
+	}
+}
+
+func validateEvent(event Event) error {
+	if !event.Kind.Valid() {
+		return invalidArgument("lifecycle event kind is invalid")
+	}
+	if event.ID == "" || strings.TrimSpace(event.ID) != event.ID {
+		return invalidArgument("lifecycle event ID is required")
+	}
+	if event.OccurredAt.IsZero() || event.OccurredAt.Location() != time.UTC {
+		return invalidArgument("lifecycle event time must be UTC")
+	}
+	if event.Kind == EventDataStatusChanged {
+		if !event.DataStatus.Valid() || event.OperationalTETA != nil {
+			return invalidArgument("data-status event payload is invalid")
+		}
+		return nil
+	}
+	if event.DataStatus != "" {
+		return invalidArgument("only a data-status event may change DataStatus")
+	}
+	if event.Kind == EventPredictionAccepted {
+		if event.OperationalTETA == nil || event.OperationalTETA.IsZero() || event.OperationalTETA.Location() != time.UTC {
+			return invalidArgument("accepted prediction requires a UTC operational TETA")
+		}
+		return nil
+	}
+	if event.OperationalTETA != nil {
+		return invalidArgument("only an accepted prediction may carry operational TETA")
+	}
+	return nil
+}
+
+func invalidArgument(message string) error {
+	return &aman.DomainError{Class: aman.ErrorInvalidArgument, Message: message}
+}
+
+func invalidTransition(state aman.FlightState, event EventKind, message string) error {
+	return &aman.DomainError{
+		Class:   aman.ErrorInvalidTransition,
+		Message: fmt.Sprintf("%s from %s: %s", event, state, message),
+	}
+}

--- a/backend/internal/aman/lifecycle/reducer_test.go
+++ b/backend/internal/aman/lifecycle/reducer_test.go
@@ -1,0 +1,247 @@
+package lifecycle_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/aman/lifecycle"
+	"FlightStrips/internal/aman/prediction"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReduceRunsFullLifecycleWithRecordedReasons(t *testing.T) {
+	now := lifecycleTime()
+	config := lifecycle.DefaultConfig()
+	flight := lifecycleFlight(now, aman.StatePlanned)
+
+	steps := []struct {
+		event  lifecycle.Event
+		want   aman.FlightState
+		reason aman.LifecycleReason
+	}{
+		{event: event("airborne", lifecycle.EventAirborneDetected, now), want: aman.StateAirborne, reason: aman.LifecycleReasonAirborneDetected},
+		{event: predictionEvent("unstable", now.Add(time.Minute), now.Add(46*time.Minute)), want: aman.StateUnstable, reason: aman.LifecycleReasonUnstableHorizon},
+		{event: predictionEvent("stable", now.Add(6*time.Minute), now.Add(26*time.Minute)), want: aman.StateStable, reason: aman.LifecycleReasonStableHorizon},
+		{event: event("go-around", lifecycle.EventGoAroundConfirmed, now.Add(7*time.Minute)), want: aman.StateGoAround, reason: aman.LifecycleReasonGoAroundConfirmed},
+		{event: predictionEvent("re-enter", now.Add(8*time.Minute), now.Add(53*time.Minute)), want: aman.StateUnstable, reason: aman.LifecycleReasonUnstableHorizon},
+		{event: event("landed", lifecycle.EventLandingConfirmed, now.Add(9*time.Minute)), want: aman.StateLanded, reason: aman.LifecycleReasonLandingConfirmed},
+		{event: event("removed", lifecycle.EventLandedTimeout, now.Add(10*time.Minute)), want: aman.StateRemoved, reason: aman.LifecycleReasonLandedTimeout},
+	}
+
+	for _, step := range steps {
+		result, err := lifecycle.Reduce(config, flight, step.event)
+		require.NoError(t, err)
+		require.NotNil(t, result.Transition)
+		require.Equal(t, flight.State, result.Transition.From)
+		require.Equal(t, step.want, result.Transition.To)
+		require.Equal(t, step.reason, result.Transition.Reason)
+		require.Equal(t, step.want, result.Flight.State)
+		require.Equal(t, step.reason, result.Flight.Lifecycle.Reason)
+		require.Equal(t, step.event.OccurredAt, result.Flight.Lifecycle.EnteredAt)
+		flight = result.Flight
+	}
+	require.NoError(t, flight.Validate())
+}
+
+func TestReduceUsesExactHorizonAndDwellBoundaries(t *testing.T) {
+	now := lifecycleTime()
+	config := lifecycle.DefaultConfig()
+	flight := lifecycleFlight(now, aman.StateAirborne)
+
+	before, err := lifecycle.Reduce(config, flight, predictionEvent("outside-unstable", now.Add(time.Minute), now.Add(46*time.Minute+time.Nanosecond)))
+	require.NoError(t, err)
+	require.Equal(t, aman.StateAirborne, before.Flight.State)
+	require.Nil(t, before.Transition)
+
+	atUnstable, err := lifecycle.Reduce(config, before.Flight, predictionEvent("at-unstable", now.Add(2*time.Minute), now.Add(47*time.Minute)))
+	require.NoError(t, err)
+	require.Equal(t, aman.StateUnstable, atUnstable.Flight.State)
+
+	beforeDwell, err := lifecycle.Reduce(config, atUnstable.Flight, predictionEvent("before-dwell", now.Add(7*time.Minute-time.Nanosecond), now.Add(27*time.Minute-time.Nanosecond)))
+	require.NoError(t, err)
+	require.Equal(t, aman.StateUnstable, beforeDwell.Flight.State)
+
+	atDwell, err := lifecycle.Reduce(config, beforeDwell.Flight, predictionEvent("at-dwell", now.Add(7*time.Minute), now.Add(27*time.Minute)))
+	require.NoError(t, err)
+	require.Equal(t, aman.StateStable, atDwell.Flight.State)
+	require.Equal(t, aman.LifecycleReasonStableHorizon, atDwell.Flight.Lifecycle.Reason)
+}
+
+func TestReduceKeepsDataStatusOrthogonalAndBlocksStaleAdvancement(t *testing.T) {
+	now := lifecycleTime()
+	config := lifecycle.DefaultConfig()
+	flight := lifecycleFlight(now, aman.StateAirborne)
+
+	stale, err := lifecycle.Reduce(config, flight, statusEvent("stale", now.Add(time.Minute), aman.DataStale))
+	require.NoError(t, err)
+	require.Equal(t, aman.StateAirborne, stale.Flight.State)
+	require.Equal(t, aman.DataStale, stale.Flight.DataStatus)
+
+	blocked, err := lifecycle.Reduce(config, stale.Flight, predictionEvent("stale-prediction", now.Add(2*time.Minute), now.Add(47*time.Minute)))
+	require.NoError(t, err)
+	require.Equal(t, aman.StateAirborne, blocked.Flight.State)
+	require.Nil(t, blocked.Transition)
+
+	disconnected, err := lifecycle.Reduce(config, blocked.Flight, statusEvent("disconnected", now.Add(3*time.Minute), aman.DataDisconnected))
+	require.NoError(t, err)
+	require.Equal(t, aman.StateAirborne, disconnected.Flight.State)
+	require.Equal(t, aman.DataDisconnected, disconnected.Flight.DataStatus)
+
+	restored, err := lifecycle.Reduce(config, disconnected.Flight, statusEvent("restored", now.Add(4*time.Minute), aman.DataFresh))
+	require.NoError(t, err)
+	advanced, err := lifecycle.Reduce(config, restored.Flight, predictionEvent("fresh-prediction", now.Add(5*time.Minute), now.Add(50*time.Minute)))
+	require.NoError(t, err)
+	require.Equal(t, aman.StateUnstable, advanced.Flight.State)
+}
+
+func TestReduceIsIdempotentAndRejectsOutOfOrderOrInvalidTransitions(t *testing.T) {
+	now := lifecycleTime()
+	config := lifecycle.DefaultConfig()
+	flight := lifecycleFlight(now, aman.StatePlanned)
+	firstEvent := event("airborne", lifecycle.EventAirborneDetected, now.Add(time.Minute))
+	first, err := lifecycle.Reduce(config, flight, firstEvent)
+	require.NoError(t, err)
+
+	duplicate, err := lifecycle.Reduce(config, first.Flight, firstEvent)
+	require.NoError(t, err)
+	require.True(t, duplicate.Duplicate)
+	require.Equal(t, first.Flight, duplicate.Flight)
+
+	_, err = lifecycle.Reduce(config, first.Flight, predictionEvent("old", now, now.Add(45*time.Minute)))
+	requireDomainClass(t, err, aman.ErrorInvalidTransition)
+	_, err = lifecycle.Reduce(config, first.Flight, event("airborne", lifecycle.EventManualRemoval, now.Add(2*time.Minute)))
+	requireDomainClass(t, err, aman.ErrorInvalidTransition)
+	_, err = lifecycle.Reduce(config, first.Flight, event("cancel", lifecycle.EventPlannedCancellation, now.Add(2*time.Minute)))
+	requireDomainClass(t, err, aman.ErrorInvalidTransition)
+	_, err = lifecycle.Reduce(config, first.Flight, event("timeout", lifecycle.EventLandedTimeout, now.Add(2*time.Minute)))
+	requireDomainClass(t, err, aman.ErrorInvalidTransition)
+
+	cancelled, err := lifecycle.Reduce(config, lifecycleFlight(now, aman.StatePlanned), event("cancel-planned", lifecycle.EventPlannedCancellation, now.Add(time.Minute)))
+	require.NoError(t, err)
+	require.Equal(t, aman.StateRemoved, cancelled.Flight.State)
+	require.Equal(t, aman.LifecycleReasonPlannedCancellation, cancelled.Flight.Lifecycle.Reason)
+
+	removed, err := lifecycle.Reduce(config, lifecycleFlight(now, aman.StateStable), event("manual-remove", lifecycle.EventManualRemoval, now.Add(time.Minute)))
+	require.NoError(t, err)
+	require.Equal(t, aman.StateRemoved, removed.Flight.State)
+}
+
+func TestReduceRestartReplayIsEquivalent(t *testing.T) {
+	now := lifecycleTime()
+	config := lifecycle.DefaultConfig()
+	flight := lifecycleFlight(now, aman.StateAirborne)
+	unstable, err := lifecycle.Reduce(config, flight, predictionEvent("unstable", now.Add(time.Minute), now.Add(46*time.Minute)))
+	require.NoError(t, err)
+
+	persisted, err := json.Marshal(unstable.Flight)
+	require.NoError(t, err)
+	var restored aman.AMANFlight
+	require.NoError(t, json.Unmarshal(persisted, &restored))
+	require.NoError(t, restored.Validate())
+
+	next := predictionEvent("stable", now.Add(6*time.Minute), now.Add(26*time.Minute))
+	want, err := lifecycle.Reduce(config, unstable.Flight, next)
+	require.NoError(t, err)
+	got, err := lifecycle.Reduce(config, restored, next)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestLifecycleAndPredictionPreserveCanonicalFreezePolicy(t *testing.T) {
+	now := lifecycleTime()
+	lifecycleConfig := lifecycle.DefaultConfig()
+	state := lifecycleFlight(now, aman.StateUnstable)
+	state.Lifecycle = &aman.LifecycleState{
+		EnteredAt: now.Add(-lifecycleConfig.MinimumUnstableDwell), Reason: aman.LifecycleReasonUnstableHorizon,
+		LastEventID: "unstable", LastEventFingerprint: "persisted", LastEventAt: now.Add(-lifecycleConfig.MinimumUnstableDwell),
+	}
+
+	stable, err := lifecycle.Reduce(lifecycleConfig, state, predictionEvent("stable", now, now.Add(20*time.Minute)))
+	require.NoError(t, err)
+	require.Equal(t, aman.StateStable, stable.Flight.State)
+	holding := "north-hold"
+	stable.Flight.SelectedHolding = &holding
+
+	predictionConfig := prediction.DefaultConfig()
+	raw := rawPrediction(now.Add(time.Minute), now.Add(20*time.Minute))
+	holdingFix := raw.GeneratedAt.Add(predictionConfig.SuperstableHorizon)
+	raw.HoldingFixETA = &holdingFix
+	slot := aman.Slot{Time: now.Add(25 * time.Minute), RunwayGroupID: "north", Sequence: 3, Reason: "spacing"}
+	frozen, err := prediction.Reduce(predictionConfig, stable.Flight, prediction.Input{Raw: raw, State: stable.Flight.State, Slot: &slot})
+	require.NoError(t, err)
+	require.Equal(t, aman.StateStable, frozen.Flight.State)
+	require.Equal(t, aman.FreezeSuperstable, frozen.Flight.FreezeReason)
+	require.Equal(t, slot, *frozen.Flight.FrozenSlot)
+
+	drifted, err := prediction.Reduce(predictionConfig, frozen.Flight, prediction.Input{
+		Raw: rawPrediction(now.Add(2*time.Minute), now.Add(24*time.Minute)), State: frozen.Flight.State, RouteRevision: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, *frozen.Flight.FrozenOperationalTETA, drifted.Flight.Prediction.OperationalTETA)
+	require.Positive(t, drifted.RawDrift)
+
+	manual := now.Add(22 * time.Minute)
+	overridden, err := prediction.Reduce(predictionConfig, drifted.Flight, prediction.Input{
+		Raw: rawPrediction(now.Add(3*time.Minute), now.Add(23*time.Minute)), State: drifted.Flight.State, ManualOverride: &manual,
+	})
+	require.NoError(t, err)
+	require.Equal(t, aman.FreezeManual, overridden.Flight.FreezeReason)
+
+	released, err := prediction.Reduce(predictionConfig, overridden.Flight, prediction.Input{
+		Raw: rawPrediction(now.Add(4*time.Minute), now.Add(23*time.Minute)), State: overridden.Flight.State, ReleaseFreeze: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, aman.FreezeNone, released.Flight.FreezeReason)
+
+	goAroundState, err := lifecycle.Reduce(lifecycleConfig, released.Flight, event("go-around", lifecycle.EventGoAroundConfirmed, now.Add(5*time.Minute)))
+	require.NoError(t, err)
+	goAround, err := prediction.Reduce(predictionConfig, goAroundState.Flight, prediction.Input{
+		Raw: rawPrediction(now.Add(6*time.Minute), now.Add(30*time.Minute)), State: goAroundState.Flight.State, ConfirmedGoAround: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, aman.StateGoAround, goAround.Flight.State)
+	require.Equal(t, aman.FreezeNone, goAround.Flight.FreezeReason)
+	require.Nil(t, goAround.Flight.Slot)
+}
+
+func lifecycleTime() time.Time {
+	return time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)
+}
+
+func lifecycleFlight(now time.Time, state aman.FlightState) aman.AMANFlight {
+	return aman.AMANFlight{
+		ID: "flight-1", VATSIMCID: "1234567", CurrentCallsign: "SAS123", State: state,
+		DataStatus: aman.DataFresh, FreezeReason: aman.FreezeNone, UpdatedAt: now,
+	}
+}
+
+func event(id string, kind lifecycle.EventKind, at time.Time) lifecycle.Event {
+	return lifecycle.Event{ID: id, Kind: kind, OccurredAt: at}
+}
+
+func predictionEvent(id string, at, operationalTETA time.Time) lifecycle.Event {
+	return lifecycle.Event{ID: id, Kind: lifecycle.EventPredictionAccepted, OccurredAt: at, OperationalTETA: &operationalTETA}
+}
+
+func statusEvent(id string, at time.Time, status aman.DataStatus) lifecycle.Event {
+	return lifecycle.Event{ID: id, Kind: lifecycle.EventDataStatusChanged, OccurredAt: at, DataStatus: status}
+}
+
+func rawPrediction(generatedAt, rawTETA time.Time) aman.Prediction {
+	return aman.Prediction{
+		RawTETA: rawTETA, GeneratedAt: generatedAt, InputObservedAt: generatedAt,
+		Confidence: aman.ConfidenceHigh, Publishable: true, DatasetVersion: "2607", GeometryDigest: "geometry",
+		ModelVersion: "performance-wind-v1", ConfigVersion: "ekch-v1", Sources: []string{"vatsim", "airacnet"},
+	}
+}
+
+func requireDomainClass(t *testing.T, err error, class aman.ErrorClass) {
+	t.Helper()
+	require.Error(t, err)
+	var domainError *aman.DomainError
+	require.True(t, errors.As(err, &domainError))
+	require.Equal(t, class, domainError.Class)
+}

--- a/backend/internal/aman/prediction/reducer.go
+++ b/backend/internal/aman/prediction/reducer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"strings"
 	"time"
 
 	"FlightStrips/internal/aman"
@@ -144,7 +145,8 @@ func Reduce(config Config, flight aman.AMANFlight, input Input) (Result, error) 
 
 	// Superstable happens only at the exact configured holding-fix boundary,
 	// never before/after it and never until a complete slot exists.
-	if atSuperstableBoundary(input.Raw.GeneratedAt, input.Raw.HoldingFixETA, config.SuperstableHorizon) && flight.Slot != nil {
+	if atSuperstableBoundary(input.Raw.GeneratedAt, input.Raw.HoldingFixETA, config.SuperstableHorizon) &&
+		flight.SelectedHolding != nil && strings.TrimSpace(*flight.SelectedHolding) != "" && flight.Slot != nil {
 		freezeAt := input.Raw.GeneratedAt
 		frozenTETA := candidate
 		frozenSlot := cloneSlot(flight.Slot)

--- a/backend/internal/aman/prediction/reducer_test.go
+++ b/backend/internal/aman/prediction/reducer_test.go
@@ -121,6 +121,12 @@ func TestReduceDoesNotFreezeWithoutSlotOrOutsideExactBoundary(t *testing.T) {
 	result, err = Reduce(config, predictionFlight(now), Input{Raw: raw, State: aman.StateStable})
 	require.NoError(t, err)
 	require.Equal(t, aman.FreezeNone, result.Flight.FreezeReason)
+
+	withoutSelectedHolding := predictionFlight(now)
+	withoutSelectedHolding.SelectedHolding = nil
+	result, err = Reduce(config, withoutSelectedHolding, Input{Raw: raw, State: aman.StateStable, Slot: &slot})
+	require.NoError(t, err)
+	require.Equal(t, aman.FreezeNone, result.Flight.FreezeReason)
 }
 
 func TestReduceIgnoresStaleRawAndFrozenSlotUpdates(t *testing.T) {
@@ -152,7 +158,8 @@ func predictionTime() time.Time {
 }
 
 func predictionFlight(now time.Time) aman.AMANFlight {
-	return aman.AMANFlight{ID: "flight-1", VATSIMCID: "1234567", CurrentCallsign: "SAS123", State: aman.StateStable, DataStatus: aman.DataFresh, FreezeReason: aman.FreezeNone, UpdatedAt: now}
+	holding := "north-hold"
+	return aman.AMANFlight{ID: "flight-1", VATSIMCID: "1234567", CurrentCallsign: "SAS123", State: aman.StateStable, DataStatus: aman.DataFresh, SelectedHolding: &holding, FreezeReason: aman.FreezeNone, UpdatedAt: now}
 }
 
 func rawPrediction(generatedAt, rawTETA time.Time) aman.Prediction {

--- a/backend/internal/aman/types.go
+++ b/backend/internal/aman/types.go
@@ -39,6 +39,40 @@ func (s FlightState) Valid() bool {
 	}
 }
 
+// LifecycleReason records why the flight entered its current lifecycle state.
+// It is persisted with the aggregate so restart and replay do not have to
+// infer a transition from the current prediction or source status.
+type LifecycleReason string
+
+const (
+	LifecycleReasonInitial             LifecycleReason = "initial"
+	LifecycleReasonAirborneDetected    LifecycleReason = "airborne_detected"
+	LifecycleReasonUnstableHorizon     LifecycleReason = "unstable_horizon"
+	LifecycleReasonStableHorizon       LifecycleReason = "stable_horizon"
+	LifecycleReasonGoAroundConfirmed   LifecycleReason = "go_around_confirmed"
+	LifecycleReasonLandingConfirmed    LifecycleReason = "landing_confirmed"
+	LifecycleReasonManualRemoval       LifecycleReason = "manual_removal"
+	LifecycleReasonLandedTimeout       LifecycleReason = "landed_timeout"
+	LifecycleReasonPlannedCancellation LifecycleReason = "planned_cancellation"
+)
+
+func (r LifecycleReason) Valid() bool {
+	switch r {
+	case LifecycleReasonInitial,
+		LifecycleReasonAirborneDetected,
+		LifecycleReasonUnstableHorizon,
+		LifecycleReasonStableHorizon,
+		LifecycleReasonGoAroundConfirmed,
+		LifecycleReasonLandingConfirmed,
+		LifecycleReasonManualRemoval,
+		LifecycleReasonLandedTimeout,
+		LifecycleReasonPlannedCancellation:
+		return true
+	default:
+		return false
+	}
+}
+
 type DataStatus string
 
 const (
@@ -347,6 +381,18 @@ type GoAroundDetectionState struct {
 	EpisodeID *string
 }
 
+// LifecycleState is the persisted ordering cursor and current-state entry
+// metadata owned by the lifecycle reducer. The event fingerprint makes an
+// exact retry idempotent; LastEventAt rejects delayed events that would
+// otherwise regress the aggregate after a restart.
+type LifecycleState struct {
+	EnteredAt            time.Time
+	Reason               LifecycleReason
+	LastEventID          string
+	LastEventFingerprint string
+	LastEventAt          time.Time
+}
+
 // RunwayGroupPolicy is the airport-state identity for a runway group. The
 // sequence component owns the policy's rate and spacing declarations.
 type RunwayGroupPolicy struct {
@@ -379,6 +425,7 @@ type AMANFlight struct {
 	Order                 *int
 	ETAReview             *ETAReview
 	GoAroundDetection     *GoAroundDetectionState
+	Lifecycle             *LifecycleState
 	UpdatedAt             time.Time
 }
 
@@ -609,6 +656,17 @@ func (f AMANFlight) Validate() error {
 			return invalid("route progress is invalid")
 		}
 	}
+	if f.Lifecycle != nil {
+		if err := f.Lifecycle.Validate(); err != nil {
+			return err
+		}
+		if f.Lifecycle.EnteredAt.After(f.Lifecycle.LastEventAt) {
+			return invalid("lifecycle state entry cannot follow its event cursor")
+		}
+		if !f.lifecycleReasonMatchesState() {
+			return invalid("lifecycle reason does not match flight state")
+		}
+	}
 	if err := f.validateFreeze(); err != nil {
 		return err
 	}
@@ -618,6 +676,43 @@ func (f AMANFlight) Validate() error {
 		}
 	}
 	return requireUTCTime("updated at", f.UpdatedAt)
+}
+
+func (s LifecycleState) Validate() error {
+	if !s.Reason.Valid() {
+		return invalid("lifecycle reason is invalid")
+	}
+	if err := requireUTCTime("lifecycle entered at", s.EnteredAt); err != nil {
+		return err
+	}
+	if err := requireUTCTime("lifecycle last event at", s.LastEventAt); err != nil {
+		return err
+	}
+	if !isTrimmedNonEmpty(s.LastEventID) || !isTrimmedNonEmpty(s.LastEventFingerprint) {
+		return invalid("lifecycle last event identity is required")
+	}
+	return nil
+}
+
+func (f AMANFlight) lifecycleReasonMatchesState() bool {
+	switch f.Lifecycle.Reason {
+	case LifecycleReasonInitial:
+		return true
+	case LifecycleReasonAirborneDetected:
+		return f.State == StateAirborne
+	case LifecycleReasonUnstableHorizon:
+		return f.State == StateUnstable
+	case LifecycleReasonStableHorizon:
+		return f.State == StateStable
+	case LifecycleReasonGoAroundConfirmed:
+		return f.State == StateGoAround
+	case LifecycleReasonLandingConfirmed:
+		return f.State == StateLanded
+	case LifecycleReasonManualRemoval, LifecycleReasonLandedTimeout, LifecycleReasonPlannedCancellation:
+		return f.State == StateRemoved
+	default:
+		return false
+	}
 }
 
 func (f AMANFlight) validateFreeze() error {

--- a/backend/internal/aman/types_test.go
+++ b/backend/internal/aman/types_test.go
@@ -53,6 +53,7 @@ func TestDomainTypesDoNotDeclareWireJSONTags(t *testing.T) {
 		reflect.TypeFor[RouteFact](),
 		reflect.TypeFor[ETAReview](),
 		reflect.TypeFor[GoAroundDetectionState](),
+		reflect.TypeFor[LifecycleState](),
 		reflect.TypeFor[RunwayGroupPolicy](),
 		reflect.TypeFor[AMANFlight](),
 		reflect.TypeFor[AirportState](),


### PR DESCRIPTION
## Summary
- add a deterministic, event-ordered AMAN lifecycle reducer
- persist lifecycle transition reasons and idempotency ordering state
- keep data freshness orthogonal and require a selected holding for Superstable freeze

## Validation
- go test ./internal/aman/...

Closes #319
Part of #298