### PR TITLE
feat(aman): detect and report go-arounds

### DIFF
--- a/backend/internal/aman/lifecycle/go_around.go
+++ b/backend/internal/aman/lifecycle/go_around.go
@@ -1,0 +1,423 @@
+package lifecycle
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"FlightStrips/internal/aman"
+)
+
+const maximumGoAroundEvidence = 64
+
+// GoAroundReason identifies the independent multi-sample evidence that
+// confirmed one go-around episode.
+type GoAroundReason string
+
+const (
+	GoAroundReasonClimb      GoAroundReason = "climb"
+	GoAroundReasonTrackAway  GoAroundReason = "track_away"
+	GoAroundReasonRunwayExit GoAroundReason = "runway_exit_without_landing"
+)
+
+func (r GoAroundReason) Valid() bool {
+	return r == GoAroundReasonClimb || r == GoAroundReasonTrackAway || r == GoAroundReasonRunwayExit
+}
+
+// GoAroundConfig contains detector policy rather than airport geometry. The
+// owning application persists its version in AirportState and supplies the
+// canonical final-path corridor selected for the flight.
+type GoAroundConfig struct {
+	EvidenceLimit                   int
+	ArmSamples                      int
+	ConfirmSamples                  int
+	ArmBelowAltitudeFeet            int
+	InboundToleranceDegrees         float64
+	MinimumClimbFeet                int
+	TrackAwayDegrees                float64
+	RunwayExitAfterThresholdNM      float64
+	LandingAltitudeToleranceFeet    int
+	MinimumAirborneGroundspeedKnots float64
+}
+
+func (c GoAroundConfig) Validate() error {
+	if c.EvidenceLimit < 2 || c.EvidenceLimit > maximumGoAroundEvidence || c.ArmSamples < 2 || c.ConfirmSamples < 2 || c.EvidenceLimit < c.ArmSamples || c.EvidenceLimit < c.ConfirmSamples {
+		return invalidArgument("go-around sample counts or evidence limit are invalid")
+	}
+	if c.ArmBelowAltitudeFeet <= 0 || c.MinimumClimbFeet <= 0 || c.LandingAltitudeToleranceFeet < 0 {
+		return invalidArgument("go-around altitude policy is invalid")
+	}
+	if !finiteNumber(c.InboundToleranceDegrees) || c.InboundToleranceDegrees <= 0 || c.InboundToleranceDegrees >= 90 || !finiteNumber(c.TrackAwayDegrees) || c.TrackAwayDegrees <= c.InboundToleranceDegrees || c.TrackAwayDegrees > 180 {
+		return invalidArgument("go-around track policy is invalid")
+	}
+	if !finiteNumber(c.RunwayExitAfterThresholdNM) || c.RunwayExitAfterThresholdNM < 0 || !finiteNumber(c.MinimumAirborneGroundspeedKnots) || c.MinimumAirborneGroundspeedKnots < 0 {
+		return invalidArgument("go-around runway-exit policy is invalid")
+	}
+	return nil
+}
+
+// FinalPathCorridor is the canonical, provider-neutral final geometry used by
+// the detector. An adapter maps the selected #309 runway geometry into this
+// type; the detector never calls a navigation provider or EuroScope.
+type FinalPathCorridor struct {
+	ID                     string
+	ThresholdLatitude      float64
+	ThresholdLongitude     float64
+	ThresholdElevationFeet int
+	InboundCourseDegrees   float64
+	LengthNM               float64
+	HalfWidthNM            float64
+}
+
+func (c FinalPathCorridor) Validate() error {
+	if c.ID == "" || strings.TrimSpace(c.ID) != c.ID {
+		return invalidArgument("final-path corridor ID is required")
+	}
+	if !finiteNumber(c.ThresholdLatitude) || !finiteNumber(c.ThresholdLongitude) || c.ThresholdLatitude < -90 || c.ThresholdLatitude > 90 || c.ThresholdLongitude < -180 || c.ThresholdLongitude > 180 {
+		return invalidArgument("final-path threshold coordinate is invalid")
+	}
+	if !finiteNumber(c.InboundCourseDegrees) || c.InboundCourseDegrees < 0 || c.InboundCourseDegrees >= 360 || !finiteNumber(c.LengthNM) || c.LengthNM <= 0 || !finiteNumber(c.HalfWidthNM) || c.HalfWidthNM <= 0 {
+		return invalidArgument("final-path corridor geometry is invalid")
+	}
+	return nil
+}
+
+// GoAroundInput supplies one normalized observation and all explicit facts
+// that can disarm a detector. Previous is copied before reduction.
+type GoAroundInput struct {
+	FlightID           aman.FlightID
+	Observation        aman.FlightObservation
+	Corridor           FinalPathCorridor
+	Previous           aman.GoAroundDetectionState
+	PolicyVersion      string
+	Now                time.Time
+	InScope            bool
+	LandingConfirmed   bool
+	RouteChanged       bool
+	RunwayGroupChanged bool
+}
+
+// GoAroundConfirmed is the typed operational event emitted once per arming
+// episode. SupportingObservationTimes are oldest-first audit evidence.
+type GoAroundConfirmed struct {
+	ID                         string
+	EpisodeID                  string
+	FlightID                   aman.FlightID
+	Reason                     GoAroundReason
+	ConfirmedAt                time.Time
+	SupportingObservationTimes []time.Time
+}
+
+// LifecycleEvent maps the detector result into the state-machine event owned
+// by #319 without allowing the detector to mutate lifecycle or slots itself.
+func (e GoAroundConfirmed) LifecycleEvent() Event {
+	return Event{ID: e.ID, Kind: EventGoAroundConfirmed, OccurredAt: e.ConfirmedAt}
+}
+
+type GoAroundResult struct {
+	State     aman.GoAroundDetectionState
+	Confirmed *GoAroundConfirmed
+	Duplicate bool
+}
+
+// GoAroundDetector is the lifecycle-owned stateful detector boundary.
+type GoAroundDetector interface {
+	Detect(GoAroundInput) (GoAroundResult, error)
+}
+
+type goAroundDetector struct{ config GoAroundConfig }
+
+func NewGoAroundDetector(config GoAroundConfig) (GoAroundDetector, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+	return &goAroundDetector{config: config}, nil
+}
+
+func (d *goAroundDetector) Detect(input GoAroundInput) (GoAroundResult, error) {
+	if err := validateGoAroundInput(input); err != nil {
+		return GoAroundResult{}, err
+	}
+	if !zeroDetectionState(input.Previous) {
+		if err := input.Previous.Validate(); err != nil {
+			return GoAroundResult{}, err
+		}
+	}
+	state := cloneDetectionState(input.Previous)
+	if state.PolicyVersion != input.PolicyVersion {
+		disarm(&state, true)
+		state.PolicyVersion = input.PolicyVersion
+	}
+
+	surveillance := input.Observation.Surveillance
+	if input.LandingConfirmed || input.Observation.SourceStatus != aman.DataFresh {
+		disarm(&state, true)
+		return checkedGoAroundResult(state, nil, false)
+	}
+	if surveillance == nil {
+		return checkedGoAroundResult(state, nil, false)
+	}
+	if duplicateOrOutOfOrder(state, *surveillance) {
+		return checkedGoAroundResult(state, nil, true)
+	}
+	if input.RouteChanged || input.RunwayGroupChanged || (state.Armed && state.ArmedCorridorID != input.Corridor.ID) {
+		disarm(&state, true)
+	}
+	if !input.InScope && !state.Armed {
+		disarm(&state, true)
+		acceptCursor(&state, *surveillance)
+		return checkedGoAroundResult(state, nil, false)
+	}
+
+	evidence, complete, retain := d.evidence(input, state)
+	acceptCursor(&state, *surveillance)
+	if !complete {
+		state.ArmCount, state.ClimbCount, state.TrackAwayCount, state.RunwayExitCount = 0, 0, 0, 0
+		if retain {
+			appendEvidence(&state, evidence, d.config.EvidenceLimit)
+		}
+		return checkedGoAroundResult(state, nil, false)
+	}
+
+	along, lateral := relativeNM(input.Corridor, evidence.LatitudeDegrees, evidence.LongitudeDegrees)
+	insideFinal := along >= -input.Corridor.LengthNM && along <= 0 && math.Abs(lateral) <= input.Corridor.HalfWidthNM
+	inbound := angularDifference(*evidence.TrackTrueDegrees, input.Corridor.InboundCourseDegrees) <= d.config.InboundToleranceDegrees
+	armEvidence := insideFinal && inbound && evidence.AltitudeFeet <= d.config.ArmBelowAltitudeFeet
+	if !state.Armed {
+		if armEvidence {
+			state.ArmCount++
+		} else {
+			state.ArmCount = 0
+		}
+	}
+
+	previous, hasPrevious := lastEvidence(state.Evidence)
+	justArmed := false
+	if !state.Armed && state.ArmCount >= d.config.ArmSamples {
+		state.Armed = true
+		state.Episode++
+		state.ArmedCorridorID = input.Corridor.ID
+		state.ArmedAt = ptrTime(firstSupportingTime(state.Evidence, evidence, d.config.ArmSamples))
+		state.ClimbCount, state.TrackAwayCount, state.RunwayExitCount = 0, 0, 0
+		justArmed = true
+	}
+
+	if state.Armed && !justArmed {
+		if along >= 0 {
+			state.ThresholdCrossed = true
+		}
+		evidence.ClimbEvidence = hasPrevious && evidence.AltitudeFeet-previous.AltitudeFeet >= d.config.MinimumClimbFeet
+		evidence.TrackAwayEvidence = angularDifference(*evidence.TrackTrueDegrees, input.Corridor.InboundCourseDegrees) >= d.config.TrackAwayDegrees
+		evidence.RunwayExitEvidence = state.ThresholdCrossed && (along >= d.config.RunwayExitAfterThresholdNM || math.Abs(lateral) > input.Corridor.HalfWidthNM) && evidence.AltitudeFeet >= input.Corridor.ThresholdElevationFeet+d.config.LandingAltitudeToleranceFeet && evidence.GroundspeedKnots >= d.config.MinimumAirborneGroundspeedKnots
+		state.ClimbCount = consecutive(state.ClimbCount, evidence.ClimbEvidence)
+		state.TrackAwayCount = consecutive(state.TrackAwayCount, evidence.TrackAwayEvidence)
+		state.RunwayExitCount = consecutive(state.RunwayExitCount, evidence.RunwayExitEvidence)
+	}
+
+	appendEvidence(&state, evidence, d.config.EvidenceLimit)
+	if justArmed {
+		return checkedGoAroundResult(state, nil, false)
+	}
+	reason := GoAroundReason("")
+	switch {
+	case state.ClimbCount >= d.config.ConfirmSamples:
+		reason = GoAroundReasonClimb
+	case state.TrackAwayCount >= d.config.ConfirmSamples:
+		reason = GoAroundReasonTrackAway
+	case state.RunwayExitCount >= d.config.ConfirmSamples:
+		reason = GoAroundReasonRunwayExit
+	}
+	if reason == "" {
+		return checkedGoAroundResult(state, nil, false)
+	}
+
+	episodeID := fmt.Sprintf("%s/go-around/%d", input.FlightID, state.Episode)
+	confirmed := &GoAroundConfirmed{
+		ID: episodeID + "/confirmed", EpisodeID: episodeID, FlightID: input.FlightID,
+		Reason: reason, ConfirmedAt: input.Now, SupportingObservationTimes: supportingTimes(state.Evidence, reason, d.config.ConfirmSamples),
+	}
+	state.LastEmittedEpisode = state.Episode
+	disarm(&state, false)
+	return checkedGoAroundResult(state, confirmed, false)
+}
+
+func validateGoAroundInput(input GoAroundInput) error {
+	if strings.TrimSpace(string(input.FlightID)) == "" || input.FlightID != input.Observation.FlightID {
+		return invalidArgument("go-around input flight identity is invalid")
+	}
+	if err := input.Observation.Validate(); err != nil {
+		return err
+	}
+	if err := input.Corridor.Validate(); err != nil {
+		return err
+	}
+	if input.PolicyVersion == "" || strings.TrimSpace(input.PolicyVersion) != input.PolicyVersion {
+		return invalidArgument("go-around policy version is required")
+	}
+	if input.Now.IsZero() || input.Now.Location() != time.UTC {
+		return invalidArgument("go-around injected time must be UTC")
+	}
+	if input.Observation.Surveillance != nil && input.Observation.Surveillance.ObservedAt != nil && input.Observation.Surveillance.ObservedAt.After(input.Now) {
+		return invalidArgument("go-around observation cannot be in the future")
+	}
+	return nil
+}
+
+func (d *goAroundDetector) evidence(input GoAroundInput, state aman.GoAroundDetectionState) (aman.GoAroundEvidence, bool, bool) {
+	surveillance := *input.Observation.Surveillance
+	evidence := aman.GoAroundEvidence{
+		ObservedAt: *surveillance.ObservedAt, Sequence: cloneUint64(surveillance.Sequence),
+		LatitudeDegrees: surveillance.LatitudeDegrees, LongitudeDegrees: surveillance.LongitudeDegrees,
+	}
+	if surveillance.AltitudeFeet == nil || surveillance.GroundspeedKnots == nil {
+		return evidence, false, false
+	}
+	evidence.AltitudeFeet = *surveillance.AltitudeFeet
+	evidence.GroundspeedKnots = *surveillance.GroundspeedKnots
+	if surveillance.TrackTrueDegrees != nil {
+		evidence.TrackTrueDegrees = cloneFloat64(surveillance.TrackTrueDegrees)
+	} else if previous, ok := lastEvidence(state.Evidence); ok {
+		if track, ok := bearing(previous.LatitudeDegrees, previous.LongitudeDegrees, evidence.LatitudeDegrees, evidence.LongitudeDegrees); ok {
+			evidence.TrackTrueDegrees = &track
+		}
+	}
+	return evidence, evidence.TrackTrueDegrees != nil, true
+}
+
+func duplicateOrOutOfOrder(state aman.GoAroundDetectionState, observation aman.SurveillanceFact) bool {
+	if state.LastProcessedSequence != nil && observation.Sequence != nil && *observation.Sequence <= *state.LastProcessedSequence {
+		return true
+	}
+	return state.LastProcessedAt != nil && observation.ObservedAt != nil && !observation.ObservedAt.After(*state.LastProcessedAt)
+}
+
+func acceptCursor(state *aman.GoAroundDetectionState, observation aman.SurveillanceFact) {
+	state.LastProcessedAt = ptrTime(*observation.ObservedAt)
+	state.LastProcessedSequence = cloneUint64(observation.Sequence)
+}
+
+func appendEvidence(state *aman.GoAroundDetectionState, evidence aman.GoAroundEvidence, limit int) {
+	state.Evidence = append(state.Evidence, evidence)
+	if len(state.Evidence) > limit {
+		state.Evidence = append([]aman.GoAroundEvidence(nil), state.Evidence[len(state.Evidence)-limit:]...)
+	}
+}
+
+func disarm(state *aman.GoAroundDetectionState, clearEvidence bool) {
+	state.ArmCount, state.ClimbCount, state.TrackAwayCount, state.RunwayExitCount = 0, 0, 0, 0
+	state.Armed, state.ThresholdCrossed = false, false
+	state.ArmedAt, state.ArmedCorridorID = nil, ""
+	if clearEvidence {
+		state.Evidence = nil
+	}
+}
+
+func checkedGoAroundResult(state aman.GoAroundDetectionState, confirmed *GoAroundConfirmed, duplicate bool) (GoAroundResult, error) {
+	if err := state.Validate(); err != nil {
+		return GoAroundResult{}, err
+	}
+	return GoAroundResult{State: state, Confirmed: confirmed, Duplicate: duplicate}, nil
+}
+
+func cloneDetectionState(state aman.GoAroundDetectionState) aman.GoAroundDetectionState {
+	state.Evidence = append([]aman.GoAroundEvidence(nil), state.Evidence...)
+	for index := range state.Evidence {
+		state.Evidence[index].Sequence = cloneUint64(state.Evidence[index].Sequence)
+		state.Evidence[index].TrackTrueDegrees = cloneFloat64(state.Evidence[index].TrackTrueDegrees)
+	}
+	state.ArmedAt = cloneTime(state.ArmedAt)
+	state.LastProcessedAt = cloneTime(state.LastProcessedAt)
+	state.LastProcessedSequence = cloneUint64(state.LastProcessedSequence)
+	return state
+}
+
+func zeroDetectionState(state aman.GoAroundDetectionState) bool {
+	return state.PolicyVersion == "" && len(state.Evidence) == 0 && state.ArmCount == 0 && state.ClimbCount == 0 && state.TrackAwayCount == 0 && state.RunwayExitCount == 0 && !state.Armed && state.ArmedAt == nil && state.ArmedCorridorID == "" && state.Episode == 0 && state.LastEmittedEpisode == 0 && state.LastProcessedAt == nil && state.LastProcessedSequence == nil && !state.ThresholdCrossed
+}
+
+func lastEvidence(values []aman.GoAroundEvidence) (aman.GoAroundEvidence, bool) {
+	if len(values) == 0 {
+		return aman.GoAroundEvidence{}, false
+	}
+	return values[len(values)-1], true
+}
+
+func firstSupportingTime(existing []aman.GoAroundEvidence, current aman.GoAroundEvidence, count int) time.Time {
+	all := append(append([]aman.GoAroundEvidence(nil), existing...), current)
+	return all[len(all)-count].ObservedAt
+}
+
+func supportingTimes(evidence []aman.GoAroundEvidence, reason GoAroundReason, count int) []time.Time {
+	result := make([]time.Time, 0, count)
+	for index := len(evidence) - 1; index >= 0 && len(result) < count; index-- {
+		value := evidence[index]
+		matches := reason == GoAroundReasonClimb && value.ClimbEvidence || reason == GoAroundReasonTrackAway && value.TrackAwayEvidence || reason == GoAroundReasonRunwayExit && value.RunwayExitEvidence
+		if !matches {
+			break
+		}
+		result = append(result, value.ObservedAt)
+	}
+	for left, right := 0, len(result)-1; left < right; left, right = left+1, right-1 {
+		result[left], result[right] = result[right], result[left]
+	}
+	return result
+}
+
+func consecutive(current int, matched bool) int {
+	if !matched {
+		return 0
+	}
+	return current + 1
+}
+
+func relativeNM(corridor FinalPathCorridor, latitude, longitude float64) (float64, float64) {
+	north := (latitude - corridor.ThresholdLatitude) * 60
+	east := (longitude - corridor.ThresholdLongitude) * 60 * math.Cos(corridor.ThresholdLatitude*math.Pi/180)
+	course := corridor.InboundCourseDegrees * math.Pi / 180
+	inboundEast, inboundNorth := math.Sin(course), math.Cos(course)
+	return east*inboundEast + north*inboundNorth, east*inboundNorth - north*inboundEast
+}
+
+func bearing(fromLatitude, fromLongitude, toLatitude, toLongitude float64) (float64, bool) {
+	lat1, lat2 := fromLatitude*math.Pi/180, toLatitude*math.Pi/180
+	deltaLongitude := (toLongitude - fromLongitude) * math.Pi / 180
+	y := math.Sin(deltaLongitude) * math.Cos(lat2)
+	x := math.Cos(lat1)*math.Sin(lat2) - math.Sin(lat1)*math.Cos(lat2)*math.Cos(deltaLongitude)
+	if math.Hypot(x, y) < 1e-12 {
+		return 0, false
+	}
+	return math.Mod(math.Atan2(y, x)*180/math.Pi+360, 360), true
+}
+
+func angularDifference(first, second float64) float64 {
+	difference := math.Abs(first - second)
+	if difference > 180 {
+		return 360 - difference
+	}
+	return difference
+}
+
+func finiteNumber(value float64) bool    { return !math.IsNaN(value) && !math.IsInf(value, 0) }
+func ptrTime(value time.Time) *time.Time { return &value }
+func cloneTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+func cloneUint64(value *uint64) *uint64 {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+func cloneFloat64(value *float64) *float64 {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}

--- a/backend/internal/aman/lifecycle/go_around.go
+++ b/backend/internal/aman/lifecycle/go_around.go
@@ -19,10 +19,11 @@ const (
 	GoAroundReasonClimb      GoAroundReason = "climb"
 	GoAroundReasonTrackAway  GoAroundReason = "track_away"
 	GoAroundReasonRunwayExit GoAroundReason = "runway_exit_without_landing"
+	GoAroundReasonController GoAroundReason = "controller_marked"
 )
 
 func (r GoAroundReason) Valid() bool {
-	return r == GoAroundReasonClimb || r == GoAroundReasonTrackAway || r == GoAroundReasonRunwayExit
+	return r == GoAroundReasonClimb || r == GoAroundReasonTrackAway || r == GoAroundReasonRunwayExit || r == GoAroundReasonController
 }
 
 // GoAroundConfig contains detector policy rather than airport geometry. The
@@ -96,6 +97,15 @@ type GoAroundInput struct {
 	LandingConfirmed   bool
 	RouteChanged       bool
 	RunwayGroupChanged bool
+	ControllerMarked   *ControllerGoAround
+}
+
+// ControllerGoAround is the authorized controller fact that a strip has gone
+// around. Command idempotency and authorization remain at the command boundary;
+// the detector persists the last accepted command so replay remains stable.
+type ControllerGoAround struct {
+	CommandID string
+	Actor     string
 }
 
 // GoAroundConfirmed is the typed operational event emitted once per arming
@@ -107,6 +117,7 @@ type GoAroundConfirmed struct {
 	Reason                     GoAroundReason
 	ConfirmedAt                time.Time
 	SupportingObservationTimes []time.Time
+	ControllerActor            *string
 }
 
 // LifecycleEvent maps the detector result into the state-machine event owned
@@ -148,6 +159,9 @@ func (d *goAroundDetector) Detect(input GoAroundInput) (GoAroundResult, error) {
 	if state.PolicyVersion != input.PolicyVersion {
 		disarm(&state, true)
 		state.PolicyVersion = input.PolicyVersion
+	}
+	if input.ControllerMarked != nil {
+		return controllerConfirmed(state, input)
 	}
 
 	surveillance := input.Observation.Surveillance
@@ -261,7 +275,26 @@ func validateGoAroundInput(input GoAroundInput) error {
 	if input.Observation.Surveillance != nil && input.Observation.Surveillance.ObservedAt != nil && input.Observation.Surveillance.ObservedAt.After(input.Now) {
 		return invalidArgument("go-around observation cannot be in the future")
 	}
+	if input.ControllerMarked != nil && (!isTrimmed(input.ControllerMarked.CommandID) || !isTrimmed(input.ControllerMarked.Actor)) {
+		return invalidArgument("controller go-around command identity is required")
+	}
 	return nil
+}
+
+func controllerConfirmed(state aman.GoAroundDetectionState, input GoAroundInput) (GoAroundResult, error) {
+	command := input.ControllerMarked
+	if state.LastControllerCommandID == command.CommandID {
+		return checkedGoAroundResult(state, nil, true)
+	}
+	state.LastControllerCommandID = command.CommandID
+	disarm(&state, false)
+	actor := command.Actor
+	episodeID := fmt.Sprintf("%s/go-around/controller/%s", input.FlightID, command.CommandID)
+	confirmed := &GoAroundConfirmed{
+		ID: episodeID + "/confirmed", EpisodeID: episodeID, FlightID: input.FlightID,
+		Reason: GoAroundReasonController, ConfirmedAt: input.Now, ControllerActor: &actor,
+	}
+	return checkedGoAroundResult(state, confirmed, false)
 }
 
 func (d *goAroundDetector) evidence(input GoAroundInput, state aman.GoAroundDetectionState) (aman.GoAroundEvidence, bool, bool) {
@@ -333,7 +366,7 @@ func cloneDetectionState(state aman.GoAroundDetectionState) aman.GoAroundDetecti
 }
 
 func zeroDetectionState(state aman.GoAroundDetectionState) bool {
-	return state.PolicyVersion == "" && len(state.Evidence) == 0 && state.ArmCount == 0 && state.ClimbCount == 0 && state.TrackAwayCount == 0 && state.RunwayExitCount == 0 && !state.Armed && state.ArmedAt == nil && state.ArmedCorridorID == "" && state.Episode == 0 && state.LastEmittedEpisode == 0 && state.LastProcessedAt == nil && state.LastProcessedSequence == nil && !state.ThresholdCrossed
+	return state.PolicyVersion == "" && len(state.Evidence) == 0 && state.ArmCount == 0 && state.ClimbCount == 0 && state.TrackAwayCount == 0 && state.RunwayExitCount == 0 && !state.Armed && state.ArmedAt == nil && state.ArmedCorridorID == "" && state.Episode == 0 && state.LastEmittedEpisode == 0 && state.LastProcessedAt == nil && state.LastProcessedSequence == nil && !state.ThresholdCrossed && state.LastControllerCommandID == ""
 }
 
 func lastEvidence(values []aman.GoAroundEvidence) (aman.GoAroundEvidence, bool) {
@@ -399,6 +432,7 @@ func angularDifference(first, second float64) float64 {
 }
 
 func finiteNumber(value float64) bool    { return !math.IsNaN(value) && !math.IsInf(value, 0) }
+func isTrimmed(value string) bool        { return value != "" && strings.TrimSpace(value) == value }
 func ptrTime(value time.Time) *time.Time { return &value }
 func cloneTime(value *time.Time) *time.Time {
 	if value == nil {

--- a/backend/internal/aman/lifecycle/go_around_test.go
+++ b/backend/internal/aman/lifecycle/go_around_test.go
@@ -1,0 +1,360 @@
+package lifecycle_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/aman/lifecycle"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGoAroundDetectorConfirmsClimbOnceAndTransitionsThroughLifecycle(t *testing.T) {
+	detector := newDetector(t, detectorConfig())
+	base := lifecycleTime()
+	state := aman.GoAroundDetectionState{}
+	var beforeConfirmation aman.GoAroundDetectionState
+	var confirmed *lifecycle.GoAroundConfirmed
+
+	for index, sample := range []struct {
+		latitude float64
+		altitude int
+	}{
+		{-0.030, 1200},
+		{-0.020, 1100},
+		{-0.010, 1250},
+		{-0.005, 1400},
+	} {
+		if index == 3 {
+			beforeConfirmation = state
+		}
+		at := base.Add(time.Duration(index+1) * time.Second)
+		result, err := detector.Detect(detectorInput(state, observation(uint64(index+1), at, sample.latitude, 0, sample.altitude, 160, floatPointer(0)), at))
+		require.NoError(t, err)
+		state = result.State
+		if result.Confirmed != nil {
+			confirmed = result.Confirmed
+		}
+	}
+
+	require.NotNil(t, confirmed)
+	require.Equal(t, lifecycle.GoAroundReasonClimb, confirmed.Reason)
+	require.Equal(t, "flight-1/go-around/1", confirmed.EpisodeID)
+	require.Equal(t, confirmed.EpisodeID+"/confirmed", confirmed.ID)
+	require.Equal(t, []time.Time{base.Add(3 * time.Second), base.Add(4 * time.Second)}, confirmed.SupportingObservationTimes)
+	require.Equal(t, uint64(1), state.LastEmittedEpisode)
+	require.False(t, state.Armed)
+
+	flight := lifecycleFlight(base, aman.StateStable)
+	transition, err := lifecycle.Reduce(lifecycle.DefaultConfig(), flight, confirmed.LifecycleEvent())
+	require.NoError(t, err)
+	require.Equal(t, aman.StateGoAround, transition.Flight.State)
+	require.Equal(t, confirmed.ID, transition.Transition.EventID)
+
+	lastAt := base.Add(4 * time.Second)
+	duplicate, err := detector.Detect(detectorInput(state, observation(4, lastAt, -0.005, 0, 1400, 160, floatPointer(0)), lastAt))
+	require.NoError(t, err)
+	require.True(t, duplicate.Duplicate)
+	require.Nil(t, duplicate.Confirmed)
+	require.Equal(t, state, duplicate.State)
+
+	replayed, err := detector.Detect(detectorInput(beforeConfirmation, observation(4, lastAt, -0.005, 0, 1400, 160, floatPointer(0)), lastAt))
+	require.NoError(t, err)
+	require.Equal(t, confirmed, replayed.Confirmed)
+	require.Equal(t, state, replayed.State)
+}
+
+func TestGoAroundDetectorConfirmsDerivedTrackAwayAndRunwayExit(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		reason lifecycle.GoAroundReason
+		points []detectorPoint
+	}{
+		{
+			name: "derived track away", reason: lifecycle.GoAroundReasonTrackAway,
+			points: []detectorPoint{
+				{latitude: -0.030, altitude: 1200, track: floatPointer(0)},
+				{latitude: -0.020, altitude: 1100, track: floatPointer(0)},
+				{latitude: -0.020, longitude: 0.004, altitude: 1100},
+				{latitude: -0.020, longitude: 0.008, altitude: 1100},
+			},
+		},
+		{
+			name: "runway exit without landing", reason: lifecycle.GoAroundReasonRunwayExit,
+			points: []detectorPoint{
+				{latitude: -0.030, altitude: 900, track: floatPointer(0)},
+				{latitude: -0.020, altitude: 800, track: floatPointer(0)},
+				{latitude: 0.002, altitude: 500, track: floatPointer(0)},
+				{latitude: 0.004, altitude: 500, track: floatPointer(0)},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			detector := newDetector(t, detectorConfig())
+			state := aman.GoAroundDetectionState{}
+			var confirmed *lifecycle.GoAroundConfirmed
+			for index, point := range test.points {
+				at := lifecycleTime().Add(time.Duration(index+1) * time.Second)
+				result, err := detector.Detect(detectorInput(state, observation(uint64(index+1), at, point.latitude, point.longitude, point.altitude, 160, point.track), at))
+				require.NoError(t, err)
+				state, confirmed = result.State, result.Confirmed
+			}
+			require.NotNil(t, confirmed)
+			require.Equal(t, test.reason, confirmed.Reason)
+			require.Len(t, confirmed.SupportingObservationTimes, 2)
+		})
+	}
+}
+
+func TestGoAroundDetectorRejectsLandingVectorNoiseAndStaleTracks(t *testing.T) {
+	detector := newDetector(t, detectorConfig())
+	base := lifecycleTime()
+	state := armDetector(t, detector, base)
+
+	// A single climb point is insufficient and the next descending point
+	// resets the consecutive evidence counter.
+	climb, err := detector.Detect(detectorInput(state, observation(3, base.Add(3*time.Second), -0.010, 0, 1000, 160, floatPointer(0)), base.Add(3*time.Second)))
+	require.NoError(t, err)
+	require.Nil(t, climb.Confirmed)
+	descent, err := detector.Detect(detectorInput(climb.State, observation(4, base.Add(4*time.Second), -0.005, 0, 900, 160, floatPointer(0)), base.Add(4*time.Second)))
+	require.NoError(t, err)
+	require.Nil(t, descent.Confirmed)
+	require.Zero(t, descent.State.ClimbCount)
+
+	// A normal landing beyond the threshold is too low and slow to count as
+	// runway-exit-without-landing evidence.
+	landing, err := detector.Detect(detectorInput(descent.State, observation(5, base.Add(5*time.Second), 0.002, 0, 50, 25, floatPointer(0)), base.Add(5*time.Second)))
+	require.NoError(t, err)
+	require.Nil(t, landing.Confirmed)
+	require.Zero(t, landing.State.RunwayExitCount)
+
+	// Stale source state disarms and clears evidence without emitting.
+	staleObservation := observation(6, base.Add(6*time.Second), 0.004, 0, 600, 160, floatPointer(180))
+	staleObservation.SourceStatus = aman.DataStale
+	stale, err := detector.Detect(detectorInput(landing.State, staleObservation, base.Add(6*time.Second)))
+	require.NoError(t, err)
+	require.Nil(t, stale.Confirmed)
+	require.False(t, stale.State.Armed)
+	require.Empty(t, stale.State.Evidence)
+
+	// Vectoring before arming never satisfies the inbound final-path gate.
+	vectorState := aman.GoAroundDetectionState{}
+	for index := 0; index < 4; index++ {
+		at := base.Add(time.Duration(index+10) * time.Second)
+		result, err := detector.Detect(detectorInput(vectorState, observation(uint64(index+10), at, -0.03+float64(index)*0.002, 0, 1200, 160, floatPointer(90)), at))
+		require.NoError(t, err)
+		vectorState = result.State
+		require.Nil(t, result.Confirmed)
+	}
+	require.False(t, vectorState.Armed)
+	require.Zero(t, vectorState.ArmCount)
+}
+
+func TestGoAroundDetectorUsesExactBoundariesAndConsecutiveArming(t *testing.T) {
+	config := detectorConfig()
+	detector := newDetector(t, config)
+	base := lifecycleTime()
+	state := aman.GoAroundDetectionState{}
+
+	first, err := detector.Detect(detectorInput(state, observation(1, base.Add(time.Second), -0.03, 0, config.ArmBelowAltitudeFeet, 160, floatPointer(config.InboundToleranceDegrees)), base.Add(time.Second)))
+	require.NoError(t, err)
+	require.Equal(t, 1, first.State.ArmCount, "exact altitude and inbound-angle boundaries arm")
+
+	outside, err := detector.Detect(detectorInput(first.State, observation(2, base.Add(2*time.Second), -0.02, 0, config.ArmBelowAltitudeFeet+1, 160, floatPointer(config.InboundToleranceDegrees)), base.Add(2*time.Second)))
+	require.NoError(t, err)
+	require.Zero(t, outside.State.ArmCount)
+	require.False(t, outside.State.Armed)
+
+	second, err := detector.Detect(detectorInput(outside.State, observation(3, base.Add(3*time.Second), -0.02, 0, 1000, 160, floatPointer(0)), base.Add(3*time.Second)))
+	require.NoError(t, err)
+	third, err := detector.Detect(detectorInput(second.State, observation(4, base.Add(4*time.Second), -0.01, 0, 900, 160, floatPointer(0)), base.Add(4*time.Second)))
+	require.NoError(t, err)
+	require.True(t, third.State.Armed)
+}
+
+func TestGoAroundDetectorPersistsBoundedStateAndHandlesOrderingAndPolicyChange(t *testing.T) {
+	config := detectorConfig()
+	config.EvidenceLimit = 4
+	config.MinimumClimbFeet = 1000
+	detector := newDetector(t, config)
+	base := lifecycleTime()
+	state := aman.GoAroundDetectionState{}
+	for index := 0; index < 8; index++ {
+		at := base.Add(time.Duration(index+1) * time.Second)
+		result, err := detector.Detect(detectorInput(state, observation(uint64(index+1), at, -0.03+float64(index)*0.001, 0, 1200, 160, floatPointer(0)), at))
+		require.NoError(t, err)
+		state = result.State
+	}
+	require.Len(t, state.Evidence, 4)
+	require.Equal(t, base.Add(5*time.Second), state.Evidence[0].ObservedAt)
+
+	persisted, err := json.Marshal(state)
+	require.NoError(t, err)
+	var restored aman.GoAroundDetectionState
+	require.NoError(t, json.Unmarshal(persisted, &restored))
+	require.NoError(t, restored.Validate())
+	require.Equal(t, state, restored)
+
+	old, err := detector.Detect(detectorInput(restored, observation(7, base.Add(7*time.Second), -0.02, 0, 1200, 160, floatPointer(0)), base.Add(9*time.Second)))
+	require.NoError(t, err)
+	require.True(t, old.Duplicate)
+	require.Equal(t, restored, old.State)
+
+	changedInput := detectorInput(restored, observation(9, base.Add(9*time.Second), -0.02, 0, 1200, 160, floatPointer(0)), base.Add(9*time.Second))
+	changedInput.PolicyVersion = "go-around-v2"
+	changed, err := detector.Detect(changedInput)
+	require.NoError(t, err)
+	require.Equal(t, "go-around-v2", changed.State.PolicyVersion)
+	require.False(t, changed.State.Armed)
+	require.Len(t, changed.State.Evidence, 1, "policy change disarms before accepting current evidence")
+	require.Equal(t, restored.Episode, changed.State.Episode)
+}
+
+func TestGoAroundDetectorRestartAtEveryObservationIsEquivalent(t *testing.T) {
+	detector := newDetector(t, detectorConfig())
+	base := lifecycleTime()
+	inputs := []lifecycle.GoAroundInput{}
+	state := aman.GoAroundDetectionState{}
+	for index, point := range []detectorPoint{
+		{latitude: -0.030, altitude: 1200, track: floatPointer(0)},
+		{latitude: -0.020, altitude: 1100, track: floatPointer(0)},
+		{latitude: -0.010, altitude: 1250, track: floatPointer(0)},
+		{latitude: -0.005, altitude: 1400, track: floatPointer(0)},
+	} {
+		at := base.Add(time.Duration(index+1) * time.Second)
+		inputs = append(inputs, detectorInput(state, observation(uint64(index+1), at, point.latitude, point.longitude, point.altitude, 160, point.track), at))
+		result, err := detector.Detect(inputs[index])
+		require.NoError(t, err)
+		state = result.State
+	}
+	wantState := state
+	wantEventID := "flight-1/go-around/1/confirmed"
+
+	for checkpoint := range inputs {
+		checkpointState := aman.GoAroundDetectionState{}
+		var eventID string
+		for index := 0; index <= checkpoint; index++ {
+			input := inputs[index]
+			input.Previous = checkpointState
+			result, err := detector.Detect(input)
+			require.NoError(t, err)
+			checkpointState = result.State
+			if result.Confirmed != nil {
+				eventID = result.Confirmed.ID
+			}
+		}
+		encoded, err := json.Marshal(checkpointState)
+		require.NoError(t, err)
+		var restored aman.GoAroundDetectionState
+		require.NoError(t, json.Unmarshal(encoded, &restored))
+		for index := checkpoint + 1; index < len(inputs); index++ {
+			input := inputs[index]
+			input.Previous = restored
+			result, err := detector.Detect(input)
+			require.NoError(t, err)
+			restored = result.State
+			if result.Confirmed != nil {
+				eventID = result.Confirmed.ID
+			}
+		}
+		require.Equal(t, wantEventID, eventID, "checkpoint %d", checkpoint)
+		require.Equal(t, wantState, restored, "checkpoint %d", checkpoint)
+	}
+}
+
+func TestGoAroundDetectorDisarmsOnRouteRunwayAndScopeChanges(t *testing.T) {
+	base := lifecycleTime()
+	for _, change := range []struct {
+		name  string
+		apply func(*lifecycle.GoAroundInput)
+	}{
+		{"route", func(input *lifecycle.GoAroundInput) { input.RouteChanged = true }},
+		{"runway group", func(input *lifecycle.GoAroundInput) { input.RunwayGroupChanged = true }},
+	} {
+		t.Run(change.name, func(t *testing.T) {
+			detector := newDetector(t, detectorConfig())
+			armed := armDetector(t, detector, base)
+			input := detectorInput(armed, observation(3, base.Add(3*time.Second), -0.01, 0, 900, 160, floatPointer(0)), base.Add(3*time.Second))
+			change.apply(&input)
+			result, err := detector.Detect(input)
+			require.NoError(t, err)
+			require.False(t, result.State.Armed)
+			require.Equal(t, 1, result.State.ArmCount, "current evidence starts a new arming run after disarm")
+			require.Len(t, result.State.Evidence, 1)
+		})
+	}
+
+	detector := newDetector(t, detectorConfig())
+	first, err := detector.Detect(detectorInput(aman.GoAroundDetectionState{}, observation(1, base.Add(time.Second), -0.03, 0, 900, 160, floatPointer(0)), base.Add(time.Second)))
+	require.NoError(t, err)
+	require.Equal(t, 1, first.State.ArmCount)
+	leaving := detectorInput(first.State, observation(2, base.Add(2*time.Second), -0.02, 0, 900, 160, floatPointer(0)), base.Add(2*time.Second))
+	leaving.InScope = false
+	left, err := detector.Detect(leaving)
+	require.NoError(t, err)
+	require.False(t, left.State.Armed)
+	require.Zero(t, left.State.ArmCount)
+	require.Empty(t, left.State.Evidence)
+}
+
+type detectorPoint struct {
+	latitude, longitude float64
+	altitude            int
+	track               *float64
+}
+
+func detectorConfig() lifecycle.GoAroundConfig {
+	return lifecycle.GoAroundConfig{
+		EvidenceLimit: 8, ArmSamples: 2, ConfirmSamples: 2, ArmBelowAltitudeFeet: 2000,
+		InboundToleranceDegrees: 20, MinimumClimbFeet: 100, TrackAwayDegrees: 60,
+		RunwayExitAfterThresholdNM: 0.1, LandingAltitudeToleranceFeet: 200, MinimumAirborneGroundspeedKnots: 80,
+	}
+}
+
+func finalCorridor() lifecycle.FinalPathCorridor {
+	return lifecycle.FinalPathCorridor{
+		ID: "EKCH-22L", ThresholdLatitude: 0, ThresholdLongitude: 0, ThresholdElevationFeet: 0,
+		InboundCourseDegrees: 0, LengthNM: 3, HalfWidthNM: 0.5,
+	}
+}
+
+func newDetector(t *testing.T, config lifecycle.GoAroundConfig) lifecycle.GoAroundDetector {
+	t.Helper()
+	detector, err := lifecycle.NewGoAroundDetector(config)
+	require.NoError(t, err)
+	return detector
+}
+
+func detectorInput(state aman.GoAroundDetectionState, current aman.FlightObservation, now time.Time) lifecycle.GoAroundInput {
+	return lifecycle.GoAroundInput{
+		FlightID: "flight-1", Observation: current, Corridor: finalCorridor(), Previous: state,
+		PolicyVersion: "go-around-v1", Now: now, InScope: true,
+	}
+}
+
+func observation(sequence uint64, at time.Time, latitude, longitude float64, altitude int, groundspeed float64, track *float64) aman.FlightObservation {
+	return aman.FlightObservation{
+		FlightID: "flight-1", VATSIMCID: "1234567", Callsign: "SAS123", Origin: "ESSA", Destination: "EKCH",
+		ReconciledAt: at, SourceStatus: aman.DataFresh,
+		Surveillance: &aman.SurveillanceFact{
+			LatitudeDegrees: latitude, LongitudeDegrees: longitude, AltitudeFeet: &altitude,
+			GroundspeedKnots: &groundspeed, TrackTrueDegrees: track, Sequence: &sequence, ObservedAt: &at,
+		},
+	}
+}
+
+func armDetector(t *testing.T, detector lifecycle.GoAroundDetector, base time.Time) aman.GoAroundDetectionState {
+	t.Helper()
+	state := aman.GoAroundDetectionState{}
+	for index, latitude := range []float64{-0.03, -0.02} {
+		at := base.Add(time.Duration(index+1) * time.Second)
+		result, err := detector.Detect(detectorInput(state, observation(uint64(index+1), at, latitude, 0, 900, 160, floatPointer(0)), at))
+		require.NoError(t, err)
+		state = result.State
+	}
+	require.True(t, state.Armed)
+	return state
+}
+
+func floatPointer(value float64) *float64 { return &value }

--- a/backend/internal/aman/lifecycle/go_around_test.go
+++ b/backend/internal/aman/lifecycle/go_around_test.go
@@ -65,6 +65,32 @@ func TestGoAroundDetectorConfirmsClimbOnceAndTransitionsThroughLifecycle(t *test
 	require.Equal(t, state, replayed.State)
 }
 
+func TestGoAroundDetectorAcceptsAnAuthorizedControllerMarkWithoutSurveillance(t *testing.T) {
+	detector := newDetector(t, detectorConfig())
+	at := lifecycleTime().Add(time.Minute)
+	input := detectorInput(aman.GoAroundDetectionState{}, observation(1, at, -0.02, 0, 1000, 160, floatPointer(0)), at)
+	input.Observation.Surveillance = nil
+	input.Observation.SourceStatus = aman.DataStale
+	input.ControllerMarked = &lifecycle.ControllerGoAround{CommandID: "command-1", Actor: "1345678"}
+
+	result, err := detector.Detect(input)
+	require.NoError(t, err)
+	require.NotNil(t, result.Confirmed)
+	require.Equal(t, lifecycle.GoAroundReasonController, result.Confirmed.Reason)
+	require.Equal(t, "flight-1/go-around/controller/command-1/confirmed", result.Confirmed.ID)
+	require.Equal(t, "1345678", *result.Confirmed.ControllerActor)
+	require.Empty(t, result.Confirmed.SupportingObservationTimes)
+	require.NoError(t, result.State.Validate())
+
+	duplicateInput := input
+	duplicateInput.Previous = result.State
+	duplicateInput.Now = at.Add(time.Second)
+	duplicate, err := detector.Detect(duplicateInput)
+	require.NoError(t, err)
+	require.True(t, duplicate.Duplicate)
+	require.Nil(t, duplicate.Confirmed)
+}
+
 func TestGoAroundDetectorConfirmsDerivedTrackAwayAndRunwayExit(t *testing.T) {
 	for _, test := range []struct {
 		name   string

--- a/backend/internal/aman/types.go
+++ b/backend/internal/aman/types.go
@@ -374,9 +374,7 @@ type RouteProgress struct {
 	AlongTrackNM       float64
 }
 
-// ETAReview and GoAroundDetectionState reserve the aggregate's owned state
-// without defining command, persistence, or detector implementation details.
-// Their full workflows are owned by their respective components.
+// ETAReview reserves aggregate-owned state for its owning workflow.
 type ETAReview struct {
 	Status string
 }
@@ -398,8 +396,40 @@ func (r OperationalExceptionReason) Valid() bool {
 	return r == OperationalExceptionSuddenInsideFreeze
 }
 
+// GoAroundEvidence is one accepted surveillance sample retained by the
+// go-around detector. Evidence is persisted oldest-first so replay and restart
+// do not need to recover provider history.
+type GoAroundEvidence struct {
+	ObservedAt         time.Time
+	Sequence           *uint64
+	LatitudeDegrees    float64
+	LongitudeDegrees   float64
+	AltitudeFeet       int
+	GroundspeedKnots   float64
+	TrackTrueDegrees   *float64
+	ClimbEvidence      bool
+	TrackAwayEvidence  bool
+	RunwayExitEvidence bool
+}
+
+// GoAroundDetectionState is the complete persisted detector cursor. Episode
+// is incremented only when an approach arms; LastEmittedEpisode makes an
+// already-confirmed episode idempotent across commit retries and restart.
 type GoAroundDetectionState struct {
-	EpisodeID *string
+	PolicyVersion         string
+	Evidence              []GoAroundEvidence
+	ArmCount              int
+	ClimbCount            int
+	TrackAwayCount        int
+	RunwayExitCount       int
+	Armed                 bool
+	ArmedAt               *time.Time
+	ArmedCorridorID       string
+	Episode               uint64
+	LastEmittedEpisode    uint64
+	LastProcessedAt       *time.Time
+	LastProcessedSequence *uint64
+	ThresholdCrossed      bool
 }
 
 // LifecycleState is the persisted ordering cursor and current-state entry
@@ -719,6 +749,11 @@ func (f AMANFlight) Validate() error {
 			return err
 		}
 	}
+	if f.GoAroundDetection != nil {
+		if err := f.GoAroundDetection.Validate(); err != nil {
+			return err
+		}
+	}
 	if err := f.validateFreeze(); err != nil {
 		return err
 	}
@@ -728,6 +763,85 @@ func (f AMANFlight) Validate() error {
 		}
 	}
 	return requireUTCTime("updated at", f.UpdatedAt)
+}
+
+func (s GoAroundDetectionState) Validate() error {
+	if s.empty() {
+		return nil
+	}
+	if !isTrimmedNonEmpty(s.PolicyVersion) {
+		return invalid("go-around detector policy version is required")
+	}
+	if len(s.Evidence) > 64 {
+		return invalid("go-around detector evidence exceeds the durable bound")
+	}
+	for index, evidence := range s.Evidence {
+		if err := evidence.Validate(); err != nil {
+			return err
+		}
+		if index > 0 && !evidence.ObservedAt.After(s.Evidence[index-1].ObservedAt) {
+			return invalid("go-around detector evidence must be ordered oldest-first")
+		}
+		if index > 0 && evidence.Sequence != nil && s.Evidence[index-1].Sequence != nil && *evidence.Sequence <= *s.Evidence[index-1].Sequence {
+			return invalid("go-around detector evidence sequence must increase")
+		}
+	}
+	for _, count := range []int{s.ArmCount, s.ClimbCount, s.TrackAwayCount, s.RunwayExitCount} {
+		if count < 0 || count > len(s.Evidence) {
+			return invalid("go-around detector counter is invalid")
+		}
+	}
+	if s.LastEmittedEpisode > s.Episode {
+		return invalid("go-around emitted episode exceeds the current episode")
+	}
+	if s.LastProcessedAt != nil {
+		if err := requireUTCTime("go-around last processed at", *s.LastProcessedAt); err != nil {
+			return err
+		}
+	}
+	if s.LastProcessedSequence != nil && s.LastProcessedAt == nil {
+		return invalid("go-around sequence cursor requires an observation time")
+	}
+	if len(s.Evidence) > 0 && (s.LastProcessedAt == nil || s.Evidence[len(s.Evidence)-1].ObservedAt.After(*s.LastProcessedAt)) {
+		return invalid("go-around evidence exceeds the processed observation cursor")
+	}
+	if len(s.Evidence) > 0 && s.Evidence[len(s.Evidence)-1].Sequence != nil && s.LastProcessedSequence != nil && *s.Evidence[len(s.Evidence)-1].Sequence > *s.LastProcessedSequence {
+		return invalid("go-around evidence exceeds the processed sequence cursor")
+	}
+	if s.Armed {
+		if s.ArmedAt == nil || !isTrimmedNonEmpty(s.ArmedCorridorID) || s.Episode == 0 || s.Episode <= s.LastEmittedEpisode {
+			return invalid("armed go-around detector requires episode metadata")
+		}
+		if err := requireUTCTime("go-around armed at", *s.ArmedAt); err != nil {
+			return err
+		}
+		if s.LastProcessedAt == nil || s.ArmedAt.After(*s.LastProcessedAt) {
+			return invalid("go-around armed time exceeds the processed observation cursor")
+		}
+	} else if s.ArmedAt != nil || s.ArmedCorridorID != "" || s.ThresholdCrossed {
+		return invalid("disarmed go-around detector retains arming state")
+	}
+	return nil
+}
+
+func (s GoAroundDetectionState) empty() bool {
+	return s.PolicyVersion == "" && len(s.Evidence) == 0 && s.ArmCount == 0 && s.ClimbCount == 0 && s.TrackAwayCount == 0 && s.RunwayExitCount == 0 && !s.Armed && s.ArmedAt == nil && s.ArmedCorridorID == "" && s.Episode == 0 && s.LastEmittedEpisode == 0 && s.LastProcessedAt == nil && s.LastProcessedSequence == nil && !s.ThresholdCrossed
+}
+
+func (e GoAroundEvidence) Validate() error {
+	if err := requireUTCTime("go-around evidence observed at", e.ObservedAt); err != nil {
+		return err
+	}
+	if !finite(e.LatitudeDegrees) || !finite(e.LongitudeDegrees) || e.LatitudeDegrees < -90 || e.LatitudeDegrees > 90 || e.LongitudeDegrees < -180 || e.LongitudeDegrees > 180 {
+		return invalid("go-around evidence coordinate is invalid")
+	}
+	if e.AltitudeFeet < -2000 || !finite(e.GroundspeedKnots) || e.GroundspeedKnots < 0 {
+		return invalid("go-around evidence surveillance values are invalid")
+	}
+	if e.TrackTrueDegrees != nil && (!finite(*e.TrackTrueDegrees) || *e.TrackTrueDegrees < 0 || *e.TrackTrueDegrees >= 360) {
+		return invalid("go-around evidence track is invalid")
+	}
+	return nil
 }
 
 func (s LifecycleState) Validate() error {
@@ -886,4 +1000,8 @@ func invalid(message string) error {
 
 func isTrimmedNonEmpty(value string) bool {
 	return value != "" && strings.TrimSpace(value) == value
+}
+
+func finite(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0)
 }

--- a/backend/internal/aman/types.go
+++ b/backend/internal/aman/types.go
@@ -416,20 +416,21 @@ type GoAroundEvidence struct {
 // is incremented only when an approach arms; LastEmittedEpisode makes an
 // already-confirmed episode idempotent across commit retries and restart.
 type GoAroundDetectionState struct {
-	PolicyVersion         string
-	Evidence              []GoAroundEvidence
-	ArmCount              int
-	ClimbCount            int
-	TrackAwayCount        int
-	RunwayExitCount       int
-	Armed                 bool
-	ArmedAt               *time.Time
-	ArmedCorridorID       string
-	Episode               uint64
-	LastEmittedEpisode    uint64
-	LastProcessedAt       *time.Time
-	LastProcessedSequence *uint64
-	ThresholdCrossed      bool
+	PolicyVersion           string
+	Evidence                []GoAroundEvidence
+	ArmCount                int
+	ClimbCount              int
+	TrackAwayCount          int
+	RunwayExitCount         int
+	Armed                   bool
+	ArmedAt                 *time.Time
+	ArmedCorridorID         string
+	Episode                 uint64
+	LastEmittedEpisode      uint64
+	LastProcessedAt         *time.Time
+	LastProcessedSequence   *uint64
+	ThresholdCrossed        bool
+	LastControllerCommandID string
 }
 
 // LifecycleState is the persisted ordering cursor and current-state entry
@@ -802,6 +803,9 @@ func (s GoAroundDetectionState) Validate() error {
 	if s.LastProcessedSequence != nil && s.LastProcessedAt == nil {
 		return invalid("go-around sequence cursor requires an observation time")
 	}
+	if s.LastControllerCommandID != "" && !isTrimmedNonEmpty(s.LastControllerCommandID) {
+		return invalid("go-around controller command identity is invalid")
+	}
 	if len(s.Evidence) > 0 && (s.LastProcessedAt == nil || s.Evidence[len(s.Evidence)-1].ObservedAt.After(*s.LastProcessedAt)) {
 		return invalid("go-around evidence exceeds the processed observation cursor")
 	}
@@ -825,7 +829,7 @@ func (s GoAroundDetectionState) Validate() error {
 }
 
 func (s GoAroundDetectionState) empty() bool {
-	return s.PolicyVersion == "" && len(s.Evidence) == 0 && s.ArmCount == 0 && s.ClimbCount == 0 && s.TrackAwayCount == 0 && s.RunwayExitCount == 0 && !s.Armed && s.ArmedAt == nil && s.ArmedCorridorID == "" && s.Episode == 0 && s.LastEmittedEpisode == 0 && s.LastProcessedAt == nil && s.LastProcessedSequence == nil && !s.ThresholdCrossed
+	return s.PolicyVersion == "" && len(s.Evidence) == 0 && s.ArmCount == 0 && s.ClimbCount == 0 && s.TrackAwayCount == 0 && s.RunwayExitCount == 0 && !s.Armed && s.ArmedAt == nil && s.ArmedCorridorID == "" && s.Episode == 0 && s.LastEmittedEpisode == 0 && s.LastProcessedAt == nil && s.LastProcessedSequence == nil && !s.ThresholdCrossed && s.LastControllerCommandID == ""
 }
 
 func (e GoAroundEvidence) Validate() error {


### PR DESCRIPTION
## Summary
- add a provider-neutral, persisted go-around detector with deterministic episode IDs
- arm on fresh final-corridor observations and require multi-sample climb, track-away, or runway-exit evidence
- hand off the typed confirmation to the #319 lifecycle reducer without mutating slots

## Validation
- go test ./internal/aman/lifecycle ./internal/aman ./internal/repository/postgres -run 'TestGoAround|TestAMANRepositoryRoundTripIdempotencyAndRollback' -count=1
- go test -race ./internal/aman/lifecycle

Closes #318
Part of #298

> Stacked on #408; sequence-cascade handling remains with #323.