### PR TITLE
feat(aman): handle stale and disconnected traffic

### DIFF
--- a/backend/internal/aman/lifecycle/reducer.go
+++ b/backend/internal/aman/lifecycle/reducer.go
@@ -16,14 +16,18 @@ import (
 type Config struct {
 	UnstableHorizon      time.Duration
 	StableHorizon        time.Duration
+	SuperstableHorizon   time.Duration
 	MinimumUnstableDwell time.Duration
+	RemovalTimeout       time.Duration
 }
 
 func DefaultConfig() Config {
 	return Config{
 		UnstableHorizon:      45 * time.Minute,
 		StableHorizon:        20 * time.Minute,
+		SuperstableHorizon:   10 * time.Minute,
 		MinimumUnstableDwell: 5 * time.Minute,
+		RemovalTimeout:       5 * time.Minute,
 	}
 }
 
@@ -34,8 +38,14 @@ func (c Config) Validate() error {
 	if c.StableHorizon <= 0 || c.StableHorizon >= c.UnstableHorizon {
 		return invalidArgument("Stable horizon must be positive and shorter than the Unstable horizon")
 	}
+	if c.SuperstableHorizon <= 0 || c.SuperstableHorizon >= c.StableHorizon {
+		return invalidArgument("Superstable horizon must be positive and shorter than the Stable horizon")
+	}
 	if c.MinimumUnstableDwell < 0 {
 		return invalidArgument("minimum Unstable dwell cannot be negative")
+	}
+	if c.RemovalTimeout <= 0 {
+		return invalidArgument("removal timeout must be greater than zero")
 	}
 	return nil
 }
@@ -49,6 +59,12 @@ const (
 	EventAirborneDetected    EventKind = "airborne_detected"
 	EventPredictionAccepted  EventKind = "prediction_accepted"
 	EventDataStatusChanged   EventKind = "data_status_changed"
+	EventSourceRestarted     EventKind = "source_restarted"
+	EventSuddenAppearance    EventKind = "sudden_appearance"
+	EventFlightObserved      EventKind = "flight_observed"
+	EventFlightMissing       EventKind = "flight_missing"
+	EventRemovalTimeout      EventKind = "removal_timeout"
+	EventPredictionExpired   EventKind = "prediction_expired"
 	EventGoAroundConfirmed   EventKind = "go_around_confirmed"
 	EventLandingConfirmed    EventKind = "landing_confirmed"
 	EventManualRemoval       EventKind = "manual_removal"
@@ -61,6 +77,12 @@ func (k EventKind) Valid() bool {
 	case EventAirborneDetected,
 		EventPredictionAccepted,
 		EventDataStatusChanged,
+		EventSourceRestarted,
+		EventSuddenAppearance,
+		EventFlightObserved,
+		EventFlightMissing,
+		EventRemovalTimeout,
+		EventPredictionExpired,
 		EventGoAroundConfirmed,
 		EventLandingConfirmed,
 		EventManualRemoval,
@@ -98,6 +120,10 @@ type Result struct {
 	Transition *Transition
 	Duplicate  bool
 }
+
+const (
+	PredictionExpiredSourceData = "source_data_expired"
+)
 
 // Reduce applies one accepted event to a copy of flight. Exact retries are
 // idempotent. A different event at or before the persisted cursor is rejected
@@ -143,12 +169,18 @@ func Reduce(config Config, flight aman.AMANFlight, event Event) (Result, error) 
 		enteredAt = event.OccurredAt
 		reason = transitionReason
 	}
+	flight.State = to
 	if event.Kind == EventDataStatusChanged {
 		flight.DataStatus = event.DataStatus
 	}
-
-	flight.State = to
+	if event.Kind == EventSourceRestarted {
+		flight.DataStatus = aman.DataDisconnected
+	}
+	if event.Kind == EventSuddenAppearance {
+		flight.DataStatus = aman.DataFresh
+	}
 	flight.UpdatedAt = event.OccurredAt
+	previousLifecycle := flight.Lifecycle
 	flight.Lifecycle = &aman.LifecycleState{
 		EnteredAt:            enteredAt,
 		Reason:               reason,
@@ -156,6 +188,11 @@ func Reduce(config Config, flight aman.AMANFlight, event Event) (Result, error) 
 		LastEventFingerprint: fingerprint(event),
 		LastEventAt:          event.OccurredAt,
 	}
+	if previousLifecycle != nil {
+		flight.Lifecycle.ReconciliationPending = previousLifecycle.ReconciliationPending
+		flight.Lifecycle.Absence = cloneAbsence(previousLifecycle.Absence)
+	}
+	applyOperationalExceptionState(config, &flight, event)
 
 	result := Result{Flight: flight}
 	if to != from {
@@ -179,6 +216,43 @@ func nextState(config Config, flight aman.AMANFlight, enteredAt time.Time, event
 			return "", "", invalidTransition(flight.State, event.Kind, "Removed is terminal")
 		}
 		return flight.State, "", nil
+	case EventSourceRestarted:
+		if flight.State == aman.StateRemoved {
+			return "", "", invalidTransition(flight.State, event.Kind, "Removed is terminal")
+		}
+		return flight.State, "", nil
+	case EventSuddenAppearance:
+		if flight.State != aman.StatePlanned {
+			return "", "", invalidTransition(flight.State, event.Kind, "sudden appearance requires a newly planned aggregate")
+		}
+		untilArrival := event.OperationalTETA.Sub(event.OccurredAt)
+		switch {
+		case untilArrival <= config.StableHorizon:
+			return aman.StateStable, aman.LifecycleReasonSuddenAppearance, nil
+		case untilArrival <= config.UnstableHorizon:
+			return aman.StateUnstable, aman.LifecycleReasonSuddenAppearance, nil
+		default:
+			return aman.StateAirborne, aman.LifecycleReasonSuddenAppearance, nil
+		}
+	case EventFlightObserved, EventFlightMissing, EventPredictionExpired:
+		if flight.State == aman.StateRemoved {
+			return "", "", invalidTransition(flight.State, event.Kind, "Removed is terminal")
+		}
+		if (event.Kind == EventFlightObserved || event.Kind == EventFlightMissing) && flight.DataStatus != aman.DataFresh {
+			return "", "", invalidTransition(flight.State, event.Kind, "current reconciliation requires fresh source data")
+		}
+		return flight.State, "", nil
+	case EventRemovalTimeout:
+		if flight.State == aman.StateRemoved {
+			return "", "", invalidTransition(flight.State, event.Kind, "Removed is terminal")
+		}
+		if flight.DataStatus != aman.DataFresh || flight.Lifecycle == nil || flight.Lifecycle.ReconciliationPending || flight.Lifecycle.Absence == nil || flight.Lifecycle.Absence.RemovalDueAt == nil {
+			return "", "", invalidTransition(flight.State, event.Kind, "removal requires a running fresh-data absence timer")
+		}
+		if event.OccurredAt.Before(*flight.Lifecycle.Absence.RemovalDueAt) {
+			return "", "", invalidTransition(flight.State, event.Kind, "removal timeout has not elapsed")
+		}
+		return aman.StateRemoved, aman.LifecycleReasonSourceDisappearance, nil
 	case EventAirborneDetected:
 		switch flight.State {
 		case aman.StatePlanned:
@@ -256,6 +330,12 @@ func validateEvent(event Event) error {
 		}
 		return nil
 	}
+	if event.Kind == EventSuddenAppearance {
+		if event.DataStatus != "" || event.OperationalTETA == nil || event.OperationalTETA.IsZero() || event.OperationalTETA.Location() != time.UTC || !event.OperationalTETA.After(event.OccurredAt) {
+			return invalidArgument("sudden appearance requires a future UTC operational TETA")
+		}
+		return nil
+	}
 	if event.DataStatus != "" {
 		return invalidArgument("only a data-status event may change DataStatus")
 	}
@@ -269,6 +349,82 @@ func validateEvent(event Event) error {
 		return invalidArgument("only an accepted prediction may carry operational TETA")
 	}
 	return nil
+}
+
+func applyOperationalExceptionState(config Config, flight *aman.AMANFlight, event Event) {
+	switch event.Kind {
+	case EventDataStatusChanged:
+		applySourceStatus(flight, event.DataStatus, event.OccurredAt)
+	case EventSourceRestarted:
+		applySourceStatus(flight, aman.DataDisconnected, event.OccurredAt)
+	case EventSuddenAppearance:
+		flight.Lifecycle.ReconciliationPending = false
+		flight.Lifecycle.Absence = nil
+		flight.OperationalException = suddenException(config, event)
+	case EventFlightObserved:
+		flight.Lifecycle.ReconciliationPending = false
+		flight.Lifecycle.Absence = nil
+	case EventFlightMissing:
+		applyMissing(config, flight, event.OccurredAt)
+	case EventPredictionExpired:
+		if flight.Prediction != nil {
+			prediction := *flight.Prediction
+			prediction.Publishable = false
+			reason := PredictionExpiredSourceData
+			prediction.DegradationReason = &reason
+			flight.Prediction = &prediction
+		}
+	}
+}
+
+func applySourceStatus(flight *aman.AMANFlight, _ aman.DataStatus, at time.Time) {
+	flight.Lifecycle.ReconciliationPending = true
+	pauseAbsence(flight.Lifecycle.Absence, at)
+}
+
+func applyMissing(config Config, flight *aman.AMANFlight, at time.Time) {
+	flight.Lifecycle.ReconciliationPending = false
+	if flight.Lifecycle.Absence == nil {
+		due := at.Add(config.RemovalTimeout)
+		flight.Lifecycle.Absence = &aman.AbsenceState{MissingSince: at, RemovalDueAt: &due}
+		return
+	}
+	if flight.Lifecycle.Absence.RemovalDueAt == nil {
+		due := at.Add(flight.Lifecycle.Absence.Remaining)
+		flight.Lifecycle.Absence.RemovalDueAt = &due
+		flight.Lifecycle.Absence.Remaining = 0
+	}
+}
+
+func pauseAbsence(absence *aman.AbsenceState, at time.Time) {
+	if absence == nil || absence.RemovalDueAt == nil {
+		return
+	}
+	remaining := absence.RemovalDueAt.Sub(at)
+	if remaining < 0 {
+		remaining = 0
+	}
+	absence.Remaining = remaining
+	absence.RemovalDueAt = nil
+}
+
+func suddenException(config Config, event Event) *aman.OperationalException {
+	if event.OperationalTETA.Sub(event.OccurredAt) > config.SuperstableHorizon {
+		return nil
+	}
+	return &aman.OperationalException{Reason: aman.OperationalExceptionSuddenInsideFreeze, DetectedAt: event.OccurredAt}
+}
+
+func cloneAbsence(value *aman.AbsenceState) *aman.AbsenceState {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	if value.RemovalDueAt != nil {
+		deadline := *value.RemovalDueAt
+		copy.RemovalDueAt = &deadline
+	}
+	return &copy
 }
 
 func invalidArgument(message string) error {

--- a/backend/internal/aman/lifecycle/reducer_test.go
+++ b/backend/internal/aman/lifecycle/reducer_test.go
@@ -3,10 +3,12 @@ package lifecycle_test
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"FlightStrips/internal/aman"
+	"FlightStrips/internal/aman/compatibility"
 	"FlightStrips/internal/aman/lifecycle"
 	"FlightStrips/internal/aman/prediction"
 	"github.com/stretchr/testify/require"
@@ -95,6 +97,141 @@ func TestReduceKeepsDataStatusOrthogonalAndBlocksStaleAdvancement(t *testing.T) 
 	advanced, err := lifecycle.Reduce(config, restored.Flight, predictionEvent("fresh-prediction", now.Add(5*time.Minute), now.Add(50*time.Minute)))
 	require.NoError(t, err)
 	require.Equal(t, aman.StateUnstable, advanced.Flight.State)
+}
+
+func TestReduceRestartsDisconnectedAndReconcilesBeforeResumingRemoval(t *testing.T) {
+	now := lifecycleTime()
+	config := lifecycle.DefaultConfig()
+	flight := lifecycleFlight(now, aman.StateAirborne)
+
+	missing, err := lifecycle.Reduce(config, flight, event("missing", lifecycle.EventFlightMissing, now.Add(time.Minute)))
+	require.NoError(t, err)
+	require.Equal(t, now.Add(time.Minute+config.RemovalTimeout), *missing.Flight.Lifecycle.Absence.RemovalDueAt)
+
+	restartedEvent := event("restart-1", lifecycle.EventSourceRestarted, now.Add(2*time.Minute))
+	restarted, err := lifecycle.Reduce(config, missing.Flight, restartedEvent)
+	require.NoError(t, err)
+	require.Equal(t, aman.DataDisconnected, restarted.Flight.DataStatus)
+	require.True(t, restarted.Flight.Lifecycle.ReconciliationPending)
+	require.Nil(t, restarted.Flight.Lifecycle.Absence.RemovalDueAt)
+	require.Equal(t, 4*time.Minute, restarted.Flight.Lifecycle.Absence.Remaining)
+
+	duplicate, err := lifecycle.Reduce(config, restarted.Flight, restartedEvent)
+	require.NoError(t, err)
+	require.True(t, duplicate.Duplicate)
+	require.Equal(t, restarted.Flight, duplicate.Flight)
+	_, err = lifecycle.Reduce(config, restarted.Flight, statusEvent("late-stale", now.Add(time.Minute+30*time.Second), aman.DataStale))
+	requireDomainClass(t, err, aman.ErrorInvalidTransition)
+	_, err = lifecycle.Reduce(config, restarted.Flight, statusEvent("restart-1", now.Add(2*time.Minute), aman.DataFresh))
+	requireDomainClass(t, err, aman.ErrorInvalidTransition)
+
+	persisted, err := json.Marshal(restarted.Flight)
+	require.NoError(t, err)
+	var restoredFlight aman.AMANFlight
+	require.NoError(t, json.Unmarshal(persisted, &restoredFlight))
+	require.NoError(t, restoredFlight.Validate())
+
+	fresh, err := lifecycle.Reduce(config, restoredFlight, statusEvent("source-restored", now.Add(32*time.Minute), aman.DataFresh))
+	require.NoError(t, err)
+	require.True(t, fresh.Flight.Lifecycle.ReconciliationPending)
+	require.Nil(t, fresh.Flight.Lifecycle.Absence.RemovalDueAt, "fresh status alone must not resume the timer")
+
+	_, err = lifecycle.Reduce(config, fresh.Flight, event("premature-timeout", lifecycle.EventRemovalTimeout, now.Add(33*time.Minute)))
+	requireDomainClass(t, err, aman.ErrorInvalidTransition)
+
+	confirmedMissing, err := lifecycle.Reduce(config, fresh.Flight, event("fresh-snapshot-missing", lifecycle.EventFlightMissing, now.Add(34*time.Minute)))
+	require.NoError(t, err)
+	require.False(t, confirmedMissing.Flight.Lifecycle.ReconciliationPending)
+	require.Equal(t, now.Add(38*time.Minute), *confirmedMissing.Flight.Lifecycle.Absence.RemovalDueAt)
+
+	_, err = lifecycle.Reduce(config, confirmedMissing.Flight, event("early-timeout", lifecycle.EventRemovalTimeout, now.Add(38*time.Minute-time.Nanosecond)))
+	requireDomainClass(t, err, aman.ErrorInvalidTransition)
+	removed, err := lifecycle.Reduce(config, confirmedMissing.Flight, event("timeout", lifecycle.EventRemovalTimeout, now.Add(38*time.Minute)))
+	require.NoError(t, err)
+	require.Equal(t, aman.StateRemoved, removed.Flight.State)
+	require.Equal(t, aman.LifecycleReasonSourceDisappearance, removed.Flight.Lifecycle.Reason)
+}
+
+func TestReduceCurrentObservationCancelsPausedDisappearance(t *testing.T) {
+	now := lifecycleTime()
+	config := lifecycle.DefaultConfig()
+	flight := lifecycleFlight(now, aman.StateAirborne)
+
+	missing, err := lifecycle.Reduce(config, flight, event("missing", lifecycle.EventFlightMissing, now.Add(time.Minute)))
+	require.NoError(t, err)
+	disconnected, err := lifecycle.Reduce(config, missing.Flight, statusEvent("disconnected", now.Add(2*time.Minute), aman.DataDisconnected))
+	require.NoError(t, err)
+	fresh, err := lifecycle.Reduce(config, disconnected.Flight, statusEvent("fresh", now.Add(20*time.Minute), aman.DataFresh))
+	require.NoError(t, err)
+	observed, err := lifecycle.Reduce(config, fresh.Flight, event("observed", lifecycle.EventFlightObserved, now.Add(21*time.Minute)))
+	require.NoError(t, err)
+	require.False(t, observed.Flight.Lifecycle.ReconciliationPending)
+	require.Nil(t, observed.Flight.Lifecycle.Absence)
+}
+
+func TestReduceSuddenAppearanceUsesDefensibleStateWithoutInventingFreeze(t *testing.T) {
+	now := lifecycleTime()
+	config := lifecycle.DefaultConfig()
+	tests := []struct {
+		name       string
+		untilTETA  time.Duration
+		wantState  aman.FlightState
+		wantReview bool
+	}{
+		{name: "outside lifecycle horizons", untilTETA: config.UnstableHorizon + time.Nanosecond, wantState: aman.StateAirborne},
+		{name: "at unstable horizon", untilTETA: config.UnstableHorizon, wantState: aman.StateUnstable},
+		{name: "at stable horizon without invented dwell", untilTETA: config.StableHorizon, wantState: aman.StateStable},
+		{name: "outside freeze horizon", untilTETA: config.SuperstableHorizon + time.Nanosecond, wantState: aman.StateStable},
+		{name: "at freeze horizon requires review", untilTETA: config.SuperstableHorizon, wantState: aman.StateStable, wantReview: true},
+		{name: "inside freeze horizon requires review", untilTETA: config.SuperstableHorizon - time.Second, wantState: aman.StateStable, wantReview: true},
+	}
+
+	for index, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flight := lifecycleFlight(now, aman.StatePlanned)
+			flight.DataStatus = aman.DataDisconnected
+			result, err := lifecycle.Reduce(config, flight, suddenEvent(fmt.Sprintf("sudden-%d", index), now.Add(time.Minute), now.Add(time.Minute+tt.untilTETA)))
+			require.NoError(t, err)
+			require.Equal(t, tt.wantState, result.Flight.State)
+			require.Equal(t, aman.DataFresh, result.Flight.DataStatus)
+			require.Equal(t, aman.LifecycleReasonSuddenAppearance, result.Flight.Lifecycle.Reason)
+			require.Equal(t, aman.FreezeNone, result.Flight.FreezeReason)
+			require.Nil(t, result.Flight.FrozenAt)
+			require.Nil(t, result.Flight.FrozenOperationalTETA)
+			require.Nil(t, result.Flight.FrozenSlot)
+			require.Nil(t, result.Flight.Prediction, "the lifecycle reducer must not manufacture prediction history or confidence")
+			require.Empty(t, result.Flight.RawTETASamples)
+			if tt.wantReview {
+				require.NotNil(t, result.Flight.OperationalException)
+				require.Equal(t, aman.OperationalExceptionSuddenInsideFreeze, result.Flight.OperationalException.Reason)
+				require.Equal(t, now.Add(time.Minute), result.Flight.OperationalException.DetectedAt)
+			} else {
+				require.Nil(t, result.Flight.OperationalException)
+			}
+			require.NoError(t, result.Flight.Validate())
+		})
+	}
+}
+
+func TestReduceExpiresOperationalPredictionWithoutLegacyFallback(t *testing.T) {
+	now := lifecycleTime()
+	config := lifecycle.DefaultConfig()
+	flight := lifecycleFlight(now, aman.StateUnstable)
+	prediction := rawPrediction(now, now.Add(30*time.Minute))
+	prediction.OperationalTETA = prediction.RawTETA
+	prediction.OperationalReason = aman.OperationalReasonPredicted
+	flight.Prediction = &prediction
+
+	stale, err := lifecycle.Reduce(config, flight, statusEvent("stale", now.Add(time.Minute), aman.DataStale))
+	require.NoError(t, err)
+	expired, err := lifecycle.Reduce(config, stale.Flight, event("prediction-expired", lifecycle.EventPredictionExpired, now.Add(2*time.Minute)))
+	require.NoError(t, err)
+	require.NotNil(t, expired.Flight.Prediction)
+	require.False(t, expired.Flight.Prediction.Publishable)
+	require.Equal(t, lifecycle.PredictionExpiredSourceData, *expired.Flight.Prediction.DegradationReason)
+	require.Nil(t, compatibility.ProjectArrivalETA(aman.ModeReadOnly, expired.Flight.Prediction, now.Add(2*time.Minute), time.Hour))
+	require.Nil(t, compatibility.ProjectArrivalETA(aman.ModeAuthoritative, expired.Flight.Prediction, now.Add(2*time.Minute), time.Hour))
+	require.NoError(t, expired.Flight.Validate())
 }
 
 func TestReduceIsIdempotentAndRejectsOutOfOrderOrInvalidTransitions(t *testing.T) {
@@ -224,6 +361,10 @@ func event(id string, kind lifecycle.EventKind, at time.Time) lifecycle.Event {
 
 func predictionEvent(id string, at, operationalTETA time.Time) lifecycle.Event {
 	return lifecycle.Event{ID: id, Kind: lifecycle.EventPredictionAccepted, OccurredAt: at, OperationalTETA: &operationalTETA}
+}
+
+func suddenEvent(id string, at, operationalTETA time.Time) lifecycle.Event {
+	return lifecycle.Event{ID: id, Kind: lifecycle.EventSuddenAppearance, OccurredAt: at, OperationalTETA: &operationalTETA}
 }
 
 func statusEvent(id string, at time.Time, status aman.DataStatus) lifecycle.Event {

--- a/backend/internal/aman/types.go
+++ b/backend/internal/aman/types.go
@@ -51,9 +51,11 @@ const (
 	LifecycleReasonStableHorizon       LifecycleReason = "stable_horizon"
 	LifecycleReasonGoAroundConfirmed   LifecycleReason = "go_around_confirmed"
 	LifecycleReasonLandingConfirmed    LifecycleReason = "landing_confirmed"
+	LifecycleReasonSuddenAppearance    LifecycleReason = "sudden_appearance"
 	LifecycleReasonManualRemoval       LifecycleReason = "manual_removal"
 	LifecycleReasonLandedTimeout       LifecycleReason = "landed_timeout"
 	LifecycleReasonPlannedCancellation LifecycleReason = "planned_cancellation"
+	LifecycleReasonSourceDisappearance LifecycleReason = "source_disappearance"
 )
 
 func (r LifecycleReason) Valid() bool {
@@ -64,9 +66,11 @@ func (r LifecycleReason) Valid() bool {
 		LifecycleReasonStableHorizon,
 		LifecycleReasonGoAroundConfirmed,
 		LifecycleReasonLandingConfirmed,
+		LifecycleReasonSuddenAppearance,
 		LifecycleReasonManualRemoval,
 		LifecycleReasonLandedTimeout,
-		LifecycleReasonPlannedCancellation:
+		LifecycleReasonPlannedCancellation,
+		LifecycleReasonSourceDisappearance:
 		return true
 	default:
 		return false
@@ -377,6 +381,23 @@ type ETAReview struct {
 	Status string
 }
 
+// OperationalException records an explicit degraded path that is orthogonal
+// to lifecycle and ETA discrepancy review state.
+type OperationalException struct {
+	Reason     OperationalExceptionReason
+	DetectedAt time.Time
+}
+
+type OperationalExceptionReason string
+
+const (
+	OperationalExceptionSuddenInsideFreeze OperationalExceptionReason = "sudden_appearance_inside_freeze_horizon_manual_review"
+)
+
+func (r OperationalExceptionReason) Valid() bool {
+	return r == OperationalExceptionSuddenInsideFreeze
+}
+
 type GoAroundDetectionState struct {
 	EpisodeID *string
 }
@@ -391,6 +412,20 @@ type LifecycleState struct {
 	LastEventID          string
 	LastEventFingerprint string
 	LastEventAt          time.Time
+	// ReconciliationPending is set across stale/disconnected periods and is
+	// cleared only when a current fresh snapshot explicitly observes or omits
+	// the flight. A fresh source-status transition alone cannot resume timers.
+	ReconciliationPending bool
+	Absence               *AbsenceState
+}
+
+// AbsenceState is the persisted disappearance timer. RemovalDueAt is nil
+// while source data is unknown. Remaining preserves only the already-earned
+// fresh-data delay, so outage time cannot advance removal after restart.
+type AbsenceState struct {
+	MissingSince time.Time
+	RemovalDueAt *time.Time
+	Remaining    time.Duration
 }
 
 // RunwayGroupPolicy is the airport-state identity for a runway group. The
@@ -424,6 +459,7 @@ type AMANFlight struct {
 	Slot                  *Slot
 	Order                 *int
 	ETAReview             *ETAReview
+	OperationalException  *OperationalException
 	GoAroundDetection     *GoAroundDetectionState
 	Lifecycle             *LifecycleState
 	UpdatedAt             time.Time
@@ -666,6 +702,22 @@ func (f AMANFlight) Validate() error {
 		if !f.lifecycleReasonMatchesState() {
 			return invalid("lifecycle reason does not match flight state")
 		}
+		if f.Lifecycle.Absence != nil {
+			if err := f.Lifecycle.Absence.Validate(); err != nil {
+				return err
+			}
+			if f.Lifecycle.ReconciliationPending && f.Lifecycle.Absence.RemovalDueAt != nil {
+				return invalid("pending source reconciliation cannot run an absence timer")
+			}
+		}
+	}
+	if f.OperationalException != nil {
+		if !f.OperationalException.Reason.Valid() {
+			return invalid("operational exception reason is invalid")
+		}
+		if err := requireUTCTime("operational exception detected at", f.OperationalException.DetectedAt); err != nil {
+			return err
+		}
 	}
 	if err := f.validateFreeze(); err != nil {
 		return err
@@ -694,6 +746,28 @@ func (s LifecycleState) Validate() error {
 	return nil
 }
 
+func (s AbsenceState) Validate() error {
+	if err := requireUTCTime("absence missing since", s.MissingSince); err != nil {
+		return err
+	}
+	if s.Remaining < 0 {
+		return invalid("absence remaining duration cannot be negative")
+	}
+	if s.RemovalDueAt == nil {
+		return nil
+	}
+	if s.Remaining != 0 {
+		return invalid("running absence timer cannot retain a paused duration")
+	}
+	if err := requireUTCTime("absence removal due at", *s.RemovalDueAt); err != nil {
+		return err
+	}
+	if s.RemovalDueAt.Before(s.MissingSince) {
+		return invalid("absence removal deadline cannot predate disappearance")
+	}
+	return nil
+}
+
 func (f AMANFlight) lifecycleReasonMatchesState() bool {
 	switch f.Lifecycle.Reason {
 	case LifecycleReasonInitial:
@@ -708,7 +782,11 @@ func (f AMANFlight) lifecycleReasonMatchesState() bool {
 		return f.State == StateGoAround
 	case LifecycleReasonLandingConfirmed:
 		return f.State == StateLanded
+	case LifecycleReasonSuddenAppearance:
+		return f.State == StateAirborne || f.State == StateUnstable || f.State == StateStable
 	case LifecycleReasonManualRemoval, LifecycleReasonLandedTimeout, LifecycleReasonPlannedCancellation:
+		return f.State == StateRemoved
+	case LifecycleReasonSourceDisappearance:
 		return f.State == StateRemoved
 	default:
 		return false

--- a/backend/internal/aman/types_test.go
+++ b/backend/internal/aman/types_test.go
@@ -52,6 +52,7 @@ func TestDomainTypesDoNotDeclareWireJSONTags(t *testing.T) {
 		reflect.TypeFor[Slot](),
 		reflect.TypeFor[RouteFact](),
 		reflect.TypeFor[ETAReview](),
+		reflect.TypeFor[OperationalException](),
 		reflect.TypeFor[GoAroundDetectionState](),
 		reflect.TypeFor[LifecycleState](),
 		reflect.TypeFor[RunwayGroupPolicy](),


### PR DESCRIPTION
## Summary
- model restart, stale, disconnected, and restored source transitions as lifecycle-domain facts
- pause absence/removal timers during outages until a fresh reconciliation result arrives
- add sudden-appearance state selection and an explicit inside-freeze operational exception without fabricated prediction, confidence, or freeze state

## Validation
- go test ./internal/aman/lifecycle ./internal/aman -run 'TestReduce.*(Source|Sudden|Outage|Prediction)|Test.*OperationalException' -count=1
- go test ./...

Closes #320
Part of #298

> Stacked on #408.