### PR TITLE
feat(aman): add initial TETA review workflow

### DIFF
--- a/backend/internal/aman/etareview/reducer.go
+++ b/backend/internal/aman/etareview/reducer.go
@@ -1,0 +1,266 @@
+// Package etareview owns the deterministic first-Unstable TETA discrepancy
+// policy. It changes only review state and delegates operational-TETA overrides
+// to the prediction package; it never writes raw prediction values.
+package etareview
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/aman/prediction"
+)
+
+type Config struct {
+	DiscrepancyThreshold time.Duration
+	ReviewDeadline       time.Duration
+}
+
+func (c Config) Validate() error {
+	if c.DiscrepancyThreshold < 0 {
+		return invalidArgument("ETA review discrepancy threshold cannot be negative")
+	}
+	if c.ReviewDeadline <= 0 {
+		return invalidArgument("ETA review deadline must be greater than zero")
+	}
+	return nil
+}
+
+type Result struct {
+	Flight  aman.AMANFlight
+	Changed bool
+}
+
+// Open evaluates only the first route-aware Unstable prediction. A difference
+// equal to the configured threshold does not open a review; the policy says
+// beyond the threshold, making the boundary explicit.
+func Open(config Config, flight aman.AMANFlight, createdAt time.Time) (Result, error) {
+	if err := config.Validate(); err != nil {
+		return Result{}, err
+	}
+	if err := validActionTime(createdAt, flight.UpdatedAt); err != nil {
+		return Result{}, err
+	}
+	if flight.ETAReview != nil && flight.ETAReview.Status != aman.ReviewNone {
+		return Result{Flight: flight}, nil
+	}
+	if flight.State != aman.StateUnstable || flight.DataStatus != aman.DataFresh || flight.ArrivalBaseline == nil || flight.Prediction == nil ||
+		flight.Prediction.OperationalReason != aman.OperationalReasonFirstUnstable {
+		return Result{Flight: flight}, nil
+	}
+	if absolute(flight.Prediction.OperationalTETA.Sub(flight.ArrivalBaseline.ArrivalAt)) <= config.DiscrepancyThreshold {
+		return Result{Flight: flight}, nil
+	}
+
+	deadline := createdAt.Add(config.ReviewDeadline)
+	flight.ETAReview = &aman.ETAReview{
+		Status:                    aman.ReviewPending,
+		CreatedAt:                 createdAt,
+		DeadlineAt:                deadline,
+		InitialBaselineTETA:       flight.ArrivalBaseline.ArrivalAt,
+		CalculatedOperationalTETA: flight.Prediction.OperationalTETA,
+		SelectedTETA:              flight.Prediction.OperationalTETA,
+	}
+	flight.UpdatedAt = createdAt
+	return Result{Flight: flight, Changed: true}, nil
+}
+
+type AcceptCalculated struct {
+	At    time.Time
+	Actor string
+	Note  *string
+}
+
+func ResolveAcceptCalculated(flight aman.AMANFlight, command AcceptCalculated) (Result, error) {
+	review, err := pendingReview(flight, command.At, command.Actor, command.Note)
+	if err != nil {
+		return Result{}, err
+	}
+	review.Status = aman.ReviewAcceptedCalculatedTETA
+	review.SelectedTETA = review.CalculatedOperationalTETA
+	resolveByActor(review, command.At, command.Actor, command.Note)
+	flight.ETAReview = review
+	flight.UpdatedAt = command.At
+	return Result{Flight: flight, Changed: true}, nil
+}
+
+type KeepInitial struct {
+	At    time.Time
+	Actor string
+	Note  *string
+}
+
+func ResolveKeepInitial(flight aman.AMANFlight, command KeepInitial) (Result, error) {
+	review, err := pendingReview(flight, command.At, command.Actor, command.Note)
+	if err != nil {
+		return Result{}, err
+	}
+	updated, err := prediction.ApplyManualOperationalTETA(flight, review.InitialBaselineTETA, command.At)
+	if err != nil {
+		return Result{}, err
+	}
+	review.Status = aman.ReviewKeptInitialFPLETA
+	review.SelectedTETA = review.InitialBaselineTETA
+	resolveByActor(review, command.At, command.Actor, command.Note)
+	updated.ETAReview = review
+	return Result{Flight: updated, Changed: true}, nil
+}
+
+type SetManual struct {
+	At         time.Time
+	Actor      string
+	Note       *string
+	ManualTETA time.Time
+}
+
+func ResolveSetManual(flight aman.AMANFlight, command SetManual) (Result, error) {
+	review, err := pendingReview(flight, command.At, command.Actor, command.Note)
+	if err != nil {
+		return Result{}, err
+	}
+	updated, err := prediction.ApplyManualOperationalTETA(flight, command.ManualTETA, command.At)
+	if err != nil {
+		return Result{}, err
+	}
+	manual := command.ManualTETA
+	review.Status = aman.ReviewManualETA
+	review.SelectedTETA = manual
+	review.ManualTETA = &manual
+	resolveByActor(review, command.At, command.Actor, command.Note)
+	updated.ETAReview = review
+	return Result{Flight: updated, Changed: true}, nil
+}
+
+// AutoAccept resolves at the exact persisted deadline even when the scheduler
+// observes it later. Before the boundary it is a deterministic no-op.
+func AutoAccept(flight aman.AMANFlight, observedAt time.Time) (Result, error) {
+	if err := validActionTime(observedAt, flight.UpdatedAt); err != nil {
+		return Result{}, err
+	}
+	if flight.ETAReview == nil || flight.ETAReview.Status != aman.ReviewPending {
+		return Result{Flight: flight}, nil
+	}
+	if observedAt.Before(flight.ETAReview.DeadlineAt) {
+		return Result{Flight: flight}, nil
+	}
+	review := cloneReview(flight.ETAReview)
+	resolvedAt := review.DeadlineAt
+	review.Status = aman.ReviewAutoAcceptedCalculatedTETA
+	review.ResolvedAt = &resolvedAt
+	review.SelectedTETA = review.CalculatedOperationalTETA
+	flight.ETAReview = review
+	flight.UpdatedAt = observedAt
+	return Result{Flight: flight, Changed: true}, nil
+}
+
+type Reset struct {
+	At    time.Time
+	Actor string
+	Note  *string
+}
+
+func ResolveReset(config prediction.Config, flight aman.AMANFlight, command Reset) (Result, error) {
+	if err := validActorCommand(command.At, flight.UpdatedAt, command.Actor, command.Note); err != nil {
+		return Result{}, err
+	}
+	if flight.ETAReview == nil || flight.ETAReview.Status == aman.ReviewNone || flight.ETAReview.Status == aman.ReviewPending {
+		return Result{}, invalidTransition("ETA review reset requires a resolved review")
+	}
+	updated := flight
+	var err error
+	if flight.FreezeReason == aman.FreezeManual {
+		updated, err = prediction.ReleaseManualOperationalTETA(config, flight, command.At)
+		if err != nil {
+			return Result{}, err
+		}
+	} else {
+		updated.UpdatedAt = command.At
+	}
+	updated.ETAReview = nil
+	return Result{Flight: updated, Changed: true}, nil
+}
+
+func pendingReview(flight aman.AMANFlight, at time.Time, actor string, note *string) (*aman.ETAReview, error) {
+	if err := validActorCommand(at, flight.UpdatedAt, actor, note); err != nil {
+		return nil, err
+	}
+	if flight.ETAReview == nil || flight.ETAReview.Status != aman.ReviewPending {
+		return nil, invalidTransition("ETA review resolution requires a pending review")
+	}
+	if !at.Before(flight.ETAReview.DeadlineAt) {
+		return nil, invalidTransition("ETA review deadline has elapsed")
+	}
+	return cloneReview(flight.ETAReview), nil
+}
+
+func validActorCommand(at, previous time.Time, actor string, note *string) error {
+	if err := validActionTime(at, previous); err != nil {
+		return err
+	}
+	if strings.TrimSpace(actor) == "" || actor != strings.TrimSpace(actor) {
+		return invalidArgument("ETA review actor is required")
+	}
+	if note != nil && (strings.TrimSpace(*note) == "" || *note != strings.TrimSpace(*note)) {
+		return invalidArgument("ETA review note must be trimmed and non-empty")
+	}
+	return nil
+}
+
+func validActionTime(at, previous time.Time) error {
+	if at.IsZero() || at.Location() != time.UTC || at.Before(previous) {
+		return invalidArgument("ETA review action time is invalid")
+	}
+	return nil
+}
+
+func resolveByActor(review *aman.ETAReview, at time.Time, actor string, note *string) {
+	resolvedAt := at
+	actorCopy := actor
+	review.ResolvedAt = &resolvedAt
+	review.Actor = &actorCopy
+	review.Note = cloneString(note)
+}
+
+func cloneReview(review *aman.ETAReview) *aman.ETAReview {
+	if review == nil {
+		return nil
+	}
+	copy := *review
+	copy.ResolvedAt = cloneTime(review.ResolvedAt)
+	copy.Actor = cloneString(review.Actor)
+	copy.Note = cloneString(review.Note)
+	copy.ManualTETA = cloneTime(review.ManualTETA)
+	return &copy
+}
+
+func cloneString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func cloneTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func absolute(value time.Duration) time.Duration {
+	if value < 0 {
+		return -value
+	}
+	return value
+}
+
+func invalidArgument(message string) error {
+	return &aman.DomainError{Class: aman.ErrorInvalidArgument, Message: message}
+}
+
+func invalidTransition(message string) error {
+	return &aman.DomainError{Class: aman.ErrorInvalidTransition, Message: fmt.Sprintf("ETA review: %s", message)}
+}

--- a/backend/internal/aman/etareview/reducer_test.go
+++ b/backend/internal/aman/etareview/reducer_test.go
@@ -1,0 +1,220 @@
+package etareview_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/aman/etareview"
+	"FlightStrips/internal/aman/prediction"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenUsesFirstUnstableEligibilityAndExactThresholdBoundary(t *testing.T) {
+	now := reviewTime()
+	config := reviewConfig()
+
+	for _, test := range []struct {
+		name       string
+		difference time.Duration
+		wantOpen   bool
+	}{
+		{name: "below", difference: config.DiscrepancyThreshold - time.Second},
+		{name: "equal", difference: config.DiscrepancyThreshold},
+		{name: "above", difference: config.DiscrepancyThreshold + time.Second, wantOpen: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			flight := reviewFlight(now)
+			flight.Prediction.OperationalTETA = flight.ArrivalBaseline.ArrivalAt.Add(test.difference)
+			rawBefore := flight.Prediction.RawTETA
+			result, err := etareview.Open(config, flight, now.Add(time.Minute))
+			require.NoError(t, err)
+			require.Equal(t, test.wantOpen, result.Changed)
+			if !test.wantOpen {
+				require.Nil(t, result.Flight.ETAReview)
+				return
+			}
+			require.Equal(t, aman.ReviewPending, result.Flight.ETAReview.Status)
+			require.Equal(t, now.Add(time.Minute), result.Flight.ETAReview.CreatedAt)
+			require.Equal(t, now.Add(time.Minute).Add(config.ReviewDeadline), result.Flight.ETAReview.DeadlineAt)
+			require.Equal(t, flight.ArrivalBaseline.ArrivalAt, result.Flight.ETAReview.InitialBaselineTETA)
+			require.Equal(t, flight.Prediction.OperationalTETA, result.Flight.ETAReview.CalculatedOperationalTETA)
+			require.Equal(t, rawBefore, result.Flight.Prediction.RawTETA)
+			require.NoError(t, result.Flight.Validate())
+		})
+	}
+
+	notFirst := reviewFlight(now)
+	notFirst.Prediction.OperationalReason = aman.OperationalReasonSmoothed
+	result, err := etareview.Open(config, notFirst, now.Add(time.Minute))
+	require.NoError(t, err)
+	require.False(t, result.Changed)
+
+	stale := reviewFlight(now)
+	stale.DataStatus = aman.DataStale
+	result, err = etareview.Open(config, stale, now.Add(time.Minute))
+	require.NoError(t, err)
+	require.False(t, result.Changed)
+}
+
+func TestTypedResolutionsSelectExactlyOneReviewStateWithoutChangingRawTETA(t *testing.T) {
+	now := reviewTime()
+	pending := openReview(t, now)
+	rawBefore := pending.Prediction.RawTETA
+	historyBefore := append([]aman.RawTETASample(nil), pending.RawTETASamples...)
+	note := "confirmed with approach"
+
+	t.Run("accept calculated", func(t *testing.T) {
+		result, err := etareview.ResolveAcceptCalculated(pending, etareview.AcceptCalculated{At: now.Add(2 * time.Minute), Actor: "1345678", Note: &note})
+		require.NoError(t, err)
+		require.Equal(t, aman.ReviewAcceptedCalculatedTETA, result.Flight.ETAReview.Status)
+		require.Equal(t, pending.Prediction.OperationalTETA, result.Flight.ETAReview.SelectedTETA)
+		require.Equal(t, aman.FreezeNone, result.Flight.FreezeReason)
+		requireRawUnchanged(t, rawBefore, historyBefore, result.Flight)
+		require.NoError(t, result.Flight.Validate())
+	})
+
+	t.Run("keep initial", func(t *testing.T) {
+		result, err := etareview.ResolveKeepInitial(pending, etareview.KeepInitial{At: now.Add(2 * time.Minute), Actor: "1345678"})
+		require.NoError(t, err)
+		require.Equal(t, aman.ReviewKeptInitialFPLETA, result.Flight.ETAReview.Status)
+		require.Equal(t, pending.ArrivalBaseline.ArrivalAt, result.Flight.Prediction.OperationalTETA)
+		require.Equal(t, aman.FreezeManual, result.Flight.FreezeReason)
+		requireRawUnchanged(t, rawBefore, historyBefore, result.Flight)
+		require.NoError(t, result.Flight.Validate())
+	})
+
+	t.Run("manual", func(t *testing.T) {
+		manual := now.Add(26 * time.Minute)
+		result, err := etareview.ResolveSetManual(pending, etareview.SetManual{At: now.Add(2 * time.Minute), Actor: "1345678", ManualTETA: manual})
+		require.NoError(t, err)
+		require.Equal(t, aman.ReviewManualETA, result.Flight.ETAReview.Status)
+		require.Equal(t, manual, *result.Flight.ETAReview.ManualTETA)
+		require.Equal(t, manual, result.Flight.Prediction.OperationalTETA)
+		require.Equal(t, aman.FreezeManual, result.Flight.FreezeReason)
+		requireRawUnchanged(t, rawBefore, historyBefore, result.Flight)
+		require.NoError(t, result.Flight.Validate())
+	})
+}
+
+func TestDeadlineIsDeterministicAndWinsAtEquality(t *testing.T) {
+	now := reviewTime()
+	pending := openReview(t, now)
+	deadline := pending.ETAReview.DeadlineAt
+
+	before, err := etareview.AutoAccept(pending, deadline.Add(-time.Nanosecond))
+	require.NoError(t, err)
+	require.False(t, before.Changed)
+
+	at, err := etareview.AutoAccept(pending, deadline)
+	require.NoError(t, err)
+	require.True(t, at.Changed)
+	require.Equal(t, aman.ReviewAutoAcceptedCalculatedTETA, at.Flight.ETAReview.Status)
+	require.Equal(t, deadline, *at.Flight.ETAReview.ResolvedAt)
+	require.NoError(t, at.Flight.Validate())
+
+	after, err := etareview.AutoAccept(pending, deadline.Add(time.Minute))
+	require.NoError(t, err)
+	require.Equal(t, deadline, *after.Flight.ETAReview.ResolvedAt)
+
+	_, err = etareview.ResolveAcceptCalculated(pending, etareview.AcceptCalculated{At: deadline, Actor: "1345678"})
+	requireDomainClass(t, err, aman.ErrorInvalidTransition)
+}
+
+func TestResetReleasesOnlyTheOperationalOverrideAndRestartPreservesReview(t *testing.T) {
+	now := reviewTime()
+	pending := openReview(t, now)
+	manual := now.Add(26 * time.Minute)
+	resolved, err := etareview.ResolveSetManual(pending, etareview.SetManual{At: now.Add(2 * time.Minute), Actor: "1345678", ManualTETA: manual})
+	require.NoError(t, err)
+
+	payload, err := json.Marshal(resolved.Flight)
+	require.NoError(t, err)
+	var restored aman.AMANFlight
+	require.NoError(t, json.Unmarshal(payload, &restored))
+	require.Equal(t, resolved.Flight, restored)
+	require.NoError(t, restored.Validate())
+
+	rawBefore := restored.Prediction.RawTETA
+	historyBefore := append([]aman.RawTETASample(nil), restored.RawTETASamples...)
+	reset, err := etareview.ResolveReset(prediction.DefaultConfig(), restored, etareview.Reset{At: now.Add(3 * time.Minute), Actor: "1345678"})
+	require.NoError(t, err)
+	require.Nil(t, reset.Flight.ETAReview)
+	require.Equal(t, aman.FreezeNone, reset.Flight.FreezeReason)
+	require.NotEqual(t, manual, reset.Flight.Prediction.OperationalTETA)
+	requireRawUnchanged(t, rawBefore, historyBefore, reset.Flight)
+	require.NoError(t, reset.Flight.Validate())
+
+	_, err = etareview.ResolveReset(prediction.DefaultConfig(), reset.Flight, etareview.Reset{At: now.Add(4 * time.Minute), Actor: "1345678"})
+	requireDomainClass(t, err, aman.ErrorInvalidTransition)
+}
+
+func TestInvalidTransitionsAndManualValueAreTyped(t *testing.T) {
+	now := reviewTime()
+	pending := openReview(t, now)
+
+	_, err := etareview.ResolveSetManual(pending, etareview.SetManual{At: now.Add(2 * time.Minute), Actor: "1345678", ManualTETA: now.Add(time.Minute)})
+	requireDomainClass(t, err, aman.ErrorInvalidArgument)
+
+	accepted, err := etareview.ResolveAcceptCalculated(pending, etareview.AcceptCalculated{At: now.Add(2 * time.Minute), Actor: "1345678"})
+	require.NoError(t, err)
+	_, err = etareview.ResolveKeepInitial(accepted.Flight, etareview.KeepInitial{At: now.Add(3 * time.Minute), Actor: "1345678"})
+	requireDomainClass(t, err, aman.ErrorInvalidTransition)
+
+	_, err = etareview.ResolveAcceptCalculated(pending, etareview.AcceptCalculated{At: now.Add(2 * time.Minute), Actor: ""})
+	requireDomainClass(t, err, aman.ErrorInvalidArgument)
+}
+
+func openReview(t *testing.T, now time.Time) aman.AMANFlight {
+	t.Helper()
+	result, err := etareview.Open(reviewConfig(), reviewFlight(now), now.Add(time.Minute))
+	require.NoError(t, err)
+	require.True(t, result.Changed)
+	return result.Flight
+}
+
+func reviewConfig() etareview.Config {
+	return etareview.Config{DiscrepancyThreshold: 5 * time.Minute, ReviewDeadline: 5 * time.Minute}
+}
+
+func reviewFlight(now time.Time) aman.AMANFlight {
+	baseline := now.Add(20 * time.Minute)
+	return aman.AMANFlight{
+		ID: "flight-1", VATSIMCID: "1234567", CurrentCallsign: "SAS123",
+		State: aman.StateUnstable, DataStatus: aman.DataFresh, FreezeReason: aman.FreezeNone, UpdatedAt: now,
+		ArrivalBaseline: &aman.BaselineState{
+			ArrivalAt: baseline, AirborneSensedAt: now.Add(-time.Hour), Source: aman.BaselineSourceAirborneFiledEET,
+			Confidence: aman.ConfidenceMedium, FlightPlanObservedAt: now.Add(-time.Hour), ModelVersion: "baseline-v1", ConfigVersion: "baseline-config-v1",
+		},
+		Prediction: &aman.Prediction{
+			RawTETA: now.Add(31 * time.Minute), OperationalTETA: now.Add(30 * time.Minute), OperationalReason: aman.OperationalReasonFirstUnstable,
+			GeneratedAt: now, InputObservedAt: now.Add(-time.Minute), Confidence: aman.ConfidenceHigh, Publishable: true,
+			DatasetVersion: "2607", GeometryDigest: "geometry", ModelVersion: "model-v1", ConfigVersion: "config-v1", Sources: []string{"vatsim"},
+		},
+		RawTETASamples: []aman.RawTETASample{
+			{TETA: now.Add(29 * time.Minute), GeneratedAt: now.Add(-2 * time.Minute)},
+			{TETA: now.Add(30 * time.Minute), GeneratedAt: now.Add(-time.Minute)},
+			{TETA: now.Add(31 * time.Minute), GeneratedAt: now},
+		},
+	}
+}
+
+func requireRawUnchanged(t *testing.T, raw time.Time, history []aman.RawTETASample, flight aman.AMANFlight) {
+	t.Helper()
+	require.Equal(t, raw, flight.Prediction.RawTETA)
+	require.Equal(t, history, flight.RawTETASamples)
+}
+
+func requireDomainClass(t *testing.T, err error, class aman.ErrorClass) {
+	t.Helper()
+	require.Error(t, err)
+	var domainError *aman.DomainError
+	require.True(t, errors.As(err, &domainError), "expected domain error, got %v", err)
+	require.Equal(t, class, domainError.Class)
+}
+
+func reviewTime() time.Time {
+	return time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)
+}

--- a/backend/internal/aman/prediction/reducer.go
+++ b/backend/internal/aman/prediction/reducer.go
@@ -159,6 +159,53 @@ func Reduce(config Config, flight aman.AMANFlight, input Input) (Result, error) 
 	return result(config, flight), nil
 }
 
+// ApplyManualOperationalTETA applies an authorized controller selection
+// without accepting a new physical prediction. It deliberately leaves RawTETA
+// and the persisted smoothing window unchanged.
+func ApplyManualOperationalTETA(flight aman.AMANFlight, operationalTETA, actionAt time.Time) (aman.AMANFlight, error) {
+	if flight.Prediction == nil {
+		return aman.AMANFlight{}, invalidArgument("manual operational TETA requires a current prediction")
+	}
+	if operationalTETA.IsZero() || operationalTETA.Location() != time.UTC || !operationalTETA.After(actionAt) {
+		return aman.AMANFlight{}, invalidArgument("manual operational TETA must be a future UTC value")
+	}
+	if actionAt.IsZero() || actionAt.Location() != time.UTC || actionAt.Before(flight.UpdatedAt) {
+		return aman.AMANFlight{}, invalidArgument("manual operational TETA action time is invalid")
+	}
+
+	freezeAt := actionAt
+	frozenTETA := operationalTETA
+	flight.FreezeReason = aman.FreezeManual
+	flight.FrozenAt = &freezeAt
+	flight.FrozenOperationalTETA = &frozenTETA
+	flight.FrozenSlot = nil
+	prediction := *flight.Prediction
+	setOperational(&flight, prediction, operationalTETA, aman.OperationalReasonManualOverride)
+	flight.UpdatedAt = actionAt
+	return flight, nil
+}
+
+// ReleaseManualOperationalTETA returns a controller-selected value to the
+// normal #314 smoothing policy without accepting or synthesizing a raw sample.
+func ReleaseManualOperationalTETA(config Config, flight aman.AMANFlight, actionAt time.Time) (aman.AMANFlight, error) {
+	if err := config.Validate(); err != nil {
+		return aman.AMANFlight{}, err
+	}
+	if flight.FreezeReason != aman.FreezeManual || flight.Prediction == nil || len(flight.RawTETASamples) == 0 {
+		return aman.AMANFlight{}, invalidTransition("manual operational TETA is not active")
+	}
+	if actionAt.IsZero() || actionAt.Location() != time.UTC || actionAt.Before(flight.UpdatedAt) {
+		return aman.AMANFlight{}, invalidArgument("manual operational TETA action time is invalid")
+	}
+
+	prediction := *flight.Prediction
+	clearFreeze(&flight)
+	candidate, reason := routineOperational(config, flight, flight.State, Input{Raw: prediction, State: flight.State})
+	setOperational(&flight, prediction, candidate, reason)
+	flight.UpdatedAt = actionAt
+	return flight, nil
+}
+
 func validateRaw(raw aman.Prediction) error {
 	// Prediction.Validate deliberately validates the operational fields too.
 	// The physical predictor supplies only RawTETA; set temporary valid values
@@ -271,4 +318,12 @@ func absolute(value time.Duration) time.Duration {
 		return -value
 	}
 	return value
+}
+
+func invalidArgument(message string) error {
+	return &aman.DomainError{Class: aman.ErrorInvalidArgument, Message: message}
+}
+
+func invalidTransition(message string) error {
+	return &aman.DomainError{Class: aman.ErrorInvalidTransition, Message: message}
 }

--- a/backend/internal/aman/prediction/reducer_test.go
+++ b/backend/internal/aman/prediction/reducer_test.go
@@ -153,6 +153,32 @@ func TestReduceIgnoresStaleRawAndFrozenSlotUpdates(t *testing.T) {
 	require.Equal(t, current.Flight, stale.Flight)
 }
 
+func TestOperationalOverrideActionsDoNotAcceptOrChangeRawPrediction(t *testing.T) {
+	now := predictionTime()
+	config := DefaultConfig()
+	flight := predictionFlight(now)
+	first, err := Reduce(config, flight, Input{Raw: rawPrediction(now, now.Add(30*time.Minute)), State: aman.StateUnstable})
+	require.NoError(t, err)
+	rawBefore := first.Flight.Prediction.RawTETA
+	historyBefore := append([]aman.RawTETASample(nil), first.Flight.RawTETASamples...)
+
+	manual := now.Add(25 * time.Minute)
+	overridden, err := ApplyManualOperationalTETA(first.Flight, manual, now.Add(time.Minute))
+	require.NoError(t, err)
+	require.Equal(t, manual, overridden.Prediction.OperationalTETA)
+	require.Equal(t, aman.OperationalReasonManualOverride, overridden.Prediction.OperationalReason)
+	require.Equal(t, aman.FreezeManual, overridden.FreezeReason)
+	require.Equal(t, rawBefore, overridden.Prediction.RawTETA)
+	require.Equal(t, historyBefore, overridden.RawTETASamples)
+
+	released, err := ReleaseManualOperationalTETA(config, overridden, now.Add(2*time.Minute))
+	require.NoError(t, err)
+	require.Equal(t, aman.FreezeNone, released.FreezeReason)
+	require.Equal(t, rawBefore, released.Prediction.RawTETA)
+	require.Equal(t, historyBefore, released.RawTETASamples)
+	require.NotEqual(t, aman.OperationalReasonManualOverride, released.Prediction.OperationalReason)
+}
+
 func predictionTime() time.Time {
 	return time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)
 }

--- a/backend/internal/aman/types.go
+++ b/backend/internal/aman/types.go
@@ -374,9 +374,44 @@ type RouteProgress struct {
 	AlongTrackNM       float64
 }
 
-// ETAReview reserves aggregate-owned state for its owning workflow.
+// ETAReviewStatus is the durable state of the first-Unstable TETA review.
+// A nil AMANFlight.ETAReview has the same meaning as ReviewNone; the explicit
+// zero status is retained for wire mappings that cannot represent a nil value.
+type ETAReviewStatus string
+
+const (
+	ReviewNone                       ETAReviewStatus = "none"
+	ReviewPending                    ETAReviewStatus = "pending"
+	ReviewAcceptedCalculatedTETA     ETAReviewStatus = "accepted_calculated_teta"
+	ReviewKeptInitialFPLETA          ETAReviewStatus = "kept_initial_fpl_eta"
+	ReviewManualETA                  ETAReviewStatus = "manual_eta"
+	ReviewAutoAcceptedCalculatedTETA ETAReviewStatus = "auto_accepted_calculated_teta"
+)
+
+func (s ETAReviewStatus) Valid() bool {
+	switch s {
+	case ReviewNone, ReviewPending, ReviewAcceptedCalculatedTETA,
+		ReviewKeptInitialFPLETA, ReviewManualETA, ReviewAutoAcceptedCalculatedTETA:
+		return true
+	default:
+		return false
+	}
+}
+
+// ETAReview records both alternatives and the selected operational value so a
+// restart never has to reconstruct the controller decision from prediction
+// history. Raw TETA remains exclusively inside Prediction.
 type ETAReview struct {
-	Status string
+	Status                    ETAReviewStatus
+	CreatedAt                 time.Time
+	DeadlineAt                time.Time
+	ResolvedAt                *time.Time
+	Actor                     *string
+	Note                      *string
+	InitialBaselineTETA       time.Time
+	CalculatedOperationalTETA time.Time
+	SelectedTETA              time.Time
+	ManualTETA                *time.Time
 }
 
 // OperationalException records an explicit degraded path that is orthogonal
@@ -715,6 +750,14 @@ func (f AMANFlight) Validate() error {
 			return err
 		}
 	}
+	if f.ETAReview != nil {
+		if err := f.ETAReview.Validate(); err != nil {
+			return err
+		}
+		if f.ETAReview.Status != ReviewNone && (f.ArrivalBaseline == nil || !f.ArrivalBaseline.ArrivalAt.Equal(f.ETAReview.InitialBaselineTETA)) {
+			return invalid("ETA review initial baseline does not match the flight baseline")
+		}
+	}
 	if f.ActiveRouteFact != nil && !f.ActiveRouteFact.State.Valid() {
 		return invalid("route fact state is invalid")
 	}
@@ -848,6 +891,80 @@ func (e GoAroundEvidence) Validate() error {
 	return nil
 }
 
+func (r ETAReview) Validate() error {
+	if !r.Status.Valid() {
+		return invalid("ETA review status is invalid")
+	}
+	if r.Status == ReviewNone {
+		if !r.CreatedAt.IsZero() || !r.DeadlineAt.IsZero() || r.ResolvedAt != nil || r.Actor != nil || r.Note != nil ||
+			!r.InitialBaselineTETA.IsZero() || !r.CalculatedOperationalTETA.IsZero() || !r.SelectedTETA.IsZero() || r.ManualTETA != nil {
+			return invalid("empty ETA review cannot retain review values")
+		}
+		return nil
+	}
+	for _, field := range []struct {
+		label string
+		value time.Time
+	}{
+		{label: "ETA review created at", value: r.CreatedAt},
+		{label: "ETA review deadline at", value: r.DeadlineAt},
+		{label: "ETA review initial baseline", value: r.InitialBaselineTETA},
+		{label: "ETA review calculated operational TETA", value: r.CalculatedOperationalTETA},
+		{label: "ETA review selected TETA", value: r.SelectedTETA},
+	} {
+		if err := requireUTCTime(field.label, field.value); err != nil {
+			return err
+		}
+	}
+	if !r.DeadlineAt.After(r.CreatedAt) {
+		return invalid("ETA review deadline must follow creation")
+	}
+	if r.Note != nil && !isTrimmedNonEmpty(*r.Note) {
+		return invalid("ETA review note must be trimmed and non-empty")
+	}
+	if r.Status == ReviewPending {
+		if r.ResolvedAt != nil || r.Actor != nil || r.Note != nil || r.ManualTETA != nil || !r.SelectedTETA.Equal(r.CalculatedOperationalTETA) {
+			return invalid("pending ETA review has resolved values")
+		}
+		return nil
+	}
+	if r.ResolvedAt == nil {
+		return invalid("resolved ETA review requires resolution time")
+	}
+	if err := requireUTCTime("ETA review resolved at", *r.ResolvedAt); err != nil {
+		return err
+	}
+	if r.ResolvedAt.Before(r.CreatedAt) {
+		return invalid("ETA review resolution cannot predate creation")
+	}
+
+	switch r.Status {
+	case ReviewAcceptedCalculatedTETA:
+		if !validReviewActor(r.Actor) || r.ManualTETA != nil || !r.SelectedTETA.Equal(r.CalculatedOperationalTETA) || !r.ResolvedAt.Before(r.DeadlineAt) {
+			return invalid("accepted calculated ETA review is inconsistent")
+		}
+	case ReviewKeptInitialFPLETA:
+		if !validReviewActor(r.Actor) || r.ManualTETA != nil || !r.SelectedTETA.Equal(r.InitialBaselineTETA) || !r.ResolvedAt.Before(r.DeadlineAt) {
+			return invalid("kept initial ETA review is inconsistent")
+		}
+	case ReviewManualETA:
+		if !validReviewActor(r.Actor) || r.ManualTETA == nil || !r.SelectedTETA.Equal(*r.ManualTETA) || !r.ResolvedAt.Before(r.DeadlineAt) {
+			return invalid("manual ETA review is inconsistent")
+		}
+		if err := requireUTCTime("ETA review manual TETA", *r.ManualTETA); err != nil {
+			return err
+		}
+	case ReviewAutoAcceptedCalculatedTETA:
+		if r.Actor != nil || r.Note != nil || r.ManualTETA != nil || !r.SelectedTETA.Equal(r.CalculatedOperationalTETA) || !r.ResolvedAt.Equal(r.DeadlineAt) {
+			return invalid("auto-accepted ETA review is inconsistent")
+		}
+	}
+	return nil
+}
+
+func validReviewActor(actor *string) bool {
+	return actor != nil && isTrimmedNonEmpty(*actor)
+}
 func (s LifecycleState) Validate() error {
 	if !s.Reason.Valid() {
 		return invalid("lifecycle reason is invalid")

--- a/backend/internal/repository/postgres/aman_test.go
+++ b/backend/internal/repository/postgres/aman_test.go
@@ -148,6 +148,85 @@ func TestAMANRepositoryRestoresHeldAirborneBaselineForFreshPredictor(t *testing.
 	require.Equal(t, first.State, held.State)
 }
 
+func TestAMANRepositoryRestoresETAReviewAndKeepsResolutionAtomicAndIdempotent(t *testing.T) {
+	pool, _ := testdata.SetupTestDB(t)
+	ctx := context.Background()
+	repo := NewAMANRepository(pool)
+
+	pendingState := amanState(1, "CID-REVIEW", "SAS317")
+	createdAt := pendingState.Flights[0].UpdatedAt
+	deadlineAt := createdAt.Add(5 * time.Minute)
+	pendingState.Flights[0].ETAReview = &aman.ETAReview{
+		Status: aman.ReviewPending, CreatedAt: createdAt, DeadlineAt: deadlineAt,
+		InitialBaselineTETA:       createdAt.Add(20 * time.Minute),
+		CalculatedOperationalTETA: pendingState.Flights[0].Prediction.OperationalTETA,
+		SelectedTETA:              pendingState.Flights[0].Prediction.OperationalTETA,
+	}
+	pendingState.Flights[0].ArrivalBaseline = reviewBaseline(createdAt)
+	openedAudit := aman.AuditRecord{
+		Airport: pendingState.Airport, Revision: pendingState.Revision, Category: "eta_review_opened",
+		Payload: []byte(`{"status":"pending"}`), RecordedAt: createdAt,
+	}
+	_, err := repo.Commit(ctx, aman.StateCommit{ExpectedRevision: 0, State: pendingState, AuditRecords: []aman.AuditRecord{openedAudit}})
+	require.NoError(t, err)
+	restoredPending, err := NewAMANRepository(pool).LoadAirportState(ctx, pendingState.Airport)
+	require.NoError(t, err)
+	require.Equal(t, pendingState, restoredPending)
+
+	manualState := amanState(2, "CID-REVIEW", "SAS317")
+	resolvedAt := createdAt.Add(time.Minute)
+	manualTETA := createdAt.Add(26 * time.Minute)
+	actor := "1345678"
+	manualState.GeneratedAt = resolvedAt
+	manualState.Flights[0].UpdatedAt = resolvedAt
+	manualState.Flights[0].Prediction.OperationalTETA = manualTETA
+	manualState.Flights[0].Prediction.OperationalReason = aman.OperationalReasonManualOverride
+	manualState.Flights[0].FreezeReason = aman.FreezeManual
+	manualState.Flights[0].FrozenAt = &resolvedAt
+	manualState.Flights[0].FrozenOperationalTETA = &manualTETA
+	manualState.Flights[0].ETAReview = &aman.ETAReview{
+		Status: aman.ReviewManualETA, CreatedAt: createdAt, DeadlineAt: deadlineAt, ResolvedAt: &resolvedAt, Actor: &actor,
+		InitialBaselineTETA:       createdAt.Add(20 * time.Minute),
+		CalculatedOperationalTETA: pendingState.Flights[0].Prediction.OperationalTETA,
+		SelectedTETA:              manualTETA, ManualTETA: &manualTETA,
+	}
+	manualState.Flights[0].ArrivalBaseline = reviewBaseline(createdAt)
+	command := aman.CommandOutcome{
+		CommandID: "review-command-1", Airport: manualState.Airport, Revision: manualState.Revision,
+		Payload: []byte(`{"status":"manual_eta"}`), RecordedAt: resolvedAt,
+	}
+	audit := aman.AuditRecord{
+		Airport: manualState.Airport, Revision: manualState.Revision, Category: "eta_review_resolved",
+		Payload: []byte(`{"status":"manual_eta"}`), RecordedAt: resolvedAt,
+	}
+	_, err = repo.Commit(ctx, aman.StateCommit{ExpectedRevision: 1, State: manualState, CommandOutcome: &command, AuditRecords: []aman.AuditRecord{audit}})
+	require.NoError(t, err)
+	restoredManual, err := NewAMANRepository(pool).LoadAirportState(ctx, manualState.Airport)
+	require.NoError(t, err)
+	require.Equal(t, manualState, restoredManual)
+	audits, err := repo.ListAuditRecords(ctx, manualState.Airport)
+	require.NoError(t, err)
+	require.Len(t, audits, 2)
+	require.Equal(t, "eta_review_opened", audits[0].Category)
+	require.Equal(t, "eta_review_resolved", audits[1].Category)
+
+	duplicateProposal := amanState(3, "CID-REVIEW", "SHOULD-NOT-PERSIST")
+	duplicate, err := NewAMANRepository(pool).Commit(ctx, aman.StateCommit{ExpectedRevision: 2, State: duplicateProposal, CommandOutcome: &command})
+	require.NoError(t, err)
+	require.True(t, duplicate.DuplicateCommand)
+	require.Equal(t, manualState, duplicate.State)
+
+	failedReset := amanState(3, "CID-REVIEW", "SAS317")
+	_, err = repo.Commit(ctx, aman.StateCommit{
+		ExpectedRevision: 2, State: failedReset,
+		AuditRecords: []aman.AuditRecord{{Airport: failedReset.Airport, Revision: failedReset.Revision, Category: "", Payload: []byte(`{}`), RecordedAt: createdAt.Add(2 * time.Minute)}},
+	})
+	require.Error(t, err)
+	afterFailure, err := repo.LoadAirportState(ctx, manualState.Airport)
+	require.NoError(t, err)
+	require.Equal(t, manualState, afterFailure, "failed reset must expose the complete state from before the transaction")
+}
+
 func TestAMANRepositoryCompareAndSwapAllocatesOneRevision(t *testing.T) {
 	pool, _ := testdata.SetupTestDB(t)
 	repo := NewAMANRepository(pool)
@@ -279,12 +358,20 @@ func amanState(revision aman.SequenceRevision, vatsimCID, callsign string) aman.
 			},
 			ActiveRouteFact: &aman.RouteFact{ID: "route-1", Fix: "KAS", ObservedAt: flightTime},
 			Slot:            &aman.Slot{Time: flightTime.Add(22 * time.Minute), RunwayGroupID: "north", Sequence: 1, Revision: revision, Reason: "spacing"},
-			Order:           intPtr(1), ETAReview: &aman.ETAReview{Status: "accepted"}, GoAroundDetection: &aman.GoAroundDetectionState{},
+			Order:           intPtr(1), GoAroundDetection: &aman.GoAroundDetectionState{},
 		}},
 	}
 }
 
 func intPtr(value int) *int { return &value }
+
+func reviewBaseline(createdAt time.Time) *aman.BaselineState {
+	return &aman.BaselineState{
+		ArrivalAt: createdAt.Add(20 * time.Minute), AirborneSensedAt: createdAt.Add(-time.Hour),
+		Source: aman.BaselineSourceAirborneFiledEET, Confidence: aman.ConfidenceMedium,
+		FlightPlanObservedAt: createdAt.Add(-time.Hour), ModelVersion: "baseline-v1", ConfigVersion: "baseline-config-v1",
+	}
+}
 
 func requireDomainErrorClass(t *testing.T, err error, class aman.ErrorClass) {
 	t.Helper()


### PR DESCRIPTION
## Summary
- add durable ETA-review states and deterministic first-Unstable discrepancy/deadline policy
- add typed accept, keep-baseline, manual, auto-accept, and reset reducers
- preserve predictor ownership: raw TETA and the smoothing window never change during review resolution

## Validation
- go test ./internal/aman/etareview ./internal/aman/prediction ./internal/aman ./internal/repository/postgres -count=1
- go vet ./internal/aman/...

Closes #317
Part of #298

> Stacked on #408. Authenticated command handling and post-commit state publishing remain with #326/#323.