### PR TITLE
[AMAN] Apply sequence freeze and go-around policies

### DIFF
--- a/backend/internal/aman/sequence/commands.go
+++ b/backend/internal/aman/sequence/commands.go
@@ -1,0 +1,133 @@
+package sequence
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"FlightStrips/internal/aman"
+)
+
+// MoveFlightCommand moves one unfrozen flight immediately before or after one
+// anchor. The transport layer derives metadata; policy validates it against
+// the supplied point-in-time input.
+type MoveFlightCommand struct {
+	Metadata       aman.CommandMetadata
+	FlightID       aman.FlightID
+	RunwayGroupID  aman.RunwayGroupID
+	BeforeFlightID *aman.FlightID
+	AfterFlightID  *aman.FlightID
+}
+
+type ApplyManualFreezeCommand struct {
+	Metadata aman.CommandMetadata
+	FlightID aman.FlightID
+	At       time.Time
+}
+
+type ReleaseManualFreezeCommand struct {
+	Metadata aman.CommandMetadata
+	FlightID aman.FlightID
+	At       time.Time
+}
+
+type SetRateCommand struct {
+	Metadata        aman.CommandMetadata
+	RunwayGroupID   aman.RunwayGroupID
+	ArrivalsPerHour uint32
+	EffectiveAt     time.Time
+}
+
+type ApplyGoAroundCommand struct {
+	Metadata   aman.CommandMetadata
+	FlightID   aman.FlightID
+	DetectedAt time.Time
+}
+
+type GoAroundPolicy struct {
+	Delay      time.Duration
+	MaxCascade int
+}
+
+func (c MoveFlightCommand) Validate(revision aman.SequenceRevision) error {
+	if err := validateMetadata(c.Metadata, revision); err != nil {
+		return err
+	}
+	if !validID(string(c.FlightID)) || !validID(string(c.RunwayGroupID)) {
+		return invalidArgument("move flight and runway group are required")
+	}
+	if (c.BeforeFlightID == nil) == (c.AfterFlightID == nil) {
+		return invalidArgument("move requires exactly one before or after anchor")
+	}
+	anchor := c.BeforeFlightID
+	if anchor == nil {
+		anchor = c.AfterFlightID
+	}
+	if !validID(string(*anchor)) || *anchor == c.FlightID {
+		return invalidArgument("move anchor must identify another flight")
+	}
+	return nil
+}
+
+func (c ApplyManualFreezeCommand) Validate(revision aman.SequenceRevision) error {
+	return validateFlightAction(c.Metadata, revision, c.FlightID, c.At)
+}
+
+func (c ReleaseManualFreezeCommand) Validate(revision aman.SequenceRevision) error {
+	return validateFlightAction(c.Metadata, revision, c.FlightID, c.At)
+}
+
+func (c SetRateCommand) Validate(revision aman.SequenceRevision) error {
+	if err := validateMetadata(c.Metadata, revision); err != nil {
+		return err
+	}
+	if !validID(string(c.RunwayGroupID)) || c.ArrivalsPerHour == 0 || !validUTC(c.EffectiveAt) {
+		return invalidArgument("rate requires a runway group, positive rate, and UTC effective time")
+	}
+	return nil
+}
+
+func (c ApplyGoAroundCommand) Validate(revision aman.SequenceRevision) error {
+	return validateFlightAction(c.Metadata, revision, c.FlightID, c.DetectedAt)
+}
+
+func (p GoAroundPolicy) Validate() error {
+	if p.Delay <= 0 || p.MaxCascade < 1 {
+		return invalidArgument("go-around delay and cascade bound must be positive")
+	}
+	return nil
+}
+
+func validateMetadata(metadata aman.CommandMetadata, revision aman.SequenceRevision) error {
+	if !validID(metadata.CommandID) {
+		return invalidArgument("command ID is required")
+	}
+	if metadata.ExpectedRevision != revision {
+		return &aman.DomainError{Class: aman.ErrorRevisionConflict, Message: fmt.Sprintf("expected revision %d does not match current revision %d", metadata.ExpectedRevision, revision)}
+	}
+	return nil
+}
+
+func validateFlightAction(metadata aman.CommandMetadata, revision aman.SequenceRevision, flightID aman.FlightID, at time.Time) error {
+	if err := validateMetadata(metadata, revision); err != nil {
+		return err
+	}
+	if !validID(string(flightID)) || !validUTC(at) {
+		return invalidArgument("flight action requires a flight and UTC time")
+	}
+	return nil
+}
+
+func validID(value string) bool { return value != "" && strings.TrimSpace(value) == value }
+
+func invalidArgument(message string) error {
+	return &aman.DomainError{Class: aman.ErrorInvalidArgument, Message: "sequence policy: " + message}
+}
+
+func invalidTransition(message string) error {
+	return &aman.DomainError{Class: aman.ErrorInvalidTransition, Message: "sequence policy: " + message}
+}
+
+func notFound(message string) error {
+	return &aman.DomainError{Class: aman.ErrorNotFound, Message: "sequence policy: " + message}
+}

--- a/backend/internal/aman/sequence/engine.go
+++ b/backend/internal/aman/sequence/engine.go
@@ -49,20 +49,23 @@ type Policy struct {
 // protected slot reference supplied by freeze/manual policy; CurrentSlot is
 // used only to report movements and never influences candidate generation.
 type Flight struct {
-	ID                  aman.FlightID
-	RunwayGroupID       aman.RunwayGroupID
-	State               aman.FlightState
-	OperationalTETA     time.Time
-	InitialBaselineTETA *time.Time
-	WakeCategory        WakeCategory
-	ManualOrder         *int
-	FreezeReason        aman.FreezeReason
-	CapturedSlot        *aman.Slot
-	CurrentSlot         *aman.Slot
+	ID                    aman.FlightID
+	RunwayGroupID         aman.RunwayGroupID
+	State                 aman.FlightState
+	OperationalTETA       time.Time
+	InitialBaselineTETA   *time.Time
+	WakeCategory          WakeCategory
+	ManualOrder           *int
+	FreezeReason          aman.FreezeReason
+	FrozenAt              *time.Time
+	FrozenOperationalTETA *time.Time
+	CapturedSlot          *aman.Slot
+	CurrentSlot           *aman.Slot
 }
 
 // Input is a complete, point-in-time pure sequence calculation.
 type Input struct {
+	Revision aman.SequenceRevision
 	Policies []Policy
 	Flights  []Flight
 }
@@ -74,6 +77,8 @@ const (
 	ReasonRateWTC           CandidateReason = "rate_wtc"
 	ReasonFreezeSuperstable CandidateReason = "freeze_superstable"
 	ReasonFreezeManual      CandidateReason = "freeze_manual"
+	ReasonGoAround          CandidateReason = "go_around"
+	ReasonGoAroundCascade   CandidateReason = "go_around_cascade"
 )
 
 // CandidateEntry is an uncommitted slot candidate. It deliberately contains
@@ -306,6 +311,14 @@ func prepareFlights(input []Flight, policies map[aman.RunwayGroupID]preparedPoli
 		if raw.FreezeReason == aman.FreezeNone && raw.CapturedSlot != nil {
 			return nil, fmt.Errorf("flight %q has captured slot without freeze reason", raw.ID)
 		}
+		if raw.FreezeReason == aman.FreezeNone && (raw.FrozenAt != nil || raw.FrozenOperationalTETA != nil) {
+			return nil, fmt.Errorf("flight %q has freeze values without freeze reason", raw.ID)
+		}
+		if raw.FrozenAt != nil || raw.FrozenOperationalTETA != nil {
+			if raw.FrozenAt == nil || raw.FrozenOperationalTETA == nil || !validUTC(*raw.FrozenAt) || !validUTC(*raw.FrozenOperationalTETA) {
+				return nil, fmt.Errorf("flight %q has incomplete freeze values", raw.ID)
+			}
+		}
 		category := normalizeCategory(raw.WakeCategory)
 		_, known := policy.categories[category]
 		if !known {
@@ -421,6 +434,13 @@ func placement(policy preparedPolicy, entries []allocatedEntry, flight preparedF
 	earlier, later := candidate.Add(-time.Nanosecond), candidate.Add(time.Nanosecond)
 	if index > 0 {
 		leading := entries[index-1]
+		if orderAfter(flight.ManualOrder, leading.flight.ManualOrder) {
+			valid = false
+			boundEarlier := leading.time.Add(-requiredGap(policy, flight, leading.flight, leading.time))
+			if boundEarlier.Before(earlier) {
+				earlier = boundEarlier
+			}
+		}
 		required := requiredGap(policy, leading.flight, flight, candidate)
 		if candidate.Sub(leading.time) < required {
 			valid = false
@@ -436,6 +456,13 @@ func placement(policy preparedPolicy, entries []allocatedEntry, flight preparedF
 	}
 	if index < len(entries) {
 		trailing := entries[index]
+		if orderBefore(flight.ManualOrder, trailing.flight.ManualOrder) {
+			valid = false
+			boundLater := trailing.time.Add(requiredGap(policy, trailing.flight, flight, trailing.time))
+			if boundLater.After(later) {
+				later = boundLater
+			}
+		}
 		required := requiredGap(policy, flight, trailing.flight, trailing.time)
 		if trailing.time.Sub(candidate) < required {
 			valid = false
@@ -450,6 +477,14 @@ func placement(policy preparedPolicy, entries []allocatedEntry, flight preparedF
 		}
 	}
 	return valid, earlier, later
+}
+
+func orderAfter(candidate, existing *int) bool {
+	return candidate != nil && existing != nil && *candidate < *existing
+}
+
+func orderBefore(candidate, existing *int) bool {
+	return candidate != nil && existing != nil && *candidate > *existing
 }
 
 func adjacentValid(policy preparedPolicy, leading, trailing allocatedEntry) bool {

--- a/backend/internal/aman/sequence/policy.go
+++ b/backend/internal/aman/sequence/policy.go
@@ -1,0 +1,476 @@
+package sequence
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"time"
+
+	"FlightStrips/internal/aman"
+)
+
+// Decision is the complete, uncommitted result of one pure sequence-policy
+// operation. #323 owns revision allocation, persistence, and publication.
+type Decision struct {
+	Input     Input
+	Candidate Result
+	Changed   bool
+}
+
+func ApplyMove(input Input, command MoveFlightCommand) (Decision, error) {
+	if err := command.Validate(input.Revision); err != nil {
+		return Decision{}, err
+	}
+	working := cloneInput(input)
+	targetIndex, target, err := activeFlight(working, command.FlightID)
+	if err != nil {
+		return Decision{}, err
+	}
+	anchorID := command.BeforeFlightID
+	if anchorID == nil {
+		anchorID = command.AfterFlightID
+	}
+	_, anchor, err := activeFlight(working, *anchorID)
+	if err != nil {
+		return Decision{}, err
+	}
+	if target.RunwayGroupID != command.RunwayGroupID || anchor.RunwayGroupID != command.RunwayGroupID {
+		return Decision{}, invalidArgument("move flight and anchor must belong to the requested runway group")
+	}
+	if target.FreezeReason != aman.FreezeNone {
+		return Decision{}, invalidTransition("move requires the flight freeze to be released first")
+	}
+
+	current, err := Generate(working)
+	if err != nil {
+		return Decision{}, err
+	}
+	if current.HasConflicts() {
+		return Decision{}, invalidTransition("move cannot start from a conflicting protected sequence")
+	}
+	order := groupOrder(current, command.RunwayGroupID)
+	from, anchorAt := slices.Index(order, command.FlightID), slices.Index(order, *anchorID)
+	if from < 0 || anchorAt < 0 {
+		return Decision{}, notFound("move flight or anchor has no active slot")
+	}
+	order = slices.Delete(order, from, from+1)
+	anchorAt = slices.Index(order, *anchorID)
+	insertAt := anchorAt
+	if command.AfterFlightID != nil {
+		insertAt++
+	}
+	order = slices.Insert(order, insertAt, command.FlightID)
+
+	for position, id := range order {
+		index := flightIndex(working.Flights, id)
+		value := position + 1
+		working.Flights[index].ManualOrder = &value
+	}
+	working.Flights[targetIndex].ManualOrder = intPointer(slices.Index(order, command.FlightID) + 1)
+
+	candidate, err := Generate(working)
+	if err != nil {
+		return Decision{}, invalidTransition("move cannot satisfy rate and WTC policy: " + err.Error())
+	}
+	if candidate.HasConflicts() {
+		return Decision{}, invalidTransition("move would conflict with a protected slot")
+	}
+	wantOrder := groupOrder(candidate, command.RunwayGroupID)
+	targetAt, finalAnchorAt := slices.Index(wantOrder, command.FlightID), slices.Index(wantOrder, *anchorID)
+	validAnchor := command.BeforeFlightID != nil && targetAt+1 == finalAnchorAt || command.AfterFlightID != nil && finalAnchorAt+1 == targetAt
+	if !validAnchor {
+		return Decision{}, invalidTransition("move cannot satisfy the requested anchor under rate and WTC policy")
+	}
+	return Decision{Input: working, Candidate: candidate, Changed: !inputsEqualOrder(input, working) || len(candidate.Movements) > 0}, nil
+}
+
+func ApplyManualFreeze(input Input, command ApplyManualFreezeCommand) (Decision, error) {
+	if err := command.Validate(input.Revision); err != nil {
+		return Decision{}, err
+	}
+	working := cloneInput(input)
+	index, flight, err := activeFlight(working, command.FlightID)
+	if err != nil {
+		return Decision{}, err
+	}
+	if flight.State == aman.StateGoAround {
+		return Decision{}, invalidTransition("go-around flight cannot be manually frozen")
+	}
+	if flight.FreezeReason != aman.FreezeNone {
+		return Decision{}, invalidTransition("manual freeze requires an unfrozen flight")
+	}
+	if flight.CurrentSlot == nil {
+		return Decision{}, invalidTransition("manual freeze requires a committed current slot")
+	}
+	at, operational := command.At, flight.OperationalTETA
+	working.Flights[index].FreezeReason = aman.FreezeManual
+	working.Flights[index].FrozenAt = &at
+	working.Flights[index].FrozenOperationalTETA = &operational
+	working.Flights[index].CapturedSlot = cloneSlot(flight.CurrentSlot)
+	candidate, err := Generate(working)
+	if err != nil {
+		return Decision{}, err
+	}
+	return Decision{Input: working, Candidate: candidate, Changed: true}, nil
+}
+
+func ReleaseManualFreeze(input Input, command ReleaseManualFreezeCommand) (Decision, error) {
+	if err := command.Validate(input.Revision); err != nil {
+		return Decision{}, err
+	}
+	working := cloneInput(input)
+	index, flight, err := activeFlight(working, command.FlightID)
+	if err != nil {
+		return Decision{}, err
+	}
+	if flight.FreezeReason != aman.FreezeManual {
+		return Decision{}, invalidTransition("manual freeze release requires FreezeManual")
+	}
+	working.Flights[index].FreezeReason = aman.FreezeNone
+	working.Flights[index].FrozenAt = nil
+	working.Flights[index].FrozenOperationalTETA = nil
+	working.Flights[index].CapturedSlot = nil
+	candidate, err := Generate(working)
+	if err != nil {
+		return Decision{}, err
+	}
+	return Decision{Input: working, Candidate: candidate, Changed: true}, nil
+}
+
+func ApplyRate(input Input, command SetRateCommand) (Decision, error) {
+	if err := command.Validate(input.Revision); err != nil {
+		return Decision{}, err
+	}
+	working := cloneInput(input)
+	policyIndex := -1
+	for index := range working.Policies {
+		if working.Policies[index].RunwayGroupID == command.RunwayGroupID {
+			policyIndex = index
+			break
+		}
+	}
+	if policyIndex < 0 {
+		return Decision{}, notFound("rate runway group was not found")
+	}
+	rates := working.Policies[policyIndex].Rates
+	changed := true
+	replaced := false
+	for index := range rates {
+		if rates[index].EffectiveAt.Equal(command.EffectiveAt) {
+			changed = rates[index].ArrivalsPerHour != command.ArrivalsPerHour
+			rates[index].ArrivalsPerHour = command.ArrivalsPerHour
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		rates = append(rates, RatePoint{EffectiveAt: command.EffectiveAt, ArrivalsPerHour: command.ArrivalsPerHour})
+	}
+	sort.Slice(rates, func(i, j int) bool { return rates[i].EffectiveAt.Before(rates[j].EffectiveAt) })
+	working.Policies[policyIndex].Rates = rates
+	candidate, err := Generate(working)
+	if err != nil {
+		return Decision{}, err
+	}
+	return Decision{Input: working, Candidate: candidate, Changed: changed || len(candidate.Movements) > 0}, nil
+}
+
+func ApplyGoAround(input Input, policy GoAroundPolicy, command ApplyGoAroundCommand) (Decision, error) {
+	if err := policy.Validate(); err != nil {
+		return Decision{}, err
+	}
+	if err := command.Validate(input.Revision); err != nil {
+		return Decision{}, err
+	}
+	working := cloneInput(input)
+	targetIndex, target, err := activeFlight(working, command.FlightID)
+	if err != nil {
+		return Decision{}, err
+	}
+	if target.State != aman.StateGoAround {
+		return Decision{}, invalidTransition("go-around sequence policy requires StateGoAround")
+	}
+	if target.CurrentSlot == nil {
+		return Decision{}, invalidTransition("go-around sequence policy requires a current slot")
+	}
+	policies, err := preparePolicies(working.Policies)
+	if err != nil {
+		return Decision{}, err
+	}
+	prepared, err := prepareFlights(working.Flights, policies)
+	if err != nil {
+		return Decision{}, err
+	}
+	groupPolicy := policies[target.RunwayGroupID]
+	groupFlights := prepared[target.RunwayGroupID]
+	var moving preparedFlight
+	entries := make([]allocatedEntry, 0, len(groupFlights))
+	for _, flight := range groupFlights {
+		if flight.ID == target.ID {
+			moving = flight
+			continue
+		}
+		if flight.State == aman.StateLanded || flight.State == aman.StateRemoved {
+			continue
+		}
+		if flight.CurrentSlot == nil {
+			return Decision{}, invalidTransition(fmt.Sprintf("go-around cascade requires current slot for flight %q", flight.ID))
+		}
+		slot := flight.CurrentSlot
+		if flight.FreezeReason != aman.FreezeNone {
+			if flight.CapturedSlot == nil {
+				return Decision{}, invalidTransition(fmt.Sprintf("frozen flight %q has no captured slot", flight.ID))
+			}
+			slot = flight.CapturedSlot
+		}
+		entries = append(entries, allocatedEntry{flight: flight, time: slot.Time, reason: protectedReason(flight)})
+	}
+	moving.FreezeReason = aman.FreezeNone
+	moving.CapturedSlot = nil
+	moving.FrozenAt = nil
+	moving.FrozenOperationalTETA = nil
+	moving.ManualOrder = nil
+	sortEntries(entries)
+
+	earliest := command.DetectedAt.Add(policy.Delay)
+	var allocated []allocatedEntry
+	var cascaded map[aman.FlightID]struct{}
+	for attempts := 0; attempts <= len(entries)+1; attempts++ {
+		candidate, ok := nextGridAtOrAfter(groupPolicy, earliest)
+		if !ok {
+			return Decision{}, invalidTransition("go-around has no rate slot at or after its target")
+		}
+		allocated, cascaded, earliest, err = cascadeGoAround(groupPolicy, entries, moving, candidate, policy.MaxCascade)
+		if err != nil {
+			return Decision{}, err
+		}
+		if allocated != nil {
+			break
+		}
+	}
+	if allocated == nil {
+		return Decision{}, invalidTransition("go-around could not pass a protected manual slot")
+	}
+
+	working.Flights[targetIndex].FreezeReason = aman.FreezeNone
+	working.Flights[targetIndex].FrozenAt = nil
+	working.Flights[targetIndex].FrozenOperationalTETA = nil
+	working.Flights[targetIndex].CapturedSlot = nil
+	working.Flights[targetIndex].ManualOrder = nil
+
+	result, err := resultWithGoAroundGroup(working, target.RunwayGroupID, allocated, target.ID)
+	if err != nil {
+		return Decision{}, err
+	}
+	for _, entry := range result.Entries {
+		if entry.RunwayGroupID != target.RunwayGroupID {
+			continue
+		}
+		index := flightIndex(working.Flights, entry.FlightID)
+		working.Flights[index].ManualOrder = intPointer(entry.Sequence)
+	}
+	for _, entry := range result.Entries {
+		if _, moved := cascaded[entry.FlightID]; !moved {
+			continue
+		}
+		index := flightIndex(working.Flights, entry.FlightID)
+		if working.Flights[index].FreezeReason == aman.FreezeSuperstable {
+			working.Flights[index].CapturedSlot = &aman.Slot{Time: entry.Time, RunwayGroupID: entry.RunwayGroupID, Sequence: entry.Sequence, Revision: input.Revision, Reason: string(entry.Reason)}
+		}
+	}
+	return Decision{Input: working, Candidate: result, Changed: true}, nil
+}
+
+func cascadeGoAround(policy preparedPolicy, current []allocatedEntry, moving preparedFlight, candidate time.Time, limit int) ([]allocatedEntry, map[aman.FlightID]struct{}, time.Time, error) {
+	index := sort.Search(len(current), func(i int) bool { return !current[i].time.Before(candidate) })
+	if index > 0 {
+		leading := current[index-1]
+		required := requiredGap(policy, leading.flight, moving, candidate)
+		if candidate.Sub(leading.time) < required {
+			return nil, nil, leading.time.Add(required), nil
+		}
+	}
+	result := append([]allocatedEntry(nil), current[:index]...)
+	last := allocatedEntry{flight: moving, time: candidate, reason: ReasonGoAround}
+	result = append(result, last)
+	cascaded := map[aman.FlightID]struct{}{}
+	for position := index; position < len(current); position++ {
+		next := current[position]
+		if adjacentValid(policy, last, next) {
+			result = append(result, current[position:]...)
+			return result, cascaded, time.Time{}, nil
+		}
+		if next.flight.FreezeReason == aman.FreezeManual {
+			required := requiredGap(policy, next.flight, moving, next.time)
+			return nil, nil, next.time.Add(required), nil
+		}
+		if len(cascaded) >= limit {
+			return nil, nil, time.Time{}, invalidTransition("go-around cascade bound exceeded")
+		}
+		nextTime, ok := nextGridAtOrAfter(policy, last.time.Add(requiredGap(policy, last.flight, next.flight, last.time)))
+		if !ok {
+			return nil, nil, time.Time{}, invalidTransition("go-around cascade has no following rate slot")
+		}
+		for !adjacentValid(policy, last, allocatedEntry{flight: next.flight, time: nextTime}) {
+			nextTime, ok = nextGridAtOrAfter(policy, nextTime.Add(time.Nanosecond))
+			if !ok {
+				return nil, nil, time.Time{}, invalidTransition("go-around cascade has no WTC-valid following slot")
+			}
+		}
+		next.time = nextTime
+		next.reason = ReasonGoAroundCascade
+		result = append(result, next)
+		last = next
+		cascaded[next.flight.ID] = struct{}{}
+	}
+	return result, cascaded, time.Time{}, nil
+}
+
+func resultWithGoAroundGroup(input Input, group aman.RunwayGroupID, allocated []allocatedEntry, target aman.FlightID) (Result, error) {
+	result := Result{Entries: []CandidateEntry{}, Movements: []SlotMovement{}, Warnings: []Warning{}}
+	for index, entry := range allocated {
+		candidate := CandidateEntry{FlightID: entry.flight.ID, RunwayGroupID: group, Sequence: index + 1, Time: entry.time, OperationalTETA: entry.flight.OperationalTETA, WakeCategory: entry.flight.category, FreezeReason: entry.flight.FreezeReason, Protected: entry.flight.FreezeReason != aman.FreezeNone, Reason: entry.reason}
+		if entry.flight.ID == target {
+			candidate.FreezeReason, candidate.Protected, candidate.Reason = aman.FreezeNone, false, ReasonGoAround
+		}
+		result.Entries = append(result.Entries, candidate)
+		if movement := movementFor(entry.flight, candidate); movement != nil {
+			result.Movements = append(result.Movements, *movement)
+		}
+		if !entry.flight.known {
+			result.Warnings = append(result.Warnings, Warning{Severity: SeverityDegraded, Code: WarningUnknownWakeCategory, RunwayGroupID: group, FlightID: entry.flight.ID})
+		}
+	}
+	for _, policy := range input.Policies {
+		if policy.RunwayGroupID == group {
+			continue
+		}
+		flights := make([]Flight, 0)
+		for _, flight := range input.Flights {
+			if flight.RunwayGroupID == policy.RunwayGroupID {
+				flights = append(flights, flight)
+			}
+		}
+		other, err := Generate(Input{Revision: input.Revision, Policies: []Policy{policy}, Flights: flights})
+		if err != nil {
+			return Result{}, err
+		}
+		result.Entries = append(result.Entries, other.Entries...)
+		result.Movements = append(result.Movements, other.Movements...)
+		result.Warnings = append(result.Warnings, other.Warnings...)
+	}
+	sort.Slice(result.Entries, func(i, j int) bool {
+		if result.Entries[i].RunwayGroupID != result.Entries[j].RunwayGroupID {
+			return result.Entries[i].RunwayGroupID < result.Entries[j].RunwayGroupID
+		}
+		return result.Entries[i].Sequence < result.Entries[j].Sequence
+	})
+	sort.Slice(result.Movements, func(i, j int) bool {
+		if result.Movements[i].RunwayGroupID != result.Movements[j].RunwayGroupID {
+			return result.Movements[i].RunwayGroupID < result.Movements[j].RunwayGroupID
+		}
+		return result.Movements[i].FlightID < result.Movements[j].FlightID
+	})
+	sortWarnings(result.Warnings)
+	return result, nil
+}
+
+func cloneInput(input Input) Input {
+	copy := Input{Revision: input.Revision, Policies: make([]Policy, len(input.Policies)), Flights: make([]Flight, len(input.Flights))}
+	for index, policy := range input.Policies {
+		copy.Policies[index] = policy
+		copy.Policies[index].Rates = slices.Clone(policy.Rates)
+		copy.Policies[index].SeparationRules = slices.Clone(policy.SeparationRules)
+	}
+	for index, flight := range input.Flights {
+		copy.Flights[index] = flight
+		copy.Flights[index].InitialBaselineTETA = cloneTime(flight.InitialBaselineTETA)
+		copy.Flights[index].ManualOrder = cloneInt(flight.ManualOrder)
+		copy.Flights[index].FrozenAt = cloneTime(flight.FrozenAt)
+		copy.Flights[index].FrozenOperationalTETA = cloneTime(flight.FrozenOperationalTETA)
+		copy.Flights[index].CapturedSlot = cloneSlot(flight.CapturedSlot)
+		copy.Flights[index].CurrentSlot = cloneSlot(flight.CurrentSlot)
+	}
+	return copy
+}
+
+func activeFlight(input Input, id aman.FlightID) (int, Flight, error) {
+	index := flightIndex(input.Flights, id)
+	if index < 0 {
+		return -1, Flight{}, notFound(fmt.Sprintf("flight %q was not found", id))
+	}
+	flight := input.Flights[index]
+	if flight.State == aman.StateLanded || flight.State == aman.StateRemoved {
+		return -1, Flight{}, invalidTransition(fmt.Sprintf("flight %q is not active", id))
+	}
+	return index, flight, nil
+}
+
+func groupOrder(result Result, group aman.RunwayGroupID) []aman.FlightID {
+	values := []aman.FlightID{}
+	for _, entry := range result.Entries {
+		if entry.RunwayGroupID == group {
+			values = append(values, entry.FlightID)
+		}
+	}
+	return values
+}
+
+func protectedReason(flight preparedFlight) CandidateReason {
+	if flight.FreezeReason == aman.FreezeSuperstable {
+		return ReasonFreezeSuperstable
+	}
+	if flight.FreezeReason == aman.FreezeManual {
+		return ReasonFreezeManual
+	}
+	return ReasonRateWTC
+}
+
+func flightIndex(flights []Flight, id aman.FlightID) int {
+	return slices.IndexFunc(flights, func(flight Flight) bool { return flight.ID == id })
+}
+
+func cloneSlot(value *aman.Slot) *aman.Slot {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func cloneTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func cloneInt(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func intPointer(value int) *int { return &value }
+
+func inputsEqualOrder(a, b Input) bool {
+	if len(a.Flights) != len(b.Flights) {
+		return false
+	}
+	for index := range a.Flights {
+		left, right := a.Flights[index].ManualOrder, b.Flights[index].ManualOrder
+		if left == nil || right == nil {
+			if left != nil || right != nil {
+				return false
+			}
+			continue
+		}
+		if *left != *right {
+			return false
+		}
+	}
+	return true
+}

--- a/backend/internal/aman/sequence/policy_test.go
+++ b/backend/internal/aman/sequence/policy_test.go
@@ -1,0 +1,264 @@
+package sequence_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/aman/sequence"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManualFreezeApplyReleaseAndRoutineRecompute(t *testing.T) {
+	start := testTime()
+	input := withCommittedSlots(t, sequence.Input{Revision: 7, Policies: []sequence.Policy{simplePolicy("A", start, 60)}, Flights: []sequence.Flight{
+		flight("A", "A", start, "M"),
+		flight("B", "A", start.Add(time.Minute), "M"),
+	}})
+	metadata := aman.CommandMetadata{CommandID: "freeze-b", ExpectedRevision: 7}
+	frozen, err := sequence.ApplyManualFreeze(input, sequence.ApplyManualFreezeCommand{Metadata: metadata, FlightID: "B", At: start.Add(30 * time.Second)})
+	require.NoError(t, err)
+	value := policyFlight(t, frozen.Input, "B")
+	require.Equal(t, aman.FreezeManual, value.FreezeReason)
+	require.Equal(t, value.CurrentSlot, value.CapturedSlot)
+	require.Equal(t, value.OperationalTETA, *value.FrozenOperationalTETA)
+	require.False(t, frozen.Candidate.HasConflicts())
+
+	rate, err := sequence.ApplyRate(frozen.Input, sequence.SetRateCommand{
+		Metadata: aman.CommandMetadata{CommandID: "rate", ExpectedRevision: 7}, RunwayGroupID: "A", ArrivalsPerHour: 30, EffectiveAt: start,
+	})
+	require.NoError(t, err)
+	require.Equal(t, value.CapturedSlot.Time, entryFor(t, rate.Candidate, "B").Time)
+
+	released, err := sequence.ReleaseManualFreeze(frozen.Input, sequence.ReleaseManualFreezeCommand{
+		Metadata: aman.CommandMetadata{CommandID: "release-b", ExpectedRevision: 7}, FlightID: "B", At: start.Add(time.Minute),
+	})
+	require.NoError(t, err)
+	value = policyFlight(t, released.Input, "B")
+	require.Equal(t, aman.FreezeNone, value.FreezeReason)
+	require.Nil(t, value.FrozenAt)
+	require.Nil(t, value.FrozenOperationalTETA)
+	require.Nil(t, value.CapturedSlot)
+}
+
+func TestSuperstableAndManualSlotsAreTheOnlyRoutineConstraints(t *testing.T) {
+	start := testTime()
+	superstable := protectedFlight("SUPER", "A", start, "M", start, aman.FreezeSuperstable)
+	manual := protectedFlight("MANUAL", "A", start.Add(2*time.Minute), "M", start.Add(2*time.Minute), aman.FreezeManual)
+	input := sequence.Input{Revision: 3, Policies: []sequence.Policy{simplePolicy("A", start, 30)}, Flights: []sequence.Flight{superstable, manual}}
+	decision, err := sequence.ApplyRate(input, sequence.SetRateCommand{
+		Metadata: aman.CommandMetadata{CommandID: "reduce-rate", ExpectedRevision: 3}, RunwayGroupID: "A", ArrivalsPerHour: 20, EffectiveAt: start,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []time.Time{start, start.Add(2 * time.Minute)}, entryTimes(decision.Candidate))
+	require.True(t, decision.Candidate.HasConflicts(), "new rate exposes the frozen-spacing conflict without moving either slot")
+	require.Equal(t, sequence.WarningProtectedSpacing, decision.Candidate.Warnings[0].Code)
+}
+
+func TestRateTimelineImmediateFutureSameInstantAndRunwayIsolation(t *testing.T) {
+	start := testTime()
+	input := sequence.Input{Revision: 4, Policies: []sequence.Policy{simplePolicy("B", start, 30), simplePolicy("A", start, 60)}, Flights: []sequence.Flight{
+		flight("A", "A", start, "M"), flight("B", "B", start, "M"),
+	}}
+	first, err := sequence.ApplyRate(input, sequence.SetRateCommand{
+		Metadata: aman.CommandMetadata{CommandID: "future", ExpectedRevision: 4}, RunwayGroupID: "A", ArrivalsPerHour: 40, EffectiveAt: start.Add(10 * time.Minute),
+	})
+	require.NoError(t, err)
+	second, err := sequence.ApplyRate(first.Input, sequence.SetRateCommand{
+		Metadata: aman.CommandMetadata{CommandID: "same-instant", ExpectedRevision: 4}, RunwayGroupID: "A", ArrivalsPerHour: 20, EffectiveAt: start.Add(10 * time.Minute),
+	})
+	require.NoError(t, err)
+	immediate := sequence.SetRateCommand{
+		Metadata: aman.CommandMetadata{CommandID: "immediate", ExpectedRevision: 4}, RunwayGroupID: "A", ArrivalsPerHour: 45, EffectiveAt: start,
+	}
+	third, err := sequence.ApplyRate(second.Input, immediate)
+	require.NoError(t, err)
+
+	policyA := policyFor(t, third.Input, "A")
+	require.Equal(t, []sequence.RatePoint{{EffectiveAt: start, ArrivalsPerHour: 45}, {EffectiveAt: start.Add(10 * time.Minute), ArrivalsPerHour: 20}}, policyA.Rates)
+	require.Equal(t, []sequence.RatePoint{{EffectiveAt: start, ArrivalsPerHour: 30}}, policyFor(t, third.Input, "B").Rates)
+
+	snapshot, err := json.Marshal(second.Input)
+	require.NoError(t, err)
+	var restored sequence.Input
+	require.NoError(t, json.Unmarshal(snapshot, &restored))
+	replayed, err := sequence.ApplyRate(restored, immediate)
+	require.NoError(t, err)
+	wantJSON, err := json.Marshal(third)
+	require.NoError(t, err)
+	replayedJSON, err := json.Marshal(replayed)
+	require.NoError(t, err)
+	require.Equal(t, wantJSON, replayedJSON)
+}
+
+func TestManualMoveAnchorsAndCommandValidation(t *testing.T) {
+	start := testTime()
+	input := withCommittedSlots(t, sequence.Input{Revision: 11, Policies: []sequence.Policy{simplePolicy("A", start, 60)}, Flights: []sequence.Flight{
+		flight("A", "A", start, "M"), flight("B", "A", start.Add(time.Minute), "M"), flight("C", "A", start.Add(2*time.Minute), "M"),
+	}})
+	before := aman.FlightID("A")
+	decision, err := sequence.ApplyMove(input, sequence.MoveFlightCommand{
+		Metadata: aman.CommandMetadata{CommandID: "move-c", ExpectedRevision: 11}, FlightID: "C", RunwayGroupID: "A", BeforeFlightID: &before,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []aman.FlightID{"C", "A", "B"}, entryIDs(decision.Candidate))
+	require.Equal(t, 1, *policyFlight(t, decision.Input, "C").ManualOrder)
+
+	_, err = sequence.ApplyMove(input, sequence.MoveFlightCommand{
+		Metadata: aman.CommandMetadata{CommandID: "stale", ExpectedRevision: 10}, FlightID: "C", RunwayGroupID: "A", BeforeFlightID: &before,
+	})
+	requireDomainClass(t, err, aman.ErrorRevisionConflict)
+
+	_, err = sequence.ApplyMove(input, sequence.MoveFlightCommand{
+		Metadata: aman.CommandMetadata{CommandID: "missing", ExpectedRevision: 11}, FlightID: "UNKNOWN", RunwayGroupID: "A", BeforeFlightID: &before,
+	})
+	requireDomainClass(t, err, aman.ErrorNotFound)
+
+	_, err = sequence.ApplyMove(input, sequence.MoveFlightCommand{
+		Metadata: aman.CommandMetadata{CommandID: "wrong-group", ExpectedRevision: 11}, FlightID: "C", RunwayGroupID: "B", BeforeFlightID: &before,
+	})
+	requireDomainClass(t, err, aman.ErrorInvalidArgument)
+
+	after := aman.FlightID("B")
+	_, err = sequence.ApplyMove(input, sequence.MoveFlightCommand{
+		Metadata: aman.CommandMetadata{CommandID: "two-anchors", ExpectedRevision: 11}, FlightID: "C", RunwayGroupID: "A", BeforeFlightID: &before, AfterFlightID: &after,
+	})
+	requireDomainClass(t, err, aman.ErrorInvalidArgument)
+}
+
+func TestManualMoveRejectsImpossibleWTCAndFrozenTarget(t *testing.T) {
+	start := testTime()
+	policy := wtcPolicy("A", start, 60)
+	lead := protectedFlight("LEAD", "A", start, "H", start, aman.FreezeManual)
+	trail := protectedFlight("TRAIL", "A", start.Add(4*time.Minute), "H", start.Add(4*time.Minute), aman.FreezeManual)
+	target := flight("TARGET", "A", start.Add(6*time.Minute), "M")
+	input := withCommittedSlots(t, sequence.Input{Revision: 2, Policies: []sequence.Policy{policy}, Flights: []sequence.Flight{lead, trail, target}})
+	before := aman.FlightID("TRAIL")
+	_, err := sequence.ApplyMove(input, sequence.MoveFlightCommand{
+		Metadata: aman.CommandMetadata{CommandID: "bad-spacing", ExpectedRevision: 2}, FlightID: "TARGET", RunwayGroupID: "A", BeforeFlightID: &before,
+	})
+	requireDomainClass(t, err, aman.ErrorInvalidTransition)
+
+	targetIndex := policyFlightIndex(input, "TARGET")
+	input.Flights[targetIndex].FreezeReason = aman.FreezeManual
+	input.Flights[targetIndex].CapturedSlot = input.Flights[targetIndex].CurrentSlot
+	_, err = sequence.ApplyMove(input, sequence.MoveFlightCommand{
+		Metadata: aman.CommandMetadata{CommandID: "frozen", ExpectedRevision: 2}, FlightID: "TARGET", RunwayGroupID: "A", BeforeFlightID: &before,
+	})
+	requireDomainClass(t, err, aman.ErrorInvalidTransition)
+}
+
+func TestGoAroundCascadeMovesStableAndSuperstableWithinBound(t *testing.T) {
+	start := testTime()
+	target := withState(flight("GO", "A", start, "M"), aman.StateGoAround)
+	target.FreezeReason = aman.FreezeSuperstable
+	target.CapturedSlot = slot(start, "A", 1)
+	target.CurrentSlot = slot(start, "A", 1)
+	stable := withState(flight("STABLE", "A", start.Add(time.Minute), "M"), aman.StateStable)
+	stable.CurrentSlot = slot(start.Add(time.Minute), "A", 2)
+	superstable := protectedFlight("SUPER", "A", start.Add(2*time.Minute), "M", start.Add(2*time.Minute), aman.FreezeSuperstable)
+	superstable.CurrentSlot = slot(start.Add(2*time.Minute), "A", 3)
+	input := sequence.Input{Revision: 9, Policies: []sequence.Policy{simplePolicy("A", start, 60)}, Flights: []sequence.Flight{target, stable, superstable}}
+	command := sequence.ApplyGoAroundCommand{Metadata: aman.CommandMetadata{CommandID: "go-around", ExpectedRevision: 9}, FlightID: "GO", DetectedAt: start}
+	decision, err := sequence.ApplyGoAround(input, sequence.GoAroundPolicy{Delay: time.Minute, MaxCascade: 2}, command)
+	require.NoError(t, err)
+	require.Equal(t, start.Add(time.Minute), entryFor(t, decision.Candidate, "GO").Time)
+	require.Equal(t, start.Add(2*time.Minute), entryFor(t, decision.Candidate, "STABLE").Time)
+	require.Equal(t, start.Add(3*time.Minute), entryFor(t, decision.Candidate, "SUPER").Time)
+	require.Equal(t, aman.FreezeNone, policyFlight(t, decision.Input, "GO").FreezeReason)
+	require.Equal(t, aman.FreezeSuperstable, policyFlight(t, decision.Input, "SUPER").FreezeReason)
+	require.Equal(t, start.Add(3*time.Minute), policyFlight(t, decision.Input, "SUPER").CapturedSlot.Time)
+
+	_, err = sequence.ApplyGoAround(input, sequence.GoAroundPolicy{Delay: time.Minute, MaxCascade: 1}, command)
+	requireDomainClass(t, err, aman.ErrorInvalidTransition)
+}
+
+func TestGoAroundPreservesManualFreezeAndRestartsDeterministically(t *testing.T) {
+	start := testTime()
+	target := withState(flight("GO", "A", start, "M"), aman.StateGoAround)
+	target.CurrentSlot = slot(start, "A", 1)
+	manual := protectedFlight("MANUAL", "A", start.Add(time.Minute), "M", start.Add(time.Minute), aman.FreezeManual)
+	manual.CurrentSlot = slot(start.Add(time.Minute), "A", 2)
+	input := sequence.Input{Revision: 5, Policies: []sequence.Policy{simplePolicy("A", start, 60)}, Flights: []sequence.Flight{target, manual}}
+	command := sequence.ApplyGoAroundCommand{Metadata: aman.CommandMetadata{CommandID: "replay-go-around", ExpectedRevision: 5}, FlightID: "GO", DetectedAt: start}
+	policy := sequence.GoAroundPolicy{Delay: time.Minute, MaxCascade: 4}
+
+	want, err := sequence.ApplyGoAround(input, policy, command)
+	require.NoError(t, err)
+	require.Equal(t, start.Add(time.Minute), entryFor(t, want.Candidate, "MANUAL").Time)
+	require.Equal(t, start.Add(2*time.Minute), entryFor(t, want.Candidate, "GO").Time)
+
+	inputJSON, err := json.Marshal(input)
+	require.NoError(t, err)
+	commandJSON, err := json.Marshal(command)
+	require.NoError(t, err)
+	var restoredInput sequence.Input
+	var restoredCommand sequence.ApplyGoAroundCommand
+	require.NoError(t, json.Unmarshal(inputJSON, &restoredInput))
+	require.NoError(t, json.Unmarshal(commandJSON, &restoredCommand))
+	replayed, err := sequence.ApplyGoAround(restoredInput, policy, restoredCommand)
+	require.NoError(t, err)
+	wantJSON, err := json.Marshal(want)
+	require.NoError(t, err)
+	replayedJSON, err := json.Marshal(replayed)
+	require.NoError(t, err)
+	require.Equal(t, wantJSON, replayedJSON)
+}
+
+func withCommittedSlots(t *testing.T, input sequence.Input) sequence.Input {
+	t.Helper()
+	result, err := sequence.Generate(input)
+	require.NoError(t, err)
+	for index := range input.Flights {
+		if input.Flights[index].State == aman.StateLanded || input.Flights[index].State == aman.StateRemoved {
+			continue
+		}
+		entry := entryFor(t, result, input.Flights[index].ID)
+		input.Flights[index].CurrentSlot = &aman.Slot{Time: entry.Time, RunwayGroupID: entry.RunwayGroupID, Sequence: entry.Sequence, Revision: input.Revision, Reason: string(entry.Reason)}
+		if input.Flights[index].FreezeReason != aman.FreezeNone {
+			input.Flights[index].CapturedSlot = input.Flights[index].CurrentSlot
+		}
+	}
+	return input
+}
+
+func policyFlight(t *testing.T, input sequence.Input, id aman.FlightID) sequence.Flight {
+	t.Helper()
+	index := policyFlightIndex(input, id)
+	require.NotEqual(t, -1, index)
+	return input.Flights[index]
+}
+
+func policyFlightIndex(input sequence.Input, id aman.FlightID) int {
+	for index := range input.Flights {
+		if input.Flights[index].ID == id {
+			return index
+		}
+	}
+	return -1
+}
+
+func policyFor(t *testing.T, input sequence.Input, group aman.RunwayGroupID) sequence.Policy {
+	t.Helper()
+	for _, policy := range input.Policies {
+		if policy.RunwayGroupID == group {
+			return policy
+		}
+	}
+	t.Fatalf("policy %q not found", group)
+	return sequence.Policy{}
+}
+
+func slot(at time.Time, group aman.RunwayGroupID, order int) *aman.Slot {
+	return &aman.Slot{Time: at, RunwayGroupID: group, Sequence: order, Reason: "committed"}
+}
+
+func requireDomainClass(t *testing.T, err error, class aman.ErrorClass) {
+	t.Helper()
+	require.Error(t, err)
+	var domain *aman.DomainError
+	require.True(t, errors.As(err, &domain))
+	require.Equal(t, class, domain.Class)
+}


### PR DESCRIPTION
## Summary

Implements the pure AMAN sequence-policy layer on top of #322.

- adds separate typed commands for moves, manual freezes, rate changes, and go-arounds
- validates expected revisions and command payloads before producing uncommitted decisions
- preserves `FreezeReason` as the single constraint source
- applies deterministic rate timelines, anchor-checked moves, and bounded go-around cascades

## Scope

This is the #321 policy slice only. #323 remains the sole transactional revision writer; #326 remains responsible for authenticated handler transport.

## Validation

- `go test ./internal/aman/sequence -count=1`
- `go vet ./internal/aman/sequence`
- `go test ./internal/aman/...`
- `go test ./...`

Closes #321