### PR TITLE
[AMAN] Coordinate sequence commits and recovery

### DIFF
--- a/backend/internal/aman/persistence.go
+++ b/backend/internal/aman/persistence.go
@@ -37,9 +37,9 @@ type ValidationEvidence struct {
 	RecordedAt time.Time
 }
 
-// StateCommit is the single atomic AMAN persistence operation. A successful
-// commit advances exactly one airport revision, optionally records a command
-// result, and appends its audit and validation evidence.
+// StateCommit is the single atomic AMAN persistence operation. A changed
+// commit advances exactly one airport revision. An unchanged command commit
+// retains ExpectedRevision while atomically recording its outcome and audit.
 type StateCommit struct {
 	ExpectedRevision   SequenceRevision
 	State              AirportState
@@ -126,8 +126,8 @@ func (c StateCommit) Validate() error {
 	if err := c.State.Validate(); err != nil {
 		return err
 	}
-	if c.State.Revision != c.ExpectedRevision+1 {
-		return invalid("state revision must be exactly one greater than expected revision")
+	if c.State.Revision != c.ExpectedRevision && c.State.Revision != c.ExpectedRevision+1 {
+		return invalid("state revision must equal expected revision or be exactly one greater")
 	}
 	if c.CommandOutcome != nil {
 		if err := c.CommandOutcome.validateFor(c.State.Airport, c.State.Revision); err != nil {

--- a/backend/internal/aman/sequence/coordinator.go
+++ b/backend/internal/aman/sequence/coordinator.go
@@ -1,0 +1,334 @@
+package sequence
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	"FlightStrips/internal/aman"
+)
+
+// FullStatePublisher maps the complete committed airport state onto the
+// existing frontend and EuroScope hubs. Transport DTOs and login handlers are
+// owned by their respective tasks; this boundary deliberately has no outbox,
+// acknowledgement, or retry contract.
+type FullStatePublisher interface {
+	PublishAMANState(context.Context, aman.AirportState) error
+}
+
+// AuditEntry is audit data before the coordinator binds it to the committed
+// airport revision and transaction time.
+type AuditEntry struct {
+	Category string
+	Payload  json.RawMessage
+}
+
+// CommandChange is the uncommitted result of one typed command. Apply must not
+// allocate a revision or change the airport identity; Coordinator is the sole
+// sequence-revision writer.
+type CommandChange struct {
+	State   aman.AirportState
+	Changed bool
+	Outcome json.RawMessage
+	Audit   []AuditEntry
+}
+
+// CommandMutation adapts a typed policy operation to the persisted aggregate.
+// It receives a detached copy so a failed policy or commit cannot mutate the
+// repository-owned current state in memory.
+type CommandMutation func(aman.AirportState) (CommandChange, error)
+
+type CommandResult struct {
+	State     aman.AirportState
+	Outcome   aman.CommandOutcome
+	Changed   bool
+	Duplicate bool
+}
+
+// PublicationError means the transaction committed successfully but direct
+// full-state publication failed. Callers must not treat it as a rollback.
+// Reconnect and command retry recover through persisted state and outcome.
+type PublicationError struct{ Err error }
+
+func (e *PublicationError) Error() string {
+	return "publish committed AMAN state: " + e.Err.Error()
+}
+
+func (e *PublicationError) Unwrap() error { return e.Err }
+
+type CoordinatorDependencies struct {
+	States    aman.AirportStateReader
+	Outcomes  aman.CommandOutcomeReader
+	Committer aman.StateCommitter
+	Publisher FullStatePublisher
+	Now       func() time.Time
+}
+
+// Coordinator serializes commands per airport in process while retaining the
+// repository compare-and-swap as the final authority across processes.
+type Coordinator struct {
+	states    aman.AirportStateReader
+	outcomes  aman.CommandOutcomeReader
+	committer aman.StateCommitter
+	publisher FullStatePublisher
+	now       func() time.Time
+
+	locksMu sync.Mutex
+	locks   map[string]*sync.Mutex
+}
+
+func NewCoordinator(deps CoordinatorDependencies) (*Coordinator, error) {
+	for _, dependency := range []struct {
+		name  string
+		value any
+	}{
+		{"state reader", deps.States},
+		{"command outcome reader", deps.Outcomes},
+		{"state committer", deps.Committer},
+		{"full-state publisher", deps.Publisher},
+	} {
+		if isNilDependency(dependency.value) {
+			return nil, fmt.Errorf("AMAN sequence coordinator requires %s", dependency.name)
+		}
+	}
+	if deps.Now == nil {
+		deps.Now = time.Now
+	}
+	return &Coordinator{
+		states: deps.States, outcomes: deps.Outcomes, committer: deps.Committer,
+		publisher: deps.Publisher, now: deps.Now, locks: make(map[string]*sync.Mutex),
+	}, nil
+}
+
+func (*Coordinator) Name() string { return "AMAN sequence coordinator" }
+
+// CurrentState is the restart/reconnect path. It always reads the latest
+// persisted replacement state and never depends on prior publication.
+func (c *Coordinator) CurrentState(ctx context.Context, airport string) (aman.AirportState, error) {
+	if err := validateAirport(airport); err != nil {
+		return aman.AirportState{}, err
+	}
+	return c.states.LoadAirportState(ctx, airport)
+}
+
+// ExecuteCommand coordinates one already-authorized typed command. Duplicate
+// IDs are resolved before policy, and unchanged outcomes are persisted without
+// allocating or publishing a revision.
+func (c *Coordinator) ExecuteCommand(ctx context.Context, airport string, metadata aman.CommandMetadata, apply CommandMutation) (CommandResult, error) {
+	if err := validateCommandRequest(airport, metadata, apply); err != nil {
+		return CommandResult{}, err
+	}
+	lock := c.airportLock(airport)
+	lock.Lock()
+	defer lock.Unlock()
+
+	if duplicate, ok, err := c.loadDuplicate(ctx, airport, metadata.CommandID); err != nil || ok {
+		return duplicate, err
+	}
+
+	current, err := c.states.LoadAirportState(ctx, airport)
+	if err != nil {
+		return CommandResult{}, err
+	}
+	if metadata.ExpectedRevision != current.Revision {
+		return CommandResult{State: current}, revisionConflict(metadata.ExpectedRevision, current.Revision)
+	}
+
+	detached, err := cloneState(current)
+	if err != nil {
+		return CommandResult{}, err
+	}
+	change, err := apply(detached)
+	if err != nil {
+		return CommandResult{State: current}, err
+	}
+	now := c.now().UTC()
+	commit, err := prepareCommit(current, metadata, change, now)
+	if err != nil {
+		return CommandResult{State: current}, err
+	}
+	committed, err := c.committer.Commit(ctx, commit)
+	if err != nil {
+		return CommandResult{State: current}, err
+	}
+	if committed.CommandOutcome == nil {
+		return CommandResult{State: committed.State}, errors.New("AMAN sequence commit returned no command outcome")
+	}
+	result := CommandResult{
+		State: committed.State, Outcome: *committed.CommandOutcome,
+		Changed: change.Changed && !committed.DuplicateCommand, Duplicate: committed.DuplicateCommand,
+	}
+	if committed.DuplicateCommand || !change.Changed {
+		return result, nil
+	}
+
+	// The request may have timed out immediately after commit. Publication is
+	// still attempted once, but it is never persisted or retried here.
+	if err := c.publisher.PublishAMANState(context.WithoutCancel(ctx), committed.State); err != nil {
+		return result, &PublicationError{Err: err}
+	}
+	return result, nil
+}
+
+func (c *Coordinator) loadDuplicate(ctx context.Context, airport, commandID string) (CommandResult, bool, error) {
+	outcome, err := c.outcomes.LoadCommandOutcome(ctx, commandID)
+	if err != nil {
+		if isNotFound(err) {
+			return CommandResult{}, false, nil
+		}
+		return CommandResult{}, false, err
+	}
+	if outcome.Airport != airport {
+		return CommandResult{}, false, &aman.DomainError{Class: aman.ErrorInvalidArgument, Message: "command ID already belongs to another airport"}
+	}
+	state, err := c.states.LoadAirportState(ctx, airport)
+	if err != nil {
+		return CommandResult{}, false, err
+	}
+	return CommandResult{State: state, Outcome: outcome, Duplicate: true}, true, nil
+}
+
+func (c *Coordinator) airportLock(airport string) *sync.Mutex {
+	c.locksMu.Lock()
+	defer c.locksMu.Unlock()
+	lock := c.locks[airport]
+	if lock == nil {
+		lock = &sync.Mutex{}
+		c.locks[airport] = lock
+	}
+	return lock
+}
+
+func prepareCommit(current aman.AirportState, metadata aman.CommandMetadata, change CommandChange, recordedAt time.Time) (aman.StateCommit, error) {
+	if change.State.Airport != current.Airport {
+		return aman.StateCommit{}, invalidCoordinatorChange("policy changed airport identity")
+	}
+	if change.State.Revision != current.Revision {
+		return aman.StateCommit{}, invalidCoordinatorChange("policy attempted to allocate a sequence revision")
+	}
+	if !json.Valid(change.Outcome) {
+		return aman.StateCommit{}, invalidCoordinatorChange("command outcome must be valid JSON")
+	}
+	if len(change.Audit) == 0 {
+		return aman.StateCommit{}, invalidCoordinatorChange("accepted command requires an audit record")
+	}
+
+	next := change.State
+	if change.Changed {
+		if current.Revision == aman.SequenceRevision(math.MaxUint64) {
+			return aman.StateCommit{}, invalidCoordinatorChange("sequence revision is exhausted")
+		}
+		next.Revision = current.Revision + 1
+		next.GeneratedAt = recordedAt
+		for index := range next.Flights {
+			if next.Flights[index].Slot != nil {
+				next.Flights[index].Slot.Revision = next.Revision
+			}
+		}
+	} else {
+		equal, err := equalStates(current, next)
+		if err != nil {
+			return aman.StateCommit{}, err
+		}
+		if !equal {
+			return aman.StateCommit{}, invalidCoordinatorChange("unchanged command modified airport state")
+		}
+		next = current
+	}
+
+	outcome := aman.CommandOutcome{
+		CommandID: metadata.CommandID, Airport: current.Airport, Revision: next.Revision,
+		Payload: append([]byte(nil), change.Outcome...), RecordedAt: recordedAt,
+	}
+	audits := make([]aman.AuditRecord, 0, len(change.Audit))
+	for _, entry := range change.Audit {
+		if strings.TrimSpace(entry.Category) == "" || entry.Category != strings.TrimSpace(entry.Category) || !json.Valid(entry.Payload) {
+			return aman.StateCommit{}, invalidCoordinatorChange("audit category and JSON payload are required")
+		}
+		audits = append(audits, aman.AuditRecord{
+			Airport: current.Airport, Revision: next.Revision, Category: entry.Category,
+			Payload: append([]byte(nil), entry.Payload...), RecordedAt: recordedAt,
+		})
+	}
+	return aman.StateCommit{
+		ExpectedRevision: current.Revision, State: next, CommandOutcome: &outcome, AuditRecords: audits,
+	}, nil
+}
+
+func validateCommandRequest(airport string, metadata aman.CommandMetadata, apply CommandMutation) error {
+	if err := validateAirport(airport); err != nil {
+		return err
+	}
+	if metadata.CommandID == "" || metadata.CommandID != strings.TrimSpace(metadata.CommandID) {
+		return &aman.DomainError{Class: aman.ErrorInvalidArgument, Message: "command ID is required"}
+	}
+	if apply == nil {
+		return &aman.DomainError{Class: aman.ErrorInvalidArgument, Message: "typed command mutation is required"}
+	}
+	return nil
+}
+
+func validateAirport(airport string) error {
+	if airport == "" || airport != strings.TrimSpace(airport) {
+		return &aman.DomainError{Class: aman.ErrorInvalidArgument, Message: "airport is required"}
+	}
+	return nil
+}
+
+func revisionConflict(expected, current aman.SequenceRevision) error {
+	return &aman.DomainError{Class: aman.ErrorRevisionConflict, Message: fmt.Sprintf("expected revision %d does not match current revision %d", expected, current)}
+}
+
+func invalidCoordinatorChange(message string) error {
+	return &aman.DomainError{Class: aman.ErrorInvalidArgument, Message: "sequence coordinator: " + message}
+}
+
+func isNotFound(err error) bool {
+	var domain *aman.DomainError
+	return errors.As(err, &domain) && domain.Class == aman.ErrorNotFound
+}
+
+func cloneState(state aman.AirportState) (aman.AirportState, error) {
+	encoded, err := json.Marshal(state)
+	if err != nil {
+		return aman.AirportState{}, fmt.Errorf("clone AMAN airport state: %w", err)
+	}
+	var cloned aman.AirportState
+	if err := json.Unmarshal(encoded, &cloned); err != nil {
+		return aman.AirportState{}, fmt.Errorf("clone AMAN airport state: %w", err)
+	}
+	return cloned, nil
+}
+
+func equalStates(left, right aman.AirportState) (bool, error) {
+	leftJSON, err := json.Marshal(left)
+	if err != nil {
+		return false, fmt.Errorf("compare AMAN airport state: %w", err)
+	}
+	rightJSON, err := json.Marshal(right)
+	if err != nil {
+		return false, fmt.Errorf("compare AMAN airport state: %w", err)
+	}
+	return string(leftJSON) == string(rightJSON), nil
+}
+
+func isNilDependency(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}
+
+var _ aman.Component = (*Coordinator)(nil)

--- a/backend/internal/aman/sequence/coordinator_test.go
+++ b/backend/internal/aman/sequence/coordinator_test.go
@@ -1,0 +1,413 @@
+package sequence_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/aman/sequence"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoordinatorSerializesSameAirportAndRepositoryCASRemainsFinalAuthority(t *testing.T) {
+	repository := newCoordinatorRepository(coordinatorState(4))
+	first := newTestCoordinator(t, repository, &recordingPublisher{repository: repository})
+	second := newTestCoordinator(t, repository, &recordingPublisher{repository: repository})
+	ready := make(chan struct{}, 2)
+	release := make(chan struct{})
+	mutation := func(state aman.AirportState) (sequence.CommandChange, error) {
+		ready <- struct{}{}
+		<-release
+		state.Flights[0].Order = intPointer(2)
+		return commandChange(state, true), nil
+	}
+
+	errorsSeen := make(chan error, 2)
+	for _, coordinator := range []*sequence.Coordinator{first, second} {
+		go func(coordinator *sequence.Coordinator) {
+			_, err := coordinator.ExecuteCommand(context.Background(), "EKCH", aman.CommandMetadata{CommandID: fmt.Sprintf("race-%p", coordinator), ExpectedRevision: 4}, mutation)
+			errorsSeen <- err
+		}(coordinator)
+	}
+	<-ready
+	<-ready
+	close(release)
+
+	var successes, conflicts int
+	for range 2 {
+		err := <-errorsSeen
+		if err == nil {
+			successes++
+			continue
+		}
+		requireDomainError(t, err, aman.ErrorRevisionConflict)
+		conflicts++
+	}
+	require.Equal(t, 1, successes)
+	require.Equal(t, 1, conflicts)
+	require.Equal(t, aman.SequenceRevision(5), repository.current().Revision)
+}
+
+func TestCoordinatorInProcessSerializationRejectsStaleCommandBeforePolicy(t *testing.T) {
+	repository := newCoordinatorRepository(coordinatorState(4))
+	coordinator := newTestCoordinator(t, repository, &recordingPublisher{repository: repository})
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var stalePolicyCalls atomic.Int32
+
+	firstResult := make(chan error, 1)
+	go func() {
+		_, err := coordinator.ExecuteCommand(context.Background(), "EKCH", aman.CommandMetadata{CommandID: "first", ExpectedRevision: 4}, func(state aman.AirportState) (sequence.CommandChange, error) {
+			close(firstStarted)
+			<-releaseFirst
+			state.Flights[0].Order = intPointer(2)
+			return commandChange(state, true), nil
+		})
+		firstResult <- err
+	}()
+	<-firstStarted
+
+	staleResult := make(chan error, 1)
+	go func() {
+		_, err := coordinator.ExecuteCommand(context.Background(), "EKCH", aman.CommandMetadata{CommandID: "stale", ExpectedRevision: 4}, func(state aman.AirportState) (sequence.CommandChange, error) {
+			stalePolicyCalls.Add(1)
+			return commandChange(state, true), nil
+		})
+		staleResult <- err
+	}()
+	close(releaseFirst)
+	require.NoError(t, <-firstResult)
+	requireDomainError(t, <-staleResult, aman.ErrorRevisionConflict)
+	require.Zero(t, stalePolicyCalls.Load())
+}
+
+func TestCoordinatorDuplicateIsIdempotentBeforeAndAfterRestart(t *testing.T) {
+	repository := newCoordinatorRepository(coordinatorState(7))
+	publisher := &recordingPublisher{repository: repository}
+	coordinator := newTestCoordinator(t, repository, publisher)
+	metadata := aman.CommandMetadata{CommandID: "move-1", ExpectedRevision: 7}
+	var policyCalls atomic.Int32
+	mutation := func(state aman.AirportState) (sequence.CommandChange, error) {
+		policyCalls.Add(1)
+		state.Flights[0].Order = intPointer(2)
+		return commandChange(state, true), nil
+	}
+
+	first, err := coordinator.ExecuteCommand(context.Background(), "EKCH", metadata, mutation)
+	require.NoError(t, err)
+	require.True(t, first.Changed)
+	require.False(t, first.Duplicate)
+	require.Equal(t, aman.SequenceRevision(8), first.State.Revision)
+
+	duplicate, err := coordinator.ExecuteCommand(context.Background(), "EKCH", metadata, mutation)
+	require.NoError(t, err)
+	require.True(t, duplicate.Duplicate)
+	require.False(t, duplicate.Changed)
+	require.Equal(t, first.Outcome, duplicate.Outcome)
+
+	restarted := newTestCoordinator(t, repository, publisher)
+	afterRestart, err := restarted.ExecuteCommand(context.Background(), "EKCH", metadata, mutation)
+	require.NoError(t, err)
+	require.True(t, afterRestart.Duplicate)
+	require.Equal(t, int32(1), policyCalls.Load(), "stored duplicates must not re-run policy")
+	require.Equal(t, 1, publisher.calls())
+}
+
+func TestCoordinatorPersistsNoOpOutcomeWithoutRevisionOrPublication(t *testing.T) {
+	repository := newCoordinatorRepository(coordinatorState(11))
+	publisher := &recordingPublisher{repository: repository}
+	coordinator := newTestCoordinator(t, repository, publisher)
+	metadata := aman.CommandMetadata{CommandID: "same-rate", ExpectedRevision: 11}
+
+	result, err := coordinator.ExecuteCommand(context.Background(), "EKCH", metadata, func(state aman.AirportState) (sequence.CommandChange, error) {
+		return commandChange(state, false), nil
+	})
+	require.NoError(t, err)
+	require.False(t, result.Changed)
+	require.Equal(t, aman.SequenceRevision(11), result.State.Revision)
+	require.Equal(t, aman.SequenceRevision(11), result.Outcome.Revision)
+	require.Equal(t, 0, publisher.calls())
+
+	restarted := newTestCoordinator(t, repository, publisher)
+	duplicate, err := restarted.ExecuteCommand(context.Background(), "EKCH", metadata, func(aman.AirportState) (sequence.CommandChange, error) {
+		t.Fatal("durable no-op outcome did not survive restart")
+		return sequence.CommandChange{}, nil
+	})
+	require.NoError(t, err)
+	require.True(t, duplicate.Duplicate)
+	require.Equal(t, aman.SequenceRevision(11), duplicate.State.Revision)
+	require.Len(t, repository.auditRecords(), 1)
+}
+
+func TestCoordinatorTransactionFailureNeverPublishesOrExposesPartialState(t *testing.T) {
+	repository := newCoordinatorRepository(coordinatorState(2))
+	repository.commitError = errors.New("injected transaction failure")
+	publisher := &recordingPublisher{repository: repository}
+	coordinator := newTestCoordinator(t, repository, publisher)
+
+	_, err := coordinator.ExecuteCommand(context.Background(), "EKCH", aman.CommandMetadata{CommandID: "failed", ExpectedRevision: 2}, changedOrder(2))
+	require.ErrorContains(t, err, "injected transaction failure")
+	require.Equal(t, aman.SequenceRevision(2), repository.current().Revision)
+	require.Empty(t, repository.outcomeRecords())
+	require.Empty(t, repository.auditRecords())
+	require.Equal(t, 0, publisher.calls())
+}
+
+func TestCoordinatorPublicationFailureLeavesCommittedStateRecoverableOnReconnect(t *testing.T) {
+	repository := newCoordinatorRepository(coordinatorState(3))
+	publisher := &recordingPublisher{repository: repository, err: errors.New("frontend unavailable")}
+	coordinator := newTestCoordinator(t, repository, publisher)
+	metadata := aman.CommandMetadata{CommandID: "committed-before-send", ExpectedRevision: 3}
+
+	result, err := coordinator.ExecuteCommand(context.Background(), "EKCH", metadata, changedOrder(2))
+	var publicationError *sequence.PublicationError
+	require.ErrorAs(t, err, &publicationError)
+	require.True(t, result.Changed)
+	require.Equal(t, aman.SequenceRevision(4), result.State.Revision)
+	require.Equal(t, aman.SequenceRevision(4), repository.current().Revision)
+	require.Equal(t, 1, publisher.calls())
+	require.Equal(t, []string{"commit:4", "publish:4"}, repository.stepsCopy(), "publication must follow storage")
+
+	restarted := newTestCoordinator(t, repository, &recordingPublisher{repository: repository})
+	reconnected, err := restarted.CurrentState(context.Background(), "EKCH")
+	require.NoError(t, err)
+	require.Equal(t, result.State, reconnected)
+
+	duplicate, err := restarted.ExecuteCommand(context.Background(), "EKCH", metadata, func(aman.AirportState) (sequence.CommandChange, error) {
+		t.Fatal("retry after a post-commit timeout must use the stored outcome")
+		return sequence.CommandChange{}, nil
+	})
+	require.NoError(t, err)
+	require.True(t, duplicate.Duplicate)
+}
+
+func TestCoordinatorIsTheOnlySequenceRevisionWriter(t *testing.T) {
+	repository := newCoordinatorRepository(coordinatorState(5))
+	coordinator := newTestCoordinator(t, repository, &recordingPublisher{repository: repository})
+
+	_, err := coordinator.ExecuteCommand(context.Background(), "EKCH", aman.CommandMetadata{CommandID: "second-writer", ExpectedRevision: 5}, func(state aman.AirportState) (sequence.CommandChange, error) {
+		state.Revision++
+		return commandChange(state, true), nil
+	})
+	requireDomainError(t, err, aman.ErrorInvalidArgument)
+	require.ErrorContains(t, err, "attempted to allocate")
+	require.Equal(t, aman.SequenceRevision(5), repository.current().Revision)
+	require.Empty(t, repository.outcomeRecords())
+}
+
+func TestCoordinatorRejectsUnchangedMutationThatModifiesState(t *testing.T) {
+	repository := newCoordinatorRepository(coordinatorState(9))
+	coordinator := newTestCoordinator(t, repository, &recordingPublisher{repository: repository})
+
+	_, err := coordinator.ExecuteCommand(context.Background(), "EKCH", aman.CommandMetadata{CommandID: "false-noop", ExpectedRevision: 9}, func(state aman.AirportState) (sequence.CommandChange, error) {
+		state.Flights[0].Order = intPointer(9)
+		return commandChange(state, false), nil
+	})
+	requireDomainError(t, err, aman.ErrorInvalidArgument)
+	require.Equal(t, aman.SequenceRevision(9), repository.current().Revision)
+}
+
+func TestCoordinatorPublishesAfterCommitEvenWhenRequestContextWasCancelled(t *testing.T) {
+	repository := newCoordinatorRepository(coordinatorState(1))
+	publisher := &recordingPublisher{repository: repository, requireLiveContext: true}
+	coordinator := newTestCoordinator(t, repository, publisher)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := coordinator.ExecuteCommand(ctx, "EKCH", aman.CommandMetadata{CommandID: "timed-out", ExpectedRevision: 1}, changedOrder(2))
+	require.NoError(t, err)
+	require.Equal(t, aman.SequenceRevision(2), result.State.Revision)
+	require.Equal(t, 1, publisher.calls())
+}
+
+func newTestCoordinator(t *testing.T, repository *coordinatorRepository, publisher sequence.FullStatePublisher) *sequence.Coordinator {
+	t.Helper()
+	coordinator, err := sequence.NewCoordinator(sequence.CoordinatorDependencies{
+		States: repository, Outcomes: repository, Committer: repository, Publisher: publisher,
+		Now: func() time.Time { return testTime().Add(time.Hour) },
+	})
+	require.NoError(t, err)
+	return coordinator
+}
+
+func changedOrder(order int) sequence.CommandMutation {
+	return func(state aman.AirportState) (sequence.CommandChange, error) {
+		state.Flights[0].Order = intPointer(order)
+		return commandChange(state, true), nil
+	}
+}
+
+func commandChange(state aman.AirportState, changed bool) sequence.CommandChange {
+	return sequence.CommandChange{
+		State: state, Changed: changed, Outcome: json.RawMessage(`{"status":"accepted"}`),
+		Audit: []sequence.AuditEntry{{Category: "sequence_command_accepted", Payload: json.RawMessage(`{"status":"accepted"}`)}},
+	}
+}
+
+func coordinatorState(revision aman.SequenceRevision) aman.AirportState {
+	at := testTime().Add(time.Duration(revision) * time.Minute)
+	return aman.AirportState{
+		Airport: "EKCH", Revision: revision, GeneratedAt: at, PolicyVersion: "policy-v1", Mode: aman.ModeAuthoritative, Authoritative: true,
+		RunwayGroups: []aman.RunwayGroupPolicy{{ID: "A"}},
+		Flights: []aman.AMANFlight{{
+			ID: "flight-1", VATSIMCID: "123", CurrentCallsign: "SAS123", State: aman.StateStable, DataStatus: aman.DataFresh,
+			FreezeReason: aman.FreezeNone, Slot: &aman.Slot{Time: at.Add(10 * time.Minute), RunwayGroupID: "A", Sequence: 1, Revision: revision, Reason: "rate_wtc"},
+			Order: intPointer(1), UpdatedAt: at,
+		}},
+	}
+}
+
+type coordinatorRepository struct {
+	mu          sync.Mutex
+	state       aman.AirportState
+	outcomes    map[string]aman.CommandOutcome
+	audits      []aman.AuditRecord
+	steps       []string
+	commitError error
+}
+
+func newCoordinatorRepository(state aman.AirportState) *coordinatorRepository {
+	return &coordinatorRepository{state: state, outcomes: make(map[string]aman.CommandOutcome)}
+}
+
+func (r *coordinatorRepository) LoadAirportState(_ context.Context, airport string) (aman.AirportState, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.state.Airport != airport {
+		return aman.AirportState{}, &aman.DomainError{Class: aman.ErrorNotFound, Message: "airport not found"}
+	}
+	return cloneCoordinatorState(r.state), nil
+}
+
+func (r *coordinatorRepository) LoadCommandOutcome(_ context.Context, commandID string) (aman.CommandOutcome, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	outcome, ok := r.outcomes[commandID]
+	if !ok {
+		return aman.CommandOutcome{}, &aman.DomainError{Class: aman.ErrorNotFound, Message: "outcome not found"}
+	}
+	outcome.Payload = append([]byte(nil), outcome.Payload...)
+	return outcome, nil
+}
+
+func (r *coordinatorRepository) Commit(_ context.Context, commit aman.StateCommit) (aman.CommitResult, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if commit.CommandOutcome != nil {
+		if outcome, ok := r.outcomes[commit.CommandOutcome.CommandID]; ok {
+			copy := outcome
+			return aman.CommitResult{State: cloneCoordinatorState(r.state), CommandOutcome: &copy, DuplicateCommand: true}, nil
+		}
+	}
+	if err := commit.Validate(); err != nil {
+		return aman.CommitResult{}, err
+	}
+	if r.state.Revision != commit.ExpectedRevision {
+		return aman.CommitResult{}, &aman.DomainError{Class: aman.ErrorRevisionConflict, Message: "CAS conflict"}
+	}
+	if r.commitError != nil {
+		return aman.CommitResult{}, r.commitError
+	}
+	if commit.State.Revision == commit.ExpectedRevision+1 {
+		r.state = cloneCoordinatorState(commit.State)
+	}
+	if commit.CommandOutcome != nil {
+		outcome := *commit.CommandOutcome
+		outcome.Payload = append([]byte(nil), outcome.Payload...)
+		r.outcomes[outcome.CommandID] = outcome
+	}
+	r.audits = append(r.audits, commit.AuditRecords...)
+	r.steps = append(r.steps, fmt.Sprintf("commit:%d", commit.State.Revision))
+	result := aman.CommitResult{State: cloneCoordinatorState(r.state)}
+	if commit.CommandOutcome != nil {
+		outcome := *commit.CommandOutcome
+		result.CommandOutcome = &outcome
+	}
+	return result, nil
+}
+
+func (r *coordinatorRepository) current() aman.AirportState {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return cloneCoordinatorState(r.state)
+}
+
+func (r *coordinatorRepository) outcomeRecords() map[string]aman.CommandOutcome {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	copy := make(map[string]aman.CommandOutcome, len(r.outcomes))
+	for key, value := range r.outcomes {
+		copy[key] = value
+	}
+	return copy
+}
+
+func (r *coordinatorRepository) auditRecords() []aman.AuditRecord {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]aman.AuditRecord(nil), r.audits...)
+}
+
+func (r *coordinatorRepository) stepsCopy() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.steps...)
+}
+
+type recordingPublisher struct {
+	mu                 sync.Mutex
+	repository         *coordinatorRepository
+	states             []aman.AirportState
+	err                error
+	requireLiveContext bool
+}
+
+func (p *recordingPublisher) PublishAMANState(ctx context.Context, state aman.AirportState) error {
+	if p.requireLiveContext && ctx.Err() != nil {
+		return errors.New("publication inherited cancelled request context")
+	}
+	stored := p.repository.current()
+	if stored.Revision != state.Revision {
+		return fmt.Errorf("published revision %d before commit %d", state.Revision, stored.Revision)
+	}
+	p.mu.Lock()
+	p.states = append(p.states, cloneCoordinatorState(state))
+	p.mu.Unlock()
+	p.repository.mu.Lock()
+	p.repository.steps = append(p.repository.steps, fmt.Sprintf("publish:%d", state.Revision))
+	p.repository.mu.Unlock()
+	return p.err
+}
+
+func (p *recordingPublisher) calls() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.states)
+}
+
+func cloneCoordinatorState(state aman.AirportState) aman.AirportState {
+	encoded, err := json.Marshal(state)
+	if err != nil {
+		panic(err)
+	}
+	var cloned aman.AirportState
+	if err := json.Unmarshal(encoded, &cloned); err != nil {
+		panic(err)
+	}
+	return cloned
+}
+
+func intPointer(value int) *int { return &value }
+
+func requireDomainError(t *testing.T, err error, class aman.ErrorClass) {
+	t.Helper()
+	var domain *aman.DomainError
+	require.ErrorAs(t, err, &domain)
+	require.Equal(t, class, domain.Class)
+}

--- a/backend/internal/database/aman.sql.go
+++ b/backend/internal/database/aman.sql.go
@@ -286,6 +286,20 @@ func (q *Queries) ListAMANValidationEvidence(ctx context.Context, airport string
 	return items, nil
 }
 
+const lockAMANAirportState = `-- name: LockAMANAirportState :one
+SELECT revision
+FROM aman_airport_states
+WHERE airport = $1
+FOR UPDATE
+`
+
+func (q *Queries) LockAMANAirportState(ctx context.Context, airport string) (int64, error) {
+	row := q.db.QueryRow(ctx, lockAMANAirportState, airport)
+	var revision int64
+	err := row.Scan(&revision)
+	return revision, err
+}
+
 const lockAMANCommand = `-- name: LockAMANCommand :exec
 SELECT pg_advisory_xact_lock(hashtextextended($1, 0))
 `

--- a/backend/internal/repository/postgres/aman.go
+++ b/backend/internal/repository/postgres/aman.go
@@ -40,6 +40,9 @@ func (r *amanRepository) LoadAirportState(ctx context.Context, airport string) (
 
 func (r *amanRepository) LoadCommandOutcome(ctx context.Context, commandID string) (aman.CommandOutcome, error) {
 	row, err := r.queries.GetAMANCommandOutcome(ctx, commandID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return aman.CommandOutcome{}, &aman.DomainError{Class: aman.ErrorNotFound, Message: "AMAN command outcome was not found"}
+	}
 	if err != nil {
 		return aman.CommandOutcome{}, err
 	}
@@ -178,57 +181,72 @@ func (r *amanRepository) Commit(ctx context.Context, commit aman.StateCommit) (a
 		return aman.CommitResult{}, err
 	}
 
-	current, err := queries.GetAMANAirportState(ctx, commit.State.Airport)
+	lockedRevision, err := queries.LockAMANAirportState(ctx, commit.State.Airport)
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return aman.CommitResult{}, err
 	}
 	if errors.Is(err, pgx.ErrNoRows) && commit.ExpectedRevision != 0 {
 		return aman.CommitResult{}, revisionConflict()
 	}
-	if err == nil && aman.SequenceRevision(current.Revision) != commit.ExpectedRevision {
+	if err == nil && aman.SequenceRevision(lockedRevision) != commit.ExpectedRevision {
 		return aman.CommitResult{}, revisionConflict()
 	}
-
-	runwayGroups, err := json.Marshal(commit.State.RunwayGroups)
-	if err != nil {
-		return aman.CommitResult{}, fmt.Errorf("encode AMAN runway groups: %w", err)
-	}
-	_, err = queries.UpsertAMANAirportState(ctx, database.UpsertAMANAirportStateParams{
-		Airport:       commit.State.Airport,
-		Revision:      int64(commit.State.Revision),
-		GeneratedAt:   requiredTimestamp(commit.State.GeneratedAt),
-		PolicyVersion: commit.State.PolicyVersion,
-		Mode:          string(commit.State.Mode),
-		Authoritative: commit.State.Authoritative,
-		RunwayGroups:  runwayGroups,
-		Revision_2:    int64(commit.ExpectedRevision),
-	})
-	if errors.Is(err, pgx.ErrNoRows) {
-		return aman.CommitResult{}, revisionConflict()
-	}
-	if err != nil {
-		return aman.CommitResult{}, mapAMANWriteError(err)
-	}
-
-	if err := queries.DeleteAMANFlightsForAirport(ctx, commit.State.Airport); err != nil {
-		return aman.CommitResult{}, err
-	}
-	for _, flight := range commit.State.Flights {
-		payload, err := json.Marshal(flight)
-		if err != nil {
-			return aman.CommitResult{}, fmt.Errorf("encode AMAN flight %q: %w", flight.ID, err)
+	changed := commit.State.Revision == commit.ExpectedRevision+1
+	if !changed {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return aman.CommitResult{}, revisionConflict()
 		}
-		if err := queries.UpsertAMANFlight(ctx, database.UpsertAMANFlightParams{
-			FlightID:        string(flight.ID),
-			Airport:         commit.State.Airport,
-			VatsimCid:       flight.VATSIMCID,
-			CurrentCallsign: flight.CurrentCallsign,
-			State:           string(flight.State),
-			DataStatus:      string(flight.DataStatus),
-			UpdatedAt:       requiredTimestamp(flight.UpdatedAt),
-			Payload:         payload,
-		}); err != nil {
+		stored, err := loadAMANAirportState(ctx, queries, commit.State.Airport)
+		if err != nil {
+			return aman.CommitResult{}, err
+		}
+		if !airportStatesEqual(stored, commit.State) {
+			return aman.CommitResult{}, &aman.DomainError{Class: aman.ErrorInvalidArgument, Message: "unchanged commit state differs from persisted state"}
+		}
+	}
+
+	if changed {
+		runwayGroups, err := json.Marshal(commit.State.RunwayGroups)
+		if err != nil {
+			return aman.CommitResult{}, fmt.Errorf("encode AMAN runway groups: %w", err)
+		}
+		_, err = queries.UpsertAMANAirportState(ctx, database.UpsertAMANAirportStateParams{
+			Airport:       commit.State.Airport,
+			Revision:      int64(commit.State.Revision),
+			GeneratedAt:   requiredTimestamp(commit.State.GeneratedAt),
+			PolicyVersion: commit.State.PolicyVersion,
+			Mode:          string(commit.State.Mode),
+			Authoritative: commit.State.Authoritative,
+			RunwayGroups:  runwayGroups,
+			Revision_2:    int64(commit.ExpectedRevision),
+		})
+		if errors.Is(err, pgx.ErrNoRows) {
+			return aman.CommitResult{}, revisionConflict()
+		}
+		if err != nil {
 			return aman.CommitResult{}, mapAMANWriteError(err)
+		}
+
+		if err := queries.DeleteAMANFlightsForAirport(ctx, commit.State.Airport); err != nil {
+			return aman.CommitResult{}, err
+		}
+		for _, flight := range commit.State.Flights {
+			payload, err := json.Marshal(flight)
+			if err != nil {
+				return aman.CommitResult{}, fmt.Errorf("encode AMAN flight %q: %w", flight.ID, err)
+			}
+			if err := queries.UpsertAMANFlight(ctx, database.UpsertAMANFlightParams{
+				FlightID:        string(flight.ID),
+				Airport:         commit.State.Airport,
+				VatsimCid:       flight.VATSIMCID,
+				CurrentCallsign: flight.CurrentCallsign,
+				State:           string(flight.State),
+				DataStatus:      string(flight.DataStatus),
+				UpdatedAt:       requiredTimestamp(flight.UpdatedAt),
+				Payload:         payload,
+			}); err != nil {
+				return aman.CommitResult{}, mapAMANWriteError(err)
+			}
 		}
 	}
 
@@ -339,6 +357,12 @@ func cloneAirportState(value aman.AirportState) aman.AirportState {
 	value.Flights = append([]aman.AMANFlight(nil), value.Flights...)
 	value.RunwayGroups = append([]aman.RunwayGroupPolicy(nil), value.RunwayGroups...)
 	return value
+}
+
+func airportStatesEqual(left, right aman.AirportState) bool {
+	leftJSON, leftErr := json.Marshal(left)
+	rightJSON, rightErr := json.Marshal(right)
+	return leftErr == nil && rightErr == nil && string(leftJSON) == string(rightJSON)
 }
 
 func revisionConflict() error {

--- a/backend/internal/repository/postgres/aman_test.go
+++ b/backend/internal/repository/postgres/aman_test.go
@@ -85,6 +85,54 @@ func TestAMANRepositoryRoundTripIdempotencyAndRollback(t *testing.T) {
 	require.Equal(t, corrected, loaded, "a failed transaction must leave the complete prior aggregate")
 }
 
+func TestAMANRepositoryPersistsNoOpCommandWithoutAdvancingState(t *testing.T) {
+	pool, _ := testdata.SetupTestDB(t)
+	ctx := context.Background()
+	repo := NewAMANRepository(pool)
+	state := amanState(1, "CID-NOOP", "SAS100")
+	_, err := repo.Commit(ctx, aman.StateCommit{ExpectedRevision: 0, State: state})
+	require.NoError(t, err)
+
+	outcome := aman.CommandOutcome{
+		CommandID: "no-op-command", Airport: state.Airport, Revision: state.Revision,
+		Payload: []byte(`{"result":"unchanged"}`), RecordedAt: amanTestTime.Add(2 * time.Minute),
+	}
+	audit := aman.AuditRecord{
+		Airport: state.Airport, Revision: state.Revision, Category: "command_unchanged",
+		Payload: []byte(`{"result":"unchanged"}`), RecordedAt: outcome.RecordedAt,
+	}
+	result, err := repo.Commit(ctx, aman.StateCommit{
+		ExpectedRevision: state.Revision, State: state, CommandOutcome: &outcome, AuditRecords: []aman.AuditRecord{audit},
+	})
+	require.NoError(t, err)
+	require.False(t, result.DuplicateCommand)
+	require.Equal(t, state, result.State)
+
+	restarted := NewAMANRepository(pool)
+	loaded, err := restarted.LoadAirportState(ctx, state.Airport)
+	require.NoError(t, err)
+	require.Equal(t, state, loaded)
+	storedOutcome, err := restarted.LoadCommandOutcome(ctx, outcome.CommandID)
+	require.NoError(t, err)
+	require.Equal(t, outcome.CommandID, storedOutcome.CommandID)
+	require.Equal(t, outcome.Airport, storedOutcome.Airport)
+	require.Equal(t, outcome.Revision, storedOutcome.Revision)
+	require.Equal(t, outcome.RecordedAt, storedOutcome.RecordedAt)
+	require.JSONEq(t, string(outcome.Payload), string(storedOutcome.Payload))
+	audits, err := restarted.ListAuditRecords(ctx, state.Airport)
+	require.NoError(t, err)
+	require.Len(t, audits, 1)
+	require.Equal(t, state.Revision, audits[0].Revision)
+
+	invalidNoOp := loaded
+	invalidNoOp.Flights[0].CurrentCallsign = "SHOULD-NOT-PERSIST"
+	_, err = restarted.Commit(ctx, aman.StateCommit{ExpectedRevision: state.Revision, State: invalidNoOp})
+	requireDomainErrorClass(t, err, aman.ErrorInvalidArgument)
+	loaded, err = restarted.LoadAirportState(ctx, state.Airport)
+	require.NoError(t, err)
+	require.Equal(t, state, loaded)
+}
+
 func TestAMANRepositoryRollsBackInvalidAuditAndCommitsStructuredAudit(t *testing.T) {
 	pool, _ := testdata.SetupTestDB(t)
 	repo := NewAMANRepository(pool)

--- a/backend/queries/aman.sql
+++ b/backend/queries/aman.sql
@@ -37,6 +37,12 @@ SELECT *
 FROM aman_airport_states
 WHERE airport = $1;
 
+-- name: LockAMANAirportState :one
+SELECT revision
+FROM aman_airport_states
+WHERE airport = $1
+FOR UPDATE;
+
 -- name: UpsertAMANAirportState :one
 INSERT INTO aman_airport_states (
     airport, revision, generated_at, policy_version, mode, authoritative, runway_groups


### PR DESCRIPTION
## Summary

Implements the AMAN sequence coordinator as the sole sequence-revision writer.

- serializes in-process airport commands while retaining repository CAS authority
- persists duplicate and no-op command outcomes atomically without allocating a revision
- commits changed aggregate state, outcomes, and audit records atomically
- publishes complete persisted state only after commit, with reconnect reads from persistence
- uses no durable WebSocket outbox, delivery acknowledgement, or retry state

## Scope

This is the #323 coordinator/recovery slice. It exposes an AMAN-neutral full-state publisher for later #325/#326 transport adaptation; it does not add handlers or UI DTOs.

## Validation

- `go test ./internal/aman/sequence ./internal/repository/postgres -count=1`
- `go test -race ./internal/aman/sequence -count=1`
- `go test ./internal/aman/... ./internal/repository/postgres`
- `go test ./...`

Closes #323