### PR TITLE
[AMAN] Calculate earlier-slot queue offers

### DIFF
--- a/backend/internal/aman/sequence/coordinator.go
+++ b/backend/internal/aman/sequence/coordinator.go
@@ -33,10 +33,11 @@ type AuditEntry struct {
 // allocate a revision or change the airport identity; Coordinator is the sole
 // sequence-revision writer.
 type CommandChange struct {
-	State   aman.AirportState
-	Changed bool
-	Outcome json.RawMessage
-	Audit   []AuditEntry
+	State       aman.AirportState
+	Changed     bool
+	Outcome     json.RawMessage
+	Audit       []AuditEntry
+	QueueOffers *QueueOfferCalculation
 }
 
 // CommandMutation adapts a typed policy operation to the persisted aggregate.
@@ -230,8 +231,21 @@ func prepareCommit(current aman.AirportState, metadata aman.CommandMetadata, cha
 			if next.Flights[index].Slot != nil {
 				next.Flights[index].Slot.Revision = next.Revision
 			}
+			// Offers cannot be carried across a changed airport revision. A
+			// supplied calculation below replaces them from the same slot input.
+			next.Flights[index].QueueOffers = nil
+		}
+		if change.QueueOffers != nil {
+			projected, err := change.QueueOffers.project(next, next.Revision, recordedAt)
+			if err != nil {
+				return aman.StateCommit{}, err
+			}
+			next = projected
 		}
 	} else {
+		if change.QueueOffers != nil {
+			return aman.StateCommit{}, invalidCoordinatorChange("unchanged command cannot recompute queue offers")
+		}
 		equal, err := equalStates(current, next)
 		if err != nil {
 			return aman.StateCommit{}, err

--- a/backend/internal/aman/sequence/queue.go
+++ b/backend/internal/aman/sequence/queue.go
@@ -1,0 +1,258 @@
+package sequence
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"FlightStrips/internal/aman"
+)
+
+// QueueOfferConfig owns the explicit lifetime of an earlier-slot opportunity.
+// The effective expiry is capped at the candidate slot time.
+type QueueOfferConfig struct {
+	Validity time.Duration
+}
+
+// QueueOfferCalculation carries the pure sequence input through the existing
+// coordinator seam until that coordinator binds slots and offers to the next
+// committed revision.
+type QueueOfferCalculation struct {
+	Input  Input
+	Config QueueOfferConfig
+}
+
+type queueEntry struct {
+	flight preparedFlight
+	slot   aman.Slot
+}
+
+type pendingOffer struct {
+	offer            aman.QueueOffer
+	assignedSequence int
+	flight           preparedFlight
+}
+
+type offerKey struct {
+	group    aman.RunwayGroupID
+	sequence int
+	at       time.Time
+}
+
+// CalculateQueueOffers calculates occupied earlier-slot opportunities from a
+// committed sequence revision. It neither mutates input nor allocates a new
+// revision.
+func CalculateQueueOffers(input Input, config QueueOfferConfig, at time.Time) ([]aman.QueueOffer, error) {
+	if input.Revision == 0 {
+		return nil, fmt.Errorf("queue offers require a committed airport revision")
+	}
+	if config.Validity <= 0 {
+		return nil, fmt.Errorf("queue offers require positive validity")
+	}
+	if !validUTC(at) {
+		return nil, fmt.Errorf("queue offer calculation time must be UTC")
+	}
+	policies, err := preparePolicies(input.Policies)
+	if err != nil {
+		return nil, err
+	}
+	prepared, err := prepareFlights(input.Flights, policies)
+	if err != nil {
+		return nil, err
+	}
+
+	pending := make(map[offerKey][]pendingOffer)
+	for group, flights := range prepared {
+		entries, err := queueEntries(input.Revision, flights)
+		if err != nil {
+			return nil, err
+		}
+		policy := policies[group]
+		for targetIndex, target := range entries {
+			if !queueEligible(target.flight) {
+				continue
+			}
+			for candidateIndex := 0; candidateIndex < targetIndex; candidateIndex++ {
+				candidate := entries[candidateIndex]
+				if candidate.slot.Time.Before(target.flight.OperationalTETA.Add(-policy.EarlyTolerance)) {
+					continue
+				}
+				if crossesProtectedOrder(entries, candidateIndex, targetIndex) {
+					continue
+				}
+				expiresAt := at.Add(config.Validity)
+				if candidate.slot.Time.Before(expiresAt) {
+					expiresAt = candidate.slot.Time
+				}
+				if !expiresAt.After(at) {
+					continue
+				}
+				remaining := make([]allocatedEntry, 0, len(entries)-2)
+				for index, entry := range entries {
+					if index == candidateIndex || index == targetIndex {
+						continue
+					}
+					remaining = append(remaining, allocatedEntry{flight: entry.flight, time: entry.slot.Time, reason: CandidateReason(entry.slot.Reason)})
+				}
+				valid, _, _ := placement(policy, remaining, target.flight, candidate.slot.Time)
+				if !valid {
+					continue
+				}
+				key := offerKey{group: group, sequence: candidate.slot.Sequence, at: candidate.slot.Time}
+				pending[key] = append(pending[key], pendingOffer{
+					offer: aman.QueueOffer{
+						FlightID: target.flight.ID, RunwayGroupID: group, CandidateSlot: candidate.slot,
+						ExpiresAt: expiresAt, AirportRevision: input.Revision, Reason: aman.QueueOfferEarlierOccupiedSlot,
+					},
+					assignedSequence: target.slot.Sequence,
+					flight:           target.flight,
+				})
+			}
+		}
+	}
+
+	offers := make([]aman.QueueOffer, 0)
+	for _, candidates := range pending {
+		sort.Slice(candidates, func(i, j int) bool {
+			if candidates[i].assignedSequence != candidates[j].assignedSequence {
+				return candidates[i].assignedSequence < candidates[j].assignedSequence
+			}
+			return flightLess(candidates[i].flight, candidates[j].flight)
+		})
+		for index := range candidates {
+			candidates[index].offer.QueuePosition = index + 1
+			offers = append(offers, candidates[index].offer)
+		}
+	}
+	sort.Slice(offers, func(i, j int) bool {
+		a, b := offers[i], offers[j]
+		if a.RunwayGroupID != b.RunwayGroupID {
+			return a.RunwayGroupID < b.RunwayGroupID
+		}
+		if a.CandidateSlot.Sequence != b.CandidateSlot.Sequence {
+			return a.CandidateSlot.Sequence < b.CandidateSlot.Sequence
+		}
+		if !a.CandidateSlot.Time.Equal(b.CandidateSlot.Time) {
+			return a.CandidateSlot.Time.Before(b.CandidateSlot.Time)
+		}
+		if a.QueuePosition != b.QueuePosition {
+			return a.QueuePosition < b.QueuePosition
+		}
+		return a.FlightID < b.FlightID
+	})
+	return offers, nil
+}
+
+// ProjectQueueOffers replaces every flight's offers from one calculation and
+// rejects a stale or slot-inconsistent projection.
+func ProjectQueueOffers(state aman.AirportState, input Input, config QueueOfferConfig, at time.Time) (aman.AirportState, error) {
+	if state.Revision != input.Revision {
+		return aman.AirportState{}, &aman.DomainError{Class: aman.ErrorRevisionConflict, Message: fmt.Sprintf("queue offer revision %d does not match airport revision %d", input.Revision, state.Revision)}
+	}
+	offers, err := CalculateQueueOffers(input, config, at)
+	if err != nil {
+		return aman.AirportState{}, err
+	}
+	projected := state
+	projected.Flights = append([]aman.AMANFlight(nil), state.Flights...)
+	indexes := make(map[aman.FlightID]int, len(projected.Flights))
+	for index := range projected.Flights {
+		projected.Flights[index].QueueOffers = nil
+		indexes[projected.Flights[index].ID] = index
+	}
+	inputFlights := make(map[aman.FlightID]Flight, len(input.Flights))
+	for _, flight := range input.Flights {
+		inputFlights[flight.ID] = flight
+		index, exists := indexes[flight.ID]
+		if !exists || !slotsEqual(projected.Flights[index].Slot, flight.CurrentSlot) {
+			return aman.AirportState{}, fmt.Errorf("queue offer input flight %q does not match airport slot state", flight.ID)
+		}
+	}
+	for _, flight := range projected.Flights {
+		inputFlight, exists := inputFlights[flight.ID]
+		if flight.Slot != nil && (!exists || !slotsEqual(flight.Slot, inputFlight.CurrentSlot)) {
+			return aman.AirportState{}, fmt.Errorf("airport slot flight %q is missing from queue offer input", flight.ID)
+		}
+	}
+	for _, offer := range offers {
+		index, exists := indexes[offer.FlightID]
+		if !exists {
+			return aman.AirportState{}, fmt.Errorf("queue offer flight %q does not match airport slot state", offer.FlightID)
+		}
+		projected.Flights[index].QueueOffers = append(projected.Flights[index].QueueOffers, offer)
+	}
+	for index := range projected.Flights {
+		sort.Slice(projected.Flights[index].QueueOffers, func(i, j int) bool {
+			a, b := projected.Flights[index].QueueOffers[i], projected.Flights[index].QueueOffers[j]
+			if a.CandidateSlot.Sequence != b.CandidateSlot.Sequence {
+				return a.CandidateSlot.Sequence < b.CandidateSlot.Sequence
+			}
+			return a.QueuePosition < b.QueuePosition
+		})
+	}
+	if err := projected.Validate(); err != nil {
+		return aman.AirportState{}, err
+	}
+	return projected, nil
+}
+
+func (c QueueOfferCalculation) project(state aman.AirportState, revision aman.SequenceRevision, at time.Time) (aman.AirportState, error) {
+	input := cloneInput(c.Input)
+	input.Revision = revision
+	for index := range input.Flights {
+		if input.Flights[index].CurrentSlot != nil {
+			input.Flights[index].CurrentSlot.Revision = revision
+		}
+	}
+	return ProjectQueueOffers(state, input, c.Config, at)
+}
+
+func queueEntries(revision aman.SequenceRevision, flights []preparedFlight) ([]queueEntry, error) {
+	entries := make([]queueEntry, 0, len(flights))
+	for _, flight := range flights {
+		if flight.State == aman.StateLanded || flight.State == aman.StateRemoved || flight.CurrentSlot == nil {
+			continue
+		}
+		slot := *flight.CurrentSlot
+		if slot.Revision != revision || slot.Reason == "" {
+			return nil, fmt.Errorf("flight %q has a stale or incomplete committed slot", flight.ID)
+		}
+		entries = append(entries, queueEntry{flight: flight, slot: slot})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].slot.Sequence != entries[j].slot.Sequence {
+			return entries[i].slot.Sequence < entries[j].slot.Sequence
+		}
+		if !entries[i].slot.Time.Equal(entries[j].slot.Time) {
+			return entries[i].slot.Time.Before(entries[j].slot.Time)
+		}
+		return entries[i].flight.ID < entries[j].flight.ID
+	})
+	for index := range entries {
+		if index > 0 && (entries[index].slot.Sequence == entries[index-1].slot.Sequence || !entries[index].slot.Time.After(entries[index-1].slot.Time)) {
+			return nil, fmt.Errorf("runway group %q has duplicate or unordered committed slots", entries[index].slot.RunwayGroupID)
+		}
+	}
+	return entries, nil
+}
+
+func queueEligible(flight preparedFlight) bool {
+	return (flight.State == aman.StateUnstable || flight.State == aman.StateStable) && flight.FreezeReason == aman.FreezeNone && flight.ManualOrder == nil
+}
+
+func crossesProtectedOrder(entries []queueEntry, candidateIndex, targetIndex int) bool {
+	for index := candidateIndex + 1; index < targetIndex; index++ {
+		flight := entries[index].flight
+		if flight.FreezeReason != aman.FreezeNone || flight.ManualOrder != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func slotsEqual(left, right *aman.Slot) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return left.Time.Equal(right.Time) && left.RunwayGroupID == right.RunwayGroupID && left.Sequence == right.Sequence && left.Revision == right.Revision && left.Reason == right.Reason
+}

--- a/backend/internal/aman/sequence/queue.go
+++ b/backend/internal/aman/sequence/queue.go
@@ -74,6 +74,9 @@ func CalculateQueueOffers(input Input, config QueueOfferConfig, at time.Time) ([
 			}
 			for candidateIndex := 0; candidateIndex < targetIndex; candidateIndex++ {
 				candidate := entries[candidateIndex]
+				if candidate.flight.FreezeReason != aman.FreezeNone || candidate.flight.ManualOrder != nil {
+					continue
+				}
 				if candidate.slot.Time.Before(target.flight.OperationalTETA.Add(-policy.EarlyTolerance)) {
 					continue
 				}

--- a/backend/internal/aman/sequence/queue_test.go
+++ b/backend/internal/aman/sequence/queue_test.go
@@ -1,0 +1,302 @@
+package sequence_test
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+	"testing"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/aman/sequence"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueueOffersRespectToleranceAndAssignDeterministicPositions(t *testing.T) {
+	start := testTime()
+	policy := queuePolicy("A", start, 60)
+	policy.EarlyTolerance = 90 * time.Second
+	input := sequence.Input{Revision: 7, Policies: []sequence.Policy{policy}, Flights: []sequence.Flight{
+		queueFlight("LEAD", "A", start, "M", 1, start),
+		queueFlight("OCCUPIED", "A", start.Add(time.Minute), "M", 2, start.Add(time.Minute)),
+		queueFlight("FIRST", "A", start.Add(2*time.Minute), "M", 3, start.Add(2*time.Minute)),
+		queueFlight("SECOND", "A", start.Add(2*time.Minute), "M", 4, start.Add(3*time.Minute)),
+	}}
+	bindQueueRevision(&input)
+
+	offers, err := sequence.CalculateQueueOffers(input, sequence.QueueOfferConfig{Validity: 10 * time.Minute}, start.Add(-time.Minute))
+	require.NoError(t, err)
+	candidateTwo := make([]aman.QueueOffer, 0, 2)
+	for _, offer := range offers {
+		if offer.CandidateSlot.Sequence == 2 {
+			candidateTwo = append(candidateTwo, offer)
+		}
+		if offer.FlightID == "FIRST" {
+			require.NotEqual(t, 1, offer.CandidateSlot.Sequence, "slot outside operational TETA tolerance must not be offered")
+		}
+	}
+	require.Equal(t, []aman.QueueOffer{
+		queueOffer("FIRST", "A", 2, start.Add(time.Minute), 1, 7, start.Add(time.Minute)),
+		queueOffer("SECOND", "A", 2, start.Add(time.Minute), 2, 7, start.Add(time.Minute)),
+	}, candidateTwo)
+}
+
+func TestQueueOffersValidateBothWTCBoundaries(t *testing.T) {
+	start := testTime()
+	policy := sequence.Policy{
+		RunwayGroupID: "A", Rates: []sequence.RatePoint{{EffectiveAt: start, ArrivalsPerHour: 120}}, EarlyTolerance: 5 * time.Minute,
+		SeparationRules: []sequence.SeparationRule{
+			{Leading: "H", Trailing: "H", Minimum: 2 * time.Minute},
+			{Leading: "H", Trailing: "M", Minimum: 30 * time.Second},
+			{Leading: "M", Trailing: "H", Minimum: 30 * time.Second},
+			{Leading: "M", Trailing: "M", Minimum: 30 * time.Second},
+		}, UnknownSeparation: 2 * time.Minute,
+	}
+	input := sequence.Input{Revision: 3, Policies: []sequence.Policy{policy}, Flights: []sequence.Flight{
+		queueFlight("LEADING-H", "A", start, "H", 1, start),
+		queueFlight("CANDIDATE-M", "A", start.Add(30*time.Second), "M", 2, start.Add(30*time.Second)),
+		queueFlight("TRAILING-H", "A", start.Add(time.Minute), "H", 3, start.Add(time.Minute)),
+		queueFlight("TARGET-H", "A", start.Add(30*time.Second), "H", 4, start.Add(3*time.Minute)),
+	}}
+	bindQueueRevision(&input)
+
+	offers, err := sequence.CalculateQueueOffers(input, sequence.QueueOfferConfig{Validity: time.Minute}, start.Add(-time.Minute))
+	require.NoError(t, err)
+	for _, offer := range offers {
+		require.NotEqual(t, 2, offer.CandidateSlot.Sequence, "candidate must fail leading and trailing H/H spacing")
+	}
+}
+
+func TestQueueOffersDoNotCrossFreezeManualOrRunwayGroups(t *testing.T) {
+	start := testTime()
+	frozenAt := start.Add(-time.Minute)
+	frozenTETA := start.Add(time.Minute)
+	manualOrder := 1
+	superstable := queueFlight("SUPER", "A", start.Add(time.Minute), "M", 2, start.Add(time.Minute))
+	superstable.FreezeReason = aman.FreezeSuperstable
+	superstable.FrozenAt = &frozenAt
+	superstable.FrozenOperationalTETA = &frozenTETA
+	superstable.CapturedSlot = superstable.CurrentSlot
+	manual := queueFlight("MANUAL", "A", start.Add(2*time.Minute), "M", 3, start.Add(2*time.Minute))
+	manual.FreezeReason = aman.FreezeManual
+	manual.FrozenAt = &frozenAt
+	manual.FrozenOperationalTETA = &frozenTETA
+	manual.CapturedSlot = manual.CurrentSlot
+	ordered := queueFlight("ORDERED", "A", start.Add(3*time.Minute), "M", 4, start.Add(3*time.Minute))
+	ordered.ManualOrder = &manualOrder
+	input := sequence.Input{Revision: 5, Policies: []sequence.Policy{queuePolicy("B", start, 60), queuePolicy("A", start, 60)}, Flights: []sequence.Flight{
+		queueFlight("A-LEAD", "A", start, "M", 1, start), superstable, manual, ordered,
+		queueFlight("A-TARGET", "A", start, "M", 5, start.Add(4*time.Minute)),
+		queueFlight("B-LEAD", "B", start, "M", 1, start),
+		queueFlight("B-TARGET", "B", start, "M", 2, start.Add(time.Minute)),
+	}}
+	bindQueueRevision(&input)
+
+	offers, err := sequence.CalculateQueueOffers(input, sequence.QueueOfferConfig{Validity: 10 * time.Minute}, start.Add(-time.Minute))
+	require.NoError(t, err)
+	require.NotEmpty(t, offers)
+	for _, offer := range offers {
+		require.NotContains(t, []aman.FlightID{"SUPER", "MANUAL", "ORDERED"}, offer.FlightID)
+		if offer.FlightID == "A-TARGET" {
+			require.GreaterOrEqual(t, offer.CandidateSlot.Sequence, 4, "target cannot cross frozen or manual order boundaries")
+		}
+		if offer.FlightID == "B-TARGET" {
+			require.Equal(t, aman.RunwayGroupID("B"), offer.CandidateSlot.RunwayGroupID)
+		}
+	}
+}
+
+func TestQueueOffersExpireAndRateChangesRecompute(t *testing.T) {
+	start := testTime()
+	input := sequence.Input{Revision: 8, Policies: []sequence.Policy{queuePolicy("A", start, 60)}, Flights: []sequence.Flight{
+		queueFlight("LEAD", "A", start, "M", 1, start),
+		queueFlight("TARGET", "A", start, "M", 2, start.Add(time.Minute)),
+	}}
+	bindQueueRevision(&input)
+
+	active, err := sequence.CalculateQueueOffers(input, sequence.QueueOfferConfig{Validity: 30 * time.Second}, start.Add(-time.Minute))
+	require.NoError(t, err)
+	require.Len(t, active, 1)
+	require.Equal(t, start.Add(-30*time.Second), active[0].ExpiresAt)
+
+	expired, err := sequence.CalculateQueueOffers(input, sequence.QueueOfferConfig{Validity: 30 * time.Second}, start)
+	require.NoError(t, err)
+	require.Empty(t, expired)
+
+	rateInput := sequence.Input{Revision: 9, Policies: []sequence.Policy{queuePolicy("A", start, 60)}, Flights: []sequence.Flight{
+		queueFlight("RATE-LEAD", "A", start, "M", 1, start),
+		queueFlight("RATE-MIDDLE", "A", start, "M", 2, start.Add(time.Minute)),
+		queueFlight("RATE-TARGET", "A", start, "M", 3, start.Add(2*time.Minute)),
+	}}
+	bindQueueRevision(&rateInput)
+	beforeRateChange, err := sequence.CalculateQueueOffers(rateInput, sequence.QueueOfferConfig{Validity: time.Minute}, start.Add(-time.Minute))
+	require.NoError(t, err)
+	require.True(t, slices.ContainsFunc(beforeRateChange, func(offer aman.QueueOffer) bool { return offer.FlightID == "RATE-TARGET" }))
+	rateInput.Policies = []sequence.Policy{queuePolicy("A", start, 30)}
+	recomputed, err := sequence.CalculateQueueOffers(rateInput, sequence.QueueOfferConfig{Validity: time.Minute}, start.Add(-time.Minute))
+	require.NoError(t, err)
+	require.False(t, slices.ContainsFunc(recomputed, func(offer aman.QueueOffer) bool { return offer.FlightID == "RATE-TARGET" }), "the lower rate increases both adjacent base intervals")
+}
+
+func TestQueueOffersRejectStaleRevisionAndReplayDeterministically(t *testing.T) {
+	start := testTime()
+	input := sequence.Input{Revision: 11, Policies: []sequence.Policy{queuePolicy("B", start, 60), queuePolicy("A", start, 60)}, Flights: []sequence.Flight{
+		queueFlight("B1", "B", start, "M", 1, start), queueFlight("B2", "B", start, "M", 2, start.Add(time.Minute)),
+		queueFlight("A1", "A", start, "M", 1, start), queueFlight("A2", "A", start, "M", 2, start.Add(time.Minute)),
+	}}
+	bindQueueRevision(&input)
+	config := sequence.QueueOfferConfig{Validity: time.Minute}
+	at := start.Add(-time.Minute)
+
+	first, err := sequence.CalculateQueueOffers(input, config, at)
+	require.NoError(t, err)
+	encodedInput, err := json.Marshal(input)
+	require.NoError(t, err)
+	var restored sequence.Input
+	require.NoError(t, json.Unmarshal(encodedInput, &restored))
+	slices.Reverse(restored.Policies)
+	slices.Reverse(restored.Flights)
+	second, err := sequence.CalculateQueueOffers(restored, config, at)
+	require.NoError(t, err)
+	firstJSON, err := json.Marshal(first)
+	require.NoError(t, err)
+	secondJSON, err := json.Marshal(second)
+	require.NoError(t, err)
+	require.Equal(t, string(firstJSON), string(secondJSON))
+
+	restored.Flights[0].CurrentSlot.Revision--
+	_, err = sequence.CalculateQueueOffers(restored, config, at)
+	require.ErrorContains(t, err, "stale")
+}
+
+func TestQueueOfferProjectionPersistsWithOneAirportRevision(t *testing.T) {
+	start := testTime()
+	input := sequence.Input{Revision: 12, Policies: []sequence.Policy{queuePolicy("A", start, 60)}, Flights: []sequence.Flight{
+		queueFlight("LEAD", "A", start, "M", 1, start),
+		queueFlight("TARGET", "A", start, "M", 2, start.Add(time.Minute)),
+	}}
+	bindQueueRevision(&input)
+	generatedAt := start.Add(-time.Minute)
+	state := queueState(input, generatedAt)
+
+	projected, err := sequence.ProjectQueueOffers(state, input, sequence.QueueOfferConfig{Validity: 30 * time.Second}, generatedAt)
+	require.NoError(t, err)
+	require.Len(t, projected.Flights[1].QueueOffers, 1)
+	require.Equal(t, projected.Revision, projected.Flights[1].QueueOffers[0].AirportRevision)
+	require.Equal(t, projected.Revision, projected.Flights[1].QueueOffers[0].CandidateSlot.Revision)
+
+	encoded, err := json.Marshal(projected)
+	require.NoError(t, err)
+	var restored aman.AirportState
+	require.NoError(t, json.Unmarshal(encoded, &restored))
+	require.NoError(t, restored.Validate())
+	require.Equal(t, projected, restored)
+
+	input.Revision--
+	_, err = sequence.ProjectQueueOffers(state, input, sequence.QueueOfferConfig{Validity: time.Minute}, generatedAt)
+	var domainError *aman.DomainError
+	require.ErrorAs(t, err, &domainError)
+	require.Equal(t, aman.ErrorRevisionConflict, domainError.Class)
+}
+
+func TestCoordinatorRecomputesQueueOffersInChangedSlotRevision(t *testing.T) {
+	start := testTime()
+	input := sequence.Input{Revision: 12, Policies: []sequence.Policy{queuePolicy("A", start, 60)}, Flights: []sequence.Flight{
+		queueFlight("LEAD", "A", start, "M", 1, start),
+		queueFlight("TARGET", "A", start, "M", 2, start.Add(time.Minute)),
+	}}
+	bindQueueRevision(&input)
+	initial, err := sequence.ProjectQueueOffers(queueState(input, start.Add(-2*time.Minute)), input, sequence.QueueOfferConfig{Validity: time.Minute}, start.Add(-2*time.Minute))
+	require.NoError(t, err)
+	require.Len(t, initial.Flights[1].QueueOffers, 1)
+
+	repository := newCoordinatorRepository(initial)
+	publisher := &recordingPublisher{repository: repository}
+	coordinator, err := sequence.NewCoordinator(sequence.CoordinatorDependencies{
+		States: repository, Outcomes: repository, Committer: repository, Publisher: publisher,
+		Now: func() time.Time { return start.Add(-30 * time.Second) },
+	})
+	require.NoError(t, err)
+	metadata := aman.CommandMetadata{CommandID: "rate-recompute", ExpectedRevision: input.Revision}
+	result, err := coordinator.ExecuteCommand(context.Background(), "EKCH", metadata, func(state aman.AirportState) (sequence.CommandChange, error) {
+		state.Flights[1].Slot.Time = start.Add(2 * time.Minute)
+		updatedInput := input
+		updatedInput.Flights = slices.Clone(input.Flights)
+		for index := range updatedInput.Flights {
+			updatedInput.Flights[index].CurrentSlot = cloneQueueSlot(input.Flights[index].CurrentSlot)
+		}
+		updatedInput.Flights[1].CurrentSlot.Time = start.Add(2 * time.Minute)
+		change := commandChange(state, true)
+		change.QueueOffers = &sequence.QueueOfferCalculation{Input: updatedInput, Config: sequence.QueueOfferConfig{Validity: time.Minute}}
+		return change, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, aman.SequenceRevision(13), result.State.Revision)
+	require.Len(t, result.State.Flights[1].QueueOffers, 1)
+	offer := result.State.Flights[1].QueueOffers[0]
+	require.Equal(t, result.State.Revision, offer.AirportRevision)
+	require.Equal(t, result.State.Revision, offer.CandidateSlot.Revision)
+	require.Equal(t, result.State.Revision, result.State.Flights[1].Slot.Revision)
+	require.Equal(t, result.State, repository.current())
+	require.Equal(t, 1, publisher.calls())
+}
+
+func queuePolicy(group aman.RunwayGroupID, start time.Time, rate uint32) sequence.Policy {
+	return sequence.Policy{
+		RunwayGroupID: group, Rates: []sequence.RatePoint{{EffectiveAt: start, ArrivalsPerHour: rate}}, EarlyTolerance: 10 * time.Minute,
+		SeparationRules: []sequence.SeparationRule{{Leading: "M", Trailing: "M", Minimum: 0}}, UnknownSeparation: time.Minute,
+	}
+}
+
+func queueFlight(id aman.FlightID, group aman.RunwayGroupID, teta time.Time, category sequence.WakeCategory, number int, slotTime time.Time) sequence.Flight {
+	return sequence.Flight{
+		ID: id, RunwayGroupID: group, State: aman.StateStable, OperationalTETA: teta, WakeCategory: category, FreezeReason: aman.FreezeNone,
+		CurrentSlot: &aman.Slot{Time: slotTime, RunwayGroupID: group, Sequence: number, Revision: 7, Reason: "rate_wtc"},
+	}
+}
+
+func queueOffer(flightID aman.FlightID, group aman.RunwayGroupID, sequenceNumber int, slotTime time.Time, position int, revision aman.SequenceRevision, expiresAt time.Time) aman.QueueOffer {
+	return aman.QueueOffer{
+		FlightID: flightID, RunwayGroupID: group,
+		CandidateSlot: aman.Slot{Time: slotTime, RunwayGroupID: group, Sequence: sequenceNumber, Revision: revision, Reason: "rate_wtc"},
+		QueuePosition: position, ExpiresAt: expiresAt, AirportRevision: revision, Reason: aman.QueueOfferEarlierOccupiedSlot,
+	}
+}
+
+func bindQueueRevision(input *sequence.Input) {
+	for index := range input.Flights {
+		if input.Flights[index].CurrentSlot != nil {
+			input.Flights[index].CurrentSlot.Revision = input.Revision
+		}
+		if input.Flights[index].CapturedSlot != nil {
+			input.Flights[index].CapturedSlot.Revision = input.Revision
+		}
+	}
+}
+
+func queueState(input sequence.Input, generatedAt time.Time) aman.AirportState {
+	state := aman.AirportState{
+		Airport: "EKCH", Revision: input.Revision, GeneratedAt: generatedAt, PolicyVersion: "queue-v1", Mode: aman.ModeShadow,
+		RunwayGroups: make([]aman.RunwayGroupPolicy, len(input.Policies)), Flights: make([]aman.AMANFlight, len(input.Flights)),
+	}
+	for index, policy := range input.Policies {
+		state.RunwayGroups[index] = aman.RunwayGroupPolicy{ID: policy.RunwayGroupID}
+	}
+	for index, flight := range input.Flights {
+		slot := *flight.CurrentSlot
+		state.Flights[index] = aman.AMANFlight{
+			ID: flight.ID, VATSIMCID: "CID-" + string(flight.ID), CurrentCallsign: string(flight.ID),
+			State: flight.State, DataStatus: aman.DataFresh, FreezeReason: flight.FreezeReason,
+			Slot: &slot, UpdatedAt: generatedAt,
+		}
+	}
+	return state
+}
+
+func cloneQueueSlot(slot *aman.Slot) *aman.Slot {
+	if slot == nil {
+		return nil
+	}
+	copy := *slot
+	return &copy
+}

--- a/backend/internal/aman/sequence/queue_test.go
+++ b/backend/internal/aman/sequence/queue_test.go
@@ -98,11 +98,51 @@ func TestQueueOffersDoNotCrossFreezeManualOrRunwayGroups(t *testing.T) {
 	for _, offer := range offers {
 		require.NotContains(t, []aman.FlightID{"SUPER", "MANUAL", "ORDERED"}, offer.FlightID)
 		if offer.FlightID == "A-TARGET" {
-			require.GreaterOrEqual(t, offer.CandidateSlot.Sequence, 4, "target cannot cross frozen or manual order boundaries")
+			t.Fatalf("target received protected/manual candidate offer: %+v", offer)
 		}
 		if offer.FlightID == "B-TARGET" {
 			require.Equal(t, aman.RunwayGroupID("B"), offer.CandidateSlot.RunwayGroupID)
 		}
+	}
+}
+
+func TestQueueOffersRejectProtectedCandidateSlot(t *testing.T) {
+	start := testTime()
+	frozenAt := start.Add(-time.Minute)
+	frozenTETA := start
+	manualOrder := 1
+	tests := []struct {
+		name      string
+		configure func(*sequence.Flight)
+	}{
+		{name: "manual order", configure: func(candidate *sequence.Flight) { candidate.ManualOrder = &manualOrder }},
+		{name: "manual freeze", configure: func(candidate *sequence.Flight) {
+			candidate.FreezeReason = aman.FreezeManual
+			candidate.FrozenAt = &frozenAt
+			candidate.FrozenOperationalTETA = &frozenTETA
+			candidate.CapturedSlot = candidate.CurrentSlot
+		}},
+		{name: "Superstable freeze", configure: func(candidate *sequence.Flight) {
+			candidate.FreezeReason = aman.FreezeSuperstable
+			candidate.FrozenAt = &frozenAt
+			candidate.FrozenOperationalTETA = &frozenTETA
+			candidate.CapturedSlot = candidate.CurrentSlot
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := queueFlight("PROTECTED", "A", start, "M", 1, start)
+			test.configure(&candidate)
+			input := sequence.Input{Revision: 6, Policies: []sequence.Policy{queuePolicy("A", start, 60)}, Flights: []sequence.Flight{
+				candidate,
+				queueFlight("TARGET", "A", start, "M", 2, start.Add(time.Minute)),
+			}}
+			bindQueueRevision(&input)
+
+			offers, err := sequence.CalculateQueueOffers(input, sequence.QueueOfferConfig{Validity: time.Minute}, start.Add(-time.Minute))
+			require.NoError(t, err)
+			require.Empty(t, offers)
+		})
 	}
 }
 

--- a/backend/internal/aman/types.go
+++ b/backend/internal/aman/types.go
@@ -338,6 +338,30 @@ type Slot struct {
 	Reason        string
 }
 
+// QueueOfferReason explains why an occupied earlier slot is exposed as a
+// revision-bound opportunity. Presentation code must not infer eligibility
+// from this value.
+type QueueOfferReason string
+
+const (
+	QueueOfferEarlierOccupiedSlot QueueOfferReason = "earlier_occupied_slot"
+)
+
+func (r QueueOfferReason) Valid() bool { return r == QueueOfferEarlierOccupiedSlot }
+
+// QueueOffer is a persisted read model for one flight and one occupied earlier
+// slot. CandidateSlot and AirportRevision always belong to the same committed
+// airport replacement state.
+type QueueOffer struct {
+	FlightID        FlightID
+	RunwayGroupID   RunwayGroupID
+	CandidateSlot   Slot
+	QueuePosition   int
+	ExpiresAt       time.Time
+	AirportRevision SequenceRevision
+	Reason          QueueOfferReason
+}
+
 // RouteFact is the currently active operational route fact. Transport and
 // tracking-authority details belong to the route-fact owner, not this core
 // contract.
@@ -524,6 +548,7 @@ type AMANFlight struct {
 	FrozenSlot            *Slot
 	Slot                  *Slot
 	Order                 *int
+	QueueOffers           []QueueOffer
 	ETAReview             *ETAReview
 	OperationalException  *OperationalException
 	GoAroundDetection     *GoAroundDetectionState
@@ -806,6 +831,29 @@ func (f AMANFlight) Validate() error {
 			return err
 		}
 	}
+	seenOffers := make(map[int]struct{}, len(f.QueueOffers))
+	for index, offer := range f.QueueOffers {
+		if err := offer.validate(); err != nil {
+			return err
+		}
+		if offer.FlightID != f.ID {
+			return invalid("queue offer flight does not match its aggregate")
+		}
+		if f.Slot == nil || offer.RunwayGroupID != f.Slot.RunwayGroupID || offer.CandidateSlot.RunwayGroupID != f.Slot.RunwayGroupID || offer.CandidateSlot.Sequence >= f.Slot.Sequence || !offer.CandidateSlot.Time.Before(f.Slot.Time) {
+			return invalid("queue offer candidate is not earlier than the assigned slot")
+		}
+		if _, duplicate := seenOffers[offer.CandidateSlot.Sequence]; duplicate {
+			return invalid("flight contains duplicate queue offer candidate")
+		}
+		seenOffers[offer.CandidateSlot.Sequence] = struct{}{}
+		if index > 0 {
+			previous := f.QueueOffers[index-1]
+			if offer.CandidateSlot.Sequence < previous.CandidateSlot.Sequence ||
+				(offer.CandidateSlot.Sequence == previous.CandidateSlot.Sequence && offer.QueuePosition < previous.QueuePosition) {
+				return invalid("queue offers are not in canonical order")
+			}
+		}
+	}
 	return requireUTCTime("updated at", f.UpdatedAt)
 }
 
@@ -1072,6 +1120,25 @@ func (s Slot) validate() error {
 	return nil
 }
 
+func (o QueueOffer) validate() error {
+	if strings.TrimSpace(string(o.FlightID)) == "" || strings.TrimSpace(string(o.RunwayGroupID)) == "" || o.QueuePosition < 1 || o.AirportRevision == 0 || !o.Reason.Valid() {
+		return invalid("queue offer is incomplete")
+	}
+	if err := o.CandidateSlot.validate(); err != nil {
+		return err
+	}
+	if o.CandidateSlot.RunwayGroupID != o.RunwayGroupID || o.CandidateSlot.Revision != o.AirportRevision {
+		return invalid("queue offer candidate revision or runway group does not match")
+	}
+	if err := requireUTCTime("queue offer expiry", o.ExpiresAt); err != nil {
+		return err
+	}
+	if o.ExpiresAt.After(o.CandidateSlot.Time) {
+		return invalid("queue offer cannot outlive its candidate slot")
+	}
+	return nil
+}
+
 func (s AirportState) Validate() error {
 	if strings.TrimSpace(s.Airport) == "" || strings.TrimSpace(s.PolicyVersion) == "" || !s.Mode.Valid() {
 		return invalid("airport state is incomplete")
@@ -1090,6 +1157,14 @@ func (s AirportState) Validate() error {
 		flightIDs[flight.ID] = struct{}{}
 		if flight.Slot != nil && flight.Slot.Revision != s.Revision {
 			return invalid("slot revision must match airport state revision")
+		}
+		for _, offer := range flight.QueueOffers {
+			if offer.AirportRevision != s.Revision || offer.CandidateSlot.Revision != s.Revision {
+				return invalid("queue offer revision must match airport state revision")
+			}
+			if !offer.ExpiresAt.After(s.GeneratedAt) {
+				return invalid("queue offer must be unexpired when its airport revision is generated")
+			}
 		}
 	}
 	groupIDs := make(map[RunwayGroupID]struct{}, len(s.RunwayGroups))

--- a/backend/internal/aman/types_test.go
+++ b/backend/internal/aman/types_test.go
@@ -50,6 +50,7 @@ func TestDomainTypesDoNotDeclareWireJSONTags(t *testing.T) {
 		reflect.TypeFor[RawTETASample](),
 		reflect.TypeFor[BaselineState](),
 		reflect.TypeFor[Slot](),
+		reflect.TypeFor[QueueOffer](),
 		reflect.TypeFor[RouteFact](),
 		reflect.TypeFor[ETAReview](),
 		reflect.TypeFor[OperationalException](),
@@ -179,6 +180,33 @@ func TestAirportStateRejectsMismatchedSlotRevisionAndDuplicateFlight(t *testing.
 
 	flight.Slot.Revision = state.Revision
 	state.Flights = append(state.Flights, flight)
+	assertInvalidArgument(t, state.Validate())
+}
+
+func TestQueueOfferRequiresMatchingFlightSlotAndAirportRevision(t *testing.T) {
+	now := time.Date(2026, time.July, 18, 12, 0, 0, 0, time.UTC)
+	flight := validFlight(now)
+	flight.Slot = &Slot{Time: now.Add(3 * time.Minute), RunwayGroupID: "north", Sequence: 3, Revision: 4, Reason: "rate_wtc"}
+	flight.QueueOffers = []QueueOffer{{
+		FlightID: flight.ID, RunwayGroupID: "north",
+		CandidateSlot: Slot{Time: now.Add(time.Minute), RunwayGroupID: "north", Sequence: 1, Revision: 4, Reason: "rate_wtc"},
+		QueuePosition: 1, ExpiresAt: now.Add(time.Minute), AirportRevision: 4, Reason: QueueOfferEarlierOccupiedSlot,
+	}}
+	state := AirportState{
+		Airport: "EKCH", Revision: 4, GeneratedAt: now, PolicyVersion: "v1", Mode: ModeReadOnly,
+		Flights: []AMANFlight{flight}, RunwayGroups: []RunwayGroupPolicy{{ID: "north"}},
+	}
+	if err := state.Validate(); err != nil {
+		t.Fatalf("validate queue offer state: %v", err)
+	}
+
+	state.Flights[0].QueueOffers[0].AirportRevision = 3
+	assertInvalidArgument(t, state.Validate())
+	state.Flights[0].QueueOffers[0].AirportRevision = 4
+	state.Flights[0].QueueOffers[0].FlightID = "another-flight"
+	assertInvalidArgument(t, state.Validate())
+	state.Flights[0].QueueOffers[0].FlightID = flight.ID
+	state.Flights[0].QueueOffers[0].ExpiresAt = now
 	assertInvalidArgument(t, state.Validate())
 }
 

--- a/backend/internal/repository/postgres/aman_test.go
+++ b/backend/internal/repository/postgres/aman_test.go
@@ -196,6 +196,34 @@ func TestAMANRepositoryRestoresHeldAirborneBaselineForFreshPredictor(t *testing.
 	require.Equal(t, first.State, held.State)
 }
 
+func TestAMANRepositoryRestoresRevisionBoundQueueOffers(t *testing.T) {
+	pool, _ := testdata.SetupTestDB(t)
+	ctx := context.Background()
+	state := amanState(1, "CID-QUEUE-1", "SAS321")
+	first := state.Flights[0]
+	target := first
+	target.ID = "flight-2"
+	target.VATSIMCID = "CID-QUEUE-2"
+	target.CurrentCallsign = "SAS322"
+	target.Slot = &aman.Slot{
+		Time: first.Slot.Time.Add(time.Minute), RunwayGroupID: first.Slot.RunwayGroupID,
+		Sequence: 2, Revision: state.Revision, Reason: "rate_wtc",
+	}
+	target.Order = intPtr(2)
+	target.QueueOffers = []aman.QueueOffer{{
+		FlightID: target.ID, RunwayGroupID: first.Slot.RunwayGroupID, CandidateSlot: *first.Slot,
+		QueuePosition: 1, ExpiresAt: first.Slot.Time, AirportRevision: state.Revision,
+		Reason: aman.QueueOfferEarlierOccupiedSlot,
+	}}
+	state.Flights = append(state.Flights, target)
+
+	_, err := NewAMANRepository(pool).Commit(ctx, aman.StateCommit{ExpectedRevision: 0, State: state})
+	require.NoError(t, err)
+	restored, err := NewAMANRepository(pool).LoadAirportState(ctx, state.Airport)
+	require.NoError(t, err)
+	require.Equal(t, state, restored)
+}
+
 func TestAMANRepositoryRestoresETAReviewAndKeepsResolutionAtomicAndIdempotent(t *testing.T) {
 	pool, _ := testdata.SetupTestDB(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Implements revision-bound earlier-slot queue offers from authoritative AMAN sequence state.

- persists typed `QueueOffer` read models inside existing AMAN flight aggregates
- calculates deterministic offers using tolerance, WTC on both adjacent boundaries, runway groups, and manual/freeze constraints
- rejects Superstable and all protected/manual candidate slots
- validates expiry and airport/slot revision consistency
- binds recalculation to the coordinator’s changed-commit path and clears stale offers fail-safe

## Scope

This is the #324 backend offer slice only. It adds no frontend eligibility logic, WebSocket command/handler surface, or durable delivery outbox.

## Validation

- `go test ./internal/aman/sequence ./internal/aman ./internal/repository/postgres -count=1`
- `go test ./internal/aman/... -count=1`
- `go test -race ./internal/aman/sequence -count=1`
- `go test ./...`

Closes #324