### PR TITLE
[AMAN] Define full-replacement frontend WebSocket contracts (#325)

### DIFF
--- a/backend/internal/frontend/hub.go
+++ b/backend/internal/frontend/hub.go
@@ -30,6 +30,7 @@ import (
 
 type internalMessage struct {
 	session int32
+	airport string
 	message frontend.OutgoingMessage
 	cid     *string
 }
@@ -86,6 +87,14 @@ type Hub struct {
 
 	snapshotBuilder    *SnapshotBuilder
 	standActionService *services.StandActionService
+	amanStateProvider  AMANStateProvider
+}
+
+// AMANStateProvider returns the latest complete persisted replacement event
+// for an authenticated airport session. It has no subscribe or resnapshot
+// operation; reconnect calls this same read path again.
+type AMANStateProvider interface {
+	CurrentAMANState(context.Context, string) (frontend.AMANStateEvent, error)
 }
 
 type nextDisplayComputer interface {
@@ -104,6 +113,7 @@ type validationStatusAcknowledger interface {
 type HubDependencies struct {
 	Strips         shared.StripService
 	Authentication shared.AuthenticationService
+	AMANState      AMANStateProvider
 }
 
 func NewHub(deps HubDependencies) (*Hub, error) {
@@ -163,6 +173,7 @@ func NewHub(deps HubDependencies) (*Hub, error) {
 		handlers:              handlers,
 		stripService:          deps.Strips,
 		authenticationService: deps.Authentication,
+		amanStateProvider:     deps.AMANState,
 		messages:              make(map[int32][]frontend.MessageReceivedEvent),
 		metarCache:            make(map[int32]string),
 		arrAtisCodeCache:      make(map[int32]string),
@@ -213,6 +224,12 @@ func (hub *Hub) Broadcast(session int32, message frontend.OutgoingMessage) {
 		message: message,
 		cid:     nil,
 	}
+}
+
+// PublishAMANStateEvent broadcasts one already-projected complete replacement
+// to authenticated frontend clients for the event airport.
+func (hub *Hub) PublishAMANStateEvent(event frontend.AMANStateEvent) {
+	hub.send <- internalMessage{airport: event.Data.Airport, message: event}
 }
 
 func (hub *Hub) Send(session int32, cid string, message frontend.OutgoingMessage) {
@@ -370,6 +387,14 @@ func (hub *Hub) sendInitialEvent(ctx context.Context, client *Client) {
 	}
 
 	client.Enqueue(event)
+	if hub.amanStateProvider != nil {
+		amanState, stateErr := hub.amanStateProvider.CurrentAMANState(ctx, client.airport)
+		if stateErr != nil {
+			slog.Error("Failed to load initial AMAN state", slog.Any("error", stateErr), slog.String("airport", client.airport))
+		} else {
+			client.Enqueue(amanState)
+		}
+	}
 	if cachedAtis != nil {
 		client.Enqueue(*cachedAtis)
 	}
@@ -1398,7 +1423,7 @@ func (hub *Hub) Run(ctx context.Context) {
 				}
 			} else {
 				for client := range hub.clients {
-					if message.session == client.session {
+					if (message.airport != "" && message.airport == client.airport) || (message.airport == "" && message.session == client.session) {
 						client.Enqueue(message.message)
 					}
 				}

--- a/backend/internal/frontend/hub_aman_test.go
+++ b/backend/internal/frontend/hub_aman_test.go
@@ -1,0 +1,34 @@
+package frontend
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"FlightStrips/pkg/events"
+	frontendEvents "FlightStrips/pkg/events/frontend"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublishAMANStateEventSendsCompleteReplacementOnlyToMatchingAirport(t *testing.T) {
+	ekch := startQueuedTestClient(&Client{airport: "EKCH", send: make(chan events.OutgoingMessage, 1)})
+	essa := startQueuedTestClient(&Client{airport: "ESSA", send: make(chan events.OutgoingMessage, 1)})
+	hub := &Hub{
+		clients: map[*Client]bool{ekch: true, essa: true},
+		send:    make(chan internalMessage, 1),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go hub.Run(ctx)
+
+	expected := frontendEvents.AMANStateEvent{Version: 1, Data: frontendEvents.AMANState{Airport: "EKCH", Revision: 12}}
+	hub.PublishAMANStateEvent(expected)
+
+	require.Equal(t, expected, waitForOutgoingMessage(t, ekch.send))
+	select {
+	case message := <-essa.send:
+		t.Fatalf("unexpected cross-airport AMAN message: %#v", message)
+	case <-time.After(20 * time.Millisecond):
+	}
+}

--- a/backend/internal/frontend/hub_initial_test.go
+++ b/backend/internal/frontend/hub_initial_test.go
@@ -4,6 +4,7 @@ import (
 	internalModels "FlightStrips/internal/models"
 	"FlightStrips/internal/shared"
 	"FlightStrips/internal/testutil"
+	"FlightStrips/pkg/events"
 	frontendEvents "FlightStrips/pkg/events/frontend"
 	"context"
 	"testing"
@@ -73,4 +74,62 @@ func TestOnRegister_EnqueuesInitialSnapshot(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "EKCH", event.Airport)
 	assert.Equal(t, "EKCH_A_TWR", event.Callsign)
+}
+
+func TestOnRegister_EnqueuesLatestAMANReplacementOnInitialConnectAndReconnect(t *testing.T) {
+	provider := &reconnectAMANProvider{revision: 4}
+	hub := newAMANInitialTestHub(t, provider)
+
+	connect := func() frontendEvents.AMANStateEvent {
+		client := startQueuedTestClient(&Client{
+			hub: hub, session: 42, position: "118.105", airport: "EKCH", callsign: "EKCH_A_TWR",
+			user: shared.NewAuthenticatedUser("1234567", 0, nil), readOnly: true,
+			send: make(chan events.OutgoingMessage, 3),
+		})
+		hub.OnRegister(client)
+		_, ok := waitForOutgoingMessage(t, client.send).(frontendEvents.InitialEvent)
+		require.True(t, ok)
+		state, ok := waitForOutgoingMessage(t, client.send).(frontendEvents.AMANStateEvent)
+		require.True(t, ok)
+		return state
+	}
+
+	require.Equal(t, uint64(4), connect().Data.Revision)
+	provider.revision = 9 // simulates committed revisions missed while disconnected
+	require.Equal(t, uint64(9), connect().Data.Revision)
+	require.Equal(t, []string{"EKCH", "EKCH"}, provider.airports)
+}
+
+type reconnectAMANProvider struct {
+	revision uint64
+	airports []string
+}
+
+func (p *reconnectAMANProvider) CurrentAMANState(_ context.Context, airport string) (frontendEvents.AMANStateEvent, error) {
+	p.airports = append(p.airports, airport)
+	return frontendEvents.AMANStateEvent{Version: 1, Data: frontendEvents.AMANState{Airport: airport, Revision: p.revision}}, nil
+}
+
+func newAMANInitialTestHub(t *testing.T, provider AMANStateProvider) *Hub {
+	t.Helper()
+	return &Hub{
+		server: &testutil.MockServer{
+			ControllerRepoVal: &testutil.MockControllerRepository{ListBySessionFn: func(context.Context, int32) ([]*internalModels.Controller, error) {
+				return []*internalModels.Controller{}, nil
+			}},
+			StripRepoVal: &testutil.MockStripRepository{ListFn: func(context.Context, int32) ([]*internalModels.Strip, error) { return []*internalModels.Strip{}, nil }},
+			SectorRepoVal: &testutil.MockSectorOwnerRepository{ListBySessionFn: func(context.Context, int32) ([]*internalModels.SectorOwner, error) {
+				return []*internalModels.SectorOwner{}, nil
+			}},
+			SessionRepoVal: &testutil.MockSessionRepository{GetByIDFn: func(context.Context, int32) (*internalModels.Session, error) {
+				return &internalModels.Session{ID: 42, Name: "LIVE", Airport: "EKCH"}, nil
+			}},
+			CoordRepoVal: &testutil.MockCoordinationRepository{ListBySessionFn: func(context.Context, int32) ([]*internalModels.Coordination, error) {
+				return []*internalModels.Coordination{}, nil
+			}},
+		},
+		amanStateProvider: provider,
+		messages:          map[int32][]frontendEvents.MessageReceivedEvent{}, metarCache: map[int32]string{},
+		arrAtisCodeCache: map[int32]string{}, depAtisCodeCache: map[int32]string{},
+	}
 }

--- a/backend/pkg/events/frontend/aman.go
+++ b/backend/pkg/events/frontend/aman.go
@@ -1,0 +1,404 @@
+package frontend
+
+import (
+	"fmt"
+	"time"
+
+	"FlightStrips/internal/aman"
+)
+
+const AMANWireVersion = 1
+
+const (
+	AMANStateType           EventType = "aman.state"
+	AMANCommandRejectedType EventType = "aman.command_rejected"
+)
+
+// AMANStateEvent is the only frontend AMAN state event. Data is a complete
+// replacement; the wire contract has no patch, gap-repair, or subscription
+// messages.
+type AMANStateEvent struct {
+	Version int       `json:"version"`
+	Data    AMANState `json:"data"`
+}
+
+func (e AMANStateEvent) Marshal() ([]byte, error) { return marshall(e) }
+func (AMANStateEvent) GetType() EventType         { return AMANStateType }
+
+type AMANState struct {
+	Airport         string              `json:"airport"`
+	Revision        uint64              `json:"revision"`
+	GeneratedAt     string              `json:"generated_at"`
+	PolicyVersion   string              `json:"policy_version"`
+	EffectiveMode   string              `json:"effective_mode"`
+	Authoritative   bool                `json:"authoritative"`
+	Flights         []AMANFlight        `json:"flights"`
+	RunwayGroups    []AMANRunwayGroup   `json:"runway_groups"`
+	TechnicalHealth AMANTechnicalHealth `json:"technical_health"`
+}
+
+type AMANFlight struct {
+	FlightID        string           `json:"flight_id"`
+	Callsign        string           `json:"callsign"`
+	LifecycleState  string           `json:"lifecycle_state"`
+	DataStatus      string           `json:"data_status"`
+	RunwayGroupID   *string          `json:"runway_group_id"`
+	Feeder          *string          `json:"feeder"`
+	HoldingFix      *string          `json:"holding_fix"`
+	HoldingFixETA   *string          `json:"holding_fix_eta"`
+	RouteFact       *AMANRouteFact   `json:"route_fact"`
+	RawTETA         *string          `json:"raw_teta"`
+	OperationalTETA *string          `json:"operational_teta"`
+	GainLossSeconds *int64           `json:"gain_loss_seconds"`
+	FreezeReason    string           `json:"freeze_reason"`
+	FrozenAt        *string          `json:"frozen_at"`
+	Confidence      *string          `json:"confidence"`
+	Provenance      *AMANProvenance  `json:"provenance"`
+	InputAgeSeconds *int64           `json:"input_age_seconds"`
+	GeometryVersion *string          `json:"geometry_version"`
+	GeometryDigest  *string          `json:"geometry_digest"`
+	DistanceToGoNM  *float64         `json:"distance_to_go_nm"`
+	Slot            *AMANSlot        `json:"slot"`
+	Order           *int             `json:"order"`
+	ETAReview       *AMANETAReview   `json:"eta_review"`
+	QueueOffers     []AMANQueueOffer `json:"queue_offers"`
+}
+
+type AMANRouteFact struct {
+	ID         string `json:"id"`
+	Fix        string `json:"fix"`
+	ObservedAt string `json:"observed_at"`
+	State      string `json:"state"`
+}
+
+type AMANProvenance struct {
+	ModelVersion         string   `json:"model_version"`
+	ConfigVersion        string   `json:"config_version"`
+	PerformanceProfileID *string  `json:"performance_profile_id"`
+	WeatherSource        *string  `json:"weather_source"`
+	Sources              []string `json:"sources"`
+}
+
+type AMANSlot struct {
+	Time          string `json:"time"`
+	RunwayGroupID string `json:"runway_group_id"`
+	Sequence      int    `json:"sequence"`
+	Revision      uint64 `json:"revision"`
+	Reason        string `json:"reason"`
+}
+
+type AMANETAReview struct {
+	Status                    string  `json:"status"`
+	CreatedAt                 string  `json:"created_at"`
+	DeadlineAt                string  `json:"deadline_at"`
+	ResolvedAt                *string `json:"resolved_at"`
+	Actor                     *string `json:"actor"`
+	Note                      *string `json:"note"`
+	InitialBaselineTETA       string  `json:"initial_baseline_teta"`
+	CalculatedOperationalTETA string  `json:"calculated_operational_teta"`
+	SelectedTETA              string  `json:"selected_teta"`
+	ManualTETA                *string `json:"manual_teta"`
+}
+
+type AMANQueueOffer struct {
+	FlightID        string   `json:"flight_id"`
+	RunwayGroupID   string   `json:"runway_group_id"`
+	CandidateSlot   AMANSlot `json:"candidate_slot"`
+	QueuePosition   int      `json:"queue_position"`
+	ExpiresAt       string   `json:"expires_at"`
+	AirportRevision uint64   `json:"airport_revision"`
+	Reason          string   `json:"reason"`
+}
+
+// AMANRunwayGroup is intentionally limited to state persisted on
+// aman.AirportState. Rate schedules are not currently part of that persisted
+// aggregate and must not be borrowed from sequence-engine policy types.
+type AMANRunwayGroup struct {
+	ID string `json:"id"`
+}
+
+type AMANTechnicalHealth struct {
+	Status           string              `json:"status"`
+	Ready            bool                `json:"ready"`
+	BlockedReasons   []string            `json:"blocked_reasons"`
+	VATSIM           AMANComponentHealth `json:"vatsim"`
+	Navigation       AMANComponentHealth `json:"navigation"`
+	Weather          AMANComponentHealth `json:"weather"`
+	Repository       AMANComponentHealth `json:"repository"`
+	Predictor        AMANComponentHealth `json:"predictor"`
+	ReplayValidation AMANComponentHealth `json:"replay_validation"`
+}
+
+type AMANComponentHealth struct {
+	Status     string   `json:"status"`
+	Reason     *string  `json:"reason"`
+	UpdatedAt  *string  `json:"updated_at"`
+	AgeSeconds *float64 `json:"age_seconds"`
+}
+
+type AMANCommandRejectedEvent struct {
+	Version int                  `json:"version"`
+	Data    AMANCommandRejection `json:"data"`
+}
+
+func (e AMANCommandRejectedEvent) Marshal() ([]byte, error) { return marshall(e) }
+func (AMANCommandRejectedEvent) GetType() EventType         { return AMANCommandRejectedType }
+
+type AMANCommandRejection struct {
+	CommandID       string `json:"command_id"`
+	Code            string `json:"code"`
+	Message         string `json:"message"`
+	CurrentRevision uint64 `json:"current_revision"`
+	Retryable       bool   `json:"retryable"`
+}
+
+// NewAMANStateEvent projects one coherent domain state and its matching
+// technical-health reading into the transport-only V1 DTO. Callers must obtain
+// both values atomically; this mapper rejects mismatched desired/effective mode.
+func NewAMANStateEvent(state aman.AirportState, effectiveMode aman.EffectiveRolloutMode, health aman.TechnicalHealth) (AMANStateEvent, error) {
+	if err := state.Validate(); err != nil {
+		return AMANStateEvent{}, fmt.Errorf("map AMAN state event: %w", err)
+	}
+	if health.EffectiveMode != effectiveMode {
+		return AMANStateEvent{}, fmt.Errorf("map AMAN state event: effective mode and health must belong to the same state")
+	}
+	if health.DesiredMode != state.Mode {
+		return AMANStateEvent{}, fmt.Errorf("map AMAN state event: desired mode does not match persisted state")
+	}
+
+	generatedAt, err := aman.FormatTime(state.GeneratedAt)
+	if err != nil {
+		return AMANStateEvent{}, err
+	}
+	technicalHealth, err := mapAMANTechnicalHealth(health)
+	if err != nil {
+		return AMANStateEvent{}, fmt.Errorf("map AMAN technical health: %w", err)
+	}
+	data := AMANState{
+		Airport: state.Airport, Revision: uint64(state.Revision), GeneratedAt: generatedAt,
+		PolicyVersion: state.PolicyVersion, EffectiveMode: string(effectiveMode), Authoritative: state.Authoritative,
+		Flights: make([]AMANFlight, len(state.Flights)), RunwayGroups: make([]AMANRunwayGroup, len(state.RunwayGroups)),
+		TechnicalHealth: technicalHealth,
+	}
+	for i := range state.Flights {
+		data.Flights[i], err = mapAMANFlight(state.GeneratedAt, state.Flights[i])
+		if err != nil {
+			return AMANStateEvent{}, fmt.Errorf("map AMAN flight %q: %w", state.Flights[i].ID, err)
+		}
+	}
+	for i, group := range state.RunwayGroups {
+		data.RunwayGroups[i] = AMANRunwayGroup{ID: string(group.ID)}
+	}
+	return AMANStateEvent{Version: AMANWireVersion, Data: data}, nil
+}
+
+func NewAMANCommandRejectedEvent(commandID string, currentRevision aman.SequenceRevision, domainError *aman.DomainError, retryable bool) (AMANCommandRejectedEvent, error) {
+	if commandID == "" || domainError == nil || !domainError.Class.Valid() {
+		return AMANCommandRejectedEvent{}, fmt.Errorf("map AMAN command rejection: command ID and stable domain error are required")
+	}
+	return AMANCommandRejectedEvent{Version: AMANWireVersion, Data: AMANCommandRejection{
+		CommandID: commandID, Code: string(domainError.Class), Message: domainError.Message,
+		CurrentRevision: uint64(currentRevision), Retryable: retryable,
+	}}, nil
+}
+
+func mapAMANFlight(generatedAt time.Time, flight aman.AMANFlight) (AMANFlight, error) {
+	result := AMANFlight{
+		FlightID: string(flight.ID), Callsign: flight.CurrentCallsign, LifecycleState: string(flight.State),
+		DataStatus: string(flight.DataStatus), RunwayGroupID: stringPointer(flight.SelectedRunwayGroup),
+		Feeder: cloneString(flight.SelectedFeeder), HoldingFix: cloneString(flight.SelectedHolding),
+		FreezeReason: string(flight.FreezeReason), Order: cloneInt(flight.Order), QueueOffers: make([]AMANQueueOffer, len(flight.QueueOffers)),
+	}
+	var err error
+	if result.FrozenAt, err = formatOptionalTime(flight.FrozenAt); err != nil {
+		return AMANFlight{}, err
+	}
+	if flight.ActiveRouteFact != nil {
+		observedAt, formatErr := aman.FormatTime(flight.ActiveRouteFact.ObservedAt)
+		if formatErr != nil {
+			return AMANFlight{}, formatErr
+		}
+		state := flight.ActiveRouteFact.State
+		if state == "" {
+			state = aman.RouteFactActive
+		}
+		result.RouteFact = &AMANRouteFact{ID: flight.ActiveRouteFact.ID, Fix: flight.ActiveRouteFact.Fix, ObservedAt: observedAt, State: string(state)}
+	}
+	if flight.Prediction != nil {
+		prediction := flight.Prediction
+		if result.RawTETA, err = formatOptionalValue(prediction.RawTETA); err != nil {
+			return AMANFlight{}, err
+		}
+		if result.OperationalTETA, err = formatOptionalValue(prediction.OperationalTETA); err != nil {
+			return AMANFlight{}, err
+		}
+		if result.HoldingFixETA, err = formatOptionalTime(prediction.HoldingFixETA); err != nil {
+			return AMANFlight{}, err
+		}
+		confidence := string(prediction.Confidence)
+		result.Confidence = &confidence
+		result.Provenance = &AMANProvenance{ModelVersion: prediction.ModelVersion, ConfigVersion: prediction.ConfigVersion, PerformanceProfileID: cloneString(prediction.PerformanceProfileID), WeatherSource: cloneString(prediction.WeatherSource), Sources: append([]string(nil), prediction.Sources...)}
+		age := generatedAt.Sub(prediction.InputObservedAt)
+		if age < 0 {
+			return AMANFlight{}, fmt.Errorf("prediction input time follows state generation")
+		}
+		ageSeconds, secondsErr := aman.WholeSeconds(age)
+		if secondsErr != nil {
+			return AMANFlight{}, secondsErr
+		}
+		result.InputAgeSeconds = &ageSeconds
+		result.GeometryVersion = stringValue(prediction.DatasetVersion)
+		result.GeometryDigest = stringValue(prediction.GeometryDigest)
+		result.DistanceToGoNM = cloneFloat(prediction.DistanceToGoNM)
+	}
+	if flight.Slot != nil {
+		mapped, mapErr := mapAMANSlot(*flight.Slot)
+		if mapErr != nil {
+			return AMANFlight{}, mapErr
+		}
+		result.Slot = &mapped
+		if flight.Prediction != nil {
+			seconds, secondsErr := aman.WholeSeconds(flight.Prediction.OperationalTETA.Sub(flight.Slot.Time))
+			if secondsErr != nil {
+				return AMANFlight{}, secondsErr
+			}
+			result.GainLossSeconds = &seconds
+		}
+	}
+	if flight.ETAReview != nil {
+		result.ETAReview, err = mapAMANETAReview(*flight.ETAReview)
+		if err != nil {
+			return AMANFlight{}, err
+		}
+	}
+	for i, offer := range flight.QueueOffers {
+		candidate, mapErr := mapAMANSlot(offer.CandidateSlot)
+		if mapErr != nil {
+			return AMANFlight{}, mapErr
+		}
+		expiresAt, formatErr := aman.FormatTime(offer.ExpiresAt)
+		if formatErr != nil {
+			return AMANFlight{}, formatErr
+		}
+		result.QueueOffers[i] = AMANQueueOffer{FlightID: string(offer.FlightID), RunwayGroupID: string(offer.RunwayGroupID), CandidateSlot: candidate, QueuePosition: offer.QueuePosition, ExpiresAt: expiresAt, AirportRevision: uint64(offer.AirportRevision), Reason: string(offer.Reason)}
+	}
+	return result, nil
+}
+
+func mapAMANSlot(slot aman.Slot) (AMANSlot, error) {
+	value, err := aman.FormatTime(slot.Time)
+	return AMANSlot{Time: value, RunwayGroupID: string(slot.RunwayGroupID), Sequence: slot.Sequence, Revision: uint64(slot.Revision), Reason: slot.Reason}, err
+}
+
+func mapAMANETAReview(review aman.ETAReview) (*AMANETAReview, error) {
+	createdAt, err := aman.FormatTime(review.CreatedAt)
+	if err != nil {
+		return nil, err
+	}
+	deadlineAt, err := aman.FormatTime(review.DeadlineAt)
+	if err != nil {
+		return nil, err
+	}
+	initial, err := aman.FormatTime(review.InitialBaselineTETA)
+	if err != nil {
+		return nil, err
+	}
+	calculated, err := aman.FormatTime(review.CalculatedOperationalTETA)
+	if err != nil {
+		return nil, err
+	}
+	selected, err := aman.FormatTime(review.SelectedTETA)
+	if err != nil {
+		return nil, err
+	}
+	resolved, err := formatOptionalTime(review.ResolvedAt)
+	if err != nil {
+		return nil, err
+	}
+	manual, err := formatOptionalTime(review.ManualTETA)
+	if err != nil {
+		return nil, err
+	}
+	return &AMANETAReview{Status: string(review.Status), CreatedAt: createdAt, DeadlineAt: deadlineAt, ResolvedAt: resolved, Actor: cloneString(review.Actor), Note: cloneString(review.Note), InitialBaselineTETA: initial, CalculatedOperationalTETA: calculated, SelectedTETA: selected, ManualTETA: manual}, nil
+}
+
+func mapAMANTechnicalHealth(value aman.TechnicalHealth) (AMANTechnicalHealth, error) {
+	blockedReasons := make([]string, len(value.BlockedReasons))
+	copy(blockedReasons, value.BlockedReasons)
+	components := []*aman.ComponentHealth{&value.VATSIM, &value.Navigation, &value.Weather, &value.Repository, &value.Predictor, &value.ReplayValidation}
+	mapped := make([]AMANComponentHealth, len(components))
+	for index, component := range components {
+		var err error
+		mapped[index], err = mapAMANComponentHealth(*component, value.Status)
+		if err != nil {
+			return AMANTechnicalHealth{}, err
+		}
+	}
+	return AMANTechnicalHealth{
+		Status: string(value.Status), Ready: value.Ready, BlockedReasons: blockedReasons,
+		VATSIM: mapped[0], Navigation: mapped[1], Weather: mapped[2], Repository: mapped[3], Predictor: mapped[4], ReplayValidation: mapped[5],
+	}, nil
+}
+
+func mapAMANComponentHealth(value aman.ComponentHealth, aggregateStatus aman.HealthStatus) (AMANComponentHealth, error) {
+	reason := cloneNonEmptyString(value.Reason)
+	updatedAt, err := formatOptionalTime(value.UpdatedAt)
+	if err != nil {
+		return AMANComponentHealth{}, err
+	}
+	status := value.Status
+	if status == "" {
+		status = aman.HealthUnavailable
+		if aggregateStatus == aman.HealthDisabled {
+			status = aman.HealthDisabled
+		}
+	}
+	return AMANComponentHealth{Status: string(status), Reason: reason, UpdatedAt: updatedAt, AgeSeconds: cloneFloat(value.AgeSeconds)}, nil
+}
+
+func formatOptionalValue(value time.Time) (*string, error) {
+	result, err := aman.FormatTime(value)
+	return &result, err
+}
+func formatOptionalTime(value *time.Time) (*string, error) {
+	if value == nil {
+		return nil, nil
+	}
+	return formatOptionalValue(*value)
+}
+func stringPointer[T ~string](value *T) *string {
+	if value == nil {
+		return nil
+	}
+	result := string(*value)
+	return &result
+}
+func stringValue(value string) *string { result := value; return &result }
+func cloneString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	result := *value
+	return &result
+}
+func cloneNonEmptyString(value string) *string {
+	if value == "" {
+		return nil
+	}
+	result := value
+	return &result
+}
+func cloneInt(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	result := *value
+	return &result
+}
+func cloneFloat(value *float64) *float64 {
+	if value == nil {
+		return nil
+	}
+	result := *value
+	return &result
+}

--- a/backend/pkg/events/frontend/aman_test.go
+++ b/backend/pkg/events/frontend/aman_test.go
@@ -1,0 +1,106 @@
+package frontend
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"FlightStrips/internal/aman"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAMANStateEventMatchesSharedV1Golden(t *testing.T) {
+	event, err := NewAMANStateEvent(goldenAMANState(), aman.EffectiveAuthoritative, goldenAMANHealth())
+	require.NoError(t, err)
+
+	encoded, err := event.Marshal()
+	require.NoError(t, err)
+	expected, err := os.ReadFile("testdata/aman-state-v1.json")
+	require.NoError(t, err)
+
+	var actualJSON, expectedJSON any
+	require.NoError(t, json.Unmarshal(encoded, &actualJSON))
+	require.NoError(t, json.Unmarshal(expected, &expectedJSON))
+	require.Equal(t, expectedJSON, actualJSON)
+}
+
+func TestAMANStateEventRejectsEffectiveModeHealthFromAnotherState(t *testing.T) {
+	health := goldenAMANHealth()
+	health.EffectiveMode = aman.EffectiveBlocked
+
+	_, err := NewAMANStateEvent(goldenAMANState(), aman.EffectiveAuthoritative, health)
+	require.EqualError(t, err, "map AMAN state event: effective mode and health must belong to the same state")
+}
+
+func TestAMANStateEventNormalizesDisabledComponentHealth(t *testing.T) {
+	now := time.Date(2026, time.July, 22, 10, 0, 0, 0, time.UTC)
+	state := aman.AirportState{
+		Airport: "EKCH", GeneratedAt: now, PolicyVersion: "ekch-aman-v1", Mode: aman.ModeDisabled,
+		Flights: []aman.AMANFlight{}, RunwayGroups: []aman.RunwayGroupPolicy{},
+	}
+	health := aman.EvaluateTechnicalHealth(aman.ModeDisabled, aman.ComponentHealth{}, aman.ComponentHealth{}, aman.ComponentHealth{}, aman.ComponentHealth{}, aman.ComponentHealth{}, aman.ComponentHealth{})
+
+	event, err := NewAMANStateEvent(state, aman.EffectiveDisabled, health)
+	require.NoError(t, err)
+	require.Equal(t, "disabled", event.Data.TechnicalHealth.Status)
+	require.Equal(t, "disabled", event.Data.TechnicalHealth.VATSIM.Status)
+	require.Equal(t, "disabled", event.Data.TechnicalHealth.Navigation.Status)
+	require.Equal(t, "disabled", event.Data.TechnicalHealth.Weather.Status)
+	require.Equal(t, "disabled", event.Data.TechnicalHealth.Repository.Status)
+	require.Equal(t, "disabled", event.Data.TechnicalHealth.Predictor.Status)
+	require.Equal(t, "disabled", event.Data.TechnicalHealth.ReplayValidation.Status)
+}
+
+func TestAMANCommandRejectionCarriesStableCorrelation(t *testing.T) {
+	event, err := NewAMANCommandRejectedEvent("command-7", 9, &aman.DomainError{
+		Class: aman.ErrorRevisionConflict, Message: "revision changed",
+	}, true)
+	require.NoError(t, err)
+	require.Equal(t, AMANCommandRejectedEvent{Version: 1, Data: AMANCommandRejection{
+		CommandID: "command-7", Code: "revision_conflict", Message: "revision changed", CurrentRevision: 9, Retryable: true,
+	}}, event)
+}
+
+func goldenAMANState() aman.AirportState {
+	now := time.Date(2026, time.July, 22, 10, 0, 0, 0, time.UTC)
+	runwayGroup := aman.RunwayGroupID("ARRIVAL-22")
+	feeder, holding := "SOK", "SOK-HF"
+	dtg := 87.5
+	return aman.AirportState{
+		Airport: "EKCH", Revision: 7, GeneratedAt: now, PolicyVersion: "ekch-aman-v1",
+		Mode: aman.ModeAuthoritative, Authoritative: true,
+		RunwayGroups: []aman.RunwayGroupPolicy{{ID: runwayGroup}},
+		Flights: []aman.AMANFlight{{
+			ID: "flight-123", VATSIMCID: "1234567", CurrentCallsign: "SAS123",
+			State: aman.StateStable, DataStatus: aman.DataFresh, SelectedRunwayGroup: &runwayGroup,
+			SelectedFeeder: &feeder, SelectedHolding: &holding,
+			ActiveRouteFact: &aman.RouteFact{ID: "route-fact-1", Fix: "SOK", ObservedAt: now.Add(-2 * time.Minute), State: aman.RouteFactActive},
+			Prediction: &aman.Prediction{
+				RawTETA: now.Add(20 * time.Minute), OperationalTETA: now.Add(19 * time.Minute), OperationalReason: aman.OperationalReasonSmoothed,
+				GeneratedAt: now, InputObservedAt: now.Add(-time.Minute), Confidence: aman.ConfidenceHigh, Publishable: true,
+				DatasetVersion: "2607", GeometryDigest: "geometry-sha256", DistanceToGoNM: &dtg,
+				HoldingFixETA: timePointer(now.Add(10 * time.Minute)), ModelVersion: "performance-wind-v1", ConfigVersion: "ekch-v1", Sources: []string{"vatsim", "airacnet"},
+			},
+			FreezeReason: aman.FreezeNone,
+			Slot:         &aman.Slot{Time: now.Add(18 * time.Minute), RunwayGroupID: runwayGroup, Sequence: 3, Revision: 7, Reason: "rate_wtc"},
+			Order:        intPointer(3), QueueOffers: []aman.QueueOffer{}, UpdatedAt: now,
+		}},
+	}
+}
+
+func goldenAMANHealth() aman.TechnicalHealth {
+	now := time.Date(2026, time.July, 22, 10, 0, 0, 0, time.UTC)
+	age := float64(0)
+	ready := aman.ComponentHealth{Status: aman.HealthReady, UpdatedAt: &now, AgeSeconds: &age}
+	return aman.TechnicalHealth{
+		Enabled: true, Mode: aman.ModeAuthoritative, DesiredMode: aman.ModeAuthoritative,
+		EffectiveMode: aman.EffectiveAuthoritative, AuthorityAllowed: true, Ready: true, Status: aman.HealthReady,
+		BlockedReasons: []string{}, VATSIM: ready, Navigation: ready, Weather: ready,
+		Repository: ready, Predictor: ready, ReplayValidation: ready,
+	}
+}
+
+func timePointer(value time.Time) *time.Time { return &value }
+func intPointer(value int) *int              { return &value }

--- a/backend/pkg/events/frontend/testdata/aman-state-v1.json
+++ b/backend/pkg/events/frontend/testdata/aman-state-v1.json
@@ -1,0 +1,52 @@
+{
+  "type": "aman.state",
+  "version": 1,
+  "data": {
+    "airport": "EKCH",
+    "revision": 7,
+    "generated_at": "2026-07-22T10:00:00.000Z",
+    "policy_version": "ekch-aman-v1",
+    "effective_mode": "authoritative",
+    "authoritative": true,
+    "flights": [
+      {
+        "flight_id": "flight-123",
+        "callsign": "SAS123",
+        "lifecycle_state": "stable",
+        "data_status": "fresh",
+        "runway_group_id": "ARRIVAL-22",
+        "feeder": "SOK",
+        "holding_fix": "SOK-HF",
+        "holding_fix_eta": "2026-07-22T10:10:00.000Z",
+        "route_fact": {"id": "route-fact-1", "fix": "SOK", "observed_at": "2026-07-22T09:58:00.000Z", "state": "active"},
+        "raw_teta": "2026-07-22T10:20:00.000Z",
+        "operational_teta": "2026-07-22T10:19:00.000Z",
+        "gain_loss_seconds": 60,
+        "freeze_reason": "none",
+        "frozen_at": null,
+        "confidence": "high",
+        "provenance": {"model_version": "performance-wind-v1", "config_version": "ekch-v1", "performance_profile_id": null, "weather_source": null, "sources": ["vatsim", "airacnet"]},
+        "input_age_seconds": 60,
+        "geometry_version": "2607",
+        "geometry_digest": "geometry-sha256",
+        "distance_to_go_nm": 87.5,
+        "slot": {"time": "2026-07-22T10:18:00.000Z", "runway_group_id": "ARRIVAL-22", "sequence": 3, "revision": 7, "reason": "rate_wtc"},
+        "order": 3,
+        "eta_review": null,
+        "queue_offers": []
+      }
+    ],
+    "runway_groups": [{"id": "ARRIVAL-22"}],
+    "technical_health": {
+      "status": "ready",
+      "ready": true,
+      "blocked_reasons": [],
+      "vatsim": {"status": "ready", "reason": null, "updated_at": "2026-07-22T10:00:00.000Z", "age_seconds": 0},
+      "navigation": {"status": "ready", "reason": null, "updated_at": "2026-07-22T10:00:00.000Z", "age_seconds": 0},
+      "weather": {"status": "ready", "reason": null, "updated_at": "2026-07-22T10:00:00.000Z", "age_seconds": 0},
+      "repository": {"status": "ready", "reason": null, "updated_at": "2026-07-22T10:00:00.000Z", "age_seconds": 0},
+      "predictor": {"status": "ready", "reason": null, "updated_at": "2026-07-22T10:00:00.000Z", "age_seconds": 0},
+      "replay_validation": {"status": "ready", "reason": null, "updated_at": "2026-07-22T10:00:00.000Z", "age_seconds": 0}
+    }
+  }
+}

--- a/frontend/src/api/aman.test.ts
+++ b/frontend/src/api/aman.test.ts
@@ -1,0 +1,122 @@
+import {readFileSync} from "node:fs";
+import {resolve} from "node:path";
+import {describe, expect, it} from "vitest";
+
+import {
+  isAMANCommandRejectedEvent,
+  isAMANStateEvent,
+  replaceAMANState,
+  type AMANStateEvent,
+} from "./aman";
+
+const golden = JSON.parse(readFileSync(
+  resolve(process.cwd(), "../backend/pkg/events/frontend/testdata/aman-state-v1.json"),
+  "utf8",
+)) as unknown;
+
+function replacement(revision: number, callsign = "SAS123"): AMANStateEvent {
+  const event = structuredClone(golden) as AMANStateEvent;
+  event.data.revision = revision;
+  event.data.flights[0].callsign = callsign;
+  event.data.flights[0].slot!.revision = revision;
+  return event;
+}
+
+describe("AMAN V1 full replacement contract", () => {
+  it("accepts the shared Go/TypeScript golden fixture", () => {
+    expect(isAMANStateEvent(golden)).toBe(true);
+  });
+
+  it("ignores duplicate and older revisions, then atomically accepts any newer revision", () => {
+    const initial = replaceAMANState(null, replacement(7));
+    expect(initial.accepted).toBe(true);
+    expect(initial.state?.revision).toBe(7);
+
+    const duplicate = replaceAMANState(initial.state, replacement(7, "DUPLICATE"));
+    expect(duplicate.accepted).toBe(false);
+    expect(duplicate.state).toBe(initial.state);
+    expect(duplicate.state?.flights[0].callsign).toBe("SAS123");
+
+    const older = replaceAMANState(initial.state, replacement(4, "OLDER"));
+    expect(older.accepted).toBe(false);
+    expect(older.state).toBe(initial.state);
+
+    const newer = replacement(10, "SAS999");
+    newer.data.authoritative = false;
+    newer.data.effective_mode = "read_only";
+    newer.data.technical_health.status = "degraded";
+    newer.data.technical_health.ready = false;
+    newer.data.technical_health.blocked_reasons = ["predictor:stale"];
+    const accepted = replaceAMANState(initial.state, newer);
+
+    expect(accepted).toMatchObject({accepted: true, status: "degraded", error: null});
+    expect(accepted.state).not.toBe(newer.data);
+    expect(accepted.state).toMatchObject({
+      revision: 10,
+      authoritative: false,
+      effective_mode: "read_only",
+      flights: [{callsign: "SAS999"}],
+      technical_health: {status: "degraded", ready: false, blocked_reasons: ["predictor:stale"]},
+    });
+    expect(initial.state).toMatchObject({revision: 7, authoritative: true, flights: [{callsign: "SAS123"}]});
+  });
+
+  it("clears the whole presentation on an invalid payload", () => {
+    const initial = replaceAMANState(null, replacement(7));
+    const invalid = replacement(8) as unknown as {data: {flights: Array<{slot: {time: unknown}}>} };
+    invalid.data.flights[0].slot.time = 123;
+
+    expect(replaceAMANState(initial.state, invalid)).toEqual({
+      state: null,
+      status: "degraded",
+      error: "invalid_aman_state",
+      accepted: false,
+    });
+  });
+
+  it("accepts an explicit disabled-mode health replacement", () => {
+    const disabled = replacement(8);
+    disabled.data.effective_mode = "disabled";
+    disabled.data.authoritative = false;
+    disabled.data.flights = [];
+    disabled.data.runway_groups = [];
+    disabled.data.technical_health.status = "disabled";
+    disabled.data.technical_health.ready = false;
+    for (const component of [
+      disabled.data.technical_health.vatsim,
+      disabled.data.technical_health.navigation,
+      disabled.data.technical_health.weather,
+      disabled.data.technical_health.repository,
+      disabled.data.technical_health.predictor,
+      disabled.data.technical_health.replay_validation,
+    ]) {
+      component.status = "disabled";
+    }
+
+    expect(isAMANStateEvent(disabled)).toBe(true);
+    expect(replaceAMANState(null, disabled)).toMatchObject({accepted: true, status: "ready", error: null});
+  });
+
+  it.each(["degraded", "unavailable"] as const)("marks valid %s health as degraded presentation", (healthStatus) => {
+    const event = replacement(8);
+    event.data.technical_health.status = healthStatus;
+    event.data.technical_health.ready = false;
+
+    const accepted = replaceAMANState(null, event);
+    expect(accepted).toMatchObject({accepted: true, status: "degraded", error: null});
+    expect(replaceAMANState(accepted.state, event)).toMatchObject({accepted: false, status: "degraded", error: null});
+  });
+
+  it("validates command rejection correlation fields", () => {
+    expect(isAMANCommandRejectedEvent({
+      type: "aman.command_rejected",
+      version: 1,
+      data: {command_id: "command-7", code: "revision_conflict", message: "revision changed", current_revision: 9, retryable: true},
+    })).toBe(true);
+    expect(isAMANCommandRejectedEvent({
+      type: "aman.command_rejected",
+      version: 1,
+      data: {command_id: "", code: "revision_conflict", message: "revision changed", current_revision: 9, retryable: true},
+    })).toBe(false);
+  });
+});

--- a/frontend/src/api/aman.ts
+++ b/frontend/src/api/aman.ts
@@ -1,0 +1,255 @@
+export const AMAN_WIRE_VERSION = 1 as const;
+
+export type AMANEffectiveMode = "disabled" | "shadow" | "read_only" | "authoritative" | "blocked";
+export type AMANLifecycleState = "planned" | "airborne" | "unstable" | "stable" | "landed" | "go_around" | "removed";
+export type AMANDataStatus = "fresh" | "stale" | "disconnected";
+export type AMANFreezeReason = "none" | "superstable" | "manual";
+export type AMANConfidence = "unknown" | "low" | "medium" | "high";
+export type AMANHealthStatus = "disabled" | "ready" | "degraded" | "unavailable";
+
+export interface AMANStateEvent {
+  type: "aman.state";
+  version: typeof AMAN_WIRE_VERSION;
+  data: AMANState;
+}
+
+export interface AMANState {
+  airport: string;
+  revision: number;
+  generated_at: string;
+  policy_version: string;
+  effective_mode: AMANEffectiveMode;
+  authoritative: boolean;
+  flights: AMANFlight[];
+  runway_groups: AMANRunwayGroup[];
+  technical_health: AMANTechnicalHealth;
+}
+
+export interface AMANFlight {
+  flight_id: string;
+  callsign: string;
+  lifecycle_state: AMANLifecycleState;
+  data_status: AMANDataStatus;
+  runway_group_id: string | null;
+  feeder: string | null;
+  holding_fix: string | null;
+  holding_fix_eta: string | null;
+  route_fact: AMANRouteFact | null;
+  raw_teta: string | null;
+  operational_teta: string | null;
+  gain_loss_seconds: number | null;
+  freeze_reason: AMANFreezeReason;
+  frozen_at: string | null;
+  confidence: AMANConfidence | null;
+  provenance: AMANProvenance | null;
+  input_age_seconds: number | null;
+  geometry_version: string | null;
+  geometry_digest: string | null;
+  distance_to_go_nm: number | null;
+  slot: AMANSlot | null;
+  order: number | null;
+  eta_review: AMANETAReview | null;
+  queue_offers: AMANQueueOffer[];
+}
+
+export interface AMANRouteFact {
+  id: string;
+  fix: string;
+  observed_at: string;
+  state: "active" | "expired";
+}
+
+export interface AMANProvenance {
+  model_version: string;
+  config_version: string;
+  performance_profile_id: string | null;
+  weather_source: string | null;
+  sources: string[];
+}
+
+export interface AMANSlot {
+  time: string;
+  runway_group_id: string;
+  sequence: number;
+  revision: number;
+  reason: string;
+}
+
+export interface AMANETAReview {
+  status: string;
+  created_at: string;
+  deadline_at: string;
+  resolved_at: string | null;
+  actor: string | null;
+  note: string | null;
+  initial_baseline_teta: string;
+  calculated_operational_teta: string;
+  selected_teta: string;
+  manual_teta: string | null;
+}
+
+export interface AMANQueueOffer {
+  flight_id: string;
+  runway_group_id: string;
+  candidate_slot: AMANSlot;
+  queue_position: number;
+  expires_at: string;
+  airport_revision: number;
+  reason: string;
+}
+
+export interface AMANRunwayGroup {
+  id: string;
+}
+
+export interface AMANTechnicalHealth {
+  status: AMANHealthStatus;
+  ready: boolean;
+  blocked_reasons: string[];
+  vatsim: AMANComponentHealth;
+  navigation: AMANComponentHealth;
+  weather: AMANComponentHealth;
+  repository: AMANComponentHealth;
+  predictor: AMANComponentHealth;
+  replay_validation: AMANComponentHealth;
+}
+
+export interface AMANComponentHealth {
+  status: AMANHealthStatus;
+  reason: string | null;
+  updated_at: string | null;
+  age_seconds: number | null;
+}
+
+export interface AMANCommandRejectedEvent {
+  type: "aman.command_rejected";
+  version: typeof AMAN_WIRE_VERSION;
+  data: AMANCommandRejection;
+}
+
+export interface AMANCommandRejection {
+  command_id: string;
+  code: string;
+  message: string;
+  current_revision: number;
+  retryable: boolean;
+}
+
+export type AMANPresentationStatus = "empty" | "ready" | "degraded";
+
+export interface AMANReplacementResult {
+  state: AMANState | null;
+  status: AMANPresentationStatus;
+  error: string | null;
+  accepted: boolean;
+}
+
+const effectiveModes = new Set<AMANEffectiveMode>(["disabled", "shadow", "read_only", "authoritative", "blocked"]);
+const lifecycleStates = new Set<AMANLifecycleState>(["planned", "airborne", "unstable", "stable", "landed", "go_around", "removed"]);
+const dataStatuses = new Set<AMANDataStatus>(["fresh", "stale", "disconnected"]);
+const freezeReasons = new Set<AMANFreezeReason>(["none", "superstable", "manual"]);
+const confidences = new Set<AMANConfidence>(["unknown", "low", "medium", "high"]);
+const healthStatuses = new Set<AMANHealthStatus>(["disabled", "ready", "degraded", "unavailable"]);
+const routeFactStates = new Set(["active", "expired"]);
+
+const isObject = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null && !Array.isArray(value);
+const isString = (value: unknown): value is string => typeof value === "string";
+const isNullableString = (value: unknown): value is string | null => value === null || isString(value);
+const isFiniteNumber = (value: unknown): value is number => typeof value === "number" && Number.isFinite(value);
+const isNonNegativeInteger = (value: unknown): value is number => Number.isSafeInteger(value) && Number(value) >= 0;
+const isNullableFiniteNumber = (value: unknown): value is number | null => value === null || isFiniteNumber(value);
+const isStringArray = (value: unknown): value is string[] => Array.isArray(value) && value.every(isString);
+const isTimestamp = (value: unknown): value is string => isString(value) && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value);
+const isNullableTimestamp = (value: unknown): value is string | null => value === null || isTimestamp(value);
+
+function isSlot(value: unknown): value is AMANSlot {
+  return isObject(value) && isTimestamp(value.time) && isString(value.runway_group_id)
+    && isNonNegativeInteger(value.sequence) && isNonNegativeInteger(value.revision) && isString(value.reason);
+}
+
+function isRouteFact(value: unknown): value is AMANRouteFact {
+  return isObject(value) && isString(value.id) && isString(value.fix) && isTimestamp(value.observed_at)
+    && isString(value.state) && routeFactStates.has(value.state);
+}
+
+function isProvenance(value: unknown): value is AMANProvenance {
+  return isObject(value) && isString(value.model_version) && isString(value.config_version)
+    && isNullableString(value.performance_profile_id) && isNullableString(value.weather_source) && isStringArray(value.sources);
+}
+
+function isETAReview(value: unknown): value is AMANETAReview {
+  return isObject(value) && isString(value.status) && isTimestamp(value.created_at) && isTimestamp(value.deadline_at)
+    && isNullableTimestamp(value.resolved_at) && isNullableString(value.actor) && isNullableString(value.note)
+    && isTimestamp(value.initial_baseline_teta) && isTimestamp(value.calculated_operational_teta)
+    && isTimestamp(value.selected_teta) && isNullableTimestamp(value.manual_teta);
+}
+
+function isQueueOffer(value: unknown): value is AMANQueueOffer {
+  return isObject(value) && isString(value.flight_id) && isString(value.runway_group_id) && isSlot(value.candidate_slot)
+    && isNonNegativeInteger(value.queue_position) && isTimestamp(value.expires_at)
+    && isNonNegativeInteger(value.airport_revision) && isString(value.reason);
+}
+
+function isFlight(value: unknown): value is AMANFlight {
+  return isObject(value) && isString(value.flight_id) && value.flight_id !== "" && isString(value.callsign)
+    && isString(value.lifecycle_state) && lifecycleStates.has(value.lifecycle_state as AMANLifecycleState)
+    && isString(value.data_status) && dataStatuses.has(value.data_status as AMANDataStatus)
+    && isNullableString(value.runway_group_id) && isNullableString(value.feeder) && isNullableString(value.holding_fix)
+    && isNullableTimestamp(value.holding_fix_eta) && (value.route_fact === null || isRouteFact(value.route_fact))
+    && isNullableTimestamp(value.raw_teta) && isNullableTimestamp(value.operational_teta)
+    && isNullableFiniteNumber(value.gain_loss_seconds) && isString(value.freeze_reason)
+    && freezeReasons.has(value.freeze_reason as AMANFreezeReason) && isNullableTimestamp(value.frozen_at)
+    && (value.confidence === null || (isString(value.confidence) && confidences.has(value.confidence as AMANConfidence)))
+    && (value.provenance === null || isProvenance(value.provenance)) && isNullableFiniteNumber(value.input_age_seconds)
+    && isNullableString(value.geometry_version) && isNullableString(value.geometry_digest)
+    && isNullableFiniteNumber(value.distance_to_go_nm) && (value.slot === null || isSlot(value.slot))
+    && (value.order === null || isNonNegativeInteger(value.order)) && (value.eta_review === null || isETAReview(value.eta_review))
+    && Array.isArray(value.queue_offers) && value.queue_offers.every(isQueueOffer);
+}
+
+function isComponentHealth(value: unknown): value is AMANComponentHealth {
+  return isObject(value) && isString(value.status) && healthStatuses.has(value.status as AMANHealthStatus)
+    && isNullableString(value.reason) && isNullableTimestamp(value.updated_at) && isNullableFiniteNumber(value.age_seconds);
+}
+
+function isTechnicalHealth(value: unknown): value is AMANTechnicalHealth {
+  return isObject(value) && isString(value.status) && healthStatuses.has(value.status as AMANHealthStatus)
+    && typeof value.ready === "boolean" && isStringArray(value.blocked_reasons) && isComponentHealth(value.vatsim)
+    && isComponentHealth(value.navigation) && isComponentHealth(value.weather) && isComponentHealth(value.repository)
+    && isComponentHealth(value.predictor) && isComponentHealth(value.replay_validation);
+}
+
+export function isAMANStateEvent(value: unknown): value is AMANStateEvent {
+  if (!isObject(value) || value.type !== "aman.state" || value.version !== AMAN_WIRE_VERSION || !isObject(value.data)) return false;
+  const data = value.data;
+  return isString(data.airport) && data.airport.length === 4 && isNonNegativeInteger(data.revision)
+    && isTimestamp(data.generated_at) && isString(data.policy_version) && isString(data.effective_mode)
+    && effectiveModes.has(data.effective_mode as AMANEffectiveMode) && typeof data.authoritative === "boolean"
+    && Array.isArray(data.flights) && data.flights.every(isFlight)
+    && Array.isArray(data.runway_groups) && data.runway_groups.every((group) => isObject(group) && isString(group.id))
+    && isTechnicalHealth(data.technical_health);
+}
+
+export function replaceAMANState(current: AMANState | null, event: unknown): AMANReplacementResult {
+  if (!isAMANStateEvent(event)) {
+    return {state: null, status: "degraded", error: "invalid_aman_state", accepted: false};
+  }
+  if (current !== null && event.data.revision <= current.revision) {
+    return {state: current, status: presentationStatus(current), error: null, accepted: false};
+  }
+  const state = structuredClone(event.data);
+  return {state, status: presentationStatus(state), error: null, accepted: true};
+}
+
+function presentationStatus(state: AMANState): AMANPresentationStatus {
+  return state.technical_health.status === "degraded" || state.technical_health.status === "unavailable"
+    ? "degraded"
+    : "ready";
+}
+
+export function isAMANCommandRejectedEvent(value: unknown): value is AMANCommandRejectedEvent {
+  return isObject(value) && value.type === "aman.command_rejected" && value.version === AMAN_WIRE_VERSION
+    && isObject(value.data) && isString(value.data.command_id) && value.data.command_id !== ""
+    && isString(value.data.code) && isString(value.data.message)
+    && isNonNegativeInteger(value.data.current_revision) && typeof value.data.retryable === "boolean";
+}

--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -44,6 +44,8 @@ export enum EventType {
   FrontendStandAssignmentUpdate = "stand_assignment_update",
   FrontendStandAssignmentRemoved = "stand_assignment_removed",
   FrontendStandBlockUpdate = "stand_block_update",
+  FrontendAMANState = "aman.state",
+  FrontendAMANCommandRejected = "aman.command_rejected",
 }
 
 export enum ActionType {
@@ -678,7 +680,9 @@ export type WebSocketEvent =
   | FrontendStandStatusSnapshotEvent
   | FrontendStandAssignmentUpdateEvent
   | FrontendStandAssignmentRemovedEvent
-  | FrontendStandBlockUpdateEvent;
+  | FrontendStandBlockUpdateEvent
+  | import("./aman").AMANStateEvent
+  | import("./aman").AMANCommandRejectedEvent;
 
 export interface ActionRejectedEvent {
   type: EventType.FrontendActionRejected;

--- a/frontend/src/api/websocket.ts
+++ b/frontend/src/api/websocket.ts
@@ -42,6 +42,7 @@ import {
   type AvailableSidsEvent,
 } from "./models";
 import { FRONTEND_VERSION } from "@/lib/app-version";
+import type {AMANCommandRejectedEvent, AMANStateEvent} from "./aman";
 
 
 type EventMap = {
@@ -90,6 +91,8 @@ type EventMap = {
   [EventType.FrontendStandAssignmentUpdate]: FrontendStandAssignmentUpdateEvent;
   [EventType.FrontendStandAssignmentRemoved]: FrontendStandAssignmentRemovedEvent;
   [EventType.FrontendStandBlockUpdate]: FrontendStandBlockUpdateEvent;
+  [EventType.FrontendAMANState]: AMANStateEvent;
+  [EventType.FrontendAMANCommandRejected]: AMANCommandRejectedEvent;
 };
 
 type WebSocketClientDelegate = {
@@ -162,7 +165,7 @@ export class WebSocketClient {
       socket.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data) as WebSocketEvent;
-          const handlers = this.eventHandlers.get(data.type);
+          const handlers = this.eventHandlers.get(data.type as EventType);
           if (handlers) {
             handlers.forEach(handler => handler(data));
           }

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -53,6 +53,13 @@ import {
   type SidInfo,
 } from '../api/models.ts';
 import {WebSocketClient} from '../api/websocket.ts';
+import {
+  isAMANCommandRejectedEvent,
+  replaceAMANState,
+  type AMANCommandRejection,
+  type AMANPresentationStatus,
+  type AMANState,
+} from '../api/aman.ts';
 import missedApproachSound from "@/assets/missed_approach.mp3";
 import { isAudioMuted } from "@/lib/audio-settings";
 import {
@@ -152,6 +159,11 @@ export interface WebSocketState {
   depAtisCode: string;
 
   availableSids: SidInfo[];
+
+  amanState: AMANState | null;
+  amanPresentationStatus: AMANPresentationStatus;
+  amanError: string | null;
+  amanCommandRejections: Record<string, AMANCommandRejection>;
 
   selectedCallsign: string | null;
   selectStrip: (callsign: string | null) => void;
@@ -270,6 +282,10 @@ export const createWebSocketStore = (wsClient: WebSocketClient) => {
     arrAtisCode: "",
     depAtisCode: "",
     availableSids: [],
+    amanState: null,
+    amanPresentationStatus: "empty" as AMANPresentationStatus,
+    amanError: null,
+    amanCommandRejections: {},
     selectedCallsign: null,
     tagRequestArmed: false,
     markArmed: false,
@@ -1492,6 +1508,30 @@ export const createWebSocketStore = (wsClient: WebSocketClient) => {
   };
 
   wsClient.on(EventType.FrontendActionRejected, handleActionRejectedEvent);
+
+  wsClient.on(EventType.FrontendAMANState, (event) => {
+    const replacement = replaceAMANState(store.getState().amanState, event);
+    store.setState({
+      amanState: replacement.state,
+      amanPresentationStatus: replacement.status,
+      amanError: replacement.error,
+    });
+  });
+
+  wsClient.on(EventType.FrontendAMANCommandRejected, (event) => {
+    if (!isAMANCommandRejectedEvent(event)) {
+      return;
+    }
+    const currentRevision = store.getState().amanState?.revision;
+    if (currentRevision !== undefined && event.data.current_revision < currentRevision) {
+      return;
+    }
+    store.setState(
+      produce((state: WebSocketState) => {
+        state.amanCommandRejections[event.data.command_id] = event.data;
+      }),
+    );
+  });
 
   wsClient.on(EventType.FrontendAvailableSids, (data) => {
     store.setState({ availableSids: data.sids });


### PR DESCRIPTION
## Scope

- define versioned `aman.state` and `aman.command_rejected` frontend WebSocket DTOs
- project complete AMAN flight, sequence, authority, and technical-health state into transport-only contracts
- deliver the latest replacement on authenticated connection/reconnect and publish replacements by airport
- validate payloads in TypeScript, atomically replace only newer revisions, ignore duplicate/older revisions, and clear invalid state
- share a Go/TypeScript golden fixture and correlate command rejections by command ID

## Validation

- `go test ./pkg/events/frontend ./internal/frontend`
- `npm test -- src/api/aman.test.ts`
- `npx eslint src/api/aman.ts src/api/aman.test.ts`
- `npx tsc -b`

Closes #325
