### PR TITLE
[AMAN] Add revisioned action handlers and FMP authorization (#326)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -222,6 +222,7 @@ func amanConfigFromEnv() (aman.RuntimeConfig, error) {
 		config.Mode = aman.RolloutMode(strings.ToLower(value))
 	}
 	config.EnabledAirports = splitEnvList(os.Getenv("AMAN_ENABLED_AIRPORTS"))
+	config.FMPRoles = splitEnvList(os.Getenv("AMAN_FMP_ROLES"))
 	config.TerminalGeometryPath = strings.TrimSpace(os.Getenv("AMAN_TERMINAL_GEOMETRY_PATH"))
 	config.NavigationSourceAdapter = strings.TrimSpace(os.Getenv("AMAN_NAVIGATION_SOURCE"))
 	config.EnableEuroScopeGainLoseTags = envBool("ENABLE_AMAN_EUROSCOPE_GAIN_LOSE_TAGS", false)

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -76,7 +76,7 @@ func TestStandAssignmentAircraftFilePreservesExplicitConfiguration(t *testing.T)
 }
 
 func TestAMANConfigFromEnvDefaultsDisabled(t *testing.T) {
-	for _, key := range []string{"AMAN_MODE", "AMAN_ENABLED_AIRPORTS", "AMAN_TERMINAL_GEOMETRY_PATH", "AMAN_NAVIGATION_SOURCE", "AMAN_RECONCILIATION_INTERVAL", "AMAN_SURVEILLANCE_INTERVAL", "ENABLE_AMAN_EUROSCOPE_GAIN_LOSE_TAGS"} {
+	for _, key := range []string{"AMAN_MODE", "AMAN_ENABLED_AIRPORTS", "AMAN_FMP_ROLES", "AMAN_TERMINAL_GEOMETRY_PATH", "AMAN_NAVIGATION_SOURCE", "AMAN_RECONCILIATION_INTERVAL", "AMAN_SURVEILLANCE_INTERVAL", "ENABLE_AMAN_EUROSCOPE_GAIN_LOSE_TAGS"} {
 		t.Setenv(key, "")
 	}
 	config, err := amanConfigFromEnv()
@@ -98,6 +98,7 @@ func TestAMANConfigFromEnvParsesConfiguredRuntime(t *testing.T) {
 	}
 	t.Setenv("AMAN_MODE", "authoritative")
 	t.Setenv("AMAN_ENABLED_AIRPORTS", "EKCH,EKRN")
+	t.Setenv("AMAN_FMP_ROLES", "EKCH_APP,EKCH_CTR")
 	t.Setenv("AMAN_TERMINAL_GEOMETRY_PATH", geometry.Name())
 	t.Setenv("AMAN_NAVIGATION_SOURCE", "airacnet")
 	t.Setenv("AMAN_RECONCILIATION_INTERVAL", "21s")
@@ -108,7 +109,7 @@ func TestAMANConfigFromEnvParsesConfiguredRuntime(t *testing.T) {
 	if err != nil {
 		t.Fatalf("amanConfigFromEnv() error = %v", err)
 	}
-	if config.Mode != aman.ModeAuthoritative || len(config.EnabledAirports) != 2 || config.ReconciliationInterval != 21*time.Second || config.SurveillanceInterval != 34*time.Second || !config.EnableEuroScopeGainLoseTags {
+	if config.Mode != aman.ModeAuthoritative || len(config.EnabledAirports) != 2 || len(config.FMPRoles) != 2 || config.FMPRoles[0] != "EKCH_APP" || config.ReconciliationInterval != 21*time.Second || config.SurveillanceInterval != 34*time.Second || !config.EnableEuroScopeGainLoseTags {
 		t.Fatalf("unexpected AMAN config: %#v", config)
 	}
 }

--- a/backend/internal/aman/commands.go
+++ b/backend/internal/aman/commands.go
@@ -1,0 +1,186 @@
+package aman
+
+import (
+	"context"
+	"strings"
+	"time"
+)
+
+// CommandContext contains authority and timing facts derived by the server.
+// None of these values are accepted from a command payload.
+type CommandContext struct {
+	Airport    string
+	Actor      string
+	Role       string
+	ReceivedAt time.Time
+}
+
+type MoveFlightCommand struct {
+	Metadata       CommandMetadata
+	FlightID       FlightID
+	RunwayGroupID  RunwayGroupID
+	BeforeFlightID *FlightID
+	AfterFlightID  *FlightID
+}
+
+type LockFlightCommand struct {
+	Metadata CommandMetadata
+	FlightID FlightID
+}
+
+type UnlockFlightCommand struct {
+	Metadata CommandMetadata
+	FlightID FlightID
+}
+
+type SetRateCommand struct {
+	Metadata        CommandMetadata
+	RunwayGroupID   RunwayGroupID
+	ArrivalsPerHour uint32
+	EffectiveAt     time.Time
+}
+
+type AcceptTETACommand struct {
+	Metadata CommandMetadata
+	FlightID FlightID
+}
+
+type KeepFPLETACommand struct {
+	Metadata CommandMetadata
+	FlightID FlightID
+}
+
+type SetManualETACommand struct {
+	Metadata  CommandMetadata
+	FlightID  FlightID
+	ManualETA time.Time
+}
+
+type ResetTETAOverrideCommand struct {
+	Metadata CommandMetadata
+	FlightID FlightID
+}
+
+type ReportGoAroundCommand struct {
+	Metadata   CommandMetadata
+	FlightID   FlightID
+	DetectedAt time.Time
+}
+
+// CommandExecution is the transport-safe result of coordinator execution.
+// Outcome remains opaque because its schema belongs to the command owner.
+type CommandExecution struct {
+	CurrentRevision SequenceRevision
+	Outcome         CommandOutcome
+	Changed         bool
+	Duplicate       bool
+}
+
+// CommandService is deliberately typed per operation. It prevents a transport
+// from constructing a kind plus unrelated nullable fields while preserving the
+// coordinator as the sole revision and idempotency owner.
+type CommandService interface {
+	Component
+	CurrentRevision(context.Context, string) (SequenceRevision, error)
+	MoveFlight(context.Context, CommandContext, MoveFlightCommand) (CommandExecution, error)
+	LockFlight(context.Context, CommandContext, LockFlightCommand) (CommandExecution, error)
+	UnlockFlight(context.Context, CommandContext, UnlockFlightCommand) (CommandExecution, error)
+	SetRate(context.Context, CommandContext, SetRateCommand) (CommandExecution, error)
+	AcceptTETA(context.Context, CommandContext, AcceptTETACommand) (CommandExecution, error)
+	KeepFPLETA(context.Context, CommandContext, KeepFPLETACommand) (CommandExecution, error)
+	SetManualETA(context.Context, CommandContext, SetManualETACommand) (CommandExecution, error)
+	ResetTETAOverride(context.Context, CommandContext, ResetTETAOverrideCommand) (CommandExecution, error)
+	ReportGoAround(context.Context, CommandContext, ReportGoAroundCommand) (CommandExecution, error)
+}
+
+func (c CommandContext) Validate() error {
+	if !trimmed(c.Airport) || !trimmed(c.Actor) || !trimmed(c.Role) {
+		return commandInvalid("server-derived airport, actor, and role are required")
+	}
+	if c.ReceivedAt.IsZero() || c.ReceivedAt.Location() != time.UTC {
+		return commandInvalid("server receipt time must be UTC")
+	}
+	return nil
+}
+
+func (c MoveFlightCommand) Validate() error {
+	if err := validateCommandMetadata(c.Metadata); err != nil {
+		return err
+	}
+	if !trimmed(string(c.FlightID)) || !trimmed(string(c.RunwayGroupID)) {
+		return commandInvalid("move flight and runway group are required")
+	}
+	if (c.BeforeFlightID == nil) == (c.AfterFlightID == nil) {
+		return commandInvalid("move requires exactly one before or after anchor")
+	}
+	anchor := c.BeforeFlightID
+	if anchor == nil {
+		anchor = c.AfterFlightID
+	}
+	if !trimmed(string(*anchor)) || *anchor == c.FlightID {
+		return commandInvalid("move anchor must identify another flight")
+	}
+	return nil
+}
+
+func (c LockFlightCommand) Validate() error   { return validateFlightCommand(c.Metadata, c.FlightID) }
+func (c UnlockFlightCommand) Validate() error { return validateFlightCommand(c.Metadata, c.FlightID) }
+func (c AcceptTETACommand) Validate() error   { return validateFlightCommand(c.Metadata, c.FlightID) }
+func (c KeepFPLETACommand) Validate() error   { return validateFlightCommand(c.Metadata, c.FlightID) }
+func (c ResetTETAOverrideCommand) Validate() error {
+	return validateFlightCommand(c.Metadata, c.FlightID)
+}
+
+func (c SetRateCommand) Validate() error {
+	if err := validateCommandMetadata(c.Metadata); err != nil {
+		return err
+	}
+	if !trimmed(string(c.RunwayGroupID)) || c.ArrivalsPerHour == 0 || !utc(c.EffectiveAt) {
+		return commandInvalid("rate requires a runway group, positive rate, and UTC effective time")
+	}
+	return nil
+}
+
+func (c SetManualETACommand) Validate(receivedAt time.Time) error {
+	if err := validateFlightCommand(c.Metadata, c.FlightID); err != nil {
+		return err
+	}
+	if !utc(c.ManualETA) || !c.ManualETA.After(receivedAt) {
+		return commandInvalid("manual ETA must be a future UTC value")
+	}
+	return nil
+}
+
+func (c ReportGoAroundCommand) Validate(receivedAt time.Time) error {
+	if err := validateFlightCommand(c.Metadata, c.FlightID); err != nil {
+		return err
+	}
+	if !utc(c.DetectedAt) || c.DetectedAt.After(receivedAt) {
+		return commandInvalid("go-around detected time must be UTC and not in the future")
+	}
+	return nil
+}
+
+func validateFlightCommand(metadata CommandMetadata, flightID FlightID) error {
+	if err := validateCommandMetadata(metadata); err != nil {
+		return err
+	}
+	if !trimmed(string(flightID)) {
+		return commandInvalid("flight ID is required")
+	}
+	return nil
+}
+
+func validateCommandMetadata(metadata CommandMetadata) error {
+	if !trimmed(metadata.CommandID) {
+		return commandInvalid("command ID is required")
+	}
+	return nil
+}
+
+func commandInvalid(message string) error {
+	return &DomainError{Class: ErrorInvalidArgument, Message: "AMAN command: " + message}
+}
+
+func trimmed(value string) bool { return value != "" && value == strings.TrimSpace(value) }
+func utc(value time.Time) bool  { return !value.IsZero() && value.Location() == time.UTC }

--- a/backend/internal/aman/commands_test.go
+++ b/backend/internal/aman/commands_test.go
@@ -1,0 +1,70 @@
+package aman_test
+
+import (
+	"testing"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTypedCommandsValidateOnlyTheirOwnFields(t *testing.T) {
+	now := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	meta := aman.CommandMetadata{CommandID: "command-1", ExpectedRevision: 7}
+	before, after := aman.FlightID("before"), aman.FlightID("after")
+
+	tests := []struct {
+		name    string
+		valid   func() error
+		invalid func() error
+	}{
+		{"move", func() error {
+			return (aman.MoveFlightCommand{Metadata: meta, FlightID: "flight", RunwayGroupID: "A", BeforeFlightID: &before}).Validate()
+		}, func() error {
+			return (aman.MoveFlightCommand{Metadata: meta, FlightID: "flight", RunwayGroupID: "A", BeforeFlightID: &before, AfterFlightID: &after}).Validate()
+		}},
+		{"lock", func() error { return (aman.LockFlightCommand{Metadata: meta, FlightID: "flight"}).Validate() }, func() error { return (aman.LockFlightCommand{Metadata: meta}).Validate() }},
+		{"unlock", func() error { return (aman.UnlockFlightCommand{Metadata: meta, FlightID: "flight"}).Validate() }, func() error { return (aman.UnlockFlightCommand{Metadata: meta}).Validate() }},
+		{"rate", func() error {
+			return (aman.SetRateCommand{Metadata: meta, RunwayGroupID: "A", ArrivalsPerHour: 30, EffectiveAt: now}).Validate()
+		}, func() error {
+			return (aman.SetRateCommand{Metadata: meta, RunwayGroupID: "A", EffectiveAt: now}).Validate()
+		}},
+		{"accept TETA", func() error { return (aman.AcceptTETACommand{Metadata: meta, FlightID: "flight"}).Validate() }, func() error { return (aman.AcceptTETACommand{Metadata: meta}).Validate() }},
+		{"keep FPL ETA", func() error { return (aman.KeepFPLETACommand{Metadata: meta, FlightID: "flight"}).Validate() }, func() error { return (aman.KeepFPLETACommand{Metadata: meta}).Validate() }},
+		{"manual ETA", func() error {
+			return (aman.SetManualETACommand{Metadata: meta, FlightID: "flight", ManualETA: now.Add(time.Minute)}).Validate(now)
+		}, func() error {
+			return (aman.SetManualETACommand{Metadata: meta, FlightID: "flight", ManualETA: now}).Validate(now)
+		}},
+		{"reset TETA", func() error { return (aman.ResetTETAOverrideCommand{Metadata: meta, FlightID: "flight"}).Validate() }, func() error { return (aman.ResetTETAOverrideCommand{Metadata: meta}).Validate() }},
+		{"go around", func() error {
+			return (aman.ReportGoAroundCommand{Metadata: meta, FlightID: "flight", DetectedAt: now.Add(-time.Second)}).Validate(now)
+		}, func() error {
+			return (aman.ReportGoAroundCommand{Metadata: meta, FlightID: "flight", DetectedAt: now.Add(time.Second)}).Validate(now)
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.NoError(t, test.valid())
+			var domain *aman.DomainError
+			require.ErrorAs(t, test.invalid(), &domain)
+			require.Equal(t, aman.ErrorInvalidArgument, domain.Class)
+		})
+	}
+}
+
+func TestCommandContextRequiresServerDerivedAuthorityAndUTCReceipt(t *testing.T) {
+	valid := aman.CommandContext{Airport: "EKCH", Actor: "1234567", Role: "EKCH_FMH", ReceivedAt: time.Now().UTC()}
+	require.NoError(t, valid.Validate())
+
+	for _, invalid := range []aman.CommandContext{
+		{Actor: valid.Actor, Role: valid.Role, ReceivedAt: valid.ReceivedAt},
+		{Airport: valid.Airport, Role: valid.Role, ReceivedAt: valid.ReceivedAt},
+		{Airport: valid.Airport, Actor: valid.Actor, ReceivedAt: valid.ReceivedAt},
+		{Airport: valid.Airport, Actor: valid.Actor, Role: valid.Role, ReceivedAt: time.Now()},
+	} {
+		require.Error(t, invalid.Validate())
+	}
+}

--- a/backend/internal/aman/runtime.go
+++ b/backend/internal/aman/runtime.go
@@ -25,6 +25,7 @@ var airportIdentifier = regexp.MustCompile(`^[A-Z]{4}$`)
 // zero value is intentionally release-safe: AMAN remains disabled.
 type RuntimeConfig struct {
 	EnabledAirports             []string
+	FMPRoles                    []string
 	Mode                        RolloutMode
 	ReconciliationInterval      time.Duration
 	SurveillanceInterval        time.Duration
@@ -60,6 +61,7 @@ func (c RuntimeConfig) normalize() RuntimeConfig {
 	c = c.withDefaults()
 	c.Mode = RolloutMode(strings.ToLower(strings.TrimSpace(string(c.Mode))))
 	c.EnabledAirports = normalizeAirports(c.EnabledAirports)
+	c.FMPRoles = normalizeRoles(c.FMPRoles)
 	c.TerminalGeometryPath = strings.TrimSpace(c.TerminalGeometryPath)
 	c.NavigationSourceAdapter = strings.ToLower(strings.TrimSpace(c.NavigationSourceAdapter))
 	return c
@@ -82,6 +84,19 @@ func (c RuntimeConfig) Validate() error {
 
 	if len(c.EnabledAirports) != len(nonEmpty(original.EnabledAirports)) {
 		return fmt.Errorf("AMAN enabled airports must be unique ICAO identifiers")
+	}
+	if len(c.FMPRoles) != len(nonEmpty(original.FMPRoles)) {
+		return fmt.Errorf("AMAN FMP roles must be unique configured position names")
+	}
+	seenRoles := make(map[string]struct{}, len(c.FMPRoles))
+	for _, role := range c.FMPRoles {
+		if !isTrimmedRole(role) {
+			return fmt.Errorf("AMAN FMP role %q must be a configured position name", role)
+		}
+		if _, exists := seenRoles[role]; exists {
+			return fmt.Errorf("AMAN FMP roles must be unique configured position names")
+		}
+		seenRoles[role] = struct{}{}
 	}
 	seenAirports := make(map[string]struct{}, len(c.EnabledAirports))
 	for _, airport := range c.EnabledAirports {
@@ -120,6 +135,31 @@ func normalizeAirports(values []string) []string {
 		}
 	}
 	return airports
+}
+
+func normalizeRoles(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	roles := make([]string, 0, len(values))
+	for _, value := range values {
+		if role := strings.ToUpper(strings.TrimSpace(value)); role != "" {
+			roles = append(roles, role)
+		}
+	}
+	return roles
+}
+
+func isTrimmedRole(value string) bool {
+	if value == "" || strings.ContainsAny(value, " \t\r\n") {
+		return false
+	}
+	for _, character := range value {
+		if (character < 'A' || character > 'Z') && (character < '0' || character > '9') && character != '_' && character != '-' {
+			return false
+		}
+	}
+	return true
 }
 
 func nonEmpty(values []string) []string {
@@ -255,6 +295,7 @@ func (r *Runtime) Config() RuntimeConfig {
 	}
 	config := r.config
 	config.EnabledAirports = slices.Clone(config.EnabledAirports)
+	config.FMPRoles = slices.Clone(config.FMPRoles)
 	return config
 }
 

--- a/backend/internal/aman/runtime_test.go
+++ b/backend/internal/aman/runtime_test.go
@@ -90,6 +90,8 @@ func TestRuntimeRejectsInvalidConfiguration(t *testing.T) {
 	}{
 		{"airport", func(c *RuntimeConfig) { c.EnabledAirports = []string{"bad"} }, "ICAO"},
 		{"duplicate airport", func(c *RuntimeConfig) { c.EnabledAirports = []string{" EKCH ", "ekch"} }, "unique"},
+		{"FMP role", func(c *RuntimeConfig) { c.FMPRoles = []string{"EKCH APP"} }, "position name"},
+		{"duplicate FMP role", func(c *RuntimeConfig) { c.FMPRoles = []string{" EKCH_FMH ", "ekch_fmh"} }, "unique"},
 		{"reconciliation timing", func(c *RuntimeConfig) { c.ReconciliationInterval = -time.Second }, "reconciliation interval"},
 		{"surveillance timing", func(c *RuntimeConfig) { c.SurveillanceInterval = -time.Second }, "surveillance interval"},
 		{"source adapter", func(c *RuntimeConfig) { c.NavigationSourceAdapter = "other" }, "source adapter"},
@@ -137,6 +139,7 @@ func TestRuntimeStoresNormalizedConfiguration(t *testing.T) {
 	config := validRuntimeConfig(ModeShadow)
 	config.Mode = " SHADOW "
 	config.EnabledAirports = []string{" ekch ", "ekrn"}
+	config.FMPRoles = []string{" ekch_fmh ", "ekdk_v_ctr"}
 	config.NavigationSourceAdapter = " AIRACNET "
 	config.TerminalGeometryPath = " testdata/terminal.geojson "
 
@@ -145,6 +148,7 @@ func TestRuntimeStoresNormalizedConfiguration(t *testing.T) {
 	require.Equal(t, RuntimeConfig{
 		Mode:                    ModeShadow,
 		EnabledAirports:         []string{"EKCH", "EKRN"},
+		FMPRoles:                []string{"EKCH_FMH", "EKDK_V_CTR"},
 		ReconciliationInterval:  3 * time.Second,
 		SurveillanceInterval:    4 * time.Second,
 		TerminalGeometryPath:    "testdata/terminal.geojson",

--- a/backend/internal/aman/sequence/action_service.go
+++ b/backend/internal/aman/sequence/action_service.go
@@ -1,0 +1,112 @@
+package sequence
+
+import (
+	"context"
+	"fmt"
+
+	"FlightStrips/internal/aman"
+)
+
+// ActionMutations maps each validated typed command to its matching pure
+// domain mutation. The owning state engine supplies the policy/config inputs;
+// this service retains coordinator ownership of command IDs and revisions.
+type ActionMutations interface {
+	MoveFlight(aman.CommandContext, aman.MoveFlightCommand) (CommandMutation, error)
+	LockFlight(aman.CommandContext, aman.LockFlightCommand) (CommandMutation, error)
+	UnlockFlight(aman.CommandContext, aman.UnlockFlightCommand) (CommandMutation, error)
+	SetRate(aman.CommandContext, aman.SetRateCommand) (CommandMutation, error)
+	AcceptTETA(aman.CommandContext, aman.AcceptTETACommand) (CommandMutation, error)
+	KeepFPLETA(aman.CommandContext, aman.KeepFPLETACommand) (CommandMutation, error)
+	SetManualETA(aman.CommandContext, aman.SetManualETACommand) (CommandMutation, error)
+	ResetTETAOverride(aman.CommandContext, aman.ResetTETAOverrideCommand) (CommandMutation, error)
+	ReportGoAround(aman.CommandContext, aman.ReportGoAroundCommand) (CommandMutation, error)
+}
+
+type commandCoordinator interface {
+	CurrentState(context.Context, string) (aman.AirportState, error)
+	ExecuteCommand(context.Context, string, aman.CommandMetadata, CommandMutation) (CommandResult, error)
+}
+
+// ActionService is the command-facing sequence component. It performs common
+// validation, then routes every operation through Coordinator.ExecuteCommand;
+// it never assigns a revision itself.
+type ActionService struct {
+	coordinator commandCoordinator
+	mutations   ActionMutations
+}
+
+func NewActionService(coordinator *Coordinator, mutations ActionMutations) (*ActionService, error) {
+	if coordinator == nil {
+		return nil, fmt.Errorf("AMAN action service requires sequence coordinator")
+	}
+	if isNilDependency(mutations) {
+		return nil, fmt.Errorf("AMAN action service requires typed mutations")
+	}
+	return &ActionService{coordinator: coordinator, mutations: mutations}, nil
+}
+
+func (*ActionService) Name() string { return "AMAN typed action service" }
+
+func (s *ActionService) CurrentRevision(ctx context.Context, airport string) (aman.SequenceRevision, error) {
+	state, err := s.coordinator.CurrentState(ctx, airport)
+	return state.Revision, err
+}
+
+func (s *ActionService) MoveFlight(ctx context.Context, auth aman.CommandContext, command aman.MoveFlightCommand) (aman.CommandExecution, error) {
+	return executeTyped(s, ctx, auth, command.Metadata, command.Validate, func() (CommandMutation, error) { return s.mutations.MoveFlight(auth, command) })
+}
+
+func (s *ActionService) LockFlight(ctx context.Context, auth aman.CommandContext, command aman.LockFlightCommand) (aman.CommandExecution, error) {
+	return executeTyped(s, ctx, auth, command.Metadata, command.Validate, func() (CommandMutation, error) { return s.mutations.LockFlight(auth, command) })
+}
+
+func (s *ActionService) UnlockFlight(ctx context.Context, auth aman.CommandContext, command aman.UnlockFlightCommand) (aman.CommandExecution, error) {
+	return executeTyped(s, ctx, auth, command.Metadata, command.Validate, func() (CommandMutation, error) { return s.mutations.UnlockFlight(auth, command) })
+}
+
+func (s *ActionService) SetRate(ctx context.Context, auth aman.CommandContext, command aman.SetRateCommand) (aman.CommandExecution, error) {
+	return executeTyped(s, ctx, auth, command.Metadata, command.Validate, func() (CommandMutation, error) { return s.mutations.SetRate(auth, command) })
+}
+
+func (s *ActionService) AcceptTETA(ctx context.Context, auth aman.CommandContext, command aman.AcceptTETACommand) (aman.CommandExecution, error) {
+	return executeTyped(s, ctx, auth, command.Metadata, command.Validate, func() (CommandMutation, error) { return s.mutations.AcceptTETA(auth, command) })
+}
+
+func (s *ActionService) KeepFPLETA(ctx context.Context, auth aman.CommandContext, command aman.KeepFPLETACommand) (aman.CommandExecution, error) {
+	return executeTyped(s, ctx, auth, command.Metadata, command.Validate, func() (CommandMutation, error) { return s.mutations.KeepFPLETA(auth, command) })
+}
+
+func (s *ActionService) SetManualETA(ctx context.Context, auth aman.CommandContext, command aman.SetManualETACommand) (aman.CommandExecution, error) {
+	return executeTyped(s, ctx, auth, command.Metadata, func() error { return command.Validate(auth.ReceivedAt) }, func() (CommandMutation, error) { return s.mutations.SetManualETA(auth, command) })
+}
+
+func (s *ActionService) ResetTETAOverride(ctx context.Context, auth aman.CommandContext, command aman.ResetTETAOverrideCommand) (aman.CommandExecution, error) {
+	return executeTyped(s, ctx, auth, command.Metadata, command.Validate, func() (CommandMutation, error) { return s.mutations.ResetTETAOverride(auth, command) })
+}
+
+func (s *ActionService) ReportGoAround(ctx context.Context, auth aman.CommandContext, command aman.ReportGoAroundCommand) (aman.CommandExecution, error) {
+	return executeTyped(s, ctx, auth, command.Metadata, func() error { return command.Validate(auth.ReceivedAt) }, func() (CommandMutation, error) { return s.mutations.ReportGoAround(auth, command) })
+}
+
+func executeTyped(service *ActionService, ctx context.Context, auth aman.CommandContext, metadata aman.CommandMetadata, validate func() error, build func() (CommandMutation, error)) (aman.CommandExecution, error) {
+	if err := auth.Validate(); err != nil {
+		return aman.CommandExecution{}, err
+	}
+	if err := validate(); err != nil {
+		return aman.CommandExecution{}, err
+	}
+	mutation, err := build()
+	if err != nil {
+		return aman.CommandExecution{}, err
+	}
+	result, err := service.coordinator.ExecuteCommand(ctx, auth.Airport, metadata, mutation)
+	execution := aman.CommandExecution{
+		CurrentRevision: result.State.Revision,
+		Outcome:         result.Outcome,
+		Changed:         result.Changed,
+		Duplicate:       result.Duplicate,
+	}
+	return execution, err
+}
+
+var _ aman.CommandService = (*ActionService)(nil)

--- a/backend/internal/aman/sequence/action_service_test.go
+++ b/backend/internal/aman/sequence/action_service_test.go
@@ -1,0 +1,112 @@
+package sequence
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"github.com/stretchr/testify/require"
+)
+
+func TestActionServiceRoutesTypedMetadataThroughCoordinator(t *testing.T) {
+	coordinator := &recordingActionCoordinator{state: aman.AirportState{Airport: "EKCH", Revision: 7}}
+	mutations := &recordingActionMutations{}
+	service := &ActionService{coordinator: coordinator, mutations: mutations}
+	auth := aman.CommandContext{Airport: "EKCH", Actor: "1234567", Role: "EKCH_FMH", ReceivedAt: time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)}
+	before := aman.FlightID("flight-2")
+
+	result, err := service.MoveFlight(context.Background(), auth, aman.MoveFlightCommand{
+		Metadata: aman.CommandMetadata{CommandID: "move-1", ExpectedRevision: 7}, FlightID: "flight-1", RunwayGroupID: "A", BeforeFlightID: &before,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "move", mutations.called)
+	require.Equal(t, auth, mutations.auth)
+	require.Equal(t, "EKCH", coordinator.airport)
+	require.Equal(t, aman.CommandMetadata{CommandID: "move-1", ExpectedRevision: 7}, coordinator.metadata)
+	require.True(t, coordinator.mutationCalled)
+	require.Equal(t, aman.SequenceRevision(8), result.CurrentRevision)
+	require.True(t, result.Changed)
+}
+
+func TestActionServiceRejectsInvalidCommandBeforeMutationOrCoordinator(t *testing.T) {
+	coordinator := &recordingActionCoordinator{}
+	mutations := &recordingActionMutations{}
+	service := &ActionService{coordinator: coordinator, mutations: mutations}
+	auth := aman.CommandContext{Airport: "EKCH", Actor: "1234567", Role: "EKCH_FMH", ReceivedAt: time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)}
+
+	_, err := service.LockFlight(context.Background(), auth, aman.LockFlightCommand{Metadata: aman.CommandMetadata{CommandID: "lock-1"}})
+
+	require.Error(t, err)
+	require.Empty(t, mutations.called)
+	require.Empty(t, coordinator.airport)
+}
+
+func TestActionServiceCurrentRevisionUsesCoordinatorState(t *testing.T) {
+	service := &ActionService{coordinator: &recordingActionCoordinator{state: aman.AirportState{Airport: "EKCH", Revision: 13}}, mutations: &recordingActionMutations{}}
+	revision, err := service.CurrentRevision(context.Background(), "EKCH")
+	require.NoError(t, err)
+	require.Equal(t, aman.SequenceRevision(13), revision)
+}
+
+type recordingActionCoordinator struct {
+	state          aman.AirportState
+	airport        string
+	metadata       aman.CommandMetadata
+	mutationCalled bool
+}
+
+func (c *recordingActionCoordinator) CurrentState(_ context.Context, airport string) (aman.AirportState, error) {
+	c.airport = airport
+	return c.state, nil
+}
+
+func (c *recordingActionCoordinator) ExecuteCommand(_ context.Context, airport string, metadata aman.CommandMetadata, mutation CommandMutation) (CommandResult, error) {
+	c.airport, c.metadata = airport, metadata
+	state := aman.AirportState{Airport: airport, Revision: metadata.ExpectedRevision}
+	_, err := mutation(state)
+	c.mutationCalled = true
+	return CommandResult{State: aman.AirportState{Airport: airport, Revision: metadata.ExpectedRevision + 1}, Changed: true}, err
+}
+
+type recordingActionMutations struct {
+	called string
+	auth   aman.CommandContext
+}
+
+func (m *recordingActionMutations) mutation(name string, auth aman.CommandContext) (CommandMutation, error) {
+	m.called, m.auth = name, auth
+	return func(state aman.AirportState) (CommandChange, error) {
+		return CommandChange{State: state, Changed: true, Outcome: json.RawMessage(`{"status":"accepted"}`), Audit: []AuditEntry{{Category: "command", Payload: json.RawMessage(`{}`)}}}, nil
+	}, nil
+}
+
+func (m *recordingActionMutations) MoveFlight(auth aman.CommandContext, _ aman.MoveFlightCommand) (CommandMutation, error) {
+	return m.mutation("move", auth)
+}
+func (m *recordingActionMutations) LockFlight(auth aman.CommandContext, _ aman.LockFlightCommand) (CommandMutation, error) {
+	return m.mutation("lock", auth)
+}
+func (m *recordingActionMutations) UnlockFlight(auth aman.CommandContext, _ aman.UnlockFlightCommand) (CommandMutation, error) {
+	return m.mutation("unlock", auth)
+}
+func (m *recordingActionMutations) SetRate(auth aman.CommandContext, _ aman.SetRateCommand) (CommandMutation, error) {
+	return m.mutation("rate", auth)
+}
+func (m *recordingActionMutations) AcceptTETA(auth aman.CommandContext, _ aman.AcceptTETACommand) (CommandMutation, error) {
+	return m.mutation("accept", auth)
+}
+func (m *recordingActionMutations) KeepFPLETA(auth aman.CommandContext, _ aman.KeepFPLETACommand) (CommandMutation, error) {
+	return m.mutation("keep", auth)
+}
+func (m *recordingActionMutations) SetManualETA(auth aman.CommandContext, _ aman.SetManualETACommand) (CommandMutation, error) {
+	return m.mutation("manual", auth)
+}
+func (m *recordingActionMutations) ResetTETAOverride(auth aman.CommandContext, _ aman.ResetTETAOverrideCommand) (CommandMutation, error) {
+	return m.mutation("reset", auth)
+}
+func (m *recordingActionMutations) ReportGoAround(auth aman.CommandContext, _ aman.ReportGoAroundCommand) (CommandMutation, error) {
+	return m.mutation("go_around", auth)
+}

--- a/backend/internal/aman/types.go
+++ b/backend/internal/aman/types.go
@@ -583,6 +583,7 @@ const (
 	ErrorNotFound                     ErrorClass = "not_found"
 	ErrorRevisionConflict             ErrorClass = "revision_conflict"
 	ErrorUnauthorized                 ErrorClass = "unauthorized"
+	ErrorReadOnly                     ErrorClass = "read_only"
 	ErrorInvalidTransition            ErrorClass = "invalid_transition"
 	ErrorDependencyUnavailable        ErrorClass = "dependency_unavailable"
 	ErrorDegradedOrIncompleteGeometry ErrorClass = "degraded_or_incomplete_geometry"
@@ -594,7 +595,7 @@ const (
 
 func (c ErrorClass) Valid() bool {
 	switch c {
-	case ErrorInvalidArgument, ErrorNotFound, ErrorRevisionConflict, ErrorUnauthorized,
+	case ErrorInvalidArgument, ErrorNotFound, ErrorRevisionConflict, ErrorUnauthorized, ErrorReadOnly,
 		ErrorInvalidTransition, ErrorDependencyUnavailable, ErrorDegradedOrIncompleteGeometry,
 		ErrorUnsupportedLeg, ErrorDatasetMismatch, ErrorCorruptData, ErrorActiveFlightConflict:
 		return true

--- a/backend/internal/app/aman_runtime_test.go
+++ b/backend/internal/app/aman_runtime_test.go
@@ -71,6 +71,19 @@ func TestApplicationConfigDefaultsAMANToDisabled(t *testing.T) {
 	require.Equal(t, aman.ModeDisabled, config.AMAN.Mode)
 }
 
+func TestBuildRejectsAuthoritativeAMANWithoutTypedCommandService(t *testing.T) {
+	geometry, err := os.CreateTemp(t.TempDir(), "terminal-*.geojson")
+	require.NoError(t, err)
+	require.NoError(t, geometry.Close())
+
+	_, err = Build(context.Background(), Config{AMAN: aman.RuntimeConfig{
+		Mode: aman.ModeAuthoritative, EnabledAirports: []string{"EKCH"},
+		TerminalGeometryPath: geometry.Name(), NavigationSourceAdapter: aman.NavigationAdapterAIRACNet,
+	}}, Dependencies{AMAN: amanAppTestDependencies()})
+
+	require.EqualError(t, err, "initialize AMAN commands: authoritative runtime requires typed command service")
+}
+
 func TestBuildAddsAMANWorkersOnlyWhenEnabled(t *testing.T) {
 	poolConfig, err := pgxpool.ParseConfig("postgres://user:password@127.0.0.1:1/test")
 	require.NoError(t, err)

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -120,6 +120,10 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	if err != nil {
 		return nil, fmt.Errorf("initialize AMAN runtime: %w", err)
 	}
+	amanCommands, hasAMANCommands := deps.AMAN.SequenceService.(aman.CommandService)
+	if amanRuntime.Ownership().ControllerMutationAuthorized && !hasAMANCommands {
+		return nil, errors.New("initialize AMAN commands: authoritative runtime requires typed command service")
+	}
 	standAssignmentReadiness := configureStandAssignment(cfg.EnableStandAssignment, cfg.StandAssignmentAircraftJSON)
 	var testClock *testtools.Clock
 	satNow := time.Now
@@ -188,7 +192,7 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	serverFrequencyProviders := transports.serverFrequencyProviders
 	pdcFrequencyProviders := transports.pdcFrequencyProviders
 
-	realtime, err := assembleRealtime(stripService, controllerService, authService)
+	realtime, err := assembleRealtime(stripService, controllerService, authService, amanCommands, cfg.AMAN.FMPRoles, amanRuntime.Ownership().ControllerMutationAuthorized)
 	if err != nil {
 		if closeDB {
 			dbpool.Close()
@@ -569,9 +573,9 @@ type realtimeAssembly struct {
 	euroscope *euroscope.Hub
 }
 
-func assembleRealtime(stripService shared.StripService, controllerService shared.ControllerService, authService shared.AuthenticationService) (realtimeAssembly, error) {
+func assembleRealtime(stripService shared.StripService, controllerService shared.ControllerService, authService shared.AuthenticationService, amanCommands aman.CommandService, amanFMPRoles []string, amanMutations bool) (realtimeAssembly, error) {
 	frontendHub, err := frontend.NewHub(frontend.HubDependencies{
-		Strips: stripService, Authentication: authService,
+		Strips: stripService, Authentication: authService, AMANCommands: amanCommands, AMANFMPRoles: amanFMPRoles, AMANMutations: amanMutations,
 	})
 	if err != nil {
 		return realtimeAssembly{}, fmt.Errorf("initialize frontend hub: %w", err)

--- a/backend/internal/frontend/client.go
+++ b/backend/internal/frontend/client.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -138,7 +139,7 @@ func (c *Client) SetReadOnly(readOnly bool) {
 }
 
 func (c *Client) CanHandleMessage(messageType string) error {
-	if !c.readOnly || messageType == "token" {
+	if !c.readOnly || messageType == "token" || strings.HasPrefix(messageType, "aman.") {
 		return nil
 	}
 

--- a/backend/internal/frontend/handlers_aman.go
+++ b/backend/internal/frontend/handlers_aman.go
@@ -1,0 +1,284 @@
+package frontend
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/config"
+	"FlightStrips/internal/shared"
+	events "FlightStrips/pkg/events/frontend"
+)
+
+func registerAMANCommandHandlers(handlers *shared.MessageHandlers[events.EventType, *Client]) {
+	handlers.Add(events.AMANMoveFlightType, handleAMANMoveFlight)
+	handlers.Add(events.AMANLockFlightType, handleAMANLockFlight)
+	handlers.Add(events.AMANUnlockFlightType, handleAMANUnlockFlight)
+	handlers.Add(events.AMANSetRateType, handleAMANSetRate)
+	handlers.Add(events.AMANAcceptTETAType, handleAMANAcceptTETA)
+	handlers.Add(events.AMANKeepFPLETAType, handleAMANKeepFPLETA)
+	handlers.Add(events.AMANSetManualETAType, handleAMANSetManualETA)
+	handlers.Add(events.AMANResetTETAOverrideType, handleAMANResetTETAOverride)
+	handlers.Add(events.AMANReportGoAroundType, handleAMANReportGoAround)
+}
+
+func handleAMANMoveFlight(ctx context.Context, client *Client, message Message) error {
+	var wire events.AMANMoveFlightMessage
+	if err := decodeAMANMessage(message, events.AMANMoveFlightType, &wire); err != nil {
+		return rejectDecodedAMAN(ctx, client, commandIDFromMessage(message), err)
+	}
+	command := aman.MoveFlightCommand{
+		Metadata: commandMetadata(wire.Data.AMANCommandMeta), FlightID: aman.FlightID(wire.Data.FlightID),
+		RunwayGroupID:  aman.RunwayGroupID(wire.Data.RunwayGroupID),
+		BeforeFlightID: flightIDPointer(wire.Data.BeforeFlightID), AfterFlightID: flightIDPointer(wire.Data.AfterFlightID),
+	}
+	return runAMANCommand(ctx, client, command.Metadata.CommandID, func(auth aman.CommandContext) (aman.CommandExecution, error) {
+		return client.hub.amanCommandService.MoveFlight(ctx, auth, command)
+	})
+}
+
+func handleAMANLockFlight(ctx context.Context, client *Client, message Message) error {
+	return handleAMANFlightCommand(ctx, client, message, events.AMANLockFlightType, func(auth aman.CommandContext, data events.AMANFlightRequest) (aman.CommandExecution, error) {
+		return client.hub.amanCommandService.LockFlight(ctx, auth, aman.LockFlightCommand{Metadata: commandMetadata(data.AMANCommandMeta), FlightID: aman.FlightID(data.FlightID)})
+	})
+}
+
+func handleAMANUnlockFlight(ctx context.Context, client *Client, message Message) error {
+	return handleAMANFlightCommand(ctx, client, message, events.AMANUnlockFlightType, func(auth aman.CommandContext, data events.AMANFlightRequest) (aman.CommandExecution, error) {
+		return client.hub.amanCommandService.UnlockFlight(ctx, auth, aman.UnlockFlightCommand{Metadata: commandMetadata(data.AMANCommandMeta), FlightID: aman.FlightID(data.FlightID)})
+	})
+}
+
+func handleAMANAcceptTETA(ctx context.Context, client *Client, message Message) error {
+	return handleAMANFlightCommand(ctx, client, message, events.AMANAcceptTETAType, func(auth aman.CommandContext, data events.AMANFlightRequest) (aman.CommandExecution, error) {
+		return client.hub.amanCommandService.AcceptTETA(ctx, auth, aman.AcceptTETACommand{Metadata: commandMetadata(data.AMANCommandMeta), FlightID: aman.FlightID(data.FlightID)})
+	})
+}
+
+func handleAMANKeepFPLETA(ctx context.Context, client *Client, message Message) error {
+	return handleAMANFlightCommand(ctx, client, message, events.AMANKeepFPLETAType, func(auth aman.CommandContext, data events.AMANFlightRequest) (aman.CommandExecution, error) {
+		return client.hub.amanCommandService.KeepFPLETA(ctx, auth, aman.KeepFPLETACommand{Metadata: commandMetadata(data.AMANCommandMeta), FlightID: aman.FlightID(data.FlightID)})
+	})
+}
+
+func handleAMANResetTETAOverride(ctx context.Context, client *Client, message Message) error {
+	return handleAMANFlightCommand(ctx, client, message, events.AMANResetTETAOverrideType, func(auth aman.CommandContext, data events.AMANFlightRequest) (aman.CommandExecution, error) {
+		return client.hub.amanCommandService.ResetTETAOverride(ctx, auth, aman.ResetTETAOverrideCommand{Metadata: commandMetadata(data.AMANCommandMeta), FlightID: aman.FlightID(data.FlightID)})
+	})
+}
+
+func handleAMANSetRate(ctx context.Context, client *Client, message Message) error {
+	var wire events.AMANSetRateMessage
+	if err := decodeAMANMessage(message, events.AMANSetRateType, &wire); err != nil {
+		return rejectDecodedAMAN(ctx, client, commandIDFromMessage(message), err)
+	}
+	effectiveAt, err := parseAMANTime(wire.Data.EffectiveAt)
+	if err != nil {
+		return rejectDecodedAMAN(ctx, client, wire.Data.CommandID, err)
+	}
+	command := aman.SetRateCommand{
+		Metadata: commandMetadata(wire.Data.AMANCommandMeta), RunwayGroupID: aman.RunwayGroupID(wire.Data.RunwayGroupID),
+		ArrivalsPerHour: wire.Data.ArrivalsPerHour, EffectiveAt: effectiveAt,
+	}
+	return runAMANCommand(ctx, client, command.Metadata.CommandID, func(auth aman.CommandContext) (aman.CommandExecution, error) {
+		return client.hub.amanCommandService.SetRate(ctx, auth, command)
+	})
+}
+
+func handleAMANSetManualETA(ctx context.Context, client *Client, message Message) error {
+	var wire events.AMANSetManualETAMessage
+	if err := decodeAMANMessage(message, events.AMANSetManualETAType, &wire); err != nil {
+		return rejectDecodedAMAN(ctx, client, commandIDFromMessage(message), err)
+	}
+	manualETA, err := parseAMANTime(wire.Data.ManualETA)
+	if err != nil {
+		return rejectDecodedAMAN(ctx, client, wire.Data.CommandID, err)
+	}
+	command := aman.SetManualETACommand{Metadata: commandMetadata(wire.Data.AMANCommandMeta), FlightID: aman.FlightID(wire.Data.FlightID), ManualETA: manualETA}
+	return runAMANCommand(ctx, client, command.Metadata.CommandID, func(auth aman.CommandContext) (aman.CommandExecution, error) {
+		return client.hub.amanCommandService.SetManualETA(ctx, auth, command)
+	})
+}
+
+func handleAMANReportGoAround(ctx context.Context, client *Client, message Message) error {
+	var wire events.AMANReportGoAroundMessage
+	if err := decodeAMANMessage(message, events.AMANReportGoAroundType, &wire); err != nil {
+		return rejectDecodedAMAN(ctx, client, commandIDFromMessage(message), err)
+	}
+	detectedAt, err := parseAMANTime(wire.Data.DetectedAt)
+	if err != nil {
+		return rejectDecodedAMAN(ctx, client, wire.Data.CommandID, err)
+	}
+	command := aman.ReportGoAroundCommand{Metadata: commandMetadata(wire.Data.AMANCommandMeta), FlightID: aman.FlightID(wire.Data.FlightID), DetectedAt: detectedAt}
+	return runAMANCommand(ctx, client, command.Metadata.CommandID, func(auth aman.CommandContext) (aman.CommandExecution, error) {
+		return client.hub.amanCommandService.ReportGoAround(ctx, auth, command)
+	})
+}
+
+func handleAMANFlightCommand(ctx context.Context, client *Client, message Message, expected events.EventType, execute func(aman.CommandContext, events.AMANFlightRequest) (aman.CommandExecution, error)) error {
+	var wire events.AMANFlightMessage
+	if err := decodeAMANMessage(message, expected, &wire); err != nil {
+		return rejectDecodedAMAN(ctx, client, commandIDFromMessage(message), err)
+	}
+	return runAMANCommand(ctx, client, wire.Data.CommandID, func(auth aman.CommandContext) (aman.CommandExecution, error) {
+		return execute(auth, wire.Data)
+	})
+}
+
+func runAMANCommand(ctx context.Context, client *Client, commandID string, execute func(aman.CommandContext) (aman.CommandExecution, error)) error {
+	auth, err := client.hub.amanContext(client)
+	if err != nil {
+		return rejectDecodedAMAN(ctx, client, commandID, err)
+	}
+	execution, err := execute(auth)
+	if err != nil {
+		return rejectAMAN(ctx, client, commandID, execution.CurrentRevision, err)
+	}
+	slog.InfoContext(ctx, "AMAN command accepted", slog.String("command_id", commandID), slog.String("airport", auth.Airport), slog.String("actor", auth.Actor), slog.String("role", auth.Role), slog.Uint64("revision", uint64(execution.CurrentRevision)), slog.Bool("duplicate", execution.Duplicate))
+	return nil
+}
+
+func (hub *Hub) amanContext(client *Client) (aman.CommandContext, error) {
+	if client == nil || !client.IsAuthenticated() {
+		return aman.CommandContext{}, &aman.DomainError{Class: aman.ErrorUnauthorized, Message: "AMAN command requires an authenticated session"}
+	}
+	if client.readOnly {
+		return aman.CommandContext{}, &aman.DomainError{Class: aman.ErrorUnauthorized, Message: "observer clients cannot mutate AMAN state"}
+	}
+	if !hub.amanMutations {
+		return aman.CommandContext{}, &aman.DomainError{Class: aman.ErrorReadOnly, Message: "AMAN controller mutations are read-only in the current rollout mode"}
+	}
+	roleForPosition := configuredAMANRole
+	if hub.amanRoleForPosition != nil {
+		roleForPosition = hub.amanRoleForPosition
+	}
+	role := roleForPosition(client.position)
+	if _, authorized := hub.amanFMPRoles[strings.ToUpper(role)]; !authorized {
+		return aman.CommandContext{}, &aman.DomainError{Class: aman.ErrorUnauthorized, Message: "AMAN command requires a configured FMP role"}
+	}
+	now := time.Now
+	if hub.amanNow != nil {
+		now = hub.amanNow
+	}
+	return aman.CommandContext{Airport: client.airport, Actor: client.GetCid(), Role: role, ReceivedAt: now().UTC()}, nil
+}
+
+func configuredAMANRole(position string) string {
+	if value, err := config.GetPositionBasedOnFrequency(position); err == nil {
+		return value.Name
+	}
+	if value, err := config.GetPositionByName(position); err == nil {
+		return value.Name
+	}
+	return ""
+}
+
+func rejectDecodedAMAN(ctx context.Context, client *Client, commandID string, err error) error {
+	if commandID == "" {
+		return err
+	}
+	revision := aman.SequenceRevision(0)
+	if client != nil && client.hub != nil && client.hub.amanCommandService != nil && client.airport != "" {
+		if current, currentErr := client.hub.amanCommandService.CurrentRevision(ctx, client.airport); currentErr == nil {
+			revision = current
+		}
+	}
+	return rejectAMAN(ctx, client, commandID, revision, err)
+}
+
+func rejectAMAN(ctx context.Context, client *Client, commandID string, revision aman.SequenceRevision, err error) error {
+	domain := stableAMANError(err)
+	event, mapErr := events.NewAMANCommandRejectedEvent(commandID, revision, domain, retryableAMANError(domain.Class))
+	if mapErr != nil {
+		return mapErr
+	}
+	client.Enqueue(event)
+	slog.WarnContext(ctx, "AMAN command rejected", slog.String("command_id", commandID), slog.String("airport", client.airport), slog.String("actor", client.GetCid()), slog.String("code", string(domain.Class)), slog.Uint64("revision", uint64(revision)))
+	return nil
+}
+
+func stableAMANError(err error) *aman.DomainError {
+	var domain *aman.DomainError
+	if errors.As(err, &domain) && domain != nil && domain.Class.Valid() {
+		return domain
+	}
+	return &aman.DomainError{Class: aman.ErrorDependencyUnavailable, Message: "AMAN command could not be completed"}
+}
+
+func retryableAMANError(class aman.ErrorClass) bool {
+	return class == aman.ErrorRevisionConflict || class == aman.ErrorDependencyUnavailable
+}
+
+func decodeAMANMessage(message Message, expected events.EventType, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(message.Message))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return invalidAMANPayload(err)
+	}
+	if err := ensureAMANEOF(decoder); err != nil {
+		return err
+	}
+	var header struct {
+		Type    events.EventType `json:"type"`
+		Version int              `json:"version"`
+	}
+	if err := json.Unmarshal(message.Message, &header); err != nil {
+		return invalidAMANPayload(err)
+	}
+	if header.Type != expected || header.Version != events.AMANWireVersion {
+		return invalidAMANPayload(fmt.Errorf("expected %s version %d", expected, events.AMANWireVersion))
+	}
+	return nil
+}
+
+func ensureAMANEOF(decoder *json.Decoder) error {
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return invalidAMANPayload(errors.New("trailing JSON value"))
+		}
+		return invalidAMANPayload(err)
+	}
+	return nil
+}
+
+func invalidAMANPayload(err error) error {
+	return &aman.DomainError{Class: aman.ErrorInvalidArgument, Message: "invalid AMAN command payload: " + err.Error()}
+}
+
+func parseAMANTime(value string) (time.Time, error) {
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil || parsed.Location() != time.UTC {
+		return time.Time{}, invalidAMANPayload(errors.New("timestamp must be RFC3339 UTC"))
+	}
+	return parsed, nil
+}
+
+func commandMetadata(value events.AMANCommandMeta) aman.CommandMetadata {
+	return aman.CommandMetadata{CommandID: value.CommandID, ExpectedRevision: aman.SequenceRevision(value.ExpectedRevision)}
+}
+
+func flightIDPointer(value *string) *aman.FlightID {
+	if value == nil {
+		return nil
+	}
+	converted := aman.FlightID(*value)
+	return &converted
+}
+
+func commandIDFromMessage(message Message) string {
+	var value struct {
+		Data struct {
+			CommandID string `json:"command_id"`
+		} `json:"data"`
+	}
+	_ = json.Unmarshal(message.Message, &value)
+	return value.Data.CommandID
+}

--- a/backend/internal/frontend/handlers_aman_test.go
+++ b/backend/internal/frontend/handlers_aman_test.go
@@ -1,0 +1,163 @@
+package frontend
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/shared"
+	"FlightStrips/pkg/events"
+	frontendEvents "FlightStrips/pkg/events/frontend"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAMANHandlersMapEveryTypedCommandWithServerDerivedContext(t *testing.T) {
+	now := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		eventType frontendEvents.EventType
+		payload   string
+		operation string
+	}{
+		{"move", frontendEvents.AMANMoveFlightType, `{"type":"aman.move_flight","version":1,"data":{"command_id":"command-1","expected_revision":7,"flight_id":"flight-1","runway_group_id":"A","before_flight_id":"flight-2"}}`, "move"},
+		{"lock", frontendEvents.AMANLockFlightType, `{"type":"aman.lock_flight","version":1,"data":{"command_id":"command-1","expected_revision":7,"flight_id":"flight-1"}}`, "lock"},
+		{"unlock", frontendEvents.AMANUnlockFlightType, `{"type":"aman.unlock_flight","version":1,"data":{"command_id":"command-1","expected_revision":7,"flight_id":"flight-1"}}`, "unlock"},
+		{"rate", frontendEvents.AMANSetRateType, `{"type":"aman.set_rate","version":1,"data":{"command_id":"command-1","expected_revision":7,"runway_group_id":"A","arrivals_per_hour":30,"effective_at":"2026-07-22T12:05:00Z"}}`, "rate"},
+		{"accept", frontendEvents.AMANAcceptTETAType, `{"type":"aman.accept_teta","version":1,"data":{"command_id":"command-1","expected_revision":7,"flight_id":"flight-1"}}`, "accept"},
+		{"keep", frontendEvents.AMANKeepFPLETAType, `{"type":"aman.keep_fpl_eta","version":1,"data":{"command_id":"command-1","expected_revision":7,"flight_id":"flight-1"}}`, "keep"},
+		{"manual", frontendEvents.AMANSetManualETAType, `{"type":"aman.set_manual_eta","version":1,"data":{"command_id":"command-1","expected_revision":7,"flight_id":"flight-1","manual_eta":"2026-07-22T12:10:00Z"}}`, "manual"},
+		{"reset", frontendEvents.AMANResetTETAOverrideType, `{"type":"aman.reset_teta_override","version":1,"data":{"command_id":"command-1","expected_revision":7,"flight_id":"flight-1"}}`, "reset"},
+		{"go around", frontendEvents.AMANReportGoAroundType, `{"type":"aman.report_go_around","version":1,"data":{"command_id":"command-1","expected_revision":7,"flight_id":"flight-1","detected_at":"2026-07-22T11:59:00Z"}}`, "go_around"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service := &recordingAMANCommandService{}
+			hub, client := newAMANCommandTestClient(service, now)
+			err := hub.handlers.Handle(context.Background(), client, Message{Type: test.eventType, Message: []byte(test.payload)})
+			require.NoError(t, err)
+			require.Equal(t, test.operation, service.operation)
+			require.Equal(t, aman.CommandContext{Airport: "EKCH", Actor: "1234567", Role: "EKCH_FMH", ReceivedAt: now}, service.auth)
+			require.Equal(t, "command-1", service.metadata.CommandID)
+			require.Equal(t, aman.SequenceRevision(7), service.metadata.ExpectedRevision)
+			require.Empty(t, client.send)
+		})
+	}
+}
+
+func TestAMANHandlerRejectsSpoofedContextFieldsStrictly(t *testing.T) {
+	service := &recordingAMANCommandService{}
+	hub, client := newAMANCommandTestClient(service, time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	payload := `{"type":"aman.lock_flight","version":1,"data":{"command_id":"command-1","expected_revision":7,"flight_id":"flight-1","airport":"ZZZZ","actor":"spoof","received_at":"2026-07-22T12:00:00Z"}}`
+
+	err := hub.handlers.Handle(context.Background(), client, Message{Type: frontendEvents.AMANLockFlightType, Message: []byte(payload)})
+
+	require.NoError(t, err)
+	require.Empty(t, service.operation)
+	rejection := (<-client.send).(frontendEvents.AMANCommandRejectedEvent)
+	require.Equal(t, "command-1", rejection.Data.CommandID)
+	require.Equal(t, string(aman.ErrorInvalidArgument), rejection.Data.Code)
+	require.Equal(t, uint64(7), rejection.Data.CurrentRevision)
+	require.False(t, rejection.Data.Retryable)
+}
+
+func TestAMANHandlerRejectsObserverFMPAndReadOnlyBeforeCommandService(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func(*Hub, *Client)
+		code      aman.ErrorClass
+	}{
+		{"unauthenticated", func(_ *Hub, client *Client) { client.user = shared.AuthenticatedUser{} }, aman.ErrorUnauthorized},
+		{"observer", func(_ *Hub, client *Client) { client.readOnly = true }, aman.ErrorUnauthorized},
+		{"non FMP", func(hub *Hub, _ *Client) { hub.amanFMPRoles = map[string]struct{}{} }, aman.ErrorUnauthorized},
+		{"rollout read only", func(hub *Hub, _ *Client) { hub.amanMutations = false }, aman.ErrorReadOnly},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service := &recordingAMANCommandService{}
+			hub, client := newAMANCommandTestClient(service, time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+			test.configure(hub, client)
+			payload := `{"type":"aman.lock_flight","version":1,"data":{"command_id":"command-1","expected_revision":7,"flight_id":"flight-1"}}`
+			require.NoError(t, hub.handlers.Handle(context.Background(), client, Message{Type: frontendEvents.AMANLockFlightType, Message: []byte(payload)}))
+			require.Empty(t, service.operation)
+			rejection := (<-client.send).(frontendEvents.AMANCommandRejectedEvent)
+			require.Equal(t, string(test.code), rejection.Data.Code)
+		})
+	}
+}
+
+func TestAMANRevisionConflictUsesCommandRejectionContract(t *testing.T) {
+	service := &recordingAMANCommandService{execution: aman.CommandExecution{CurrentRevision: 12}, err: &aman.DomainError{Class: aman.ErrorRevisionConflict, Message: "revision changed"}}
+	hub, client := newAMANCommandTestClient(service, time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC))
+	payload := `{"type":"aman.lock_flight","version":1,"data":{"command_id":"command-1","expected_revision":7,"flight_id":"flight-1"}}`
+
+	require.NoError(t, hub.handlers.Handle(context.Background(), client, Message{Type: frontendEvents.AMANLockFlightType, Message: []byte(payload)}))
+	rejection := (<-client.send).(frontendEvents.AMANCommandRejectedEvent)
+	require.Equal(t, uint64(12), rejection.Data.CurrentRevision)
+	require.Equal(t, string(aman.ErrorRevisionConflict), rejection.Data.Code)
+	require.True(t, rejection.Data.Retryable)
+}
+
+func newAMANCommandTestClient(service aman.CommandService, now time.Time) (*Hub, *Client) {
+	handlers := shared.NewMessageHandlers[frontendEvents.EventType, *Client]()
+	registerAMANCommandHandlers(&handlers)
+	hub := &Hub{
+		handlers: handlers, amanCommandService: service, amanFMPRoles: map[string]struct{}{"EKCH_FMH": {}},
+		amanMutations: true, amanNow: func() time.Time { return now }, amanRoleForPosition: func(string) string { return "EKCH_FMH" },
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims{"exp": float64(time.Now().Add(time.Hour).Unix())})
+	client := &Client{
+		hub: hub, airport: "EKCH", position: "120.500", send: make(chan events.OutgoingMessage, 4),
+		closed: make(chan struct{}), user: shared.NewAuthenticatedUser("1234567", 0, token),
+	}
+	return hub, client
+}
+
+type recordingAMANCommandService struct {
+	operation string
+	auth      aman.CommandContext
+	metadata  aman.CommandMetadata
+	execution aman.CommandExecution
+	err       error
+}
+
+func (*recordingAMANCommandService) Name() string { return "recording AMAN command service" }
+func (*recordingAMANCommandService) CurrentRevision(context.Context, string) (aman.SequenceRevision, error) {
+	return 7, nil
+}
+func (s *recordingAMANCommandService) record(operation string, auth aman.CommandContext, metadata aman.CommandMetadata) (aman.CommandExecution, error) {
+	s.operation, s.auth, s.metadata = operation, auth, metadata
+	if s.execution.CurrentRevision == 0 && s.err == nil {
+		s.execution.CurrentRevision = metadata.ExpectedRevision + 1
+	}
+	return s.execution, s.err
+}
+func (s *recordingAMANCommandService) MoveFlight(_ context.Context, auth aman.CommandContext, command aman.MoveFlightCommand) (aman.CommandExecution, error) {
+	return s.record("move", auth, command.Metadata)
+}
+func (s *recordingAMANCommandService) LockFlight(_ context.Context, auth aman.CommandContext, command aman.LockFlightCommand) (aman.CommandExecution, error) {
+	return s.record("lock", auth, command.Metadata)
+}
+func (s *recordingAMANCommandService) UnlockFlight(_ context.Context, auth aman.CommandContext, command aman.UnlockFlightCommand) (aman.CommandExecution, error) {
+	return s.record("unlock", auth, command.Metadata)
+}
+func (s *recordingAMANCommandService) SetRate(_ context.Context, auth aman.CommandContext, command aman.SetRateCommand) (aman.CommandExecution, error) {
+	return s.record("rate", auth, command.Metadata)
+}
+func (s *recordingAMANCommandService) AcceptTETA(_ context.Context, auth aman.CommandContext, command aman.AcceptTETACommand) (aman.CommandExecution, error) {
+	return s.record("accept", auth, command.Metadata)
+}
+func (s *recordingAMANCommandService) KeepFPLETA(_ context.Context, auth aman.CommandContext, command aman.KeepFPLETACommand) (aman.CommandExecution, error) {
+	return s.record("keep", auth, command.Metadata)
+}
+func (s *recordingAMANCommandService) SetManualETA(_ context.Context, auth aman.CommandContext, command aman.SetManualETACommand) (aman.CommandExecution, error) {
+	return s.record("manual", auth, command.Metadata)
+}
+func (s *recordingAMANCommandService) ResetTETAOverride(_ context.Context, auth aman.CommandContext, command aman.ResetTETAOverrideCommand) (aman.CommandExecution, error) {
+	return s.record("reset", auth, command.Metadata)
+}
+func (s *recordingAMANCommandService) ReportGoAround(_ context.Context, auth aman.CommandContext, command aman.ReportGoAroundCommand) (aman.CommandExecution, error) {
+	return s.record("go_around", auth, command.Metadata)
+}

--- a/backend/internal/frontend/hub.go
+++ b/backend/internal/frontend/hub.go
@@ -1,6 +1,7 @@
 package frontend
 
 import (
+	"FlightStrips/internal/aman"
 	"FlightStrips/internal/clx"
 	"FlightStrips/internal/config"
 	"FlightStrips/internal/dependencies"
@@ -85,9 +86,14 @@ type Hub struct {
 	clxMu        sync.RWMutex
 	clxOverrides map[int32]map[string]bool
 
-	snapshotBuilder    *SnapshotBuilder
-	standActionService *services.StandActionService
-	amanStateProvider  AMANStateProvider
+	snapshotBuilder     *SnapshotBuilder
+	standActionService  *services.StandActionService
+	amanStateProvider   AMANStateProvider
+	amanCommandService  aman.CommandService
+	amanFMPRoles        map[string]struct{}
+	amanMutations       bool
+	amanNow             func() time.Time
+	amanRoleForPosition func(string) string
 }
 
 // AMANStateProvider returns the latest complete persisted replacement event
@@ -114,6 +120,9 @@ type HubDependencies struct {
 	Strips         shared.StripService
 	Authentication shared.AuthenticationService
 	AMANState      AMANStateProvider
+	AMANCommands   aman.CommandService
+	AMANFMPRoles   []string
+	AMANMutations  bool
 }
 
 func NewHub(deps HubDependencies) (*Hub, error) {
@@ -174,14 +183,32 @@ func NewHub(deps HubDependencies) (*Hub, error) {
 		stripService:          deps.Strips,
 		authenticationService: deps.Authentication,
 		amanStateProvider:     deps.AMANState,
+		amanCommandService:    deps.AMANCommands,
+		amanFMPRoles:          normalizedAMANRoles(deps.AMANFMPRoles),
+		amanMutations:         deps.AMANMutations,
+		amanNow:               time.Now,
+		amanRoleForPosition:   configuredAMANRole,
 		messages:              make(map[int32][]frontend.MessageReceivedEvent),
 		metarCache:            make(map[int32]string),
 		arrAtisCodeCache:      make(map[int32]string),
 		depAtisCodeCache:      make(map[int32]string),
 		clxOverrides:          make(map[int32]map[string]bool),
 	}
+	if deps.AMANCommands != nil {
+		registerAMANCommandHandlers(&hub.handlers)
+	}
 
 	return hub, nil
+}
+
+func normalizedAMANRoles(values []string) map[string]struct{} {
+	roles := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if role := strings.ToUpper(strings.TrimSpace(value)); role != "" {
+			roles[role] = struct{}{}
+		}
+	}
+	return roles
 }
 
 func (hub *Hub) RegisterPDCHandlers(service shared.PdcService) error {

--- a/backend/pkg/events/frontend/aman_commands.go
+++ b/backend/pkg/events/frontend/aman_commands.go
@@ -1,0 +1,80 @@
+package frontend
+
+const (
+	AMANMoveFlightType        EventType = "aman.move_flight"
+	AMANLockFlightType        EventType = "aman.lock_flight"
+	AMANUnlockFlightType      EventType = "aman.unlock_flight"
+	AMANSetRateType           EventType = "aman.set_rate"
+	AMANAcceptTETAType        EventType = "aman.accept_teta"
+	AMANKeepFPLETAType        EventType = "aman.keep_fpl_eta"
+	AMANSetManualETAType      EventType = "aman.set_manual_eta"
+	AMANResetTETAOverrideType EventType = "aman.reset_teta_override"
+	AMANReportGoAroundType    EventType = "aman.report_go_around"
+)
+
+type AMANCommandMeta struct {
+	CommandID        string `json:"command_id"`
+	ExpectedRevision uint64 `json:"expected_revision"`
+}
+
+type AMANMoveFlightRequest struct {
+	AMANCommandMeta
+	FlightID       string  `json:"flight_id"`
+	RunwayGroupID  string  `json:"runway_group_id"`
+	BeforeFlightID *string `json:"before_flight_id,omitempty"`
+	AfterFlightID  *string `json:"after_flight_id,omitempty"`
+}
+
+type AMANFlightRequest struct {
+	AMANCommandMeta
+	FlightID string `json:"flight_id"`
+}
+
+type AMANSetRateRequest struct {
+	AMANCommandMeta
+	RunwayGroupID   string `json:"runway_group_id"`
+	ArrivalsPerHour uint32 `json:"arrivals_per_hour"`
+	EffectiveAt     string `json:"effective_at"`
+}
+
+type AMANSetManualETARequest struct {
+	AMANCommandMeta
+	FlightID  string `json:"flight_id"`
+	ManualETA string `json:"manual_eta"`
+}
+
+type AMANReportGoAroundRequest struct {
+	AMANCommandMeta
+	FlightID   string `json:"flight_id"`
+	DetectedAt string `json:"detected_at"`
+}
+
+type AMANMoveFlightMessage struct {
+	Type    EventType             `json:"type"`
+	Version int                   `json:"version"`
+	Data    AMANMoveFlightRequest `json:"data"`
+}
+
+type AMANFlightMessage struct {
+	Type    EventType         `json:"type"`
+	Version int               `json:"version"`
+	Data    AMANFlightRequest `json:"data"`
+}
+
+type AMANSetRateMessage struct {
+	Type    EventType          `json:"type"`
+	Version int                `json:"version"`
+	Data    AMANSetRateRequest `json:"data"`
+}
+
+type AMANSetManualETAMessage struct {
+	Type    EventType               `json:"type"`
+	Version int                     `json:"version"`
+	Data    AMANSetManualETARequest `json:"data"`
+}
+
+type AMANReportGoAroundMessage struct {
+	Type    EventType                 `json:"type"`
+	Version int                       `json:"version"`
+	Data    AMANReportGoAroundRequest `json:"data"`
+}


### PR DESCRIPTION
## Scope

- add separate typed AMAN websocket commands for move, lock/unlock, rate, ETA decisions, and go-around reporting
- derive airport, actor, FMP role, and receipt time from the authenticated frontend session
- enforce authenticated FMP and read-only rollout authorization before domain mutation
- route command IDs and expected revisions through the existing sequence coordinator for idempotency, optimistic concurrency, audit, and revision ownership
- emit the revisioned `aman.command_rejected` contract and reject spoofed or cross-command fields strictly
- fail authoritative startup when the configured sequence component does not implement the typed command service

## Validation

- `go test ./internal/app ./internal/frontend ./internal/aman ./internal/aman/sequence ./pkg/events/frontend ./cmd/server`
- `git diff --check`

Closes #326