### PR TITLE
[AMAN] Build complete AMAN timeline and strip presentation (#328)

### DIFF
--- a/frontend/src/components/ChooseLayoutScreen.tsx
+++ b/frontend/src/components/ChooseLayoutScreen.tsx
@@ -7,6 +7,7 @@ const EKCH_SCOPES = [
   { label: "APRON ARR", layout: "AA" },
   { label: "APRON DEP", layout: "AD" },
   { label: "SEQ PLN", layout: "EST" },
+  { label: "AMAN", layout: "AMAN" },
   { label: "GW / GE", layout: "GEGW" },
   { label: "TW / TE", layout: "TWTE" },
   { label: "TWR + GND", layout: "TWRGND" },

--- a/frontend/src/components/aman/AMANBoard.test.tsx
+++ b/frontend/src/components/aman/AMANBoard.test.tsx
@@ -1,0 +1,127 @@
+import {readFileSync} from "node:fs";
+import {resolve} from "node:path";
+import {fireEvent, render, screen, within} from "@testing-library/react";
+import {describe, expect, it, vi} from "vitest";
+
+import type {AMANState, AMANStateEvent} from "@/api/aman";
+import {AMANBoardView, type AMANBoardViewProps} from "./AMANBoard";
+
+const golden = JSON.parse(readFileSync(
+  resolve(process.cwd(), "../backend/pkg/events/frontend/testdata/aman-state-v1.json"),
+  "utf8",
+)) as AMANStateEvent;
+
+function state(): AMANState {
+  return structuredClone(golden.data);
+}
+
+function renderBoard(value: AMANState | null, overrides: Partial<AMANBoardViewProps> = {}) {
+  const onSelectFlight = vi.fn();
+  render(
+    <AMANBoardView
+      connectionState="connected"
+      error={null}
+      onSelectFlight={onSelectFlight}
+      presentationStatus={value ? "ready" : "empty"}
+      selectedFlightID={null}
+      state={value}
+      {...overrides}
+    />,
+  );
+  return onSelectFlight;
+}
+
+describe("complete AMAN timeline and strips", () => {
+  it("renders null and invalid replacement state explicitly without stale partial data", () => {
+    const {rerender} = render(
+      <AMANBoardView connectionState="disconnected" error={null} onSelectFlight={() => undefined} presentationStatus="empty" selectedFlightID={null} state={null} />,
+    );
+    expect(screen.getByText("AMAN timeline unavailable")).toBeInTheDocument();
+    expect(screen.getByText(/Waiting for a complete AMAN state replacement/)).toBeInTheDocument();
+
+    rerender(<AMANBoardView connectionState="connected" error="invalid_aman_state" onSelectFlight={() => undefined} presentationStatus="degraded" selectedFlightID={null} state={null} />);
+    expect(screen.getByText(/State rejected: invalid_aman_state/)).toBeInTheDocument();
+    expect(screen.queryByText("SAS123")).not.toBeInTheDocument();
+  });
+
+  it("renders the normal golden state with backend values and explicit unavailable contract fields", () => {
+    renderBoard(state());
+    const strip = screen.getByRole("button", {name: "SAS123 AMAN strip"});
+
+    expect(screen.getByText(/Revision 7/)).toBeInTheDocument();
+    expect(within(strip).getByText("Unavailable / Unavailable")).toBeInTheDocument();
+    expect(within(strip).getByText("Unavailable / ARRIVAL-22")).toBeInTheDocument();
+    expect(within(strip).getByText("Accepted direct SOK")).toBeInTheDocument();
+    expect(within(strip).getByText("+1:00")).toBeInTheDocument();
+    expect(within(strip).getByText("87.5 NM")).toBeInTheDocument();
+    expect(within(strip).getByText(/SOK-HF \/ 10:10/)).toBeInTheDocument();
+  });
+
+  it("keeps frozen operational markers fixed while showing raw drift separately", () => {
+    const frozen = state();
+    frozen.flights[0].freeze_reason = "superstable";
+    frozen.flights[0].raw_teta = "2026-07-22T10:40:00.000Z";
+    frozen.flights[0].slot!.time = "2026-07-22T10:18:00.000Z";
+    renderBoard(frozen);
+
+    expect(screen.getByTestId("operational-marker-flight-123")).toHaveAttribute("data-marker-time", "2026-07-22T10:18:00.000Z");
+    expect(screen.getByTestId("raw-marker-flight-123")).toHaveAttribute("title", "Raw TETA 10:40 (informational only)");
+    expect(screen.getByText("Freeze superstable")).toBeInTheDocument();
+  });
+
+  it("golden-renders degraded, stale, go-around, manual freeze, queue, and discrepancy facts", () => {
+    const degraded = state();
+    const flight = degraded.flights[0];
+    degraded.technical_health.status = "degraded";
+    degraded.technical_health.ready = false;
+    degraded.technical_health.blocked_reasons = ["predictor stale"];
+    flight.data_status = "stale";
+    flight.lifecycle_state = "go_around";
+    flight.freeze_reason = "manual";
+    flight.confidence = null;
+    flight.provenance = null;
+    flight.route_fact = null;
+    flight.queue_offers = [{
+      flight_id: flight.flight_id,
+      runway_group_id: "ARRIVAL-22",
+      candidate_slot: {...flight.slot!, time: "2026-07-22T10:16:00.000Z"},
+      queue_position: 1,
+      expires_at: "2026-07-22T10:05:00.000Z",
+      airport_revision: 7,
+      reason: "earlier_available",
+    }];
+    flight.eta_review = {
+      status: "pending",
+      created_at: "2026-07-22T10:00:00.000Z",
+      deadline_at: "2026-07-22T10:05:00.000Z",
+      resolved_at: null,
+      actor: null,
+      note: null,
+      initial_baseline_teta: "2026-07-22T10:22:00.000Z",
+      calculated_operational_teta: "2026-07-22T10:19:00.000Z",
+      selected_teta: "2026-07-22T10:22:00.000Z",
+      manual_teta: null,
+    };
+
+    renderBoard(degraded, {presentationStatus: "degraded", connectionState: "disconnected"});
+    expect(screen.getByRole("alert")).toHaveTextContent("predictor stale");
+    expect(screen.getByText("go around")).toBeInTheDocument();
+    expect(screen.getByText("stale")).toBeInTheDocument();
+    expect(screen.getByText("Freeze manual")).toBeInTheDocument();
+    expect(screen.getByText("No accepted direct")).toBeInTheDocument();
+    expect(screen.getByText(/Discrepancy pending/)).toBeInTheDocument();
+    expect(screen.getByText(/#1 ARRIVAL-22 at 10:16/)).toBeInTheDocument();
+    expect(screen.getAllByText("Unavailable").length).toBeGreaterThan(2);
+  });
+
+  it("supports timeline and strip hit testing from the responsive scrolling layout", () => {
+    const onSelectFlight = renderBoard(state());
+    const marker = screen.getByRole("button", {name: "Select SAS123 timeline marker"});
+    fireEvent.click(marker);
+    fireEvent.click(screen.getByRole("button", {name: "SAS123 AMAN strip"}));
+
+    expect(onSelectFlight).toHaveBeenNthCalledWith(1, "flight-123");
+    expect(onSelectFlight).toHaveBeenNthCalledWith(2, "flight-123");
+    expect(screen.getByTestId("aman-timeline-grid")).toHaveClass("min-w-[880px]");
+  });
+});

--- a/frontend/src/components/aman/AMANBoard.tsx
+++ b/frontend/src/components/aman/AMANBoard.tsx
@@ -1,0 +1,328 @@
+import {useMemo} from "react";
+
+import type {
+  AMANConnectionState,
+  AMANFlight,
+  AMANPresentationStatus,
+  AMANState,
+} from "@/api/aman";
+import {cn} from "@/lib/utils";
+import {
+  buildAMANLanes,
+  buildTimelineRange,
+  formatAMANTime,
+  formatGainLoss,
+  layoutTimelineMarkers,
+  operationalMarkerTimestamp,
+  type AMANTimelineRange,
+} from "./presentation";
+
+const badgeBase = "inline-flex items-center rounded border px-1.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide";
+
+function modeTone(mode: AMANState["effective_mode"]): string {
+  switch (mode) {
+    case "authoritative": return "border-emerald-400 bg-emerald-950 text-emerald-200";
+    case "shadow": return "border-sky-400 bg-sky-950 text-sky-200";
+    case "read_only": return "border-amber-400 bg-amber-950 text-amber-200";
+    case "blocked": return "border-red-400 bg-red-950 text-red-200";
+    case "disabled": return "border-slate-500 bg-slate-900 text-slate-300";
+  }
+}
+
+function lifecycleTone(flight: AMANFlight): string {
+  switch (flight.lifecycle_state) {
+    case "unstable": return "border-amber-400 bg-amber-950 text-amber-100";
+    case "stable": return "border-emerald-500 bg-emerald-950 text-emerald-100";
+    case "go_around": return "border-red-400 bg-red-950 text-red-100";
+    case "landed": return "border-slate-500 bg-slate-800 text-slate-200";
+    case "removed": return "border-slate-700 bg-slate-950 text-slate-500 line-through";
+    default: return "border-sky-600 bg-sky-950 text-sky-100";
+  }
+}
+
+function dataTone(status: AMANFlight["data_status"]): string {
+  if (status === "fresh") return "border-emerald-500 bg-emerald-950 text-emerald-200";
+  if (status === "stale") return "border-amber-400 bg-amber-950 text-amber-100";
+  return "border-red-500 bg-red-950 text-red-100";
+}
+
+function freezeTone(reason: AMANFlight["freeze_reason"]): string {
+  if (reason === "superstable") return "border-cyan-300 bg-cyan-950 text-cyan-100";
+  if (reason === "manual") return "border-fuchsia-300 bg-fuchsia-950 text-fuchsia-100";
+  return "border-slate-600 bg-slate-900 text-slate-300";
+}
+
+function timelinePercent(timestamp: string | null, range: AMANTimelineRange): number | null {
+  if (timestamp === null) return null;
+  const value = Date.parse(timestamp);
+  if (!Number.isFinite(value)) return null;
+  return Math.max(0, Math.min(100, ((value - range.startMs) / (range.endMs - range.startMs)) * 100));
+}
+
+function TimelineLane({
+  label,
+  flights,
+  range,
+  selectedFlightID,
+  onSelectFlight,
+}: {
+  label: string;
+  flights: AMANFlight[];
+  range: AMANTimelineRange;
+  selectedFlightID: string | null;
+  onSelectFlight: (flightID: string) => void;
+}) {
+  const markers = layoutTimelineMarkers(flights, range);
+  const trackCount = Math.max(1, ...markers.map((marker) => marker.track + 1));
+
+  return (
+    <div className="grid grid-cols-[150px_minmax(720px,1fr)] border-t border-slate-700" data-testid={`timeline-lane-${label}`}>
+      <div className="border-r border-slate-700 bg-slate-950 px-3 py-3">
+        <div className="font-semibold text-slate-100">{label}</div>
+        <div className="text-xs text-slate-400">{flights.length} flights</div>
+      </div>
+      <div
+        className="relative bg-[linear-gradient(to_right,rgba(100,116,139,0.18)_1px,transparent_1px)] bg-[size:10%_100%]"
+        style={{height: Math.max(76, trackCount * 48 + 28)}}
+      >
+        <div className="absolute inset-x-0 bottom-3 h-px bg-slate-600" />
+        {markers.map((marker) => {
+          const selected = marker.flight.flight_id === selectedFlightID;
+          const rawLeft = timelinePercent(marker.flight.raw_teta, range);
+          return (
+            <div key={marker.flight.flight_id}>
+              {rawLeft !== null && marker.flight.raw_teta !== marker.timestamp && (
+                <div
+                  aria-label={`${marker.flight.callsign} raw TETA ${formatAMANTime(marker.flight.raw_teta)}`}
+                  className="absolute bottom-1 h-3 w-3 -translate-x-1/2 rotate-45 border border-amber-300 bg-amber-500"
+                  data-testid={`raw-marker-${marker.flight.flight_id}`}
+                  style={{left: `${rawLeft}%`}}
+                  title={`Raw TETA ${formatAMANTime(marker.flight.raw_teta)} (informational only)`}
+                />
+              )}
+              <button
+                aria-label={`Select ${marker.flight.callsign} timeline marker`}
+                className={cn(
+                  "absolute w-[92px] -translate-x-1/2 rounded border-2 bg-slate-900 px-1.5 py-1 text-left text-xs shadow-lg focus:outline-none focus:ring-2 focus:ring-white",
+                  marker.flight.freeze_reason === "superstable" && "border-cyan-300",
+                  marker.flight.freeze_reason === "manual" && "border-fuchsia-300",
+                  marker.flight.freeze_reason === "none" && "border-sky-500",
+                  selected && "ring-2 ring-white",
+                )}
+                data-marker-time={marker.timestamp}
+                data-testid={`operational-marker-${marker.flight.flight_id}`}
+                onClick={() => onSelectFlight(marker.flight.flight_id)}
+                style={{left: `${marker.leftPercent}%`, top: marker.track * 48 + 6}}
+                type="button"
+              >
+                <span className="block truncate font-bold text-white">{marker.flight.callsign}</span>
+                <span className="block text-slate-300">{formatAMANTime(marker.timestamp)} · {formatGainLoss(marker.flight.gain_loss_seconds)}</span>
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function FlightStrip({flight, selected, onSelect}: {flight: AMANFlight; selected: boolean; onSelect: () => void}) {
+  const direct = flight.route_fact === null
+    ? "No accepted direct"
+    : `${flight.route_fact.state === "active" ? "Accepted direct" : "Expired direct"} ${flight.route_fact.fix}`;
+  const markerTime = operationalMarkerTimestamp(flight);
+
+  return (
+    <button
+      aria-label={`${flight.callsign} AMAN strip`}
+      className={cn(
+        "grid w-full gap-3 rounded-lg border-2 bg-slate-900 p-3 text-left text-slate-100 shadow-md focus:outline-none focus:ring-2 focus:ring-white",
+        selected ? "border-white" : "border-slate-600",
+        flight.lifecycle_state === "go_around" && "border-red-400",
+        flight.lifecycle_state === "landed" && "opacity-70",
+      )}
+      data-flight-id={flight.flight_id}
+      onClick={onSelect}
+      type="button"
+    >
+      <header className="flex flex-wrap items-start justify-between gap-2 border-b border-slate-700 pb-2">
+        <div>
+          <div className="flex items-baseline gap-2">
+            <span className="text-xl font-black tracking-wide">{flight.callsign}</span>
+            <span className="text-sm text-slate-400">#{flight.order ?? flight.slot?.sequence ?? "Unavailable"}</span>
+          </div>
+          <div className="text-xs text-slate-400">Flight ID {flight.flight_id}</div>
+        </div>
+        <div className="flex flex-wrap justify-end gap-1">
+          <span className={cn(badgeBase, lifecycleTone(flight))}>{flight.lifecycle_state.replace("_", " ")}</span>
+          <span className={cn(badgeBase, dataTone(flight.data_status))}>{flight.data_status}</span>
+          <span className={cn(badgeBase, freezeTone(flight.freeze_reason))}>Freeze {flight.freeze_reason}</span>
+        </div>
+      </header>
+
+      <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm md:grid-cols-4">
+        <div><span className="text-slate-400">Aircraft / WTC</span><strong className="block">Unavailable / Unavailable</strong></div>
+        <div><span className="text-slate-400">Runway / group</span><strong className="block">Unavailable / {flight.runway_group_id ?? "Unavailable"}</strong></div>
+        <div><span className="text-slate-400">Sequence / order</span><strong className="block">{flight.slot?.sequence ?? "Unavailable"} / {flight.order ?? "Unavailable"}</strong></div>
+        <div><span className="text-slate-400">Slot</span><strong className="block">{formatAMANTime(flight.slot?.time ?? null)}</strong></div>
+        <div><span className="text-slate-400">Operational marker</span><strong className="block">{formatAMANTime(markerTime)}</strong></div>
+        <div><span className="text-slate-400">Operational TETA</span><strong className="block">{formatAMANTime(flight.operational_teta)}</strong></div>
+        <div className={flight.raw_teta !== flight.operational_teta ? "text-amber-200" : ""}><span className="text-slate-400">Raw TETA (drift only)</span><strong className="block">{formatAMANTime(flight.raw_teta)}</strong></div>
+        <div><span className="text-slate-400">Gain / loss</span><strong className="block">{formatGainLoss(flight.gain_loss_seconds)}</strong></div>
+        <div><span className="text-slate-400">Distance to go</span><strong className="block">{flight.distance_to_go_nm === null ? "Unavailable" : `${flight.distance_to_go_nm.toFixed(1)} NM`}</strong></div>
+        <div><span className="text-slate-400">Feeder</span><strong className="block">{flight.feeder ?? "Unavailable"}</strong></div>
+        <div><span className="text-slate-400">Published holding</span><strong className="block">Unavailable</strong></div>
+        <div><span className="text-slate-400">Selected holding / ETA</span><strong className="block">{flight.holding_fix ?? "Unavailable"} / {formatAMANTime(flight.holding_fix_eta)}</strong></div>
+        <div><span className="text-slate-400">Direct</span><strong className="block">{direct}</strong></div>
+        <div><span className="text-slate-400">Confidence</span><strong className="block">{flight.confidence ?? "Unavailable"}</strong></div>
+        <div><span className="text-slate-400">Input age</span><strong className="block">{flight.input_age_seconds === null ? "Unavailable" : `${flight.input_age_seconds}s`}</strong></div>
+        <div><span className="text-slate-400">Geometry version / digest</span><strong className="block break-all">{flight.geometry_version ?? "Unavailable"} / {flight.geometry_digest ?? "Unavailable"}</strong></div>
+      </div>
+
+      <div className="grid gap-2 text-xs text-slate-300 md:grid-cols-2">
+        <div className="rounded border border-slate-700 bg-slate-950 p-2">
+          <b>Provenance:</b>{" "}
+          {flight.provenance === null
+            ? "Unavailable"
+            : `model ${flight.provenance.model_version}; config ${flight.provenance.config_version}; performance ${flight.provenance.performance_profile_id ?? "Unavailable"}; weather ${flight.provenance.weather_source ?? "Unavailable"}; sources ${flight.provenance.sources.join(", ") || "none"}`}
+        </div>
+        <div className="rounded border border-slate-700 bg-slate-950 p-2">
+          <b>Freeze:</b> {flight.freeze_reason}{flight.frozen_at ? ` since ${formatAMANTime(flight.frozen_at)}` : ""}. Slot group {flight.slot?.runway_group_id ?? "Unavailable"}, revision {flight.slot?.revision ?? "Unavailable"}, reason {flight.slot?.reason ?? "Unavailable"}.
+        </div>
+      </div>
+
+      <div className="rounded border border-slate-700 bg-slate-950 p-2 text-xs text-slate-300">
+        <b>Direct fact:</b>{" "}
+        {flight.route_fact === null
+          ? "Unavailable"
+          : `${flight.route_fact.id}; ${flight.route_fact.fix}; ${flight.route_fact.state}; observed ${formatAMANTime(flight.route_fact.observed_at)}`}
+      </div>
+
+      {flight.eta_review && (
+        <div className="rounded border border-amber-400 bg-amber-950 p-2 text-sm text-amber-100">
+          <b>Discrepancy {flight.eta_review.status}:</b> initial/FPL {formatAMANTime(flight.eta_review.initial_baseline_teta)}, calculated {formatAMANTime(flight.eta_review.calculated_operational_teta)}, selected {formatAMANTime(flight.eta_review.selected_teta)}, manual {formatAMANTime(flight.eta_review.manual_teta)}. Created {formatAMANTime(flight.eta_review.created_at)}, deadline {formatAMANTime(flight.eta_review.deadline_at)}, resolved {formatAMANTime(flight.eta_review.resolved_at)}, actor {flight.eta_review.actor ?? "Unavailable"}, note {flight.eta_review.note ?? "Unavailable"}.
+        </div>
+      )}
+
+      <div className="rounded border border-slate-700 bg-slate-950 p-2 text-sm">
+        <b>Queue offers:</b>{" "}
+        {flight.queue_offers.length === 0 ? "None" : flight.queue_offers.map((offer) => (
+          <span className="mr-3 inline-block" key={`${offer.runway_group_id}-${offer.queue_position}-${offer.candidate_slot.revision}`}>
+            #{offer.queue_position} {offer.runway_group_id} at {formatAMANTime(offer.candidate_slot.time)} ({offer.reason}; slot revision {offer.candidate_slot.revision}; airport revision {offer.airport_revision}; expires {formatAMANTime(offer.expires_at)})
+          </span>
+        ))}
+      </div>
+    </button>
+  );
+}
+
+export interface AMANBoardViewProps {
+  state: AMANState | null;
+  presentationStatus: AMANPresentationStatus;
+  error: string | null;
+  connectionState: AMANConnectionState;
+  selectedFlightID: string | null;
+  onSelectFlight: (flightID: string) => void;
+}
+
+export function AMANBoardView({
+  state,
+  presentationStatus,
+  error,
+  connectionState,
+  selectedFlightID,
+  onSelectFlight,
+}: AMANBoardViewProps) {
+  const lanes = useMemo(() => state ? buildAMANLanes(state) : [], [state]);
+  const range = useMemo(() => state ? buildTimelineRange(state.flights) : null, [state]);
+
+  if (state === null) {
+    return (
+      <section aria-label="AMAN presentation" className="grid min-h-72 place-items-center rounded-xl border border-slate-700 bg-slate-900 p-8 text-center text-slate-100">
+        <div>
+          <h1 className="text-2xl font-bold">AMAN timeline unavailable</h1>
+          <p className="mt-2 text-slate-300">{error ? `State rejected: ${error}` : "Waiting for a complete AMAN state replacement."}</p>
+          <span className={cn(badgeBase, connectionState === "connected" ? "border-emerald-500 text-emerald-200" : "border-red-500 text-red-200")}>{connectionState}</span>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section aria-label="AMAN presentation" className="grid gap-4">
+      <header className="rounded-xl border border-slate-700 bg-slate-900 p-4 text-slate-100 shadow-lg">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-black tracking-wide">{state.airport} AMAN</h1>
+            <p className="text-sm text-slate-400">Revision {state.revision} · generated {new Date(state.generated_at).toISOString()} · policy {state.policy_version}</p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <span className={cn(badgeBase, modeTone(state.effective_mode))}>{state.effective_mode.replace("_", " ")}</span>
+            <span className={cn(badgeBase, connectionState === "connected" ? "border-emerald-500 bg-emerald-950 text-emerald-200" : "border-red-500 bg-red-950 text-red-100")}>{connectionState}</span>
+            <span className={cn(badgeBase, presentationStatus === "ready" ? "border-emerald-500 bg-emerald-950 text-emerald-200" : "border-amber-400 bg-amber-950 text-amber-100")}>{presentationStatus}</span>
+            <span className={cn(badgeBase, state.authoritative ? "border-emerald-500 bg-emerald-950 text-emerald-200" : "border-slate-500 bg-slate-950 text-slate-300")}>{state.authoritative ? "authoritative" : "non-authoritative"}</span>
+          </div>
+        </div>
+        {state.technical_health.blocked_reasons.length > 0 && (
+          <div role="alert" className="mt-3 rounded border border-red-500 bg-red-950 p-2 text-sm text-red-100">
+            Blocked: {state.technical_health.blocked_reasons.join(", ")}
+          </div>
+        )}
+        <div className="mt-3 grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+          {([
+            ["VATSIM", state.technical_health.vatsim],
+            ["Navigation", state.technical_health.navigation],
+            ["Weather", state.technical_health.weather],
+            ["Repository", state.technical_health.repository],
+            ["Predictor", state.technical_health.predictor],
+            ["Replay validation", state.technical_health.replay_validation],
+          ] as const).map(([label, health]) => (
+            <div className="rounded border border-slate-700 bg-slate-950 p-2 text-xs" key={label}>
+              <b>{label}: {health.status}</b>
+              <span className="block text-slate-400">{health.reason ?? "No degradation reason"} · updated {formatAMANTime(health.updated_at)} · age {health.age_seconds === null ? "Unavailable" : `${health.age_seconds}s`}</span>
+            </div>
+          ))}
+        </div>
+      </header>
+
+      <div className="overflow-x-auto rounded-xl border border-slate-700 bg-slate-900 shadow-lg">
+        <div className="min-w-[880px]" data-testid="aman-timeline-grid">
+          <div className="grid grid-cols-[150px_minmax(720px,1fr)] bg-slate-950 text-xs text-slate-400">
+            <div className="border-r border-slate-700 px-3 py-2 font-semibold uppercase">Runway group</div>
+            <div className="flex justify-between px-3 py-2"><span>{range ? formatAMANTime(new Date(range.startMs).toISOString()) : "Unavailable"}</span><span>Operational timeline · amber diamond = raw TETA only</span><span>{range ? formatAMANTime(new Date(range.endMs).toISOString()) : "Unavailable"}</span></div>
+          </div>
+          {range === null ? (
+            <div className="p-6 text-center text-slate-300">No operational slot or TETA markers are available.</div>
+          ) : lanes.map((lane) => (
+            <TimelineLane
+              flights={lane.flights}
+              key={lane.id}
+              label={lane.label}
+              onSelectFlight={onSelectFlight}
+              range={range}
+              selectedFlightID={selectedFlightID}
+            />
+          ))}
+        </div>
+      </div>
+
+      {lanes.map((lane) => (
+        <section aria-label={`${lane.label} AMAN strips`} className="grid gap-3" key={lane.id}>
+          <h2 className="text-lg font-bold text-white">{lane.label} sequence</h2>
+          <div className="grid gap-3 xl:grid-cols-2">
+            {lane.flights.length === 0
+              ? <div className="rounded border border-slate-700 bg-slate-900 p-4 text-slate-400">No flights in this runway group.</div>
+              : lane.flights.map((flight) => (
+                <FlightStrip
+                  flight={flight}
+                  key={flight.flight_id}
+                  onSelect={() => onSelectFlight(flight.flight_id)}
+                  selected={flight.flight_id === selectedFlightID}
+                />
+              ))}
+          </div>
+        </section>
+      ))}
+    </section>
+  );
+}

--- a/frontend/src/components/aman/AMANControls.tsx
+++ b/frontend/src/components/aman/AMANControls.tsx
@@ -33,6 +33,8 @@ export interface AMANControlsViewProps {
   commandRejections: Record<string, AMANCommandRejection>;
   onCommand: (intent: AMANCommandIntent) => void;
   onDismissRejection?: (commandID: string) => void;
+  selectedFlightID?: string | null;
+  onSelectedFlightIDChange?: (flightID: string) => void;
 }
 
 function displayTime(value: string | null): string {
@@ -101,6 +103,8 @@ export function AMANControlsView({
   commandRejections,
   onCommand,
   onDismissRejection,
+  selectedFlightID,
+  onSelectedFlightIDChange,
 }: AMANControlsViewProps) {
   const [flightID, setFlightID] = useState("");
   const [targetFlightID, setTargetFlightID] = useState("");
@@ -110,8 +114,9 @@ export function AMANControlsView({
   const [goAroundAt, setGoAroundAt] = useState("");
 
   const flights = state?.flights ?? [];
-  const selectedFlight = flights.find((flight) => flight.flight_id === flightID) ?? flights[0] ?? null;
-  const selectedFlightID = selectedFlight?.flight_id ?? "";
+  const requestedFlightID = selectedFlightID ?? flightID;
+  const selectedFlight = flights.find((flight) => flight.flight_id === requestedFlightID) ?? flights[0] ?? null;
+  const effectiveSelectedFlightID = selectedFlight?.flight_id ?? "";
   const runwayGroupID = selectedFlight?.runway_group_id ?? state?.runway_groups[0]?.id ?? null;
   const gateReason = getAMANMutationBlockReason({
     state,
@@ -169,7 +174,10 @@ export function AMANControlsView({
         <>
           <label className="grid gap-1 text-sm">
             Flight
-            <select aria-label="Flight" className={inputClass} value={selectedFlightID} onChange={(event) => setFlightID(event.target.value)}>
+            <select aria-label="Flight" className={inputClass} value={effectiveSelectedFlightID} onChange={(event) => {
+              setFlightID(event.target.value);
+              onSelectedFlightIDChange?.(event.target.value);
+            }}>
               {flights.map((flight) => <option key={flight.flight_id} value={flight.flight_id}>{flight.callsign}</option>)}
             </select>
           </label>
@@ -180,7 +188,7 @@ export function AMANControlsView({
             <h3 className="font-semibold">Sequence and freeze</h3>
             <select aria-label="Move target" className={inputClass} value={targetFlightID} onChange={(event) => setTargetFlightID(event.target.value)}>
               <option value="">Select target flight</option>
-              {flights.filter((flight) => flight.flight_id !== selectedFlightID).map((flight) => <option key={flight.flight_id} value={flight.flight_id}>{flight.callsign}</option>)}
+              {flights.filter((flight) => flight.flight_id !== effectiveSelectedFlightID).map((flight) => <option key={flight.flight_id} value={flight.flight_id}>{flight.callsign}</option>)}
             </select>
             <div className="flex flex-wrap gap-2">
               <button className={controlClass} disabled={disabled || !targetFlightID || !runwayGroupID} onClick={() => sendMove("before")}>Move before</button>
@@ -234,7 +242,15 @@ export function AMANControlsView({
   );
 }
 
-export function AMANControls({hasFMPAuthority}: {hasFMPAuthority: boolean}) {
+export function AMANControls({
+  hasFMPAuthority,
+  selectedFlightID,
+  onSelectedFlightIDChange,
+}: {
+  hasFMPAuthority: boolean;
+  selectedFlightID?: string | null;
+  onSelectedFlightIDChange?: (flightID: string) => void;
+}) {
   const state = useWebSocketStore((value) => value.amanState);
   const connectionState = useWebSocketStore((value) => value.amanConnectionState);
   const readOnly = useWebSocketStore((value) => value.readOnly);
@@ -253,6 +269,8 @@ export function AMANControls({hasFMPAuthority}: {hasFMPAuthority: boolean}) {
       commandRejections={commandRejections}
       onCommand={(intent) => { sendCommand(intent, hasFMPAuthority); }}
       onDismissRejection={dismissRejection}
+      selectedFlightID={selectedFlightID}
+      onSelectedFlightIDChange={onSelectedFlightIDChange}
     />
   );
 }

--- a/frontend/src/components/aman/performance.test.ts
+++ b/frontend/src/components/aman/performance.test.ts
@@ -1,0 +1,10 @@
+import {describe, expect, it} from "vitest";
+
+import {percentile95} from "@/lib/aman-performance";
+
+describe("AMAN paint metrics", () => {
+  it("reports p95 deterministically for repeated full replacement samples", () => {
+    expect(percentile95([])).toBeNull();
+    expect(percentile95(Array.from({length: 20}, (_, index) => index + 1))).toBe(19);
+  });
+});

--- a/frontend/src/components/aman/presentation.test.ts
+++ b/frontend/src/components/aman/presentation.test.ts
@@ -1,0 +1,88 @@
+import {readFileSync} from "node:fs";
+import {resolve} from "node:path";
+import {describe, expect, it} from "vitest";
+
+import type {AMANFlight, AMANStateEvent} from "@/api/aman";
+import {
+  buildAMANLanes,
+  buildTimelineRange,
+  layoutTimelineMarkers,
+  operationalMarkerTimestamp,
+  orderAMANFlights,
+} from "./presentation";
+
+const golden = JSON.parse(readFileSync(
+  resolve(process.cwd(), "../backend/pkg/events/frontend/testdata/aman-state-v1.json"),
+  "utf8",
+)) as AMANStateEvent;
+
+function flight(id: string, order: number | null, minutes: number): AMANFlight {
+  const value = structuredClone(golden.data.flights[0]);
+  value.flight_id = id;
+  value.callsign = id.toUpperCase();
+  value.order = order;
+  value.slot = value.slot && {
+    ...value.slot,
+    sequence: order ?? 99,
+    time: new Date(Date.UTC(2026, 6, 22, 10, minutes)).toISOString(),
+  };
+  return value;
+}
+
+describe("AMAN presentation model", () => {
+  it("uses only backend order/sequence and preserves wire order for ties", () => {
+    const flights = [flight("third", 3, 3), flight("first-a", 1, 1), flight("first-b", 1, 2), flight("missing", null, 4)];
+    flights[3].slot = null;
+
+    expect(orderAMANFlights(flights).map((value) => value.flight_id)).toEqual(["first-a", "first-b", "third", "missing"]);
+  });
+
+  it("keeps declared, discovered, and unassigned runway groups deterministic", () => {
+    const state = structuredClone(golden.data);
+    state.runway_groups = [{id: "NORTH"}];
+    state.flights = [
+      {...flight("south-2", 2, 2), runway_group_id: "SOUTH"},
+      {...flight("north", 1, 1), runway_group_id: "NORTH"},
+      {...flight("south-1", 1, 1), runway_group_id: "SOUTH"},
+      {...flight("none", null, 3), runway_group_id: null, slot: null},
+    ];
+
+    expect(buildAMANLanes(state).map((lane) => [lane.id, lane.flights.map((value) => value.flight_id)])).toEqual([
+      ["NORTH", ["north"]],
+      ["SOUTH", ["south-1", "south-2"]],
+      ["unassigned", ["none"]],
+    ]);
+  });
+
+  it("uses slot then operational TETA for marker time and never raw TETA", () => {
+    const value = flight("frozen", 1, 10);
+    value.operational_teta = "2026-07-22T10:11:00.000Z";
+    value.raw_teta = "2026-07-22T10:50:00.000Z";
+    expect(operationalMarkerTimestamp(value)).toBe(value.slot?.time);
+    value.slot = null;
+    expect(operationalMarkerTimestamp(value)).toBe(value.operational_teta);
+  });
+
+  it("allocates deterministic collision tracks without changing marker timestamps", () => {
+    const flights = [flight("a", 1, 10), flight("b", 2, 10), flight("c", 3, 20)];
+    const range = buildTimelineRange(flights)!;
+    const markers = layoutTimelineMarkers(flights, range);
+
+    expect(markers.map((marker) => marker.track)).toEqual([0, 1, 0]);
+    expect(markers.map((marker) => marker.timestamp)).toEqual(flights.map((value) => value.slot!.time));
+  });
+
+  it("builds a 200-flight replacement presentation without partial lanes", () => {
+    const state = structuredClone(golden.data);
+    state.runway_groups = [{id: "NORTH"}, {id: "SOUTH"}];
+    state.flights = Array.from({length: 200}, (_, index) => ({
+      ...flight(`flight-${index}`, index, index % 60),
+      runway_group_id: index % 2 === 0 ? "NORTH" : "SOUTH",
+    }));
+
+    const lanes = buildAMANLanes(state);
+    expect(lanes).toHaveLength(2);
+    expect(lanes.flatMap((lane) => lane.flights)).toHaveLength(200);
+    expect(new Set(lanes.flatMap((lane) => lane.flights.map((value) => value.flight_id))).size).toBe(200);
+  });
+});

--- a/frontend/src/components/aman/presentation.ts
+++ b/frontend/src/components/aman/presentation.ts
@@ -1,0 +1,123 @@
+import type {AMANFlight, AMANState} from "@/api/aman";
+
+export const AMAN_TIMELINE_MINUTES = 10;
+export const AMAN_MARKER_GAP_PERCENT = 8;
+
+export interface AMANFlightLane {
+  id: string;
+  label: string;
+  flights: AMANFlight[];
+}
+
+export interface AMANTimelineRange {
+  startMs: number;
+  endMs: number;
+}
+
+export interface AMANTimelineMarker {
+  flight: AMANFlight;
+  timestamp: string;
+  leftPercent: number;
+  track: number;
+}
+
+function sequenceValue(flight: AMANFlight): number | null {
+  return flight.order ?? flight.slot?.sequence ?? null;
+}
+
+/**
+ * AMAN order is backend-owned. This only turns the serialized order/sequence
+ * into a stable display order and preserves wire order for ties or missing data.
+ */
+export function orderAMANFlights(flights: AMANFlight[]): AMANFlight[] {
+  return flights
+    .map((flight, index) => ({flight, index, sequence: sequenceValue(flight)}))
+    .sort((left, right) => {
+      if (left.sequence === null && right.sequence === null) return left.index - right.index;
+      if (left.sequence === null) return 1;
+      if (right.sequence === null) return -1;
+      return left.sequence - right.sequence || left.index - right.index;
+    })
+    .map(({flight}) => flight);
+}
+
+export function buildAMANLanes(state: AMANState): AMANFlightLane[] {
+  const declared = state.runway_groups.map((group) => group.id);
+  const discovered = state.flights
+    .map((flight) => flight.runway_group_id)
+    .filter((groupID): groupID is string => groupID !== null && !declared.includes(groupID));
+  const groupIDs = [...declared, ...new Set(discovered)];
+
+  const lanes = groupIDs.map((groupID) => ({
+    id: groupID,
+    label: groupID,
+    flights: orderAMANFlights(state.flights.filter((flight) => flight.runway_group_id === groupID)),
+  }));
+  const unassigned = orderAMANFlights(state.flights.filter((flight) => flight.runway_group_id === null));
+  if (unassigned.length > 0) {
+    lanes.push({id: "unassigned", label: "Unassigned runway group", flights: unassigned});
+  }
+  return lanes;
+}
+
+export function operationalMarkerTimestamp(flight: AMANFlight): string | null {
+  return flight.slot?.time ?? flight.operational_teta;
+}
+
+export function buildTimelineRange(flights: AMANFlight[]): AMANTimelineRange | null {
+  const timestamps = flights
+    .map(operationalMarkerTimestamp)
+    .filter((value): value is string => value !== null)
+    .map((value) => Date.parse(value))
+    .filter(Number.isFinite);
+  if (timestamps.length === 0) return null;
+
+  const minimumSpan = AMAN_TIMELINE_MINUTES * 60_000;
+  const minimum = Math.min(...timestamps);
+  const maximum = Math.max(...timestamps);
+  const span = Math.max(maximum - minimum, minimumSpan);
+  const padding = Math.max(span * 0.05, 60_000);
+  return {startMs: minimum - padding, endMs: minimum + span + padding};
+}
+
+/** Collision tracks are display-only; marker time and order remain untouched. */
+export function layoutTimelineMarkers(
+  flights: AMANFlight[],
+  range: AMANTimelineRange,
+  minimumGapPercent = AMAN_MARKER_GAP_PERCENT,
+): AMANTimelineMarker[] {
+  const span = range.endMs - range.startMs;
+  if (span <= 0) return [];
+
+  const candidates = orderAMANFlights(flights).flatMap((flight) => {
+    const timestamp = operationalMarkerTimestamp(flight);
+    if (timestamp === null) return [];
+    const timeMs = Date.parse(timestamp);
+    if (!Number.isFinite(timeMs)) return [];
+    return [{flight, timestamp, leftPercent: Math.max(0, Math.min(100, ((timeMs - range.startMs) / span) * 100))}];
+  });
+
+  const trackEnds: number[] = [];
+  return candidates
+    .sort((left, right) => left.leftPercent - right.leftPercent)
+    .map((candidate) => {
+      let track = trackEnds.findIndex((end) => candidate.leftPercent - end >= minimumGapPercent);
+      if (track === -1) track = trackEnds.length;
+      trackEnds[track] = candidate.leftPercent;
+      return {...candidate, track};
+    });
+}
+
+export function formatAMANTime(value: string | null): string {
+  if (value === null) return "Unavailable";
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.valueOf()) ? "Invalid" : parsed.toISOString().slice(11, 16);
+}
+
+export function formatGainLoss(seconds: number | null): string {
+  if (seconds === null) return "Unavailable";
+  if (seconds === 0) return "0:00";
+  const sign = seconds > 0 ? "+" : "−";
+  const absolute = Math.abs(seconds);
+  return `${sign}${Math.floor(absolute / 60)}:${String(absolute % 60).padStart(2, "0")}`;
+}

--- a/frontend/src/lib/aman-performance.ts
+++ b/frontend/src/lib/aman-performance.ts
@@ -1,0 +1,49 @@
+export const AMAN_STATE_RECEIVED_MARK = "aman-state-received";
+export const AMAN_STATE_PAINTED_MARK = "aman-state-painted";
+export const AMAN_STATE_TO_PAINT_MEASURE = "aman-state-to-paint";
+
+function markName(prefix: string, revision: number): string {
+  return `${prefix}-${revision}`;
+}
+
+export function markAMANStateReceived(revision: number): void {
+  if (typeof performance?.mark !== "function") return;
+  const name = markName(AMAN_STATE_RECEIVED_MARK, revision);
+  performance.clearMarks?.(name);
+  performance.mark(name);
+}
+
+/** Measures the complete replacement after the browser has had a paint frame. */
+export function measureAMANStatePaint(revision: number): () => void {
+  if (typeof requestAnimationFrame !== "function" || typeof performance?.mark !== "function" || typeof performance?.measure !== "function") {
+    return () => undefined;
+  }
+
+  let cancelled = false;
+  const frame = requestAnimationFrame(() => {
+    if (cancelled) return;
+    const received = markName(AMAN_STATE_RECEIVED_MARK, revision);
+    if (performance.getEntriesByName(received, "mark").length === 0) return;
+    const painted = markName(AMAN_STATE_PAINTED_MARK, revision);
+    performance.mark(painted);
+    performance.measure(markName(AMAN_STATE_TO_PAINT_MEASURE, revision), received, painted);
+  });
+  return () => {
+    cancelled = true;
+    cancelAnimationFrame(frame);
+  };
+}
+
+export function percentile95(samples: number[]): number | null {
+  if (samples.length === 0) return null;
+  const ordered = [...samples].sort((left, right) => left - right);
+  return ordered[Math.ceil(ordered.length * 0.95) - 1];
+}
+
+export function readAMANPaintP95(): number | null {
+  if (typeof performance?.getEntriesByType !== "function") return null;
+  const samples = performance.getEntriesByType("measure")
+    .filter((entry) => entry.name.startsWith(`${AMAN_STATE_TO_PAINT_MEASURE}-`))
+    .map((entry) => entry.duration);
+  return percentile95(samples);
+}

--- a/frontend/src/routes/AppRouter.tsx
+++ b/frontend/src/routes/AppRouter.tsx
@@ -9,6 +9,7 @@ import EKCHTWTE from "@/routes/ekch/TWTE";
 import EKCHTWRGND from "@/routes/ekch/TWRGND";
 import ChooseLayoutScreen from "@/components/ChooseLayoutScreen";
 import ObserverInvalidFrequencyScreen from "@/components/ObserverInvalidFrequencyScreen";
+import EKCHAMAN from "@/routes/ekch/AMAN";
 
 const LAYOUT_MAP: Record<string, React.ComponentType> = {
   CLX: EKCHDEL,
@@ -19,6 +20,7 @@ const LAYOUT_MAP: Record<string, React.ComponentType> = {
   GEGW: EKCHGEGW,
   TWTE: EKCHTWTE,
   TWRGND: EKCHTWRGND,
+  AMAN: EKCHAMAN,
 };
 
 export default function AppRouter() {

--- a/frontend/src/routes/ekch/AMAN.test.tsx
+++ b/frontend/src/routes/ekch/AMAN.test.tsx
@@ -1,0 +1,47 @@
+import {render, screen} from "@testing-library/react";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+
+import type {WebSocketState} from "@/store/store";
+import AMAN from "./AMAN";
+
+const {controlsSpy, storeState} = vi.hoisted(() => ({
+  controlsSpy: vi.fn(),
+  storeState: {
+    amanState: null,
+    amanPresentationStatus: "empty",
+    amanError: null,
+    amanConnectionState: "connected",
+  },
+}));
+
+vi.mock("@/store/store-hooks", () => ({
+  useWebSocketStore: (selector: (state: WebSocketState) => unknown) => selector(storeState as WebSocketState),
+}));
+
+vi.mock("@/components/aman/AMANBoard", () => ({
+  AMANBoardView: () => <div>AMAN board</div>,
+}));
+
+vi.mock("@/components/aman/AMANControls", () => ({
+  AMANControls: (props: {hasFMPAuthority: boolean}) => {
+    controlsSpy(props);
+    return <div>AMAN controls</div>;
+  },
+}));
+
+vi.mock("@/lib/aman-performance", () => ({
+  markAMANStateReceived: vi.fn(),
+  measureAMANStatePaint: vi.fn(() => () => undefined),
+}));
+
+describe("AMAN route authorization", () => {
+  beforeEach(() => controlsSpy.mockClear());
+
+  it("keeps FMP controls unauthorized without a server-backed capability", () => {
+    render(<AMAN />);
+
+    expect(screen.getByText("AMAN board")).toBeInTheDocument();
+    expect(screen.getByText("AMAN controls")).toBeInTheDocument();
+    expect(controlsSpy).toHaveBeenCalledWith(expect.objectContaining({hasFMPAuthority: false}));
+  });
+});

--- a/frontend/src/routes/ekch/AMAN.tsx
+++ b/frontend/src/routes/ekch/AMAN.tsx
@@ -1,0 +1,57 @@
+import {useEffect, useLayoutEffect, useRef, useState} from "react";
+
+import {AMANBoardView} from "@/components/aman/AMANBoard";
+import {AMANControls} from "@/components/aman/AMANControls";
+import {markAMANStateReceived, measureAMANStatePaint} from "@/lib/aman-performance";
+import {useWebSocketStore} from "@/store/store-hooks";
+
+export default function AMAN() {
+  const state = useWebSocketStore((value) => value.amanState);
+  const presentationStatus = useWebSocketStore((value) => value.amanPresentationStatus);
+  const error = useWebSocketStore((value) => value.amanError);
+  const connectionState = useWebSocketStore((value) => value.amanConnectionState);
+  const [selectedFlightID, setSelectedFlightID] = useState<string | null>(null);
+  const stateAtMount = useRef(state);
+
+  const effectiveSelectedFlightID = state?.flights.some((flight) => flight.flight_id === selectedFlightID)
+    ? selectedFlightID
+    : state?.flights[0]?.flight_id ?? null;
+
+  useLayoutEffect(() => {
+    // A replacement may predate opening the manual AMAN companion view. Reset
+    // that initial mark at mount so navigation delay is not counted as paint.
+    if (stateAtMount.current !== null) {
+      markAMANStateReceived(stateAtMount.current.revision);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (state === null) return undefined;
+    return measureAMANStatePaint(state.revision);
+  }, [state]);
+
+  return (
+    <main className="h-[95.28dvh] overflow-y-auto bg-slate-950 p-3 md:p-5">
+      <div className="mx-auto grid max-w-[1920px] items-start gap-4 2xl:grid-cols-[minmax(0,1fr)_420px]">
+        <AMANBoardView
+          connectionState={connectionState}
+          error={error}
+          onSelectFlight={setSelectedFlightID}
+          presentationStatus={presentationStatus}
+          selectedFlightID={effectiveSelectedFlightID}
+          state={state}
+        />
+        <div className="2xl:sticky 2xl:top-0">
+          <AMANControls
+            // AMAN_FMP_ROLES is backend-configured and no current wire field
+            // exposes this client's capability. Keep controls unauthorized
+            // until that server-backed capability is available.
+            hasFMPAuthority={false}
+            onSelectedFlightIDChange={setSelectedFlightID}
+            selectedFlightID={effectiveSelectedFlightID}
+          />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/store/store-layout.test.ts
+++ b/frontend/src/store/store-layout.test.ts
@@ -89,7 +89,7 @@ function foreignStrip(): FrontendStrip {
   };
 }
 
-describe("EST layout behavior", () => {
+describe("manual companion layout behavior", () => {
   let client: ReturnType<typeof createMockClient>;
   let store: StoreApi<WebSocketState>;
 
@@ -115,6 +115,19 @@ describe("EST layout behavior", () => {
     client._emit(EventType.FrontendInitial, initialEvent("AD"));
 
     expect(store.getState().displayedLayout).toBe("EST");
+    expect(store.getState().followRecommendedLayout).toBe(false);
+  });
+
+  it("does not automatically open AMAN and keeps a manually opened AMAN board after reconnecting", () => {
+    client._emit(EventType.FrontendInitial, initialEvent("AMAN"));
+    expect(store.getState().displayedLayout).toBe("");
+
+    client._emit(EventType.FrontendInitial, initialEvent("AD"));
+    store.getState().setDisplayedLayout("AMAN");
+    client._emit(EventType.FrontendLayoutUpdate, {type: EventType.FrontendLayoutUpdate, layout: "AAAD"});
+    client._emit(EventType.FrontendInitial, initialEvent("AD"));
+
+    expect(store.getState().displayedLayout).toBe("AMAN");
     expect(store.getState().followRecommendedLayout).toBe(false);
   });
 

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -75,8 +75,10 @@ import {
 } from "@/lib/validation-status";
 import { normalizeCdmTime } from "@/lib/cdmTime";
 import { toast } from "sonner";
+import {markAMANStateReceived} from "@/lib/aman-performance";
 
-const KNOWN_LAYOUTS = new Set(["CLX", "AAAD", "AA", "AD", "EST", "GEGW", "TWTE", "TWRGND"]);
+const MANUAL_COMPANION_LAYOUTS = new Set(["EST", "AMAN"]);
+const KNOWN_LAYOUTS = new Set(["CLX", "AAAD", "AA", "AD", ...MANUAL_COMPANION_LAYOUTS, "GEGW", "TWTE", "TWRGND"]);
 
 function normalizeLayout(layout: string) {
   switch (layout.trim().toUpperCase()) {
@@ -443,9 +445,9 @@ export const createWebSocketStore = (wsClient: WebSocketClient) => {
       const normalizedLayout = normalizeLayout(layout);
       set({
         displayedLayout: normalizedLayout,
-        // EST is a manual companion view, not a position-driven layout. Keep it
-        // open when strip or controller updates change the recommended layout.
-        followRecommendedLayout: normalizedLayout !== "EST" && normalizedLayout === get().layout,
+        // Manual companion views are not position-driven. Keep them open when
+        // strip or controller updates change the recommended layout.
+        followRecommendedLayout: !MANUAL_COMPANION_LAYOUTS.has(normalizedLayout) && normalizedLayout === get().layout,
       });
     },
     setLayoutChooserOpen: (open) => set({ layoutChooserOpen: open }),
@@ -987,10 +989,10 @@ export const createWebSocketStore = (wsClient: WebSocketClient) => {
         state.localIp = data.local_ip ?? "";
         const normalizedLayout = normalizeLayout(data.layout);
         state.layout = normalizedLayout;
-        if (state.displayedLayout === "EST") {
-          // Preserve a manually opened EST board across reconnects.
+        if (MANUAL_COMPANION_LAYOUTS.has(state.displayedLayout)) {
+          // Preserve a manually opened companion board across reconnects.
           state.followRecommendedLayout = false;
-        } else if (KNOWN_LAYOUTS.has(normalizedLayout) && normalizedLayout !== "EST") {
+        } else if (KNOWN_LAYOUTS.has(normalizedLayout) && !MANUAL_COMPANION_LAYOUTS.has(normalizedLayout)) {
           state.displayedLayout = normalizedLayout;
           state.followRecommendedLayout = true;
         } else {
@@ -1556,6 +1558,9 @@ export const createWebSocketStore = (wsClient: WebSocketClient) => {
 
   wsClient.on(EventType.FrontendAMANState, (event) => {
     const replacement = replaceAMANState(store.getState().amanState, event);
+    if (replacement.accepted && replacement.state !== null) {
+      markAMANStateReceived(replacement.state.revision);
+    }
     store.setState(produce((state: WebSocketState) => {
       state.amanState = replacement.state;
       state.amanPresentationStatus = replacement.status;


### PR DESCRIPTION
## Scope

- add the complete AMAN companion view to the controller layout chooser
- render full-replacement AMAN state as deterministic runway-group timelines and detailed flight strips
- keep operational slot/TETA markers separate from informational raw-TETA drift, with display-only collision tracks and hit selection
- present authority, connection, technical health, lifecycle, data status, freeze, queue, direct, discrepancy, confidence, provenance, geometry, holding, and gain/loss facts from backend state
- mount the existing FMP controls and synchronize their selected flight with timeline and strip selection
- record state-received-to-paint measurements and expose p95 aggregation for repeated replacements

## Validation

- `npm test`: 23 test files and 155 tests passed
- focused AMAN/layout tests after the final authorization review: 7 test files and 30 tests passed
- `npm run build`
- focused ESLint for all changed AMAN, route, layout, and store files
- `git diff --check`

## Explicit contract and performance gaps

- The #325 server contract does not serialize aircraft type/WTC, a runway separate from runway group, or distinct published-versus-selected holding data. The presentation shows these values as unavailable and does not infer or callsign-join them.
- `AMAN_FMP_ROLES` is backend-configured, but #325/#326 expose no per-client FMP capability. The mounted controls therefore pass `hasFMPAuthority=false` and remain visibly unauthorized until a server-backed capability is introduced; no role list or callsign inference exists in the browser.
- No agreed numeric initial/replacement paint threshold is present in #328, its comments, or the repository. This PR adds receive-to-paint marks, p95 aggregation, and a complete 200-flight presentation fixture, but deliberately does not invent a pass/fail budget.

Closes #328
