### PR TITLE
fix(stand): respect arrival reservation windows

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -364,6 +364,10 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	frontendHub.SetServer(fsServer)
 	euroscopeHub.SetServer(fsServer)
 	stripService.SetRouteRecalculator(fsServer)
+	if departureLifecycle != nil {
+		departureLifecycle.SetRouteRecalculator(fsServer)
+		departureLifecycle.SetStandPublisher(frontendHub)
+	}
 	controllerService.SetFrontendNotifier(frontendHub)
 	controllerService.SetSessionRecalculator(fsServer)
 	controllerService.SetStripService(stripService)

--- a/backend/internal/services/departure_lifecycle.go
+++ b/backend/internal/services/departure_lifecycle.go
@@ -52,6 +52,8 @@ type DepartureLifecycleService struct {
 	blockExtension time.Duration
 	sweepInterval  time.Duration
 	messenger      wrongStandMessenger
+	routeRecalc    RouteRecalculator
+	standPublisher observedStandPublisher
 	warningMu      sync.Mutex
 	warnings       map[string]string
 }
@@ -60,8 +62,22 @@ type wrongStandMessenger interface {
 	SendPrivateMessageFromDelivery(session int32, callsign, message string) bool
 }
 
+type observedStandPublisher interface {
+	SendStandEvent(session int32, callsign string, stand string)
+}
+
 func (s *DepartureLifecycleService) SetWrongStandMessenger(messenger wrongStandMessenger) {
 	s.messenger = messenger
+}
+
+// SetRouteRecalculator lets the observed-stand recovery use the aircraft's
+// physical stand for its ground route even while a protected booking remains.
+func (s *DepartureLifecycleService) SetRouteRecalculator(routeRecalc RouteRecalculator) {
+	s.routeRecalc = routeRecalc
+}
+
+func (s *DepartureLifecycleService) SetStandPublisher(publisher observedStandPublisher) {
+	s.standPublisher = publisher
 }
 
 // CancelDeparture cancels transient wrong-stand state when a departure
@@ -237,6 +253,7 @@ func (s *DepartureLifecycleService) activateObservedBlock(ctx context.Context, s
 	observedRequest := request
 	observedRequest.ExpiresAt = nil
 	if _, err := s.allocations.assignObservedStand(ctx, observedRequest); err == nil {
+		s.useObservedStandForRoute(ctx, session, strip.Callsign, observed.Name)
 		s.clearUnassignedStandWarning(session, strip.Callsign)
 		return true, nil
 	} else if existing == nil {
@@ -244,8 +261,10 @@ func (s *DepartureLifecycleService) activateObservedBlock(ctx context.Context, s
 		result, allocationErr := s.allocations.Allocate(ctx, automaticRequest)
 		if allocationErr != nil {
 			if errors.Is(allocationErr, ErrAutomaticAllocationSuppressed) {
+				s.useObservedStandForRoute(ctx, session, strip.Callsign, observed.Name)
 				return false, nil
 			}
+			s.useObservedStandForRoute(ctx, session, strip.Callsign, observed.Name)
 			s.deliverUnassignedOccupiedStandWarning(session, strip.Callsign, observed.Name)
 			slog.Warn("observed departure stand is occupied and no alternative stand could be assigned",
 				slog.String("callsign", strip.Callsign),
@@ -257,6 +276,10 @@ func (s *DepartureLifecycleService) activateObservedBlock(ctx context.Context, s
 		s.clearUnassignedStandWarning(session, strip.Callsign)
 		existing = &result.Assignment
 	}
+	// Keep the allocation reservation intact, but route from the physical stand
+	// that EuroScope/VATSIM observed. A confirmed inbound booking may prevent
+	// this departure from claiming that stand, not from using its real location.
+	s.useObservedStandForRoute(ctx, session, strip.Callsign, observed.Name)
 
 	if existing.ConflictReason != nil {
 		switch *existing.ConflictReason {
@@ -284,6 +307,33 @@ func (s *DepartureLifecycleService) activateObservedBlock(ctx context.Context, s
 		return false, fmt.Errorf("publish observed stand mismatch for %s: %w", strip.Callsign, err)
 	}
 	return false, s.deliverWrongStandWarning(ctx, &updated)
+}
+
+func (s *DepartureLifecycleService) useObservedStandForRoute(ctx context.Context, session int32, callsign, stand string) {
+	stand = standName(stand)
+	if stand == "" {
+		return
+	}
+	updated, err := s.strips.UpdateStand(ctx, session, callsign, &stand, nil)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to persist observed stand for departure route",
+			slog.String("callsign", callsign), slog.String("stand", stand), slog.Any("error", err))
+		return
+	}
+	if updated != 0 && s.standPublisher != nil {
+		s.standPublisher.SendStandEvent(session, callsign, stand)
+	}
+	if s.routeRecalc == nil {
+		return
+	}
+	if err := s.routeRecalc.UpdateRouteForStripContext(ctx, callsign, session, true); err != nil {
+		slog.WarnContext(ctx, "failed to recalculate departure route from observed stand",
+			slog.String("callsign", callsign), slog.String("stand", stand), slog.Any("error", err))
+	}
+}
+
+func isWrongStandConflictReason(reason string) bool {
+	return strings.HasPrefix(reason, wrongStandPendingPrefix) || strings.HasPrefix(reason, wrongStandAwaitingPrefix)
 }
 
 func (s *DepartureLifecycleService) deliverUnassignedOccupiedStandWarning(session int32, callsign, observedStand string) {
@@ -660,6 +710,7 @@ func (s *DepartureLifecycleService) buildRequest(session int32, strip *models.St
 		FlightFacts:     facts,
 		AssignmentFacts: assignmentFacts,
 		ExpiresAt:       expiresAt,
+		DepartureTOBT:   departureTobtTime(strip, s.now()),
 	}
 	if cid := parseCID(flight.CID); cid != nil {
 		revision := flight.Revision
@@ -714,6 +765,21 @@ func (s *DepartureLifecycleService) computeBlockExpiry(strip *models.Strip) *tim
 		}
 	}
 	return nil
+}
+
+func departureTobtTime(strip *models.Strip, now time.Time) *time.Time {
+	if strip == nil {
+		return nil
+	}
+	if calculation := strip.CdmData.EffectiveCalculation(); calculation != nil && calculation.InvalidReason != nil &&
+		strings.TrimSpace(*calculation.InvalidReason) == models.CdmInvalidReasonStaleTobt {
+		return nil
+	}
+	tobt, ok := parseDepartureClockUTC(stripClockValue(strip.EffectiveTobt()), now)
+	if !ok {
+		return nil
+	}
+	return &tobt
 }
 
 func departureBlockExpiry(value string, now time.Time, extension time.Duration) (time.Time, bool) {

--- a/backend/internal/services/departure_lifecycle_test.go
+++ b/backend/internal/services/departure_lifecycle_test.go
@@ -7,6 +7,7 @@ import (
 	"FlightStrips/internal/repository"
 	"FlightStrips/internal/repository/postgres"
 	"FlightStrips/internal/sat"
+	"FlightStrips/internal/testutil"
 	"FlightStrips/internal/vatsim"
 	"context"
 	"fmt"
@@ -245,6 +246,76 @@ func TestDepartureLifecycle(t *testing.T) {
 		assert.Equal(t, "AUTOMATIC", block.Source)
 		assert.Nil(t, block.ConflictReason)
 		assert.Nil(t, block.MatchedVariant)
+	})
+
+	t.Run("observed departure displaces a provisional inbound booking", func(t *testing.T) {
+		lifecycle, allocations, session, assignments, strips, _ := departureLifecycleFixture(t, pool, queries, "", "", nil)
+		testdata.SeedTestStrip(t, queries, session, "SAS611")
+		testdata.SeedTestStrip(t, queries, session, "SAS612")
+		eta := time.Date(2026, 7, 12, 10, 20, 0, 0, time.UTC)
+		require.NoError(t, assignments.CreateAssignment(ctx, &models.StandAssignment{
+			SessionID: session, Callsign: "SAS612", Stand: "A2", Direction: "ARRIVAL",
+			Stage: StageAssigned, Source: "AUTOMATIC", ETA: &eta,
+		}))
+		_, err := strips.UpdateStand(ctx, session, "SAS612", strp("A2"), nil)
+		require.NoError(t, err)
+
+		var published StandAllocationResult
+		allocations.SetPublisher(func(_ context.Context, result StandAllocationResult) error {
+			published = result
+			return nil
+		})
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS611"), onlineFlightAtA2("SAS611", 1)))
+
+		departure, err := assignments.GetAssignment(ctx, session, "SAS611")
+		require.NoError(t, err)
+		assert.Equal(t, "A2", departure.Stand)
+		assert.Equal(t, StageDepartureBlock, departure.Stage)
+		_, err = assignments.GetAssignment(ctx, session, "SAS612")
+		require.Error(t, err, "the provisional inbound is released for the observed departure")
+		assert.Nil(t, loadStrip(t, strips, session, "SAS612").Stand)
+		require.Len(t, published.RemovedAssignments, 1)
+		assert.Equal(t, "SAS612", published.RemovedAssignments[0].Callsign)
+	})
+
+	t.Run("observed departure publishes its physical stand when a future inbound blocks its booking", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, _ := departureLifecycleFixture(t, pool, queries, "", "", nil)
+		testdata.SeedTestStrip(t, queries, session, "SAS613")
+		testdata.SeedTestStrip(t, queries, session, "SAS614")
+		eta := time.Date(2026, 7, 12, 10, 1, 0, 0, time.UTC)
+		require.NoError(t, assignments.CreateAssignment(ctx, &models.StandAssignment{
+			SessionID: session, Callsign: "SAS614", Stand: "A2", Direction: "ARRIVAL",
+			Stage: StageConfirmed, Source: "AUTOMATIC", ETA: &eta,
+		}))
+		_, err := strips.UpdateStand(ctx, session, "SAS614", strp("A2"), nil)
+		require.NoError(t, err)
+		tobt := "1000"
+		_, err = strips.SetCdmData(ctx, session, "SAS613", &models.CdmData{Tobt: &tobt})
+		require.NoError(t, err)
+		standPublisher := &observedStandPublisherFake{}
+		lifecycle.SetStandPublisher(standPublisher)
+		routeRecalculated := false
+		lifecycle.SetRouteRecalculator(&testutil.MockServer{
+			UpdateRouteForStripCtxFn: func(_ context.Context, callsign string, routeSession int32, sendUpdate bool) error {
+				assert.Equal(t, "SAS613", callsign)
+				assert.Equal(t, session, routeSession)
+				assert.True(t, sendUpdate)
+				assert.Equal(t, "A2", *loadStrip(t, strips, session, callsign).Stand)
+				routeRecalculated = true
+				return nil
+			},
+		})
+
+		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS613"), onlineFlightAtA2("SAS613", 1)))
+
+		inbound, err := assignments.GetAssignment(ctx, session, "SAS614")
+		require.NoError(t, err)
+		assert.Equal(t, "A2", inbound.Stand)
+		assert.Equal(t, StageConfirmed, inbound.Stage)
+		assert.Equal(t, "A2", *loadStrip(t, strips, session, "SAS613").Stand, "the physical stand is retained for route calculation")
+		assert.True(t, routeRecalculated)
+		require.Len(t, standPublisher.events, 1)
+		assert.Equal(t, observedStandEvent{session: session, callsign: "SAS613", stand: "A2"}, standPublisher.events[0])
 	})
 
 	t.Run("occupied observed stand records a task 19 mismatch without blocking the reserved stand", func(t *testing.T) {
@@ -701,6 +772,18 @@ type engineRecord struct {
 	ICAO   string
 	WTC    string
 	Engine string
+}
+
+type observedStandEvent struct {
+	session  int32
+	callsign string
+	stand    string
+}
+
+type observedStandPublisherFake struct{ events []observedStandEvent }
+
+func (f *observedStandPublisherFake) SendStandEvent(session int32, callsign string, stand string) {
+	f.events = append(f.events, observedStandEvent{session: session, callsign: callsign, stand: stand})
 }
 
 func mustLoadAircraftRegistry(t *testing.T, types ...string) *sat.AircraftRegistry {

--- a/backend/internal/services/stand_actions.go
+++ b/backend/internal/services/stand_actions.go
@@ -149,7 +149,7 @@ func (s *StandActionService) request(ctx context.Context, session int32, airport
 		expiresAt = existing.ExpiresAt
 	}
 	return StandAllocationRequest{SessionID: session, Callsign: strip.Callsign, Airport: strings.ToUpper(airport), Direction: direction, Stage: stage,
-		FlightFacts: facts, AssignmentFacts: sat.AssignmentFlightFacts{Callsign: strip.Callsign, AircraftType: valueString(strip.AircraftType), AircraftUse: facts.Aircraft.UseCode, BorderStatus: facts.BorderStatus, Direction: direction}, ETA: arrivalETATime(strip), ETASource: existingETASource(existing), ExpiresAt: expiresAt, VatsimRevision: strip.VatsimRevision}, nil
+		FlightFacts: facts, AssignmentFacts: sat.AssignmentFlightFacts{Callsign: strip.Callsign, AircraftType: valueString(strip.AircraftType), AircraftUse: facts.Aircraft.UseCode, BorderStatus: facts.BorderStatus, Direction: direction}, ETA: arrivalETATime(strip), ETASource: existingETASource(existing), ExpiresAt: expiresAt, DepartureTOBT: departureTobtTime(strip, time.Now().UTC()), VatsimRevision: strip.VatsimRevision}, nil
 }
 
 func (s *StandActionService) Acknowledge(ctx context.Context, session int32, position, callsign string, version int32) (*models.StandAssignment, error) {

--- a/backend/internal/services/stand_allocation.go
+++ b/backend/internal/services/stand_allocation.go
@@ -60,13 +60,21 @@ type StandAllocationRequest struct {
 	ETA             *time.Time
 	ETASource       *string
 	ExpiresAt       *time.Time
-	VatsimCID       *int64
-	VatsimRevision  *int64
+	// DepartureTOBT is used to decide whether a future arrival booking prevents
+	// a departure from taking its stand.
+	DepartureTOBT  *time.Time
+	VatsimCID      *int64
+	VatsimRevision *int64
 
 	Stand          string
 	ConflictReason string
 
 	DisplaceStage string
+	// DisplaceArrivalStages extends DisplaceStage for callers that may displace
+	// more than one non-final arrival stage. It is deliberately arrival-only:
+	// an observed departure must never displace another departure or a confirmed
+	// inbound stand booking.
+	DisplaceArrivalStages []string
 }
 
 // StandAllocationResult is complete only after the transaction commits. The
@@ -268,6 +276,10 @@ func (s *StandAllocationService) AssignManually(ctx context.Context, request Sta
 // unavailable result is expected during wrong-stand recovery, so it must not
 // be retained as a controller-facing allocation failure.
 func (s *StandAllocationService) assignObservedStand(ctx context.Context, request StandAllocationRequest) (*StandAllocationResult, error) {
+	// A departure observed on a stand is physically there. Its presence takes
+	// precedence over a provisional inbound booking, but never over the final
+	// CONFIRMED arrival stage.
+	request.DisplaceArrivalStages = []string{StageEstimated, StageAssigned}
 	return s.allocateWithFailureLogging(ctx, observedStandAllocation, request, false)
 }
 
@@ -575,7 +587,7 @@ func (s *StandAllocationService) allocateOnce(ctx context.Context, command Stand
 		return nil, selected, err
 	}
 	var removedAssignments []models.StandAssignment
-	if request.DisplaceStage != "" && selected != "" {
+	if request.displacesArrivalStage() && selected != "" {
 		removedAssignments, err = s.displaceAssignments(ctx, txStrips, txAssignments, request, selected, assignments)
 		if err != nil {
 			return nil, selected, err
@@ -730,8 +742,18 @@ func (s *StandAllocationService) availability(request StandAllocationRequest, as
 			if assignment == nil || strings.EqualFold(assignment.Callsign, request.Callsign) || expired(assignment.ExpiresAt, now) {
 				continue
 			}
+			futureArrivalBlocks := false
+			// Arrival assignments are planning information until their ETA. A
+			// flight that has not landed must not physically occupy its planned
+			// stand or prevent a departure from using it.
+			if assignment.Direction == string(sat.AssignmentDirectionArrival) && assignment.ETA != nil && assignment.ETA.After(now) {
+				futureArrivalBlocks = futureArrivalBlocksRequest(*assignment.ETA, request)
+				if !futureArrivalBlocks {
+					continue
+				}
+			}
 			if candidate == standName(assignment.Stand) {
-				if request.DisplaceStage != "" && assignment.Direction == string(sat.AssignmentDirectionArrival) && assignment.Stage == request.DisplaceStage {
+				if request.displacesAssignment(assignment) && (!futureArrivalBlocks || sameArrivalETA(request.ETA, assignment.ETA)) {
 					continue
 				}
 				result[candidate] = append(result[candidate], "reserved by "+assignment.Callsign)
@@ -762,6 +784,25 @@ func (s *StandAllocationService) availability(request StandAllocationRequest, as
 		}
 	}
 	return result
+}
+
+func sameArrivalETA(left, right *time.Time) bool {
+	return left != nil && right != nil && left.Equal(*right)
+}
+
+// futureArrivalBlocksRequest treats a future arrival as a reservation from its
+// ETA. A departure may use the stand only when its TOBT plus the stand-release
+// buffer is before that ETA; a later-arriving inbound cannot take a stand that
+// is already reserved first.
+func futureArrivalBlocksRequest(arrivalETA time.Time, request StandAllocationRequest) bool {
+	switch request.Direction {
+	case sat.AssignmentDirectionDeparture:
+		return request.DepartureTOBT != nil && request.DepartureTOBT.Add(defaultDepartureBlockExtension).After(arrivalETA)
+	case sat.AssignmentDirectionArrival:
+		return request.ETA == nil || !request.ETA.Before(arrivalETA)
+	default:
+		return false
+	}
 }
 
 func (s *StandAllocationService) configuredStandBlocks(airport, standName string) []string {
@@ -893,7 +934,7 @@ func joinAllocationReasons(reasons []string) string {
 }
 
 func (s *StandAllocationService) displaceAssignments(ctx context.Context, strips repository.StripRepository, assignments repository.StandAssignmentRepository, request StandAllocationRequest, selected string, current []*models.StandAssignment) ([]models.StandAssignment, error) {
-	if request.DisplaceStage == "" || selected == "" {
+	if !request.displacesArrivalStage() || selected == "" {
 		return nil, nil
 	}
 	removed := []models.StandAssignment{}
@@ -901,7 +942,7 @@ func (s *StandAllocationService) displaceAssignments(ctx context.Context, strips
 		if assignment == nil || strings.EqualFold(assignment.Callsign, request.Callsign) {
 			continue
 		}
-		if assignment.Direction != string(sat.AssignmentDirectionArrival) || assignment.Stage != request.DisplaceStage {
+		if !request.displacesAssignment(assignment) {
 			continue
 		}
 		if standName(assignment.Stand) != standName(selected) {
@@ -920,6 +961,20 @@ func (s *StandAllocationService) displaceAssignments(ctx context.Context, strips
 		removed = append(removed, *assignment)
 	}
 	return removed, nil
+}
+
+func (request StandAllocationRequest) displacesArrivalStage() bool {
+	return request.DisplaceStage != "" || len(request.DisplaceArrivalStages) > 0
+}
+
+func (request StandAllocationRequest) displacesAssignment(assignment *models.StandAssignment) bool {
+	if assignment == nil || assignment.Direction != string(sat.AssignmentDirectionArrival) {
+		return false
+	}
+	if assignment.Stage == request.DisplaceStage && request.DisplaceStage != "" {
+		return true
+	}
+	return slices.Contains(request.DisplaceArrivalStages, assignment.Stage)
 }
 
 func standName(value string) string      { return strings.ToUpper(strings.TrimSpace(value)) }

--- a/backend/internal/services/stand_allocation_test.go
+++ b/backend/internal/services/stand_allocation_test.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -126,6 +127,90 @@ func TestStandAllocationServiceTransactions(t *testing.T) {
 		displacedStrip, err := queries.GetStrip(ctx, database.GetStripParams{Session: session, Callsign: "SAS104"})
 		require.NoError(t, err)
 		assert.Nil(t, displacedStrip.Stand)
+	})
+
+	t.Run("future arrival booking does not occupy its stand before ETA", func(t *testing.T) {
+		service, session, _ := standAllocationFixture(t, pool, queries, "", "")
+		testdata.SeedTestStrip(t, queries, session, "SAS106")
+		testdata.SeedTestStrip(t, queries, session, "SAS107")
+		eta := time.Now().UTC().Add(time.Hour)
+		arrival := withStand(standAllocationRequest(session, "SAS106"), "A1")
+		arrival.Stage = StageConfirmed
+		arrival.ETA = &eta
+		_, err := service.AssignManually(ctx, arrival)
+		require.NoError(t, err)
+
+		departure := withStand(standAllocationRequest(session, "SAS107"), "A1")
+		departure.Direction = sat.AssignmentDirectionDeparture
+		departure.FlightFacts.Direction = sat.Departure
+		departure.Stage = StageDepartureBlock
+		result, err := service.assignObservedStand(ctx, departure)
+		require.NoError(t, err)
+		assert.Equal(t, "A1", result.Assignment.Stand)
+	})
+
+	t.Run("arrival booking occupies its stand from ETA", func(t *testing.T) {
+		service, session, _ := standAllocationFixture(t, pool, queries, "", "")
+		testdata.SeedTestStrip(t, queries, session, "SAS108")
+		testdata.SeedTestStrip(t, queries, session, "SAS109")
+		now := time.Now().UTC()
+		eta := now.Add(time.Hour)
+		service.now = func() time.Time { return now }
+		arrival := withStand(standAllocationRequest(session, "SAS108"), "A1")
+		arrival.Stage = StageConfirmed
+		arrival.ETA = &eta
+		_, err := service.AssignManually(ctx, arrival)
+		require.NoError(t, err)
+
+		service.now = func() time.Time { return eta }
+		departure := withStand(standAllocationRequest(session, "SAS109"), "A1")
+		departure.Direction = sat.AssignmentDirectionDeparture
+		departure.FlightFacts.Direction = sat.Departure
+		departure.Stage = StageDepartureBlock
+		_, err = service.assignObservedStand(ctx, departure)
+		require.ErrorIs(t, err, ErrIncompatibleManualAssignment)
+	})
+
+	t.Run("future arrival booking blocks a departure whose TOBT release is after ETA", func(t *testing.T) {
+		service, session, _ := standAllocationFixture(t, pool, queries, "", "")
+		testdata.SeedTestStrip(t, queries, session, "SAS110")
+		testdata.SeedTestStrip(t, queries, session, "SAS111")
+		now := time.Now().UTC()
+		eta := now.Add(time.Hour)
+		arrival := withStand(standAllocationRequest(session, "SAS110"), "A1")
+		arrival.Stage = StageAssigned
+		arrival.ETA = &eta
+		_, err := service.AssignManually(ctx, arrival)
+		require.NoError(t, err)
+
+		laterTobt := eta.Add(-5 * time.Minute)
+		departure := withStand(standAllocationRequest(session, "SAS111"), "A1")
+		departure.Direction = sat.AssignmentDirectionDeparture
+		departure.FlightFacts.Direction = sat.Departure
+		departure.Stage = StageDepartureBlock
+		departure.DepartureTOBT = &laterTobt
+		_, err = service.assignObservedStand(ctx, departure)
+		require.ErrorIs(t, err, ErrIncompatibleManualAssignment)
+	})
+
+	t.Run("future arrival booking blocks a later arriving inbound", func(t *testing.T) {
+		service, session, _ := standAllocationFixture(t, pool, queries, "", "")
+		testdata.SeedTestStrip(t, queries, session, "SAS112")
+		testdata.SeedTestStrip(t, queries, session, "SAS113")
+		now := time.Now().UTC()
+		firstETA := now.Add(time.Hour)
+		firstArrival := withStand(standAllocationRequest(session, "SAS112"), "A1")
+		firstArrival.Stage = StageConfirmed
+		firstArrival.ETA = &firstETA
+		_, err := service.AssignManually(ctx, firstArrival)
+		require.NoError(t, err)
+
+		laterETA := firstETA.Add(time.Hour)
+		laterArrival := withStand(standAllocationRequest(session, "SAS113"), "A1")
+		laterArrival.Stage = StageConfirmed
+		laterArrival.ETA = &laterETA
+		_, err = service.AssignManually(ctx, laterArrival)
+		require.ErrorIs(t, err, ErrIncompatibleManualAssignment)
 	})
 
 	t.Run("rejects direct occupancy and one-way or two-way blocks", func(t *testing.T) {

--- a/backend/internal/services/strip_validation.go
+++ b/backend/internal/services/strip_validation.go
@@ -112,6 +112,15 @@ func (s *StripValidationService) ReconcileStandAssignmentValidation(ctx context.
 		return err
 	}
 	current := strip.ValidationStatus
+	if isWrongStandConflictReason(conflictReason) {
+		// A wrong-stand episode is a pilot-relocation workflow. It must not
+		// appear as an actionable validation to the controller who owns the
+		// strip, even though the assignment retains its workflow marker.
+		if current != nil && current.IssueType == internalModels.ValidationIssueTypeStandAssignment {
+			return s.ClearValidationStatus(ctx, session, callsign)
+		}
+		return nil
+	}
 	blocked := len(blockedBy) > 0 || strings.TrimSpace(conflictReason) != ""
 	if !blocked {
 		if current != nil && current.IssueType == internalModels.ValidationIssueTypeStandAssignment {

--- a/backend/internal/services/strip_validation_test.go
+++ b/backend/internal/services/strip_validation_test.go
@@ -157,6 +157,24 @@ func TestReconcileStandAssignmentValidationClearsResolvedSatIssueOnly(t *testing
 	require.NoError(t, svc.ReconcileStandAssignmentValidation(context.Background(), 1, "SAS123", nil, ""))
 }
 
+func TestReconcileStandAssignmentValidationSuppressesWrongStandWorkflow(t *testing.T) {
+	cleared := false
+	repo := &validationStoreFake{
+		getByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
+			return &models.Strip{Callsign: "SAS123", ValidationStatus: &models.ValidationStatus{IssueType: models.ValidationIssueTypeStandAssignment}}, nil
+		},
+		clearValidationStatusFn: func(_ context.Context, _ int32, callsign string) error {
+			assert.Equal(t, "SAS123", callsign)
+			cleared = true
+			return nil
+		},
+	}
+	svc := newTestStripValidationService(repo, repo)
+
+	require.NoError(t, svc.ReconcileStandAssignmentValidation(context.Background(), 1, "SAS123", []string{"A2"}, wrongStandPendingPrefix+"A2"))
+	assert.True(t, cleared, "the wrong-stand workflow must not leave a controller validation behind")
+}
+
 func TestNewStripValidationServiceRejectsMissingReader(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Reserve planned arrival stands from the estimated landing time, while preventing departures whose TOBT plus 10 minutes would overlap the arrival.
- Preserve protected/confirmed arrival assignments and only displace provisional inbound bookings when the timeline permits it.
- Keep observed physical stands usable for route calculation without surfacing a controller validation error.

## Validation

- `go test ./...` (from `backend`)