### PR TITLE
feat(aman): implement CPH calculation and STAR spacing

### DIFF
--- a/backend/config/aman/ekch-terminal-2607.json
+++ b/backend/config/aman/ekch-terminal-2607.json
@@ -12,18 +12,18 @@
     { "id": "NAVIAIR-AIP-DK", "document": "EKCH RNAV STAR tabular charts: RWY 12-2/3 AIRAC AMDT 12/25 and 12/24; RWY 30-2/3 AIRAC AMDT 12/25 and 12/24; RWY 04/22 retained official tabular descriptions", "effectiveFrom": "2025-11-27T00:00:00Z", "effectiveUntil": "2026-08-06T00:00:00Z" }
   ],
   "runwayGroups": [
-    { "id": "ARRIVAL-04", "aliases": ["04", "04L", "04R"], "runways": ["04L", "04R"], "finalApproaches": [
+    { "id": "ARRIVAL-04", "aliases": ["04", "04L", "04R"], "runways": ["04L", "04R"], "sameStarSpacing": { "enabled": true, "activationRatePerHour": 20, "minimumEmptySlots": 1 }, "finalApproaches": [
       { "runway": "04L", "threshold": { "position": { "latitudeDeg": 55.5922, "longitudeDeg": 12.6035361111 }, "courseTrueDeg": 41.2 }, "courseTrueDeg": 41.2, "physicalLengthM": 3001, "provenance": { "sourceId": "NAVIAIR-AIP-DK", "sourceRevision": "EK_AD_2_EKCH_ADC_A-02-26", "importedAt": "2026-07-18T00:00:00Z", "effectiveFrom": "2026-02-19T00:00:00Z", "effectiveUntil": "2026-08-06T00:00:00Z" } },
       { "runway": "04R", "threshold": { "position": { "latitudeDeg": 55.6031, "longitudeDeg": 12.6330472222 }, "courseTrueDeg": 41.2 }, "courseTrueDeg": 41.2, "physicalLengthM": 3302, "provenance": { "sourceId": "NAVIAIR-AIP-DK", "sourceRevision": "EK_AD_2_EKCH_ADC_A-02-26", "importedAt": "2026-07-18T00:00:00Z", "effectiveFrom": "2026-02-19T00:00:00Z", "effectiveUntil": "2026-08-06T00:00:00Z" } }
     ] },
-    { "id": "ARRIVAL-22", "aliases": ["22", "22L", "22R"], "runways": ["22L", "22R"], "finalApproaches": [
+    { "id": "ARRIVAL-22", "aliases": ["22", "22L", "22R"], "runways": ["22L", "22R"], "sameStarSpacing": { "enabled": true, "activationRatePerHour": 20, "minimumEmptySlots": 1 }, "finalApproaches": [
       { "runway": "22L", "threshold": { "position": { "latitudeDeg": 55.6254111111, "longitudeDeg": 12.6675805556 }, "courseTrueDeg": 221.2 }, "courseTrueDeg": 221.2, "physicalLengthM": 3302, "provenance": { "sourceId": "NAVIAIR-AIP-DK", "sourceRevision": "EK_AD_2_EKCH_ADC_A-02-26", "importedAt": "2026-07-18T00:00:00Z", "effectiveFrom": "2026-02-19T00:00:00Z", "effectiveUntil": "2026-08-06T00:00:00Z" } },
       { "runway": "22R", "threshold": { "position": { "latitudeDeg": 55.6124777778, "longitudeDeg": 12.6348916667 }, "courseTrueDeg": 221.2 }, "courseTrueDeg": 221.2, "physicalLengthM": 3571, "provenance": { "sourceId": "NAVIAIR-AIP-DK", "sourceRevision": "EK_AD_2_EKCH_ADC_A-02-26", "importedAt": "2026-07-18T00:00:00Z", "effectiveFrom": "2026-02-19T00:00:00Z", "effectiveUntil": "2026-08-06T00:00:00Z" } }
     ] },
-    { "id": "ARRIVAL-12", "aliases": ["12"], "runways": ["12"], "finalApproaches": [
+    { "id": "ARRIVAL-12", "aliases": ["12"], "runways": ["12"], "sameStarSpacing": { "enabled": true, "activationRatePerHour": 20, "minimumEmptySlots": 1 }, "finalApproaches": [
       { "runway": "12", "threshold": { "position": { "latitudeDeg": 55.62415, "longitudeDeg": 12.6391166667 }, "courseTrueDeg": 123.2 }, "courseTrueDeg": 123.2, "physicalLengthM": 2800, "provenance": { "sourceId": "NAVIAIR-AIP-DK", "sourceRevision": "EK_AD_2_EKCH_ADC_A-02-26", "importedAt": "2026-07-18T00:00:00Z", "effectiveFrom": "2026-02-19T00:00:00Z", "effectiveUntil": "2026-08-06T00:00:00Z" } }
     ] },
-    { "id": "ARRIVAL-30", "aliases": ["30"], "runways": ["30"], "finalApproaches": [
+    { "id": "ARRIVAL-30", "aliases": ["30"], "runways": ["30"], "sameStarSpacing": { "enabled": true, "activationRatePerHour": 20, "minimumEmptySlots": 1 }, "finalApproaches": [
       { "runway": "30", "threshold": { "position": { "latitudeDeg": 55.6138527778, "longitudeDeg": 12.6669472222 }, "courseTrueDeg": 303.2 }, "courseTrueDeg": 303.2, "physicalLengthM": 2365, "provenance": { "sourceId": "NAVIAIR-AIP-DK", "sourceRevision": "EK_AD_2_EKCH_ADC_A-02-26", "importedAt": "2026-07-18T00:00:00Z", "effectiveFrom": "2026-02-19T00:00:00Z", "effectiveUntil": "2026-08-06T00:00:00Z" } }
     ] }
   ],

--- a/backend/internal/aman/lifecycle/reducer.go
+++ b/backend/internal/aman/lifecycle/reducer.go
@@ -26,8 +26,8 @@ func DefaultConfig() Config {
 		UnstableHorizon:      45 * time.Minute,
 		StableHorizon:        20 * time.Minute,
 		SuperstableHorizon:   10 * time.Minute,
-		MinimumUnstableDwell: 5 * time.Minute,
-		RemovalTimeout:       5 * time.Minute,
+		MinimumUnstableDwell: 2 * time.Minute,
+		RemovalTimeout:       time.Minute,
 	}
 }
 
@@ -227,8 +227,6 @@ func nextState(config Config, flight aman.AMANFlight, enteredAt time.Time, event
 		}
 		untilArrival := event.OperationalTETA.Sub(event.OccurredAt)
 		switch {
-		case untilArrival <= config.StableHorizon:
-			return aman.StateStable, aman.LifecycleReasonSuddenAppearance, nil
 		case untilArrival <= config.UnstableHorizon:
 			return aman.StateUnstable, aman.LifecycleReasonSuddenAppearance, nil
 		default:

--- a/backend/internal/aman/lifecycle/reducer_test.go
+++ b/backend/internal/aman/lifecycle/reducer_test.go
@@ -62,11 +62,11 @@ func TestReduceUsesExactHorizonAndDwellBoundaries(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, aman.StateUnstable, atUnstable.Flight.State)
 
-	beforeDwell, err := lifecycle.Reduce(config, atUnstable.Flight, predictionEvent("before-dwell", now.Add(7*time.Minute-time.Nanosecond), now.Add(27*time.Minute-time.Nanosecond)))
+	beforeDwell, err := lifecycle.Reduce(config, atUnstable.Flight, predictionEvent("before-dwell", now.Add(4*time.Minute-time.Nanosecond), now.Add(24*time.Minute-time.Nanosecond)))
 	require.NoError(t, err)
 	require.Equal(t, aman.StateUnstable, beforeDwell.Flight.State)
 
-	atDwell, err := lifecycle.Reduce(config, beforeDwell.Flight, predictionEvent("at-dwell", now.Add(7*time.Minute), now.Add(27*time.Minute)))
+	atDwell, err := lifecycle.Reduce(config, beforeDwell.Flight, predictionEvent("at-dwell", now.Add(4*time.Minute), now.Add(24*time.Minute)))
 	require.NoError(t, err)
 	require.Equal(t, aman.StateStable, atDwell.Flight.State)
 	require.Equal(t, aman.LifecycleReasonStableHorizon, atDwell.Flight.Lifecycle.Reason)
@@ -108,19 +108,19 @@ func TestReduceRestartsDisconnectedAndReconcilesBeforeResumingRemoval(t *testing
 	require.NoError(t, err)
 	require.Equal(t, now.Add(time.Minute+config.RemovalTimeout), *missing.Flight.Lifecycle.Absence.RemovalDueAt)
 
-	restartedEvent := event("restart-1", lifecycle.EventSourceRestarted, now.Add(2*time.Minute))
+	restartedEvent := event("restart-1", lifecycle.EventSourceRestarted, now.Add(time.Minute+20*time.Second))
 	restarted, err := lifecycle.Reduce(config, missing.Flight, restartedEvent)
 	require.NoError(t, err)
 	require.Equal(t, aman.DataDisconnected, restarted.Flight.DataStatus)
 	require.True(t, restarted.Flight.Lifecycle.ReconciliationPending)
 	require.Nil(t, restarted.Flight.Lifecycle.Absence.RemovalDueAt)
-	require.Equal(t, 4*time.Minute, restarted.Flight.Lifecycle.Absence.Remaining)
+	require.Equal(t, 40*time.Second, restarted.Flight.Lifecycle.Absence.Remaining)
 
 	duplicate, err := lifecycle.Reduce(config, restarted.Flight, restartedEvent)
 	require.NoError(t, err)
 	require.True(t, duplicate.Duplicate)
 	require.Equal(t, restarted.Flight, duplicate.Flight)
-	_, err = lifecycle.Reduce(config, restarted.Flight, statusEvent("late-stale", now.Add(time.Minute+30*time.Second), aman.DataStale))
+	_, err = lifecycle.Reduce(config, restarted.Flight, statusEvent("late-stale", now.Add(time.Minute+10*time.Second), aman.DataStale))
 	requireDomainClass(t, err, aman.ErrorInvalidTransition)
 	_, err = lifecycle.Reduce(config, restarted.Flight, statusEvent("restart-1", now.Add(2*time.Minute), aman.DataFresh))
 	requireDomainClass(t, err, aman.ErrorInvalidTransition)
@@ -142,11 +142,11 @@ func TestReduceRestartsDisconnectedAndReconcilesBeforeResumingRemoval(t *testing
 	confirmedMissing, err := lifecycle.Reduce(config, fresh.Flight, event("fresh-snapshot-missing", lifecycle.EventFlightMissing, now.Add(34*time.Minute)))
 	require.NoError(t, err)
 	require.False(t, confirmedMissing.Flight.Lifecycle.ReconciliationPending)
-	require.Equal(t, now.Add(38*time.Minute), *confirmedMissing.Flight.Lifecycle.Absence.RemovalDueAt)
+	require.Equal(t, now.Add(34*time.Minute+40*time.Second), *confirmedMissing.Flight.Lifecycle.Absence.RemovalDueAt)
 
-	_, err = lifecycle.Reduce(config, confirmedMissing.Flight, event("early-timeout", lifecycle.EventRemovalTimeout, now.Add(38*time.Minute-time.Nanosecond)))
+	_, err = lifecycle.Reduce(config, confirmedMissing.Flight, event("early-timeout", lifecycle.EventRemovalTimeout, now.Add(34*time.Minute+40*time.Second-time.Nanosecond)))
 	requireDomainClass(t, err, aman.ErrorInvalidTransition)
-	removed, err := lifecycle.Reduce(config, confirmedMissing.Flight, event("timeout", lifecycle.EventRemovalTimeout, now.Add(38*time.Minute)))
+	removed, err := lifecycle.Reduce(config, confirmedMissing.Flight, event("timeout", lifecycle.EventRemovalTimeout, now.Add(34*time.Minute+40*time.Second)))
 	require.NoError(t, err)
 	require.Equal(t, aman.StateRemoved, removed.Flight.State)
 	require.Equal(t, aman.LifecycleReasonSourceDisappearance, removed.Flight.Lifecycle.Reason)
@@ -180,10 +180,10 @@ func TestReduceSuddenAppearanceUsesDefensibleStateWithoutInventingFreeze(t *test
 	}{
 		{name: "outside lifecycle horizons", untilTETA: config.UnstableHorizon + time.Nanosecond, wantState: aman.StateAirborne},
 		{name: "at unstable horizon", untilTETA: config.UnstableHorizon, wantState: aman.StateUnstable},
-		{name: "at stable horizon without invented dwell", untilTETA: config.StableHorizon, wantState: aman.StateStable},
-		{name: "outside freeze horizon", untilTETA: config.SuperstableHorizon + time.Nanosecond, wantState: aman.StateStable},
-		{name: "at freeze horizon requires review", untilTETA: config.SuperstableHorizon, wantState: aman.StateStable, wantReview: true},
-		{name: "inside freeze horizon requires review", untilTETA: config.SuperstableHorizon - time.Second, wantState: aman.StateStable, wantReview: true},
+		{name: "at stable horizon observes dwell", untilTETA: config.StableHorizon, wantState: aman.StateUnstable},
+		{name: "outside freeze horizon observes dwell", untilTETA: config.SuperstableHorizon + time.Nanosecond, wantState: aman.StateUnstable},
+		{name: "at freeze horizon requires review and dwell", untilTETA: config.SuperstableHorizon, wantState: aman.StateUnstable, wantReview: true},
+		{name: "inside freeze horizon requires review and dwell", untilTETA: config.SuperstableHorizon - time.Second, wantState: aman.StateUnstable, wantReview: true},
 	}
 
 	for index, tt := range tests {

--- a/backend/internal/aman/operational/mutations.go
+++ b/backend/internal/aman/operational/mutations.go
@@ -1,0 +1,282 @@
+package operational
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/aman/etareview"
+	"FlightStrips/internal/aman/prediction"
+	"FlightStrips/internal/aman/sequence"
+)
+
+func (s *Service) MoveFlight(_ aman.CommandContext, command aman.MoveFlightCommand) (sequence.CommandMutation, error) {
+	return s.sequenceMutation("move_flight", command.FlightID, func(input sequence.Input) (sequence.Decision, error) {
+		return sequence.ApplyMove(input, sequence.MoveFlightCommand{Metadata: command.Metadata, FlightID: command.FlightID, RunwayGroupID: command.RunwayGroupID, BeforeFlightID: command.BeforeFlightID, AfterFlightID: command.AfterFlightID})
+	}), nil
+}
+
+func (s *Service) LockFlight(auth aman.CommandContext, command aman.LockFlightCommand) (sequence.CommandMutation, error) {
+	return s.sequenceMutation("lock_flight", command.FlightID, func(input sequence.Input) (sequence.Decision, error) {
+		return sequence.ApplyManualFreeze(input, sequence.ApplyManualFreezeCommand{Metadata: command.Metadata, FlightID: command.FlightID, At: auth.ReceivedAt})
+	}), nil
+}
+
+func (s *Service) UnlockFlight(auth aman.CommandContext, command aman.UnlockFlightCommand) (sequence.CommandMutation, error) {
+	return s.sequenceMutation("unlock_flight", command.FlightID, func(input sequence.Input) (sequence.Decision, error) {
+		return sequence.ReleaseManualFreeze(input, sequence.ReleaseManualFreezeCommand{Metadata: command.Metadata, FlightID: command.FlightID, At: auth.ReceivedAt})
+	}), nil
+}
+
+func (s *Service) SetRate(auth aman.CommandContext, command aman.SetRateCommand) (sequence.CommandMutation, error) {
+	return func(state aman.AirportState) (sequence.CommandChange, error) {
+		input := sequenceInput(state, s.deps.Terminal)
+		decision, err := sequence.ApplyRate(input, sequence.SetRateCommand{Metadata: command.Metadata, RunwayGroupID: command.RunwayGroupID, ArrivalsPerHour: command.ArrivalsPerHour, EffectiveAt: command.EffectiveAt})
+		if err != nil {
+			return sequence.CommandChange{}, err
+		}
+		for _, warning := range decision.Candidate.Warnings {
+			if warning.RunwayGroupID == command.RunwayGroupID && warning.Severity == sequence.SeverityConflict && warning.Code == sequence.WarningProtectedSameSTAR {
+				return sequence.CommandChange{}, &aman.DomainError{
+					Class: aman.ErrorInvalidTransition, Message: string(sequence.WarningProtectedSameSTAR) + ": protected slots prevent the requested runway-group rate",
+				}
+			}
+		}
+		state = applyDecision(state, decision)
+		for i := range state.RunwayGroups {
+			if state.RunwayGroups[i].ID == command.RunwayGroupID {
+				for _, policy := range decision.Input.Policies {
+					if policy.RunwayGroupID != command.RunwayGroupID {
+						continue
+					}
+					state.RunwayGroups[i].RateSchedule = make([]aman.RunwayGroupRatePoint, len(policy.Rates))
+					for rateIndex, rate := range policy.Rates {
+						state.RunwayGroups[i].RateSchedule[rateIndex] = aman.RunwayGroupRatePoint{EffectiveAt: rate.EffectiveAt, ArrivalsPerHour: rate.ArrivalsPerHour}
+					}
+					break
+				}
+			}
+		}
+		updateActiveRates(state.RunwayGroups, auth.ReceivedAt)
+		for i := range state.RunwayGroups {
+			if state.RunwayGroups[i].ID == command.RunwayGroupID {
+				state.RunwayGroups[i].SelectionSchedule = upsertRunwayGroupSelection(
+					state.RunwayGroups[i].SelectionSchedule,
+					aman.RunwayGroupSelectionPoint{EffectiveAt: command.EffectiveAt, CommandRevision: state.Revision},
+				)
+			}
+		}
+		selected, selectionChanged := updateSelectedRunwayGroup(state.RunwayGroups, auth.ReceivedAt)
+		if selectionChanged {
+			reassignFlightsToGroup(&state, selected)
+			s.resequence(&state, auth.ReceivedAt)
+		}
+		return s.commandChange(state, decision.Changed || selectionChanged, "set_rate", "", map[string]any{"runway_group_id": command.RunwayGroupID, "arrivals_per_hour": command.ArrivalsPerHour})
+	}, nil
+}
+
+func upsertRunwayGroupSelection(schedule []aman.RunwayGroupSelectionPoint, point aman.RunwayGroupSelectionPoint) []aman.RunwayGroupSelectionPoint {
+	result := append([]aman.RunwayGroupSelectionPoint(nil), schedule...)
+	replaced := false
+	for index := range result {
+		if result[index].EffectiveAt.Equal(point.EffectiveAt) {
+			result[index] = point
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		result = append(result, point)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].EffectiveAt.Before(result[j].EffectiveAt) })
+	return result
+}
+
+func reassignFlightsToGroup(state *aman.AirportState, selected aman.RunwayGroupID) {
+	for i := range state.Flights {
+		flight := &state.Flights[i]
+		if flight.State == aman.StateStable || flight.State == aman.StateLanded || flight.State == aman.StateRemoved || flight.FreezeReason != aman.FreezeNone {
+			continue
+		}
+		if flight.SelectedRunwayGroup != nil && *flight.SelectedRunwayGroup == selected {
+			continue
+		}
+		group := selected
+		flight.SelectedRunwayGroup = &group
+		flight.SelectedHolding = nil
+		flight.ActiveRouteKey = nil
+		flight.ActiveRouteDatasetID = nil
+		flight.RouteProgress = nil
+		flight.Slot = nil
+		flight.Order = nil
+		flight.ManualOrder = nil
+	}
+}
+
+func (s *Service) AcceptTETA(auth aman.CommandContext, command aman.AcceptTETACommand) (sequence.CommandMutation, error) {
+	return s.flightMutation("accept_teta", command.FlightID, func(flight aman.AMANFlight) (aman.AMANFlight, bool, error) {
+		result, err := etareview.ResolveAcceptCalculated(flight, etareview.AcceptCalculated{At: auth.ReceivedAt, Actor: auth.Actor})
+		return result.Flight, result.Changed, err
+	}), nil
+}
+
+func (s *Service) KeepFPLETA(auth aman.CommandContext, command aman.KeepFPLETACommand) (sequence.CommandMutation, error) {
+	return s.flightMutation("keep_fpl_eta", command.FlightID, func(flight aman.AMANFlight) (aman.AMANFlight, bool, error) {
+		result, err := etareview.ResolveKeepInitial(flight, etareview.KeepInitial{At: auth.ReceivedAt, Actor: auth.Actor})
+		return result.Flight, result.Changed, err
+	}), nil
+}
+
+func (s *Service) SetManualETA(auth aman.CommandContext, command aman.SetManualETACommand) (sequence.CommandMutation, error) {
+	return s.flightMutation("set_manual_eta", command.FlightID, func(flight aman.AMANFlight) (aman.AMANFlight, bool, error) {
+		if flight.ETAReview != nil && flight.ETAReview.Status == aman.ReviewPending {
+			result, err := etareview.ResolveSetManual(flight, etareview.SetManual{At: auth.ReceivedAt, Actor: auth.Actor, ManualTETA: command.ManualETA})
+			return result.Flight, result.Changed, err
+		}
+		updated, err := prediction.ApplyManualOperationalTETA(flight, command.ManualETA, auth.ReceivedAt)
+		return updated, err == nil, err
+	}), nil
+}
+
+func (s *Service) ResetTETAOverride(auth aman.CommandContext, command aman.ResetTETAOverrideCommand) (sequence.CommandMutation, error) {
+	return s.flightMutation("reset_teta_override", command.FlightID, func(flight aman.AMANFlight) (aman.AMANFlight, bool, error) {
+		if flight.ETAReview != nil && flight.ETAReview.Status != aman.ReviewNone {
+			result, err := etareview.ResolveReset(prediction.DefaultConfig(), flight, etareview.Reset{At: auth.ReceivedAt, Actor: auth.Actor})
+			return result.Flight, result.Changed, err
+		}
+		updated, err := prediction.ReleaseManualOperationalTETA(prediction.DefaultConfig(), flight, auth.ReceivedAt)
+		return updated, err == nil, err
+	}), nil
+}
+
+func (s *Service) ReportGoAround(auth aman.CommandContext, command aman.ReportGoAroundCommand) (sequence.CommandMutation, error) {
+	return func(state aman.AirportState) (sequence.CommandChange, error) {
+		index := flightIndex(state.Flights, command.FlightID)
+		if index < 0 {
+			return sequence.CommandChange{}, domainNotFound(command.FlightID)
+		}
+		if state.Flights[index].Prediction == nil {
+			return sequence.CommandChange{}, &aman.DomainError{Class: aman.ErrorInvalidTransition, Message: "go-around requires a current operational prediction"}
+		}
+		state.Flights = append([]aman.AMANFlight(nil), state.Flights...)
+		flight := &state.Flights[index]
+		target := command.DetectedAt.Add(10 * time.Minute)
+		updatedPrediction := *flight.Prediction
+		updatedPrediction.OperationalTETA = target
+		updatedPrediction.OperationalReason = aman.OperationalReasonGoAround
+		updatedPrediction.Publishable = true
+		flight.Prediction = &updatedPrediction
+		flight.State = aman.StateGoAround
+		flight.UpdatedAt = auth.ReceivedAt
+		flight.Lifecycle = &aman.LifecycleState{
+			EnteredAt: command.DetectedAt, Reason: aman.LifecycleReasonGoAroundConfirmed,
+			LastEventID: "go-around:" + command.Metadata.CommandID, LastEventFingerprint: modelVersion, LastEventAt: command.DetectedAt,
+		}
+		input := sequenceInput(state, s.deps.Terminal)
+		decision, err := sequence.ApplyGoAround(input, sequence.GoAroundPolicy{Delay: 10 * time.Minute, MaxCascade: len(input.Flights) + 1}, sequence.ApplyGoAroundCommand{Metadata: command.Metadata, FlightID: command.FlightID, DetectedAt: command.DetectedAt})
+		if err != nil {
+			return sequence.CommandChange{}, err
+		}
+		return s.commandChange(applyDecision(state, decision), true, "report_go_around", command.FlightID, nil)
+	}, nil
+}
+
+func (s *Service) sequenceMutation(action string, flightID aman.FlightID, apply func(sequence.Input) (sequence.Decision, error)) sequence.CommandMutation {
+	return func(state aman.AirportState) (sequence.CommandChange, error) {
+		decision, err := apply(sequenceInput(state, s.deps.Terminal))
+		if err != nil {
+			return sequence.CommandChange{}, err
+		}
+		return s.commandChange(applyDecision(state, decision), decision.Changed, action, flightID, nil)
+	}
+}
+
+func (s *Service) flightMutation(action string, flightID aman.FlightID, apply func(aman.AMANFlight) (aman.AMANFlight, bool, error)) sequence.CommandMutation {
+	return func(state aman.AirportState) (sequence.CommandChange, error) {
+		index := flightIndex(state.Flights, flightID)
+		if index < 0 {
+			return sequence.CommandChange{}, domainNotFound(flightID)
+		}
+		updated, changed, err := apply(state.Flights[index])
+		if err != nil {
+			return sequence.CommandChange{}, err
+		}
+		state.Flights = append([]aman.AMANFlight(nil), state.Flights...)
+		state.Flights[index] = updated
+		if changed {
+			s.resequence(&state, updated.UpdatedAt)
+		}
+		return s.commandChange(state, changed, action, flightID, nil)
+	}
+}
+
+func (s *Service) commandChange(state aman.AirportState, changed bool, action string, flightID aman.FlightID, extra map[string]any) (sequence.CommandChange, error) {
+	change, err := commandChange(state, changed, action, flightID, extra)
+	if err != nil || !changed {
+		return change, err
+	}
+	change.QueueOffers = &sequence.QueueOfferCalculation{
+		Input:  sequenceInput(state, s.deps.Terminal),
+		Config: sequence.QueueOfferConfig{Validity: queueOfferValidity},
+	}
+	return change, nil
+}
+
+func applyDecision(state aman.AirportState, decision sequence.Decision) aman.AirportState {
+	state.Flights = append([]aman.AMANFlight(nil), state.Flights...)
+	inputFlights := make(map[aman.FlightID]sequence.Flight, len(decision.Input.Flights))
+	for _, flight := range decision.Input.Flights {
+		inputFlights[flight.ID] = flight
+	}
+	entries := make(map[aman.FlightID]sequence.CandidateEntry, len(decision.Candidate.Entries))
+	for _, entry := range decision.Candidate.Entries {
+		entries[entry.FlightID] = entry
+	}
+	for i := range state.Flights {
+		if input, ok := inputFlights[state.Flights[i].ID]; ok {
+			state.Flights[i].FreezeReason = input.FreezeReason
+			state.Flights[i].FrozenAt = input.FrozenAt
+			state.Flights[i].FrozenOperationalTETA = input.FrozenOperationalTETA
+			state.Flights[i].FrozenSlot = input.CapturedSlot
+			state.Flights[i].ManualOrder = input.ManualOrder
+		}
+		if entry, ok := entries[state.Flights[i].ID]; ok {
+			state.Flights[i].Slot = &aman.Slot{Time: entry.Time, RunwayGroupID: entry.RunwayGroupID, Sequence: entry.Sequence, Revision: state.Revision, Reason: string(entry.Reason)}
+			order := entry.Sequence
+			state.Flights[i].Order = &order
+		}
+	}
+	return state
+}
+
+func commandChange(state aman.AirportState, changed bool, action string, flightID aman.FlightID, extra map[string]any) (sequence.CommandChange, error) {
+	payload := map[string]any{"action": action, "changed": changed}
+	if flightID != "" {
+		payload["flight_id"] = flightID
+	}
+	for key, value := range extra {
+		payload[key] = value
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return sequence.CommandChange{}, err
+	}
+	return sequence.CommandChange{State: state, Changed: changed, Outcome: encoded, Audit: []sequence.AuditEntry{{Category: "aman." + action, Payload: encoded}}}, nil
+}
+
+func flightIndex(flights []aman.AMANFlight, id aman.FlightID) int {
+	for index := range flights {
+		if flights[index].ID == id {
+			return index
+		}
+	}
+	return -1
+}
+
+func domainNotFound(id aman.FlightID) error {
+	return &aman.DomainError{Class: aman.ErrorNotFound, Message: fmt.Sprintf("AMAN flight %q was not found", id)}
+}
+
+var _ sequence.ActionMutations = (*Service)(nil)

--- a/backend/internal/aman/operational/service.go
+++ b/backend/internal/aman/operational/service.go
@@ -1,0 +1,916 @@
+// Package operational assembles the pure AMAN components into the durable,
+// minute-driven AMAN-CPH reconciliation owner.
+package operational
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"reflect"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/aman/materializer"
+	"FlightStrips/internal/aman/navdata"
+	"FlightStrips/internal/aman/prediction"
+	"FlightStrips/internal/aman/predictor"
+	"FlightStrips/internal/aman/sequence"
+	"FlightStrips/internal/aman/terminal"
+	"FlightStrips/internal/aman/trajectory"
+)
+
+const (
+	policyVersion          = "aman-cph-v1"
+	modelVersion           = "aman-cph-teta-v1"
+	defaultArrivalRate     = uint32(20)
+	navigationRefreshEvery = 6 * time.Hour
+	queueOfferValidity     = 2 * time.Minute
+)
+
+type NavigationMaterializer interface {
+	Refresh(context.Context, materializer.Request) error
+	MaterializeRoute(context.Context, navdata.RouteQuery, string) (navdata.RouteKey, error)
+}
+
+type GeometryCache interface {
+	navdata.GeometryReader
+	navdata.GeometrySnapshotReader
+}
+
+type Repository interface {
+	aman.AirportStateReader
+	aman.StateCommitter
+}
+
+type Dependencies struct {
+	Repository   Repository
+	Retirer      aman.VATSIMFlightIdentityRetirer
+	Materializer NavigationMaterializer
+	Geometry     GeometryCache
+	Wind         predictor.WindProfileReader
+	Terminal     terminal.Configuration
+	Airports     []string
+	Mode         aman.RolloutMode
+	Publisher    sequence.FullStatePublisher
+	Now          func() time.Time
+}
+
+type Service struct {
+	deps Dependencies
+
+	mu          sync.Mutex
+	observed    map[string]map[aman.FlightID]aman.FlightObservation
+	lastRefresh map[string]time.Time
+	health      serviceHealth
+}
+
+type serviceHealth struct {
+	vatsim, navigation, weather, repository, predictor, replay aman.ComponentHealth
+}
+
+func New(deps Dependencies) (*Service, error) {
+	if deps.Repository == nil || deps.Materializer == nil || deps.Geometry == nil || deps.Wind == nil || deps.Publisher == nil {
+		return nil, errors.New("AMAN operational service requires repository, navigation, wind, and publisher dependencies")
+	}
+	if deps.Terminal.Airport == "" || len(deps.Terminal.RunwayGroups) == 0 {
+		return nil, errors.New("AMAN operational service requires terminal configuration")
+	}
+	if deps.Now == nil {
+		deps.Now = time.Now
+	}
+	if len(deps.Airports) == 0 {
+		return nil, errors.New("AMAN operational service requires enabled airports")
+	}
+	now := deps.Now().UTC()
+	pending := func(reason string) aman.ComponentHealth {
+		return componentHealth(aman.HealthUnavailable, reason, now)
+	}
+	return &Service{
+		deps: deps, observed: map[string]map[aman.FlightID]aman.FlightObservation{}, lastRefresh: map[string]time.Time{},
+		health: serviceHealth{
+			vatsim: pending("source_not_observed"), navigation: pending("navigation_not_refreshed"),
+			weather: pending("weather_not_observed"), repository: pending("repository_not_checked"),
+			predictor: componentHealth(aman.HealthReady, "", now), replay: componentHealth(aman.HealthReady, "", now),
+		},
+	}, nil
+}
+
+func (*Service) Name() string { return "AMAN-CPH operational service" }
+
+func (s *Service) TechnicalHealth(context.Context) aman.TechnicalHealth {
+	s.mu.Lock()
+	health := s.health
+	s.mu.Unlock()
+	return aman.EvaluateTechnicalHealth(s.deps.Mode, health.vatsim, health.navigation, health.weather, health.repository, health.predictor, health.replay)
+}
+
+func (s *Service) Observe(_ context.Context, observation aman.FlightObservation) error {
+	if err := observation.Validate(); err != nil {
+		return err
+	}
+	airport := strings.ToUpper(strings.TrimSpace(observation.Destination))
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.observed[airport] == nil {
+		s.observed[airport] = map[aman.FlightID]aman.FlightObservation{}
+	}
+	s.observed[airport][observation.FlightID] = observation
+	s.health.vatsim = sourceComponentHealth(observation.SourceStatus, observation.ReconciledAt)
+	return nil
+}
+
+func (s *Service) ObserveSourceHealth(_ context.Context, status aman.DataStatus, observedAt time.Time) error {
+	s.mu.Lock()
+	s.health.vatsim = sourceComponentHealth(status, observedAt)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *Service) Run(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	s.reconcileAll(ctx)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.reconcileAll(ctx)
+		}
+	}
+}
+
+func (s *Service) reconcileAll(ctx context.Context) {
+	for _, airport := range s.deps.Airports {
+		airport = strings.ToUpper(strings.TrimSpace(airport))
+		if err := s.refreshNavigation(ctx, airport); err != nil {
+			slog.WarnContext(ctx, "AMAN navigation refresh failed; cached geometry remains eligible", "airport", airport, "error", err)
+		}
+		if err := s.reconcileAirport(ctx, airport); err != nil {
+			slog.WarnContext(ctx, "AMAN reconciliation failed", "airport", airport, "error", err)
+		}
+	}
+}
+
+func (s *Service) refreshNavigation(ctx context.Context, airport string) error {
+	now := s.deps.Now().UTC()
+	s.mu.Lock()
+	last := s.lastRefresh[airport]
+	if !last.IsZero() && now.Sub(last) < navigationRefreshEvery {
+		s.mu.Unlock()
+		return nil
+	}
+	s.mu.Unlock()
+	err := s.deps.Materializer.Refresh(ctx, materializer.Request{Airport: navdata.AirportID(airport)})
+	completedAt := s.deps.Now().UTC()
+	s.mu.Lock()
+	if err != nil {
+		s.health.navigation = componentHealth(aman.HealthUnavailable, "navigation_refresh_failed", completedAt)
+	} else {
+		s.lastRefresh[airport] = completedAt
+		s.health.navigation = componentHealth(aman.HealthReady, "", completedAt)
+	}
+	s.mu.Unlock()
+	return err
+}
+
+func (s *Service) reconcileAirport(ctx context.Context, airport string) error {
+	now := s.deps.Now().UTC()
+	initializing := false
+	current, err := s.deps.Repository.LoadAirportState(ctx, airport)
+	if err != nil {
+		var domain *aman.DomainError
+		if !errors.As(err, &domain) || domain.Class != aman.ErrorNotFound {
+			s.setHealthComponent("repository", aman.HealthUnavailable, "repository_load_failed", now)
+			return err
+		}
+		s.setHealthComponent("repository", aman.HealthReady, "", now)
+		current = s.initialState(airport, now)
+		initializing = true
+	} else {
+		s.setHealthComponent("repository", aman.HealthReady, "", now)
+	}
+	next := current
+	next.Flights = slices.Clone(current.Flights)
+	next.RunwayGroups = slices.Clone(current.RunwayGroups)
+	if len(next.RunwayGroups) == 0 {
+		next.RunwayGroups = s.initialState(airport, now).RunwayGroups
+	}
+	selectedGroup, selectionChanged := updateSelectedRunwayGroup(next.RunwayGroups, now)
+	if selectionChanged {
+		reassignFlightsToGroup(&next, selectedGroup)
+	}
+	updateActiveRates(next.RunwayGroups, now)
+	observations := s.observations(airport)
+	indexes := make(map[aman.FlightID]int, len(next.Flights))
+	for i := range next.Flights {
+		indexes[next.Flights[i].ID] = i
+	}
+
+	for _, observation := range observations {
+		index, found := indexes[observation.FlightID]
+		if !found {
+			next.Flights = append(next.Flights, newFlight(observation, now))
+			index = len(next.Flights) - 1
+			indexes[observation.FlightID] = index
+		}
+		flight := next.Flights[index]
+		updated, updateErr := s.reconcileFlight(ctx, next, flight, observation, now)
+		if updateErr != nil {
+			slog.WarnContext(ctx, "AMAN flight prediction degraded", "airport", airport, "flight_id", observation.FlightID, "error", updateErr)
+			updated = applyUnavailablePrediction(updated, observation, now, updateErr)
+		}
+		next.Flights[index] = updated
+	}
+	for i := range next.Flights {
+		if next.Flights[i].State == aman.StateRemoved || next.Flights[i].LatestObservation == nil {
+			continue
+		}
+		observation, seen := observations[next.Flights[i].ID]
+		if seen && !observation.Missing {
+			continue
+		}
+		markMissing(&next.Flights[i], now)
+	}
+
+	s.resequence(&next, now)
+	if !initializing && statesEqual(current, next) {
+		return nil
+	}
+	next.Revision = current.Revision + 1
+	next.GeneratedAt = now
+	for i := range next.Flights {
+		if next.Flights[i].State == aman.StateLanded || next.Flights[i].State == aman.StateRemoved {
+			next.Flights[i].Slot = nil
+			next.Flights[i].Order = nil
+			next.Flights[i].ManualOrder = nil
+		}
+		if next.Flights[i].Slot != nil {
+			next.Flights[i].Slot.Revision = next.Revision
+		}
+	}
+	queueInput := sequenceInput(next, s.deps.Terminal)
+	next, err = sequence.ProjectQueueOffers(next, queueInput, sequence.QueueOfferConfig{Validity: queueOfferValidity}, now)
+	if err != nil {
+		return fmt.Errorf("project AMAN queue offers: %w", err)
+	}
+	committed, err := s.deps.Repository.Commit(ctx, aman.StateCommit{ExpectedRevision: current.Revision, State: next})
+	if err != nil {
+		s.setHealthComponent("repository", aman.HealthUnavailable, "repository_commit_failed", now)
+		return err
+	}
+	s.setHealthComponent("repository", aman.HealthReady, "", now)
+	if s.deps.Retirer != nil {
+		previous := make(map[aman.FlightID]aman.FlightState, len(current.Flights))
+		for _, flight := range current.Flights {
+			previous[flight.ID] = flight.State
+		}
+		for _, flight := range committed.State.Flights {
+			if flight.State == aman.StateRemoved && previous[flight.ID] != aman.StateRemoved {
+				if retireErr := s.deps.Retirer.RetireVATSIMFlight(context.WithoutCancel(ctx), flight.ID); retireErr != nil {
+					slog.WarnContext(ctx, "retire removed AMAN VATSIM identity failed", "flight_id", flight.ID, "error", retireErr)
+				}
+			}
+		}
+	}
+	return s.deps.Publisher.PublishAMANState(context.WithoutCancel(ctx), committed.State)
+}
+
+func (s *Service) observations(airport string) map[aman.FlightID]aman.FlightObservation {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := make(map[aman.FlightID]aman.FlightObservation, len(s.observed[airport]))
+	for id, observation := range s.observed[airport] {
+		result[id] = observation
+	}
+	return result
+}
+
+func (s *Service) initialState(airport string, now time.Time) aman.AirportState {
+	groups := make([]aman.RunwayGroupPolicy, 0, len(s.deps.Terminal.RunwayGroups))
+	for index, configured := range s.deps.Terminal.RunwayGroups {
+		effective := now
+		group := aman.RunwayGroupPolicy{
+			ID: configured.ID, Selected: index == 0, ActiveRatePerHour: defaultArrivalRate, RateEffectiveAt: &effective,
+			RateSchedule: []aman.RunwayGroupRatePoint{{EffectiveAt: effective, ArrivalsPerHour: defaultArrivalRate}},
+		}
+		if index == 0 {
+			group.SelectionSchedule = []aman.RunwayGroupSelectionPoint{{EffectiveAt: effective}}
+		}
+		if spacing := configured.SameSTARSpacing; spacing != nil {
+			group.SameSTARSpacing = &aman.SameSTARSpacingPolicy{Enabled: spacing.Enabled, ActivationRatePerHour: spacing.ActivationRatePerHour, MinimumEmptySlots: spacing.MinimumEmptySlots}
+		}
+		groups = append(groups, group)
+	}
+	return aman.AirportState{
+		Airport: airport, GeneratedAt: now, PolicyVersion: policyVersion, Mode: s.deps.Mode,
+		Authoritative: s.deps.Mode == aman.ModeAuthoritative, Flights: []aman.AMANFlight{}, RunwayGroups: groups,
+	}
+}
+
+func newFlight(observation aman.FlightObservation, now time.Time) aman.AMANFlight {
+	state := aman.StatePlanned
+	if observation.TakeoffDetected != nil {
+		state = aman.StateAirborne
+	}
+	copy := observation
+	return aman.AMANFlight{
+		ID: observation.FlightID, VATSIMCID: observation.VATSIMCID, CurrentCallsign: observation.Callsign,
+		State: state, DataStatus: observation.SourceStatus, LatestObservation: &copy,
+		FreezeReason: aman.FreezeNone, UpdatedAt: now,
+	}
+}
+
+func (s *Service) reconcileFlight(ctx context.Context, state aman.AirportState, flight aman.AMANFlight, observation aman.FlightObservation, now time.Time) (aman.AMANFlight, error) {
+	copy := observation
+	flight.LatestObservation = &copy
+	flight.VATSIMCID, flight.CurrentCallsign, flight.DataStatus = observation.VATSIMCID, observation.Callsign, observation.SourceStatus
+	flight.UpdatedAt = now
+	if observation.Missing || observation.SourceStatus != aman.DataFresh {
+		return flight, nil
+	}
+	flight.Lifecycle = clearAbsence(flight.Lifecycle)
+	applyBaseline(&flight, observation, now)
+	applyPreliminaryPrediction(&flight, observation, now)
+	if observation.Surveillance == nil || observation.Surveillance.GroundspeedKnots == nil || observation.Surveillance.AltitudeFeet == nil || observation.FiledRoute == nil {
+		if flight.State != aman.StatePlanned {
+			markPredictionNonPublishable(&flight, missingEssentialReason(observation))
+		}
+		return flight, nil
+	}
+	group, ok := s.selectedGroup(flight, state.RunwayGroups)
+	if !ok {
+		return flight, fmt.Errorf("terminal has no configured runway group")
+	}
+	flight.SelectedRunwayGroup = &group
+	feeder, ok := s.feeder(*observation.FiledRoute)
+	if !ok {
+		markUnknownSTARFamily(&flight, now)
+		return flight, nil
+	}
+	flight.SelectedFeeder = stringPointer(string(feeder))
+	version, err := s.deps.Geometry.ActiveVersion(ctx, navdata.AirportID(observation.Destination))
+	if err != nil {
+		return flight, err
+	}
+	query := navdata.RouteQuery{Version: version, Origin: navdata.AirportID(observation.Origin), Destination: navdata.AirportID(observation.Destination), FiledRoute: *observation.FiledRoute, RunwayGroup: &group}
+	revision := revisionValue(observation.FlightPlan.Revision)
+	datasetID := navigationDatasetID(version)
+	var key navdata.RouteKey
+	if canReuseActiveRoute(flight, revision, group, datasetID) {
+		key = navdata.RouteKey(*flight.ActiveRouteKey)
+	} else {
+		key, err = s.deps.Materializer.MaterializeRoute(ctx, query, modelVersion)
+		if err != nil {
+			return flight, err
+		}
+		activeKey := string(key)
+		flight.ActiveRouteKey = &activeKey
+		flight.ActiveRouteDatasetID = &datasetID
+	}
+	projection, err := trajectory.Project(ctx, trajectory.Readers{Geometry: s.deps.Geometry, Snapshot: s.deps.Geometry}, trajectory.Input{
+		Airport: navdata.AirportID(observation.Destination), RouteKey: key, Feeder: feeder, RunwayGroup: group,
+		FlightPlanRevision: revision, Observation: *observation.Surveillance, Prior: flight.RouteProgress,
+	}, trajectory.Config{ReferenceTime: now, MaxObservationAge: 2 * time.Minute})
+	if err != nil {
+		return flight, err
+	}
+	if projection.DistanceToGoNM == nil || len(projection.Remaining) == 0 || projection.Completeness == trajectory.Unresolved || projection.Completeness == trajectory.OffRoute {
+		return flight, fmt.Errorf("route geometry is not publishable: %s", projection.Completeness)
+	}
+	input := predictor.PerformanceWindInput{
+		PredictionAt: now, AircraftICAO: stringValue(observation.AircraftType), WakeTurbulenceCategory: category(observation.WakeCategory),
+		AltitudeFeet: float64(*observation.Surveillance.AltitudeFeet), CurrentGroundspeedKnots: *observation.Surveillance.GroundspeedKnots,
+		Remaining: predictorLegs(projection.Remaining),
+	}
+	estimate, err := predictor.EstimatePerformanceWind(ctx, nil, s.deps.Wind, input, predictor.PerformanceWindConfig{})
+	if err != nil {
+		s.setHealthComponent("predictor", aman.HealthUnavailable, "prediction_failed", now)
+		return flight, err
+	}
+	s.setHealthComponent("predictor", aman.HealthReady, "", now)
+	weatherStatus, weatherReason := aman.HealthReady, ""
+	for _, degradation := range estimate.DegradationReasons {
+		if degradation == "WEATHER_UNAVAILABLE" || degradation == "WEATHER_INCOMPLETE" {
+			weatherStatus, weatherReason = aman.HealthDegraded, strings.ToLower(degradation)
+			break
+		}
+	}
+	s.setHealthComponent("weather", weatherStatus, weatherReason, now)
+	rawRETA := estimate.RawRETA
+	dtg := estimate.DistanceToGoNM
+	raw := aman.Prediction{
+		RawTETA: estimate.RawTETA, RawRETA: &rawRETA, GeneratedAt: now, InputObservedAt: observedAt(observation.Surveillance, now),
+		Confidence: estimate.Confidence, Publishable: true, DatasetVersion: version.Cycle, GeometryDigest: projection.GeometryDigest,
+		DistanceToGoNM: &dtg, ModelVersion: estimate.ModelVersion, ConfigVersion: s.deps.Terminal.ConfigVersion,
+		PerformanceProfileID: estimate.PerformanceProfileID, WeatherSource: estimate.WeatherSource,
+		Sources: []string{"vatsim", "airacnet", "terminal-config:" + s.deps.Terminal.ConfigVersion},
+	}
+	if len(estimate.DegradationReasons) > 0 {
+		reason := strings.Join(estimate.DegradationReasons, ",")
+		raw.DegradationReason = &reason
+	}
+	if projection.SelectedHolding != nil {
+		holding := string(projection.SelectedHolding.ID)
+		flight.SelectedHolding = &holding
+		raw.HoldingFixETA = holdingETA(now, estimate.LegDurations, projection.Remaining, projection.SelectedHolding.Fix)
+	}
+	flight.RouteProgress = projection.Progress
+	previousState := flight.State
+	nextState := lifecycleState(flight, raw.RawTETA, now)
+	reduced, err := prediction.Reduce(prediction.DefaultConfig(), flight, prediction.Input{Raw: raw, State: nextState, Slot: flight.Slot})
+	if err != nil {
+		return flight, err
+	}
+	updated := reduced.Flight
+	updateLifecycle(&updated, previousState, nextState, now)
+	return updated, nil
+}
+
+func (s *Service) feeder(route string) (navdata.FeederID, bool) {
+	tokens := strings.FieldsFunc(strings.ToUpper(route), func(r rune) bool {
+		return !((r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'))
+	})
+	for _, configured := range s.deps.Terminal.Feeders {
+		for _, token := range tokens {
+			if token == string(configured.ID) || slices.Contains(configured.Aliases, navdata.FeederID(token)) {
+				return configured.ID, true
+			}
+		}
+	}
+	return "", false
+}
+
+func (s *Service) resequence(state *aman.AirportState, now time.Time) {
+	input := sequenceInput(*state, s.deps.Terminal)
+	if len(input.Flights) == 0 || len(input.Policies) == 0 {
+		return
+	}
+	result, err := sequence.Generate(input)
+	if err != nil || result.HasConflicts() {
+		return
+	}
+	entries := make(map[aman.FlightID]sequence.CandidateEntry, len(result.Entries))
+	for _, entry := range result.Entries {
+		entries[entry.FlightID] = entry
+	}
+	for i := range state.Flights {
+		entry, ok := entries[state.Flights[i].ID]
+		if !ok {
+			continue
+		}
+		state.Flights[i].Slot = &aman.Slot{Time: entry.Time, RunwayGroupID: entry.RunwayGroupID, Sequence: entry.Sequence, Revision: state.Revision, Reason: string(entry.Reason)}
+		order := entry.Sequence
+		state.Flights[i].Order = &order
+		state.Flights[i].UpdatedAt = now
+	}
+}
+
+func sequenceInput(state aman.AirportState, config terminal.Configuration) sequence.Input {
+	input := sequence.Input{Revision: state.Revision}
+	configured := map[aman.RunwayGroupID]terminal.RunwayGroup{}
+	for _, group := range config.RunwayGroups {
+		configured[group.ID] = group
+	}
+	for _, group := range state.RunwayGroups {
+		rates := sequenceRates(group)
+		if len(rates) == 0 {
+			continue
+		}
+		policy := sequence.Policy{
+			RunwayGroupID: group.ID, Rates: rates,
+			EarlyTolerance: 30 * time.Second, SeparationRules: amanCPHSeparations(), UnknownSeparation: 3 * time.Minute,
+		}
+		if spacing := group.SameSTARSpacing; spacing != nil {
+			policy.SameSTARSpacing = sequence.SameSTARSpacing{Enabled: spacing.Enabled, ActivationRatePerHour: spacing.ActivationRatePerHour, MinimumEmptySlots: spacing.MinimumEmptySlots}
+		} else if spacing := configured[group.ID].SameSTARSpacing; spacing != nil {
+			policy.SameSTARSpacing = sequence.SameSTARSpacing{Enabled: spacing.Enabled, ActivationRatePerHour: spacing.ActivationRatePerHour, MinimumEmptySlots: spacing.MinimumEmptySlots}
+		}
+		input.Policies = append(input.Policies, policy)
+	}
+	for _, flight := range state.Flights {
+		if flight.Prediction == nil || flight.SelectedRunwayGroup == nil || flight.State == aman.StatePlanned || flight.State == aman.StateLanded || flight.State == aman.StateRemoved ||
+			(!flight.Prediction.Publishable && flight.FreezeReason == aman.FreezeNone) {
+			continue
+		}
+		wakeCategory := ""
+		if flight.LatestObservation != nil {
+			wakeCategory = strings.ToUpper(stringValue(flight.LatestObservation.WakeCategory))
+		}
+		input.Flights = append(input.Flights, sequence.Flight{
+			ID: flight.ID, RunwayGroupID: *flight.SelectedRunwayGroup, State: flight.State, OperationalTETA: flight.Prediction.OperationalTETA,
+			WakeCategory: sequence.WakeCategory(wakeCategory), STARFamily: stringValue(flight.SelectedFeeder),
+			ManualOrder:  flight.ManualOrder,
+			FreezeReason: flight.FreezeReason, FrozenAt: flight.FrozenAt, FrozenOperationalTETA: flight.FrozenOperationalTETA,
+			CapturedSlot: flight.FrozenSlot, CurrentSlot: flight.Slot,
+		})
+	}
+	return input
+}
+
+func sequenceRates(group aman.RunwayGroupPolicy) []sequence.RatePoint {
+	if len(group.RateSchedule) > 0 {
+		rates := make([]sequence.RatePoint, len(group.RateSchedule))
+		for i, rate := range group.RateSchedule {
+			rates[i] = sequence.RatePoint{EffectiveAt: rate.EffectiveAt, ArrivalsPerHour: rate.ArrivalsPerHour}
+		}
+		return rates
+	}
+	if group.ActiveRatePerHour == 0 || group.RateEffectiveAt == nil {
+		return nil
+	}
+	return []sequence.RatePoint{{EffectiveAt: *group.RateEffectiveAt, ArrivalsPerHour: group.ActiveRatePerHour}}
+}
+
+func updateActiveRates(groups []aman.RunwayGroupPolicy, now time.Time) {
+	for i := range groups {
+		for _, rate := range groups[i].RateSchedule {
+			if rate.EffectiveAt.After(now) {
+				break
+			}
+			effective := rate.EffectiveAt
+			groups[i].ActiveRatePerHour = rate.ArrivalsPerHour
+			groups[i].RateEffectiveAt = &effective
+		}
+	}
+}
+
+func updateSelectedRunwayGroup(groups []aman.RunwayGroupPolicy, now time.Time) (aman.RunwayGroupID, bool) {
+	if len(groups) == 0 {
+		return "", false
+	}
+	selectedIndex := -1
+	for index := range groups {
+		if groups[index].Selected {
+			selectedIndex = index
+			break
+		}
+	}
+	candidateIndex, candidatePoint := -1, aman.RunwayGroupSelectionPoint{}
+	for index := range groups {
+		for _, point := range groups[index].SelectionSchedule {
+			if point.EffectiveAt.After(now) {
+				break
+			}
+			if candidateIndex < 0 || point.EffectiveAt.After(candidatePoint.EffectiveAt) ||
+				(point.EffectiveAt.Equal(candidatePoint.EffectiveAt) && point.CommandRevision > candidatePoint.CommandRevision) {
+				candidateIndex, candidatePoint = index, point
+			}
+		}
+	}
+	if candidateIndex < 0 {
+		if selectedIndex >= 0 {
+			return groups[selectedIndex].ID, false
+		}
+		candidateIndex = 0
+	}
+	changed := selectedIndex != candidateIndex
+	for index := range groups {
+		groups[index].Selected = index == candidateIndex
+	}
+	return groups[candidateIndex].ID, changed
+}
+
+func amanCPHSeparations() []sequence.SeparationRule {
+	categories := []sequence.WakeCategory{"L", "M", "H", "J"}
+	rules := make([]sequence.SeparationRule, 0, len(categories)*len(categories))
+	for _, leading := range categories {
+		for _, trailing := range categories {
+			gap := time.Duration(0)
+			if leading == "H" {
+				gap = 120 * time.Second
+			}
+			if leading == "J" || trailing == "L" {
+				gap = 180 * time.Second
+			}
+			rules = append(rules, sequence.SeparationRule{Leading: leading, Trailing: trailing, Minimum: gap})
+		}
+	}
+	return rules
+}
+
+func (s *Service) selectedGroup(flight aman.AMANFlight, groups []aman.RunwayGroupPolicy) (aman.RunwayGroupID, bool) {
+	if flight.SelectedRunwayGroup != nil && (flight.State == aman.StateStable || flight.FreezeReason != aman.FreezeNone) {
+		return *flight.SelectedRunwayGroup, true
+	}
+	for _, group := range groups {
+		if group.Selected {
+			return group.ID, true
+		}
+	}
+	if flight.SelectedRunwayGroup != nil {
+		return *flight.SelectedRunwayGroup, true
+	}
+	if len(groups) > 0 {
+		return groups[0].ID, true
+	}
+	if len(s.deps.Terminal.RunwayGroups) > 0 {
+		return s.deps.Terminal.RunwayGroups[0].ID, true
+	}
+	return "", false
+}
+
+func applyBaseline(flight *aman.AMANFlight, observation aman.FlightObservation, now time.Time) {
+	if observation.TakeoffDetected == nil || observation.PlannedTiming == nil || observation.PlannedTiming.EstimatedEnrouteTime == nil || flight.ArrivalBaseline != nil {
+		return
+	}
+	arrival := observation.TakeoffDetected.Add(*observation.PlannedTiming.EstimatedEnrouteTime)
+	observed := now
+	if observation.FlightPlan.ObservedAt != nil {
+		observed = *observation.FlightPlan.ObservedAt
+	}
+	flight.ArrivalBaseline = &aman.BaselineState{
+		ArrivalAt: arrival, AirborneSensedAt: *observation.TakeoffDetected, Source: aman.BaselineSourceAirborneFiledEET,
+		Confidence: aman.ConfidenceMedium, FlightPlanRevision: observation.FlightPlan.Revision, FlightPlanObservedAt: observed,
+		ModelVersion: "aman-baseline-v1", ConfigVersion: "aman-baseline-defaults-v1",
+	}
+	if flight.State == aman.StatePlanned {
+		flight.State = aman.StateAirborne
+	}
+}
+
+func applyPreliminaryPrediction(flight *aman.AMANFlight, observation aman.FlightObservation, now time.Time) {
+	if observation.PlannedTiming == nil || observation.PlannedTiming.EstimatedEnrouteTime == nil {
+		return
+	}
+	if flight.Prediction != nil && flight.Prediction.ModelVersion == modelVersion {
+		return
+	}
+	var arrival time.Time
+	model := "aman-planned-eobt-exot-eet-v1"
+	if observation.TakeoffDetected != nil {
+		takeoff := *observation.TakeoffDetected
+		if flight.ArrivalBaseline != nil {
+			takeoff = flight.ArrivalBaseline.AirborneSensedAt
+		}
+		arrival = takeoff.Add(*observation.PlannedTiming.EstimatedEnrouteTime)
+		model = "aman-airborne-takeoff-eet-v1"
+	} else if observation.PlannedTiming.EstimatedOffBlockTime != nil {
+		arrival = observation.PlannedTiming.EstimatedOffBlockTime.Add(predictor.DefaultEXOT).Add(*observation.PlannedTiming.EstimatedEnrouteTime)
+	}
+	if arrival.IsZero() || !arrival.After(now) {
+		return
+	}
+	flight.Prediction = &aman.Prediction{
+		RawTETA: arrival, OperationalTETA: arrival, OperationalReason: aman.OperationalReasonPredicted,
+		GeneratedAt: now, InputObservedAt: now, Confidence: aman.ConfidenceMedium, Publishable: true,
+		DatasetVersion: "flight-plan", GeometryDigest: "flight-plan", ModelVersion: model,
+		ConfigVersion: policyVersion, Sources: []string{"vatsim"},
+	}
+}
+
+func lifecycleState(flight aman.AMANFlight, teta, now time.Time) aman.FlightState {
+	until := teta.Sub(now)
+	switch flight.State {
+	case aman.StatePlanned, aman.StateAirborne, aman.StateGoAround:
+		if until <= 45*time.Minute {
+			return aman.StateUnstable
+		}
+	case aman.StateUnstable:
+		entered := flight.UpdatedAt
+		if flight.Lifecycle != nil {
+			entered = flight.Lifecycle.EnteredAt
+		}
+		if until <= 20*time.Minute && now.Sub(entered) >= 2*time.Minute {
+			return aman.StateStable
+		}
+	}
+	return flight.State
+}
+
+func updateLifecycle(flight *aman.AMANFlight, previousState, state aman.FlightState, now time.Time) {
+	reason := aman.LifecycleReasonInitial
+	entered := now
+	if flight.Lifecycle != nil {
+		reason, entered = flight.Lifecycle.Reason, flight.Lifecycle.EnteredAt
+	}
+	if previousState != state {
+		entered = now
+	}
+	switch state {
+	case aman.StateAirborne:
+		reason = aman.LifecycleReasonAirborneDetected
+	case aman.StateUnstable:
+		reason = aman.LifecycleReasonUnstableHorizon
+	case aman.StateStable:
+		reason = aman.LifecycleReasonStableHorizon
+	}
+	flight.State = state
+	flight.Lifecycle = &aman.LifecycleState{EnteredAt: entered, Reason: reason, LastEventID: fmt.Sprintf("tick-%d", now.UnixNano()), LastEventFingerprint: modelVersion, LastEventAt: now}
+}
+
+func markMissing(flight *aman.AMANFlight, now time.Time) {
+	if flight.Lifecycle == nil {
+		flight.Lifecycle = &aman.LifecycleState{EnteredAt: flight.UpdatedAt, Reason: aman.LifecycleReasonInitial, LastEventID: "missing", LastEventFingerprint: modelVersion, LastEventAt: now}
+	}
+	if flight.Lifecycle.Absence == nil {
+		due := now.Add(time.Minute)
+		flight.Lifecycle.Absence = &aman.AbsenceState{MissingSince: now, RemovalDueAt: &due}
+	} else if flight.Lifecycle.Absence.RemovalDueAt != nil && !now.Before(*flight.Lifecycle.Absence.RemovalDueAt) {
+		flight.State = aman.StateRemoved
+		flight.Lifecycle.Reason = aman.LifecycleReasonSourceDisappearance
+		flight.Lifecycle.EnteredAt = now
+	}
+	flight.Lifecycle.LastEventAt = now
+	flight.UpdatedAt = now
+}
+
+func clearAbsence(value *aman.LifecycleState) *aman.LifecycleState {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	copy.Absence = nil
+	copy.ReconciliationPending = false
+	return &copy
+}
+
+func applyUnavailablePrediction(flight aman.AMANFlight, observation aman.FlightObservation, now time.Time, cause error) aman.AMANFlight {
+	copy := observation
+	flight.LatestObservation, flight.DataStatus, flight.UpdatedAt = &copy, observation.SourceStatus, now
+	markPredictionNonPublishable(&flight, cause.Error())
+	return flight
+}
+
+func missingEssentialReason(observation aman.FlightObservation) string {
+	missing := make([]string, 0, 3)
+	if observation.Surveillance == nil {
+		missing = append(missing, "surveillance")
+	} else {
+		if observation.Surveillance.GroundspeedKnots == nil {
+			missing = append(missing, "groundspeed")
+		}
+		if observation.Surveillance.AltitudeFeet == nil {
+			missing = append(missing, "altitude")
+		}
+	}
+	if observation.FiledRoute == nil {
+		missing = append(missing, "filed_route")
+	}
+	return "missing_essential_data:" + strings.Join(missing, ",")
+}
+
+func markPredictionNonPublishable(flight *aman.AMANFlight, reason string) {
+	if flight.Prediction == nil {
+		return
+	}
+	prediction := *flight.Prediction
+	prediction.Publishable = false
+	prediction.DegradationReason = &reason
+	flight.Prediction = &prediction
+	if flight.FreezeReason == aman.FreezeNone {
+		flight.Slot = nil
+		flight.Order = nil
+		flight.ManualOrder = nil
+		flight.QueueOffers = nil
+	}
+}
+
+func markUnknownSTARFamily(flight *aman.AMANFlight, now time.Time) {
+	flight.SelectedFeeder = nil
+	flight.SelectedHolding = nil
+	flight.ActiveRouteKey = nil
+	flight.ActiveRouteDatasetID = nil
+	flight.RouteProgress = nil
+	if flight.Prediction == nil {
+		return
+	}
+	prediction := *flight.Prediction
+	reason := string(sequence.WarningUnknownSTARFamily)
+	prediction.DegradationReason = &reason
+	if strings.HasPrefix(prediction.ModelVersion, "aman-planned-") || strings.HasPrefix(prediction.ModelVersion, "aman-airborne-") {
+		prediction.Publishable = true
+	}
+	if prediction.Confidence == aman.ConfidenceHigh {
+		prediction.Confidence = aman.ConfidenceMedium
+	}
+	flight.Prediction = &prediction
+	previousState := flight.State
+	nextState := lifecycleState(*flight, prediction.OperationalTETA, now)
+	updateLifecycle(flight, previousState, nextState, now)
+}
+
+func predictorLegs(legs []trajectory.RemainingLeg) []predictor.RouteLeg {
+	result := make([]predictor.RouteLeg, len(legs))
+	for i, leg := range legs {
+		result[i] = predictor.RouteLeg{ID: leg.ID, DistanceNM: leg.DistanceNM, CourseTrueDegrees: leg.CourseTrueDegrees, Start: predictor.WindCoordinate{LatitudeDegrees: leg.Start.LatitudeDeg, LongitudeDegrees: leg.Start.LongitudeDeg}, End: predictor.WindCoordinate{LatitudeDegrees: leg.End.LatitudeDeg, LongitudeDegrees: leg.End.LongitudeDeg}}
+	}
+	return result
+}
+
+func holdingETA(now time.Time, durations []time.Duration, legs []trajectory.RemainingLeg, fix navdata.FixID) *time.Time {
+	if len(durations) != len(legs) {
+		return nil
+	}
+	elapsed := time.Duration(0)
+	for index, leg := range legs {
+		elapsed += durations[index]
+		if leg.To == fix {
+			at := now.Add(elapsed)
+			return &at
+		}
+	}
+	return nil
+}
+
+func category(value *string) predictor.AircraftCategory {
+	switch strings.ToUpper(stringValue(value)) {
+	case "L":
+		return predictor.CategoryLight
+	case "H":
+		return predictor.CategoryHeavy
+	case "J":
+		return predictor.CategorySuper
+	default:
+		return predictor.CategoryMedium
+	}
+}
+
+func observedAt(fact *aman.SurveillanceFact, fallback time.Time) time.Time {
+	if fact != nil && fact.ObservedAt != nil {
+		return *fact.ObservedAt
+	}
+	return fallback
+}
+func revisionValue(value *uint64) uint64 {
+	if value == nil {
+		return 0
+	}
+	return *value
+}
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+func stringPointer(value string) *string { return &value }
+
+func navigationDatasetID(version navdata.DatasetVersion) string {
+	return strings.Join([]string{
+		version.Cycle,
+		version.SourceRevision,
+		version.EffectiveFrom.UTC().Format(time.RFC3339Nano),
+		version.EffectiveUntil.UTC().Format(time.RFC3339Nano),
+	}, "|")
+}
+
+func canReuseActiveRoute(flight aman.AMANFlight, revision uint64, group aman.RunwayGroupID, datasetID string) bool {
+	return flight.ActiveRouteKey != nil &&
+		flight.ActiveRouteDatasetID != nil &&
+		*flight.ActiveRouteDatasetID == datasetID &&
+		flight.RouteProgress != nil &&
+		flight.RouteProgress.FlightPlanRevision == revision &&
+		flight.RouteProgress.RunwayGroupID == group
+}
+
+func componentHealth(status aman.HealthStatus, reason string, at time.Time) aman.ComponentHealth {
+	at = at.UTC()
+	return aman.ComponentHealth{Status: status, Reason: reason, UpdatedAt: &at}
+}
+
+func sourceComponentHealth(status aman.DataStatus, at time.Time) aman.ComponentHealth {
+	switch status {
+	case aman.DataFresh:
+		return componentHealth(aman.HealthReady, "", at)
+	case aman.DataStale:
+		return componentHealth(aman.HealthDegraded, "source_stale", at)
+	default:
+		return componentHealth(aman.HealthUnavailable, "source_disconnected", at)
+	}
+}
+
+func (s *Service) setHealthComponent(name string, status aman.HealthStatus, reason string, at time.Time) {
+	value := componentHealth(status, reason, at)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	switch name {
+	case "navigation":
+		s.health.navigation = value
+	case "weather":
+		s.health.weather = value
+	case "repository":
+		s.health.repository = value
+	case "predictor":
+		s.health.predictor = value
+	}
+}
+
+func statesEqual(left, right aman.AirportState) bool {
+	left.Revision, right.Revision = 0, 0
+	left.GeneratedAt, right.GeneratedAt = time.Time{}, time.Time{}
+	return reflect.DeepEqual(left, right)
+}
+
+var _ aman.ObservationSink = (*Service)(nil)
+var _ aman.ObservationSourceHealthSink = (*Service)(nil)
+var _ aman.Worker = (*Service)(nil)
+var _ aman.Component = (*Service)(nil)
+var _ aman.TechnicalHealthReporter = (*Service)(nil)

--- a/backend/internal/aman/operational/service_test.go
+++ b/backend/internal/aman/operational/service_test.go
@@ -1,0 +1,503 @@
+package operational
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/aman/materializer"
+	"FlightStrips/internal/aman/navdata"
+	"FlightStrips/internal/aman/predictor"
+	"FlightStrips/internal/aman/sequence"
+	"FlightStrips/internal/aman/terminal"
+	"FlightStrips/internal/aman/trajectory"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSequenceInputCarriesConfiguredSTARFamilySpacingAndWTC(t *testing.T) {
+	start := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	effective := start
+	group := aman.RunwayGroupID("ARRIVAL-22")
+	spacing := &aman.SameSTARSpacingPolicy{Enabled: true, ActivationRatePerHour: 20, MinimumEmptySlots: 1}
+	wake := "M"
+	feeder := "MONAK"
+	state := aman.AirportState{
+		Revision:     1,
+		RunwayGroups: []aman.RunwayGroupPolicy{{ID: group, ActiveRatePerHour: 20, RateEffectiveAt: &effective, SameSTARSpacing: spacing}},
+		Flights: []aman.AMANFlight{
+			operationalFlight("ONE", group, feeder, wake, start),
+			operationalFlight("TWO", group, feeder, wake, start),
+		},
+	}
+	config := terminal.Configuration{RunwayGroups: []terminal.RunwayGroup{{ID: group}}}
+	input := sequenceInput(state, config)
+	require.Len(t, input.Policies, 1)
+	require.Equal(t, sequence.SameSTARSpacing{Enabled: true, ActivationRatePerHour: 20, MinimumEmptySlots: 1}, input.Policies[0].SameSTARSpacing)
+	require.Equal(t, feeder, input.Flights[0].STARFamily)
+
+	result, err := sequence.Generate(input)
+	require.NoError(t, err)
+	require.Len(t, result.Entries, 2)
+	require.Equal(t, 6*time.Minute, result.Entries[1].Time.Sub(result.Entries[0].Time))
+}
+
+func TestPreliminaryPredictionsUseDocumentedPlannedAndAirborneTimes(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	eobt := now.Add(time.Hour)
+	eet := 90 * time.Minute
+	observation := aman.FlightObservation{PlannedTiming: &aman.PlannedTiming{EstimatedOffBlockTime: &eobt, EstimatedEnrouteTime: &eet}}
+	planned := aman.AMANFlight{State: aman.StatePlanned}
+	applyPreliminaryPrediction(&planned, observation, now)
+	require.Equal(t, eobt.Add(15*time.Minute+eet), planned.Prediction.RawTETA)
+	require.Equal(t, "aman-planned-eobt-exot-eet-v1", planned.Prediction.ModelVersion)
+
+	takeoff := now.Add(5 * time.Minute)
+	observation.TakeoffDetected = &takeoff
+	airborne := aman.AMANFlight{State: aman.StateAirborne}
+	applyPreliminaryPrediction(&airborne, observation, now)
+	require.Equal(t, takeoff.Add(eet), airborne.Prediction.RawTETA)
+	require.Equal(t, "aman-airborne-takeoff-eet-v1", airborne.Prediction.ModelVersion)
+
+	laterDetection := takeoff.Add(10 * time.Minute)
+	observation.TakeoffDetected = &laterDetection
+	anchored := aman.AMANFlight{
+		State:           aman.StateAirborne,
+		ArrivalBaseline: &aman.BaselineState{AirborneSensedAt: takeoff},
+	}
+	applyPreliminaryPrediction(&anchored, observation, now)
+	require.Equal(t, takeoff.Add(eet), anchored.Prediction.RawTETA)
+}
+
+func TestServicePersistsLatestObservationAndRemovesAfterSixtySeconds(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	repository := &memoryRepository{}
+	publisher := &recordingPublisher{}
+	service, err := New(Dependencies{
+		Repository: repository, Materializer: unavailableNavigation{}, Geometry: unavailableGeometry{}, Wind: unavailableWind{},
+		Publisher: publisher, Terminal: terminal.Configuration{Airport: "EKCH", ConfigVersion: "test", RunwayGroups: []terminal.RunwayGroup{{ID: "ARRIVAL-22"}}},
+		Airports: []string{"EKCH"}, Mode: aman.ModeShadow, Now: func() time.Time { return now },
+	})
+	require.NoError(t, err)
+	eobt, eet := now.Add(time.Hour), 90*time.Minute
+	observedAt := now
+	observation := aman.FlightObservation{
+		FlightID: "flight-1", VATSIMCID: "123", Callsign: "SAS123", Origin: "ENGM", Destination: "EKCH",
+		PlannedTiming: &aman.PlannedTiming{EstimatedOffBlockTime: &eobt, EstimatedEnrouteTime: &eet},
+		FlightPlan:    aman.FlightPlanFact{ObservedAt: &observedAt}, ReconciledAt: now, SourceStatus: aman.DataFresh,
+	}
+	require.NoError(t, service.Observe(context.Background(), observation))
+	require.NoError(t, service.reconcileAirport(context.Background(), "EKCH"))
+	require.Equal(t, aman.SequenceRevision(1), repository.state.Revision)
+	require.Equal(t, observation, *repository.state.Flights[0].LatestObservation)
+	require.Equal(t, eobt.Add(15*time.Minute+eet), repository.state.Flights[0].Prediction.RawTETA)
+	require.Len(t, publisher.states, 1)
+
+	now = now.Add(time.Minute)
+	observation.Missing, observation.ReconciledAt = true, now
+	require.NoError(t, service.Observe(context.Background(), observation))
+	require.NoError(t, service.reconcileAirport(context.Background(), "EKCH"))
+	require.Equal(t, now.Add(time.Minute), *repository.state.Flights[0].Lifecycle.Absence.RemovalDueAt)
+
+	now = now.Add(time.Minute)
+	require.NoError(t, service.reconcileAirport(context.Background(), "EKCH"))
+	require.Equal(t, aman.StateRemoved, repository.state.Flights[0].State)
+}
+
+func TestUnknownSTARFamilyRemainsDegradedAndSequenceable(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	service, err := New(Dependencies{
+		Repository: &memoryRepository{}, Materializer: unavailableNavigation{}, Geometry: unavailableGeometry{}, Wind: unavailableWind{},
+		Publisher: &recordingPublisher{}, Terminal: terminal.Configuration{Airport: "EKCH", ConfigVersion: "test", RunwayGroups: []terminal.RunwayGroup{{
+			ID: "ARRIVAL-22", SameSTARSpacing: &terminal.SameSTARSpacing{Enabled: true, ActivationRatePerHour: 20, MinimumEmptySlots: 1},
+		}}},
+		Airports: []string{"EKCH"}, Mode: aman.ModeShadow, Now: func() time.Time { return now },
+	})
+	require.NoError(t, err)
+	takeoff, eet, route, wake := now.Add(-time.Minute), 30*time.Minute, "DCT NOTASTAR", "M"
+	altitude, groundspeed, observedAt := 10000, 300.0, now
+	observation := aman.FlightObservation{
+		FlightID: "flight-unknown", VATSIMCID: "456", Callsign: "SAS456", Origin: "ENGM", Destination: "EKCH",
+		FiledRoute: &route, WakeCategory: &wake, PlannedTiming: &aman.PlannedTiming{EstimatedEnrouteTime: &eet}, TakeoffDetected: &takeoff,
+		FlightPlan: aman.FlightPlanFact{ObservedAt: &observedAt}, ReconciledAt: now, SourceStatus: aman.DataFresh,
+		Surveillance: &aman.SurveillanceFact{
+			LatitudeDegrees: 55, LongitudeDegrees: 12, AltitudeFeet: &altitude,
+			GroundspeedKnots: &groundspeed, ObservedAt: &observedAt,
+		},
+	}
+	state := service.initialState("EKCH", now)
+	updated, err := service.reconcileFlight(context.Background(), state, newFlight(observation, now), observation, now)
+	require.NoError(t, err)
+	require.Nil(t, updated.SelectedFeeder)
+	require.Equal(t, aman.RunwayGroupID("ARRIVAL-22"), *updated.SelectedRunwayGroup)
+	require.NotNil(t, updated.Prediction)
+	require.True(t, updated.Prediction.Publishable)
+	require.Equal(t, string(sequence.WarningUnknownSTARFamily), *updated.Prediction.DegradationReason)
+
+	state.Flights = []aman.AMANFlight{updated}
+	input := sequenceInput(state, service.deps.Terminal)
+	require.Len(t, input.Flights, 1)
+	result, err := sequence.Generate(input)
+	require.NoError(t, err)
+	require.Len(t, result.Entries, 1)
+	require.Contains(t, result.Warnings, sequence.Warning{
+		Severity: sequence.SeverityDegraded, Code: sequence.WarningUnknownSTARFamily,
+		RunwayGroupID: "ARRIVAL-22", FlightID: "flight-unknown",
+	})
+}
+
+func TestAirbornePredictionIsNotPublishableWithoutEssentialInputs(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	service, err := New(Dependencies{
+		Repository: &memoryRepository{}, Materializer: unavailableNavigation{}, Geometry: unavailableGeometry{}, Wind: unavailableWind{},
+		Publisher: &recordingPublisher{}, Terminal: terminal.Configuration{Airport: "EKCH", ConfigVersion: "test", RunwayGroups: []terminal.RunwayGroup{{ID: "ARRIVAL-22"}}},
+		Airports: []string{"EKCH"}, Mode: aman.ModeShadow, Now: func() time.Time { return now },
+	})
+	require.NoError(t, err)
+	takeoff, eet := now.Add(-time.Minute), 30*time.Minute
+	observation := aman.FlightObservation{
+		FlightID: "missing-input", VATSIMCID: "456", Callsign: "SAS456", Origin: "ENGM", Destination: "EKCH",
+		PlannedTiming: &aman.PlannedTiming{EstimatedEnrouteTime: &eet}, TakeoffDetected: &takeoff,
+		ReconciledAt: now, SourceStatus: aman.DataFresh,
+	}
+
+	updated, err := service.reconcileFlight(context.Background(), service.initialState("EKCH", now), newFlight(observation, now), observation, now)
+	require.NoError(t, err)
+	require.NotNil(t, updated.Prediction)
+	require.False(t, updated.Prediction.Publishable)
+	require.Equal(t, "missing_essential_data:surveillance,filed_route", *updated.Prediction.DegradationReason)
+	require.Empty(t, sequenceInput(aman.AirportState{
+		Revision:     1,
+		RunwayGroups: service.initialState("EKCH", now).RunwayGroups,
+		Flights:      []aman.AMANFlight{updated},
+	}, service.deps.Terminal).Flights)
+}
+
+func TestFutureRateChangePreservesCurrentAndPendingSchedule(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	service, err := New(Dependencies{
+		Repository: &memoryRepository{}, Materializer: unavailableNavigation{}, Geometry: unavailableGeometry{}, Wind: unavailableWind{},
+		Publisher: &recordingPublisher{}, Terminal: terminal.Configuration{Airport: "EKCH", ConfigVersion: "test", RunwayGroups: []terminal.RunwayGroup{{ID: "ARRIVAL-22"}}},
+		Airports: []string{"EKCH"}, Mode: aman.ModeShadow, Now: func() time.Time { return now },
+	})
+	require.NoError(t, err)
+	state := service.initialState("EKCH", now)
+	state.Revision = 7
+	future := now.Add(15 * time.Minute)
+	mutation, err := service.SetRate(aman.CommandContext{ReceivedAt: now}, aman.SetRateCommand{
+		Metadata:      aman.CommandMetadata{CommandID: "future-rate", ExpectedRevision: 7},
+		RunwayGroupID: "ARRIVAL-22", ArrivalsPerHour: 30, EffectiveAt: future,
+	})
+	require.NoError(t, err)
+	change, err := mutation(state)
+	require.NoError(t, err)
+	group := change.State.RunwayGroups[0]
+	require.Equal(t, uint32(20), group.ActiveRatePerHour)
+	require.Len(t, group.RateSchedule, 2)
+	require.Equal(t, []sequence.RatePoint{
+		{EffectiveAt: now, ArrivalsPerHour: 20},
+		{EffectiveAt: future, ArrivalsPerHour: 30},
+	}, sequenceInput(change.State, service.deps.Terminal).Policies[0].Rates)
+
+	updateActiveRates(change.State.RunwayGroups, future)
+	require.Equal(t, uint32(30), change.State.RunwayGroups[0].ActiveRatePerHour)
+	require.Equal(t, future, *change.State.RunwayGroups[0].RateEffectiveAt)
+}
+
+func TestRateSelectionMovesOnlyReorderableFlightsAtEffectiveTime(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	service, err := New(Dependencies{
+		Repository: &memoryRepository{}, Materializer: unavailableNavigation{}, Geometry: unavailableGeometry{}, Wind: unavailableWind{},
+		Publisher: &recordingPublisher{}, Terminal: terminal.Configuration{Airport: "EKCH", ConfigVersion: "test", RunwayGroups: []terminal.RunwayGroup{{ID: "ARRIVAL-04"}, {ID: "ARRIVAL-22"}}},
+		Airports: []string{"EKCH"}, Mode: aman.ModeShadow, Now: func() time.Time { return now },
+	})
+	require.NoError(t, err)
+	state := service.initialState("EKCH", now)
+	state.Revision = 7
+	wake, feeder := "M", "MONAK"
+	unstable := operationalFlight("UNSTABLE", "ARRIVAL-04", feeder, wake, now.Add(20*time.Minute))
+	stable := operationalFlight("STABLE", "ARRIVAL-04", feeder, wake, now.Add(23*time.Minute))
+	stable.State = aman.StateStable
+	state.Flights = []aman.AMANFlight{unstable, stable}
+	future := now.Add(15 * time.Minute)
+
+	mutation, err := service.SetRate(aman.CommandContext{ReceivedAt: now}, aman.SetRateCommand{
+		Metadata:      aman.CommandMetadata{CommandID: "select-22", ExpectedRevision: 7},
+		RunwayGroupID: "ARRIVAL-22", ArrivalsPerHour: 30, EffectiveAt: future,
+	})
+	require.NoError(t, err)
+	change, err := mutation(state)
+	require.NoError(t, err)
+	require.True(t, change.State.RunwayGroups[0].Selected)
+	require.False(t, change.State.RunwayGroups[1].Selected)
+	require.Equal(t, aman.RunwayGroupID("ARRIVAL-04"), *change.State.Flights[0].SelectedRunwayGroup)
+
+	selected, changed := updateSelectedRunwayGroup(change.State.RunwayGroups, future)
+	require.True(t, changed)
+	require.Equal(t, aman.RunwayGroupID("ARRIVAL-22"), selected)
+	reassignFlightsToGroup(&change.State, selected)
+	require.Equal(t, aman.RunwayGroupID("ARRIVAL-22"), *change.State.Flights[0].SelectedRunwayGroup)
+	require.Equal(t, aman.RunwayGroupID("ARRIVAL-04"), *change.State.Flights[1].SelectedRunwayGroup)
+}
+
+func TestFutureRateCommandsPreserveRunwaySelectionHistory(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	service, err := New(Dependencies{
+		Repository: &memoryRepository{}, Materializer: unavailableNavigation{}, Geometry: unavailableGeometry{}, Wind: unavailableWind{},
+		Publisher: &recordingPublisher{}, Terminal: terminal.Configuration{Airport: "EKCH", ConfigVersion: "test", RunwayGroups: []terminal.RunwayGroup{{ID: "ARRIVAL-04"}, {ID: "ARRIVAL-22"}}},
+		Airports: []string{"EKCH"}, Mode: aman.ModeShadow, Now: func() time.Time { return now },
+	})
+	require.NoError(t, err)
+	state := service.initialState("EKCH", now)
+	state.Revision = 7
+
+	applyRate := func(group aman.RunwayGroupID, effectiveAt time.Time) {
+		mutation, mutationErr := service.SetRate(aman.CommandContext{ReceivedAt: now}, aman.SetRateCommand{
+			Metadata: aman.CommandMetadata{
+				CommandID:        "select-" + string(group) + "-" + effectiveAt.Format("1504"),
+				ExpectedRevision: state.Revision,
+			},
+			RunwayGroupID: group, ArrivalsPerHour: 20, EffectiveAt: effectiveAt,
+		})
+		require.NoError(t, mutationErr)
+		change, changeErr := mutation(state)
+		require.NoError(t, changeErr)
+		state = change.State
+		state.Revision++
+	}
+
+	first, second, third := now.Add(10*time.Minute), now.Add(20*time.Minute), now.Add(30*time.Minute)
+	applyRate("ARRIVAL-22", first)
+	applyRate("ARRIVAL-04", second)
+	applyRate("ARRIVAL-22", third)
+
+	selected, changed := updateSelectedRunwayGroup(state.RunwayGroups, first)
+	require.True(t, changed)
+	require.Equal(t, aman.RunwayGroupID("ARRIVAL-22"), selected)
+	selected, changed = updateSelectedRunwayGroup(state.RunwayGroups, second)
+	require.True(t, changed)
+	require.Equal(t, aman.RunwayGroupID("ARRIVAL-04"), selected)
+	selected, changed = updateSelectedRunwayGroup(state.RunwayGroups, third)
+	require.True(t, changed)
+	require.Equal(t, aman.RunwayGroupID("ARRIVAL-22"), selected)
+}
+
+func TestGoAroundUpdatesOperationalTETABeforeCascading(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	service, err := New(Dependencies{
+		Repository: &memoryRepository{}, Materializer: unavailableNavigation{}, Geometry: unavailableGeometry{}, Wind: unavailableWind{},
+		Publisher: &recordingPublisher{}, Terminal: terminal.Configuration{Airport: "EKCH", ConfigVersion: "test", RunwayGroups: []terminal.RunwayGroup{{ID: "ARRIVAL-22"}}},
+		Airports: []string{"EKCH"}, Mode: aman.ModeShadow, Now: func() time.Time { return now },
+	})
+	require.NoError(t, err)
+	state := service.initialState("EKCH", now)
+	state.Revision = 4
+	flight := operationalFlight("GO-AROUND", "ARRIVAL-22", "MONAK", "M", now.Add(3*time.Minute))
+	flight.State = aman.StateStable
+	flight.Slot = &aman.Slot{
+		Time: now.Add(3 * time.Minute), RunwayGroupID: "ARRIVAL-22",
+		Sequence: 1, Revision: state.Revision, Reason: string(sequence.ReasonRateWTC),
+	}
+	state.Flights = []aman.AMANFlight{flight}
+
+	command := aman.ReportGoAroundCommand{
+		Metadata:   aman.CommandMetadata{CommandID: "go-around", ExpectedRevision: state.Revision},
+		FlightID:   flight.ID,
+		DetectedAt: now,
+	}
+	mutation, err := service.ReportGoAround(aman.CommandContext{ReceivedAt: now}, command)
+	require.NoError(t, err)
+	change, err := mutation(state)
+	require.NoError(t, err)
+	updated := change.State.Flights[0]
+	require.Equal(t, now.Add(10*time.Minute), updated.Prediction.OperationalTETA)
+	require.Equal(t, aman.OperationalReasonGoAround, updated.Prediction.OperationalReason)
+	require.True(t, updated.Prediction.Publishable)
+	require.NotNil(t, updated.Slot)
+	require.False(t, updated.Slot.Time.Before(now.Add(10*time.Minute)))
+	require.NotNil(t, change.QueueOffers)
+}
+
+func TestRateChangeRejectsProtectedSameSTARConflict(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	service, err := New(Dependencies{
+		Repository: &memoryRepository{}, Materializer: unavailableNavigation{}, Geometry: unavailableGeometry{}, Wind: unavailableWind{},
+		Publisher: &recordingPublisher{}, Terminal: terminal.Configuration{Airport: "EKCH", ConfigVersion: "test", RunwayGroups: []terminal.RunwayGroup{{
+			ID: "ARRIVAL-22", SameSTARSpacing: &terminal.SameSTARSpacing{Enabled: true, ActivationRatePerHour: 20, MinimumEmptySlots: 1},
+		}}},
+		Airports: []string{"EKCH"}, Mode: aman.ModeShadow, Now: func() time.Time { return now },
+	})
+	require.NoError(t, err)
+	state := service.initialState("EKCH", now)
+	state.Revision = 4
+	state.RunwayGroups[0].ActiveRatePerHour = 19
+	state.RunwayGroups[0].RateSchedule = []aman.RunwayGroupRatePoint{{EffectiveAt: now.Add(-time.Hour), ArrivalsPerHour: 19}}
+	wake, feeder := "M", "MONAK"
+	lead := protectedOperationalFlight("LEAD", "ARRIVAL-22", feeder, wake, now, 1, aman.FreezeManual)
+	trail := protectedOperationalFlight("TRAIL", "ARRIVAL-22", feeder, wake, now.Add(3*time.Minute), 2, aman.FreezeSuperstable)
+	state.Flights = []aman.AMANFlight{lead, trail}
+
+	mutation, err := service.SetRate(aman.CommandContext{ReceivedAt: now}, aman.SetRateCommand{
+		Metadata:      aman.CommandMetadata{CommandID: "activate-spacing", ExpectedRevision: 4},
+		RunwayGroupID: "ARRIVAL-22", ArrivalsPerHour: 20, EffectiveAt: now,
+	})
+	require.NoError(t, err)
+	_, err = mutation(state)
+	var domain *aman.DomainError
+	require.ErrorAs(t, err, &domain)
+	require.Equal(t, aman.ErrorInvalidTransition, domain.Class)
+	require.ErrorContains(t, err, string(sequence.WarningProtectedSameSTAR))
+	require.Equal(t, uint32(19), state.RunwayGroups[0].ActiveRatePerHour)
+}
+
+func TestActiveRouteReuseIncludesNavigationDatasetVersion(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	version := navdata.DatasetVersion{
+		Cycle: "2607", SourceRevision: "revision-a",
+		EffectiveFrom: now.Add(-24 * time.Hour), EffectiveUntil: now.Add(24 * time.Hour),
+	}
+	key, group := "route-key", aman.RunwayGroupID("ARRIVAL-22")
+	datasetID := navigationDatasetID(version)
+	flight := aman.AMANFlight{
+		ActiveRouteKey: &key, ActiveRouteDatasetID: &datasetID,
+		RouteProgress: &aman.RouteProgress{FlightPlanRevision: 7, RunwayGroupID: group},
+	}
+	require.True(t, canReuseActiveRoute(flight, 7, group, datasetID))
+	version.SourceRevision = "revision-b"
+	require.False(t, canReuseActiveRoute(flight, 7, group, navigationDatasetID(version)))
+}
+
+func TestHoldingETAUsesPerLegDurations(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	legs := []trajectory.RemainingLeg{
+		{To: "HOLD", DistanceNM: 90},
+		{To: "RUNWAY", DistanceNM: 10},
+	}
+	got := holdingETA(now, []time.Duration{20 * time.Minute, 2 * time.Minute}, legs, "HOLD")
+	require.NotNil(t, got)
+	require.Equal(t, now.Add(20*time.Minute), *got)
+	require.Nil(t, holdingETA(now, []time.Duration{20 * time.Minute}, legs, "HOLD"))
+}
+
+func TestFailedNavigationRefreshRetriesAndHealthFailsClosed(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	navigation := &countingNavigation{}
+	service, err := New(Dependencies{
+		Repository: &memoryRepository{}, Materializer: navigation, Geometry: unavailableGeometry{}, Wind: unavailableWind{},
+		Publisher: &recordingPublisher{}, Terminal: terminal.Configuration{Airport: "EKCH", ConfigVersion: "test", RunwayGroups: []terminal.RunwayGroup{{ID: "ARRIVAL-22"}}},
+		Airports: []string{"EKCH"}, Mode: aman.ModeAuthoritative, Now: func() time.Time { return now },
+	})
+	require.NoError(t, err)
+	require.False(t, service.TechnicalHealth(context.Background()).AuthorityAllowed)
+	require.NoError(t, service.ObserveSourceHealth(context.Background(), aman.DataFresh, now))
+	require.Error(t, service.refreshNavigation(context.Background(), "EKCH"))
+	require.Error(t, service.refreshNavigation(context.Background(), "EKCH"))
+	require.Equal(t, 2, navigation.attempts)
+	health := service.TechnicalHealth(context.Background())
+	require.Equal(t, aman.HealthReady, health.VATSIM.Status)
+	require.Equal(t, aman.HealthUnavailable, health.Navigation.Status)
+	require.False(t, health.AuthorityAllowed)
+}
+
+func TestServiceCommitsInitialEmptyAirportState(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	repository := &memoryRepository{}
+	publisher := &recordingPublisher{}
+	service, err := New(Dependencies{
+		Repository: repository, Materializer: unavailableNavigation{}, Geometry: unavailableGeometry{}, Wind: unavailableWind{},
+		Publisher: publisher, Terminal: terminal.Configuration{Airport: "EKCH", ConfigVersion: "test", RunwayGroups: []terminal.RunwayGroup{{ID: "ARRIVAL-22"}}},
+		Airports: []string{"EKCH"}, Mode: aman.ModeShadow, Now: func() time.Time { return now },
+	})
+	require.NoError(t, err)
+	require.NoError(t, service.reconcileAirport(context.Background(), "EKCH"))
+	require.True(t, repository.has)
+	require.Equal(t, aman.SequenceRevision(1), repository.state.Revision)
+	require.Empty(t, repository.state.Flights)
+	require.Len(t, publisher.states, 1)
+}
+
+func operationalFlight(id string, group aman.RunwayGroupID, feeder, wake string, teta time.Time) aman.AMANFlight {
+	observation := aman.FlightObservation{WakeCategory: &wake}
+	return aman.AMANFlight{
+		ID: aman.FlightID(id), State: aman.StateUnstable, SelectedRunwayGroup: &group, SelectedFeeder: &feeder,
+		LatestObservation: &observation, FreezeReason: aman.FreezeNone,
+		Prediction: &aman.Prediction{OperationalTETA: teta, Publishable: true},
+	}
+}
+
+func protectedOperationalFlight(id string, group aman.RunwayGroupID, feeder, wake string, slotAt time.Time, sequenceNumber int, reason aman.FreezeReason) aman.AMANFlight {
+	flight := operationalFlight(id, group, feeder, wake, slotAt)
+	flight.State = aman.StateStable
+	flight.FreezeReason = reason
+	flight.FrozenAt = &slotAt
+	flight.FrozenOperationalTETA = &slotAt
+	flight.FrozenSlot = &aman.Slot{Time: slotAt, RunwayGroupID: group, Sequence: sequenceNumber, Revision: 4, Reason: "protected"}
+	return flight
+}
+
+type memoryRepository struct {
+	state aman.AirportState
+	has   bool
+}
+
+func (r *memoryRepository) LoadAirportState(context.Context, string) (aman.AirportState, error) {
+	if !r.has {
+		return aman.AirportState{}, &aman.DomainError{Class: aman.ErrorNotFound, Message: "missing"}
+	}
+	return r.state, nil
+}
+func (r *memoryRepository) Commit(_ context.Context, commit aman.StateCommit) (aman.CommitResult, error) {
+	if err := commit.Validate(); err != nil {
+		return aman.CommitResult{}, err
+	}
+	r.state, r.has = commit.State, true
+	return aman.CommitResult{State: commit.State}, nil
+}
+
+type recordingPublisher struct{ states []aman.AirportState }
+
+func (p *recordingPublisher) PublishAMANState(_ context.Context, state aman.AirportState) error {
+	p.states = append(p.states, state)
+	return nil
+}
+
+type unavailableNavigation struct{}
+
+func (unavailableNavigation) Refresh(context.Context, materializer.Request) error {
+	return errors.New("offline")
+}
+func (unavailableNavigation) MaterializeRoute(context.Context, navdata.RouteQuery, string) (navdata.RouteKey, error) {
+	return "", errors.New("offline")
+}
+
+type countingNavigation struct{ attempts int }
+
+func (n *countingNavigation) Refresh(context.Context, materializer.Request) error {
+	n.attempts++
+	return errors.New("offline")
+}
+func (*countingNavigation) MaterializeRoute(context.Context, navdata.RouteQuery, string) (navdata.RouteKey, error) {
+	return "", errors.New("offline")
+}
+
+type unavailableGeometry struct{}
+
+func (unavailableGeometry) ActiveVersion(context.Context, navdata.AirportID) (navdata.DatasetVersion, error) {
+	return navdata.DatasetVersion{}, errors.New("offline")
+}
+func (unavailableGeometry) Route(context.Context, navdata.RouteKey) (navdata.RouteGeometry, error) {
+	return navdata.RouteGeometry{}, errors.New("offline")
+}
+func (unavailableGeometry) TerminalPath(context.Context, navdata.AirportID, navdata.FeederID, aman.RunwayGroupID) (navdata.TerminalPath, error) {
+	return navdata.TerminalPath{}, errors.New("offline")
+}
+func (unavailableGeometry) ActiveGeometrySnapshot(context.Context, navdata.AirportID) (navdata.ActiveGeometrySnapshot, error) {
+	return navdata.ActiveGeometrySnapshot{}, errors.New("offline")
+}
+
+type unavailableWind struct{}
+
+func (unavailableWind) WindProfile(context.Context, predictor.WindProfileRequest) (predictor.WindProfile, error) {
+	return predictor.WindProfile{}, errors.New("offline")
+}

--- a/backend/internal/aman/persistence.go
+++ b/backend/internal/aman/persistence.go
@@ -92,6 +92,12 @@ type ObservationSink interface {
 	Observe(context.Context, FlightObservation) error
 }
 
+// ObservationSourceHealthSink receives source-wide health even when a fresh
+// snapshot contains no flights.
+type ObservationSourceHealthSink interface {
+	ObserveSourceHealth(context.Context, DataStatus, time.Time) error
+}
+
 // VATSIMFlightIdentityBinder is the narrow durable identity capability needed
 // by a VATSIM observation adapter. It finds the active binding for a stable
 // VATSIM CID, so a corrected callsign never rekeys an active AMAN flight.

--- a/backend/internal/aman/prediction/reducer.go
+++ b/backend/internal/aman/prediction/reducer.go
@@ -143,8 +143,8 @@ func Reduce(config Config, flight aman.AMANFlight, input Input) (Result, error) 
 	candidate, reason := routineOperational(config, flight, previousState, input)
 	setOperational(&flight, input.Raw, candidate, reason)
 
-	// Superstable happens only at the exact configured holding-fix boundary,
-	// never before/after it and never until a complete slot exists.
+	// Superstable begins at or inside the configured holding-fix horizon and
+	// never until a complete slot exists.
 	if atSuperstableBoundary(input.Raw.GeneratedAt, input.Raw.HoldingFixETA, config.SuperstableHorizon) &&
 		flight.SelectedHolding != nil && strings.TrimSpace(*flight.SelectedHolding) != "" && flight.Slot != nil {
 		freezeAt := input.Raw.GeneratedAt
@@ -299,7 +299,7 @@ func median(values []time.Time) time.Time {
 }
 
 func atSuperstableBoundary(now time.Time, holdingFixETA *time.Time, horizon time.Duration) bool {
-	return holdingFixETA != nil && now.Add(horizon).Equal(*holdingFixETA)
+	return holdingFixETA != nil && !holdingFixETA.After(now.Add(horizon)) && holdingFixETA.After(now)
 }
 
 func clearFreeze(flight *aman.AMANFlight) {

--- a/backend/internal/aman/predictor/performance_wind.go
+++ b/backend/internal/aman/predictor/performance_wind.go
@@ -16,8 +16,9 @@ import (
 const (
 	defaultMinimumGroundspeedKnots = 120.0
 	defaultMaximumGroundspeedKnots = 600.0
-	defaultMaxWindCorrection       = 0.20
 	defaultPerformanceVersion      = "aman-performance-defaults-v1"
+	amanCPHModelVersion            = "aman-cph-teta-v1"
+	descentFeetPerNM               = 318.4
 )
 
 // AircraftPerformanceRepository supplies versioned, provider-neutral profile
@@ -75,9 +76,6 @@ type RouteLeg struct {
 
 type PerformanceWindConfig struct {
 	MinimumGroundspeedKnots, MaximumGroundspeedKnots float64
-	// MaxWindCorrectionPercent caps the total duration change around no-wind
-	// geometry. 0 selects 20 percent; values must otherwise be in (0, 1).
-	MaxWindCorrectionPercent float64
 }
 
 func (c PerformanceWindConfig) normalized() (PerformanceWindConfig, error) {
@@ -87,30 +85,32 @@ func (c PerformanceWindConfig) normalized() (PerformanceWindConfig, error) {
 	if c.MaximumGroundspeedKnots == 0 {
 		c.MaximumGroundspeedKnots = defaultMaximumGroundspeedKnots
 	}
-	if c.MaxWindCorrectionPercent == 0 {
-		c.MaxWindCorrectionPercent = defaultMaxWindCorrection
-	}
-	if !finite(c.MinimumGroundspeedKnots) || !finite(c.MaximumGroundspeedKnots) || !finite(c.MaxWindCorrectionPercent) || c.MinimumGroundspeedKnots <= 0 || c.MaximumGroundspeedKnots < c.MinimumGroundspeedKnots || c.MaxWindCorrectionPercent <= 0 || c.MaxWindCorrectionPercent >= 1 {
+	if !finite(c.MinimumGroundspeedKnots) || !finite(c.MaximumGroundspeedKnots) || c.MinimumGroundspeedKnots <= 0 || c.MaximumGroundspeedKnots < c.MinimumGroundspeedKnots {
 		return c, errPerformanceWindConfig
 	}
 	return c, nil
 }
 
 type PerformanceWindInput struct {
-	PredictionAt           time.Time
-	AircraftICAO           string
-	WakeTurbulenceCategory AircraftCategory
-	AltitudeFeet           float64
-	Remaining              []RouteLeg
+	PredictionAt            time.Time
+	AircraftICAO            string
+	WakeTurbulenceCategory  AircraftCategory
+	AltitudeFeet            float64
+	CurrentGroundspeedKnots float64
+	Remaining               []RouteLeg
 }
 
 type PerformanceWindResult struct {
 	RawTETA                                         time.Time
+	RawRETA                                         time.Time
 	NoWindDuration, Duration                        time.Duration
+	DistanceToGoNM                                  float64
 	Confidence                                      aman.Confidence
+	ModelVersion                                    string
 	PerformanceProfileID, PerformanceProfileVersion *string
 	WeatherSource, WeatherSourceRevision            *string
 	DegradationReasons                              []string
+	LegDurations                                    []time.Duration
 }
 
 // EstimatePerformanceWind calculates only the latest physical/raw route
@@ -121,7 +121,7 @@ func EstimatePerformanceWind(ctx context.Context, performance AircraftPerformanc
 	if err != nil {
 		return PerformanceWindResult{}, err
 	}
-	if !validPredictionInstant(input.PredictionAt) || !finite(input.AltitudeFeet) || input.AltitudeFeet < 0 || len(input.Remaining) == 0 {
+	if !validPredictionInstant(input.PredictionAt) || !finite(input.AltitudeFeet) || input.AltitudeFeet < 0 || !finite(input.CurrentGroundspeedKnots) || input.CurrentGroundspeedKnots <= 0 || len(input.Remaining) == 0 {
 		return PerformanceWindResult{}, errPerformanceWindInput
 	}
 	for _, leg := range input.Remaining {
@@ -130,25 +130,28 @@ func EstimatePerformanceWind(ctx context.Context, performance AircraftPerformanc
 		}
 	}
 
-	result := PerformanceWindResult{Confidence: aman.ConfidenceHigh}
-	profile, exact, unavailable := selectProfile(ctx, performance, input)
-	if unavailable {
-		result.DegradationReasons = append(result.DegradationReasons, "PERFORMANCE_PROFILE_UNAVAILABLE")
-		result.Confidence = aman.ConfidenceMedium
-	} else if !exact {
-		result.DegradationReasons = append(result.DegradationReasons, "PERFORMANCE_PROFILE_FALLBACK")
-		result.Confidence = aman.ConfidenceMedium
+	_ = performance // AMAN-CPH uses fixed category bands, not external cruise profiles.
+	segments := buildDescentSegments(input)
+	if len(segments) == 0 {
+		return PerformanceWindResult{}, errPerformanceWindInput
 	}
-	result.PerformanceProfileID, result.PerformanceProfileVersion = pointerString(profile.ID), pointerString(profile.Version)
-	base := durationFor(input.Remaining, profile.CruiseTrueAirspeedKnots, config)
+	distance := routeDistance(input.Remaining)
+	result := PerformanceWindResult{
+		Confidence: aman.ConfidenceHigh, ModelVersion: amanCPHModelVersion, DistanceToGoNM: distance,
+		PerformanceProfileID: pointerString("aman-cph-speed-bands"), PerformanceProfileVersion: pointerString(amanCPHModelVersion),
+	}
+	result.RawRETA = input.PredictionAt.Add(durationForDistance(distance, input.CurrentGroundspeedKnots, config))
+
+	base, baseLegDurations := durationBreakdownForSegments(segments, input, nil, config)
 	result.NoWindDuration, result.Duration = base, base
+	result.LegDurations = baseLegDurations
 
 	if wind == nil {
 		result = degradeWind(result, "WEATHER_UNAVAILABLE")
 		result.RawTETA = input.PredictionAt.Add(result.Duration)
 		return result, nil
 	}
-	requests := windRequests(input, profile.CruiseTrueAirspeedKnots, config)
+	requests := windRequestsForSegments(input, segments, config)
 	weather, err := wind.WindProfile(ctx, WindProfileRequest{Samples: requests})
 	if err != nil || !validWindProfile(weather, requests, input.PredictionAt) {
 		result = degradeWind(result, "WEATHER_UNAVAILABLE")
@@ -157,16 +160,182 @@ func EstimatePerformanceWind(ctx context.Context, performance AircraftPerformanc
 	}
 	result.WeatherSource = pointerString(weather.SourceID)
 	result.WeatherSourceRevision = pointerString(weather.SourceRevision)
-	windDuration, ok := durationWithWind(input.Remaining, profile.CruiseTrueAirspeedKnots, weather, input.AltitudeFeet, config)
+	windDuration, windLegDurations, ok := durationForWeather(segments, input, weather, config)
 	if !ok {
 		result = degradeWind(result, "WEATHER_INCOMPLETE")
 		result.RawTETA = input.PredictionAt.Add(result.Duration)
 		return result, nil
 	}
-	low, high := durationBounds(base, config.MaxWindCorrectionPercent)
-	result.Duration = maxDuration(low, minDuration(high, windDuration))
+	result.Duration = windDuration
+	result.LegDurations = windLegDurations
 	result.RawTETA = input.PredictionAt.Add(result.Duration)
 	return result, nil
+}
+
+type descentSegment struct {
+	distanceNM, courseTrueDegrees, altitudeFeet float64
+	position                                    WindCoordinate
+	legIndex                                    int
+	preTOD                                      bool
+}
+
+func buildDescentSegments(input PerformanceWindInput) []descentSegment {
+	total := routeDistance(input.Remaining)
+	boundaries := []float64{0, total}
+	for _, altitude := range []float64{input.AltitudeFeet, 27000, 10000, 5000, 3000, 0} {
+		travelled := total - min(input.AltitudeFeet, altitude)/descentFeetPerNM
+		if travelled > 0 && travelled < total {
+			boundaries = append(boundaries, travelled)
+		}
+	}
+	travelled := 0.0
+	for _, leg := range input.Remaining {
+		travelled += leg.DistanceNM
+		if travelled > 0 && travelled < total {
+			boundaries = append(boundaries, travelled)
+		}
+	}
+	slices.Sort(boundaries)
+	boundaries = slices.Compact(boundaries)
+	segments := make([]descentSegment, 0, len(boundaries)-1)
+	for i := 1; i < len(boundaries); i++ {
+		from, to := boundaries[i-1], boundaries[i]
+		if to <= from {
+			continue
+		}
+		mid := (from + to) / 2
+		leg, legIndex, fraction, ok := routePosition(input.Remaining, mid)
+		if !ok {
+			continue
+		}
+		remaining := total - mid
+		descentDistance := input.AltitudeFeet / descentFeetPerNM
+		preTOD := remaining > descentDistance
+		altitude := input.AltitudeFeet
+		if !preTOD {
+			altitude = min(input.AltitudeFeet, remaining*descentFeetPerNM)
+		}
+		segments = append(segments, descentSegment{
+			distanceNM: to - from, courseTrueDegrees: leg.CourseTrueDegrees,
+			altitudeFeet: altitude, position: interpolateCoordinate(leg.Start, leg.End, fraction),
+			legIndex: legIndex, preTOD: preTOD,
+		})
+	}
+	return segments
+}
+
+func durationForSegments(segments []descentSegment, input PerformanceWindInput, weather *WindProfile, config PerformanceWindConfig) time.Duration {
+	total, _ := durationBreakdownForSegments(segments, input, weather, config)
+	return total
+}
+
+func durationBreakdownForSegments(segments []descentSegment, input PerformanceWindInput, weather *WindProfile, config PerformanceWindConfig) (time.Duration, []time.Duration) {
+	inferredIAS := tasToIAS(input.CurrentGroundspeedKnots, input.AltitudeFeet)
+	if weather != nil && len(weather.Samples) == len(segments)+1 {
+		if east, north, ok := interpolateWind(weather.Samples[0].Levels, input.AltitudeFeet); ok {
+			inferredIAS = tasToIAS(input.CurrentGroundspeedKnots-tailwind(input.Remaining[0].CourseTrueDegrees, east, north), input.AltitudeFeet)
+		}
+	}
+	total := time.Duration(0)
+	legDurations := make([]time.Duration, len(input.Remaining))
+	for i, segment := range segments {
+		groundspeed := input.CurrentGroundspeedKnots
+		if !segment.preTOD {
+			ias := descentIAS(input.WakeTurbulenceCategory, segment.altitudeFeet, inferredIAS)
+			groundspeed = iasToTAS(ias, segment.altitudeFeet)
+			if weather != nil {
+				east, north, ok := interpolateWind(weather.Samples[i+1].Levels, segment.altitudeFeet)
+				if !ok {
+					return 0, nil
+				}
+				groundspeed += tailwind(segment.courseTrueDegrees, east, north)
+			}
+		}
+		duration := durationForDistance(segment.distanceNM, groundspeed, config)
+		total += duration
+		legDurations[segment.legIndex] += duration
+	}
+	return total, legDurations
+}
+
+func durationForWeather(segments []descentSegment, input PerformanceWindInput, weather WindProfile, config PerformanceWindConfig) (time.Duration, []time.Duration, bool) {
+	duration, legs := durationBreakdownForSegments(segments, input, &weather, config)
+	return duration, legs, duration > 0
+}
+
+func windRequestsForSegments(input PerformanceWindInput, segments []descentSegment, config PerformanceWindConfig) []WindSampleRequest {
+	requests := make([]WindSampleRequest, 1, len(segments)+1)
+	requests[0] = WindSampleRequest{Position: input.Remaining[0].Start, At: input.PredictionAt, AltitudeFeet: input.AltitudeFeet}
+	elapsed := time.Duration(0)
+	inferredIAS := tasToIAS(input.CurrentGroundspeedKnots, input.AltitudeFeet)
+	for _, segment := range segments {
+		speed := input.CurrentGroundspeedKnots
+		if !segment.preTOD {
+			speed = iasToTAS(descentIAS(input.WakeTurbulenceCategory, segment.altitudeFeet, inferredIAS), segment.altitudeFeet)
+		}
+		duration := durationForDistance(segment.distanceNM, speed, config)
+		requests = append(requests, WindSampleRequest{Position: segment.position, At: input.PredictionAt.Add(elapsed + duration/2), AltitudeFeet: segment.altitudeFeet})
+		elapsed += duration
+	}
+	return requests
+}
+
+func descentIAS(category AircraftCategory, altitude, inferredHighIAS float64) float64 {
+	switch {
+	case altitude > 27000:
+		return max(inferredHighIAS, 150)
+	case altitude > 10000:
+		if category == CategoryHeavy || category == CategorySuper {
+			return 300
+		}
+		return 280
+	case altitude > 5000:
+		return 250
+	case altitude > 3000:
+		return 210
+	default:
+		return 150
+	}
+}
+
+func densityRatio(altitudeFeet float64) float64 {
+	altitudeFeet = max(0, altitudeFeet)
+	if altitudeFeet <= 36089 {
+		return math.Pow(1-6.87535e-6*altitudeFeet, 4.2561)
+	}
+	return 0.2971 * math.Exp(-(altitudeFeet-36089)/20806.7)
+}
+
+func iasToTAS(ias, altitudeFeet float64) float64 { return ias / math.Sqrt(densityRatio(altitudeFeet)) }
+func tasToIAS(tas, altitudeFeet float64) float64 {
+	return max(1, tas*math.Sqrt(densityRatio(altitudeFeet)))
+}
+func tailwind(course, east, north float64) float64 {
+	radians := course * math.Pi / 180
+	return east*math.Sin(radians) + north*math.Cos(radians)
+}
+func routeDistance(legs []RouteLeg) float64 {
+	total := 0.0
+	for _, leg := range legs {
+		total += leg.DistanceNM
+	}
+	return total
+}
+func routePosition(legs []RouteLeg, travelled float64) (RouteLeg, int, float64, bool) {
+	start := 0.0
+	for index, leg := range legs {
+		if travelled <= start+leg.DistanceNM {
+			return leg, index, clamp((travelled-start)/leg.DistanceNM, 0, 1), true
+		}
+		start += leg.DistanceNM
+	}
+	return RouteLeg{}, 0, 0, false
+}
+func interpolateCoordinate(a, b WindCoordinate, fraction float64) WindCoordinate {
+	return WindCoordinate{LatitudeDegrees: a.LatitudeDegrees + (b.LatitudeDegrees-a.LatitudeDegrees)*fraction, LongitudeDegrees: a.LongitudeDegrees + (b.LongitudeDegrees-a.LongitudeDegrees)*fraction}
+}
+func durationForDistance(distance, speed float64, config PerformanceWindConfig) time.Duration {
+	return time.Duration(float64(time.Hour) * distance / clamp(speed, config.MinimumGroundspeedKnots, config.MaximumGroundspeedKnots))
 }
 
 func degradeWind(result PerformanceWindResult, reason string) PerformanceWindResult {

--- a/backend/internal/aman/predictor/performance_wind_test.go
+++ b/backend/internal/aman/predictor/performance_wind_test.go
@@ -10,151 +10,127 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSelectProfileMapsICAOAndFallsBackDeterministically(t *testing.T) {
-	now := performanceNow()
-	repo := profilesRepository{profiles: []PerformanceProfile{
-		{ID: "medium-z", Version: "v1", WakeTurbulenceCategory: CategoryMedium, CruiseTrueAirspeedKnots: 400},
-		{ID: "a320", Version: "v2", AircraftICAOTypes: []string{"A320"}, WakeTurbulenceCategory: CategoryMedium, CruiseTrueAirspeedKnots: 430},
-		{ID: "heavy", Version: "v1", WakeTurbulenceCategory: CategoryHeavy, CruiseTrueAirspeedKnots: 450},
-		{ID: "medium-a", Version: "v1", WakeTurbulenceCategory: CategoryMedium, CruiseTrueAirspeedKnots: 410},
-	}}
-	for _, test := range []struct {
-		name, icao string
-		category   AircraftCategory
-		want       string
-	}{
-		{"known ICAO", "a320", CategoryHeavy, "a320"},
-		{"known WTC", "unknown", CategoryHeavy, "heavy"},
-		{"unknown uses stable medium fallback", "unknown", "unknown", "medium-a"},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			got, _, _ := selectProfile(context.Background(), repo, PerformanceWindInput{PredictionAt: now, AircraftICAO: test.icao, WakeTurbulenceCategory: test.category})
-			require.Equal(t, test.want, got.ID)
-		})
-	}
+func TestAMANCPHDescentSpeedBands(t *testing.T) {
+	require.Equal(t, 275.0, descentIAS(CategoryMedium, 30000, 275))
+	require.Equal(t, 300.0, descentIAS(CategoryHeavy, 20000, 275))
+	require.Equal(t, 300.0, descentIAS(CategorySuper, 20000, 275))
+	require.Equal(t, 280.0, descentIAS(CategoryMedium, 20000, 275))
+	require.Equal(t, 280.0, descentIAS("unknown", 20000, 275))
+	require.Equal(t, 250.0, descentIAS(CategoryHeavy, 8000, 275))
+	require.Equal(t, 210.0, descentIAS(CategoryMedium, 4000, 275))
+	require.Equal(t, 150.0, descentIAS(CategoryMedium, 2000, 275))
 }
 
-func TestEstimatePerformanceWindProjectsInterpolatedWindAndBoundsCorrection(t *testing.T) {
-	now, input := performanceNow(), performanceInput()
-	profile := profilesRepository{profiles: []PerformanceProfile{{ID: "A320", Version: "v1", AircraftICAOTypes: []string{"A320"}, WakeTurbulenceCategory: CategoryMedium, CruiseTrueAirspeedKnots: 400}}}
-	for _, test := range []struct {
-		name    string
-		east    float64
-		config  PerformanceWindConfig
-		compare func(*testing.T, PerformanceWindResult)
-	}{
-		{"tailwind decreases arrival", 40, PerformanceWindConfig{}, func(t *testing.T, got PerformanceWindResult) {
-			require.Less(t, got.Duration, got.NoWindDuration)
-			require.Equal(t, aman.ConfidenceHigh, got.Confidence)
-		}},
-		{"headwind increases arrival", -40, PerformanceWindConfig{}, func(t *testing.T, got PerformanceWindResult) { require.Greater(t, got.Duration, got.NoWindDuration) }},
-		{"cap limits extreme headwind", -1000, PerformanceWindConfig{MinimumGroundspeedKnots: 20, MaximumGroundspeedKnots: 900, MaxWindCorrectionPercent: .1}, func(t *testing.T, got PerformanceWindResult) {
-			require.Equal(t, time.Duration(float64(got.NoWindDuration)*1.1), got.Duration)
-		}},
-		{"groundspeed clamp limits extreme tailwind", 1000, PerformanceWindConfig{MinimumGroundspeedKnots: 120, MaximumGroundspeedKnots: 500, MaxWindCorrectionPercent: .9}, func(t *testing.T, got PerformanceWindResult) {
-			require.Equal(t, time.Duration(float64(time.Hour)*100/500), got.Duration)
-		}},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			wind := fixedWind{east: test.east, now: now}
-			got, err := EstimatePerformanceWind(context.Background(), profile, wind, input, test.config)
-			require.NoError(t, err)
-			require.Equal(t, now.Add(got.Duration), got.RawTETA)
-			test.compare(t, got)
-		})
-	}
+func TestAMANCPHBuildsThreeDegreeProfileAndUsesCurrentSpeedBeforeTOD(t *testing.T) {
+	input := performanceInput()
+	input.AltitudeFeet = 10000
+	input.CurrentGroundspeedKnots = 400
+	input.Remaining[0].DistanceNM = 100
+	segments := buildDescentSegments(input)
+	require.NotEmpty(t, segments)
+	require.True(t, segments[0].preTOD)
+	require.InDelta(t, 10000/descentFeetPerNM, routeDistance(input.Remaining)-firstDescentDistance(segments), .01)
+
+	result, err := EstimatePerformanceWind(context.Background(), nil, nil, input, PerformanceWindConfig{})
+	require.NoError(t, err)
+	require.Equal(t, amanCPHModelVersion, result.ModelVersion)
+	require.Equal(t, input.PredictionAt.Add(15*time.Minute), result.RawRETA)
+	require.Greater(t, result.Duration, 0*time.Second)
+	require.Equal(t, result.NoWindDuration, result.Duration)
+	require.Contains(t, result.DegradationReasons, "WEATHER_UNAVAILABLE")
 }
 
-func TestEstimatePerformanceWindPreservesGeometryForRepositoryAndWeatherDegradation(t *testing.T) {
-	now, input := performanceNow(), performanceInput()
-	for _, test := range []struct {
-		name        string
-		performance AircraftPerformanceRepository
-		wind        WindProfileReader
-		want        string
-	}{
-		{"performance repository failure", failingProfiles{}, fixedWind{now: now}, "PERFORMANCE_PROFILE_UNAVAILABLE"},
-		{"missing weather", nil, nil, "WEATHER_UNAVAILABLE"},
-		{"provider failure", profilesRepository{}, failingWind{}, "WEATHER_UNAVAILABLE"},
-		{"stale cached weather", profilesRepository{}, fixedWind{now: now.Add(-2 * time.Hour), expires: now.Add(-time.Minute)}, "WEATHER_UNAVAILABLE"},
-		{"incomplete weather", profilesRepository{}, incompleteWind{now: now}, "WEATHER_INCOMPLETE"},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			got, err := EstimatePerformanceWind(context.Background(), test.performance, test.wind, input, PerformanceWindConfig{})
-			require.NoError(t, err)
-			require.False(t, got.RawTETA.IsZero())
-			require.Equal(t, now.Add(got.NoWindDuration), got.RawTETA)
-			require.Equal(t, aman.ConfidenceMedium, got.Confidence)
-			require.Contains(t, got.DegradationReasons, test.want)
-			require.NotNil(t, got.PerformanceProfileID)
-		})
-	}
+func TestAMANCPHProjectsWindWithoutGlobalCorrectionCap(t *testing.T) {
+	input := performanceInput()
+	input.AltitudeFeet = 10000
+	input.CurrentGroundspeedKnots = 300
+	input.Remaining[0].DistanceNM = 10000 / descentFeetPerNM
+	repository := profilesRepository{}
+
+	noWind, err := EstimatePerformanceWind(context.Background(), repository, nil, input, PerformanceWindConfig{MinimumGroundspeedKnots: 20, MaximumGroundspeedKnots: 900})
+	require.NoError(t, err)
+	headwind, err := EstimatePerformanceWind(context.Background(), repository, fixedWind{east: -200, now: input.PredictionAt}, input, PerformanceWindConfig{MinimumGroundspeedKnots: 20, MaximumGroundspeedKnots: 900})
+	require.NoError(t, err)
+	tailwind, err := EstimatePerformanceWind(context.Background(), repository, fixedWind{east: 200, now: input.PredictionAt}, input, PerformanceWindConfig{MinimumGroundspeedKnots: 20, MaximumGroundspeedKnots: 900})
+	require.NoError(t, err)
+	require.Greater(t, headwind.Duration, noWind.Duration)
+	require.Less(t, tailwind.Duration, noWind.Duration)
+	require.Greater(t, headwind.Duration, time.Duration(float64(noWind.Duration)*1.2), "wind duration is not capped at the old 20 percent bound")
 }
 
-func TestInterpolateWind(t *testing.T) {
+func TestAMANCPHRequestsCurrentWindBeforeRouteSegmentWinds(t *testing.T) {
+	input := performanceInput()
+	segments := buildDescentSegments(input)
+
+	requests := windRequestsForSegments(input, segments, PerformanceWindConfig{})
+
+	require.Len(t, requests, len(segments)+1)
+	require.Equal(t, input.Remaining[0].Start, requests[0].Position)
+	require.Equal(t, input.PredictionAt, requests[0].At)
+	require.Equal(t, input.AltitudeFeet, requests[0].AltitudeFeet)
+}
+
+func TestAMANCPHRETAAndLightAircraftBehavior(t *testing.T) {
+	input := performanceInput()
+	input.CurrentGroundspeedKnots = 200
+	input.Remaining[0].DistanceNM = 100
+	input.WakeTurbulenceCategory = CategoryHeavy
+	heavy, err := EstimatePerformanceWind(context.Background(), nil, nil, input, PerformanceWindConfig{})
+	require.NoError(t, err)
+	require.Equal(t, input.PredictionAt.Add(30*time.Minute), heavy.RawRETA)
+
+	input.WakeTurbulenceCategory = CategoryLight
+	light, err := EstimatePerformanceWind(context.Background(), nil, fixedWind{east: 100, now: input.PredictionAt}, input, PerformanceWindConfig{})
+	require.NoError(t, err)
+	require.NotEqual(t, light.RawRETA, light.RawTETA)
+	require.Less(t, light.Duration, 30*time.Minute)
+	require.Equal(t, 280.0, descentIAS(CategoryLight, 20000, 250))
+}
+
+func TestAMANCPHReturnsActualDurationForEachRouteLeg(t *testing.T) {
+	input := performanceInput()
+	input.Remaining = []RouteLeg{
+		{ID: "FAST", DistanceNM: 40, CourseTrueDegrees: 90, Start: WindCoordinate{LatitudeDegrees: 55, LongitudeDegrees: 12}, End: WindCoordinate{LatitudeDegrees: 55, LongitudeDegrees: 13}},
+		{ID: "SLOW", DistanceNM: 60, CourseTrueDegrees: 180, Start: WindCoordinate{LatitudeDegrees: 55, LongitudeDegrees: 13}, End: WindCoordinate{LatitudeDegrees: 54, LongitudeDegrees: 13}},
+	}
+
+	result, err := EstimatePerformanceWind(context.Background(), nil, fixedWind{east: 100, now: input.PredictionAt}, input, PerformanceWindConfig{})
+	require.NoError(t, err)
+	require.Len(t, result.LegDurations, len(input.Remaining))
+	require.Equal(t, result.Duration, result.LegDurations[0]+result.LegDurations[1])
+	require.NotEqual(t, result.LegDurations[0], result.LegDurations[1])
+}
+
+func TestAMANCPHMissingWeatherDegradesButMissingEssentialInputFails(t *testing.T) {
+	input := performanceInput()
+	result, err := EstimatePerformanceWind(context.Background(), nil, failingWind{}, input, PerformanceWindConfig{})
+	require.NoError(t, err)
+	require.False(t, result.RawTETA.IsZero())
+	require.Equal(t, aman.ConfidenceMedium, result.Confidence)
+	require.Contains(t, result.DegradationReasons, "WEATHER_UNAVAILABLE")
+
+	input.CurrentGroundspeedKnots = 0
+	_, err = EstimatePerformanceWind(context.Background(), nil, nil, input, PerformanceWindConfig{})
+	require.ErrorIs(t, err, errPerformanceWindInput)
+}
+
+func TestInterpolateWindAndISAConversions(t *testing.T) {
 	east, north, ok := interpolateWind([]WindLevel{{AltitudeFeet: 10000, EastKnots: 40, NorthKnots: 20}, {AltitudeFeet: 0, EastKnots: 0, NorthKnots: 10}}, 5000)
 	require.True(t, ok)
 	require.InDelta(t, 20, east, .001)
 	require.InDelta(t, 15, north, .001)
-	_, _, ok = interpolateWind([]WindLevel{{AltitudeFeet: 0}}, 5000)
-	require.False(t, ok)
+	require.InDelta(t, 250, tasToIAS(iasToTAS(250, 10000), 10000), .001)
 }
 
-func TestWindRequestsUseLegMidpointsAndEstimatedTraversalTimes(t *testing.T) {
+func TestSelectProfileRemainsDeterministicForProvenanceConsumers(t *testing.T) {
 	now := performanceNow()
-	input := PerformanceWindInput{PredictionAt: now, AltitudeFeet: 10000, Remaining: []RouteLeg{
-		{ID: "one", DistanceNM: 100, CourseTrueDegrees: 90, Start: WindCoordinate{LatitudeDegrees: 55, LongitudeDegrees: 10}, End: WindCoordinate{LatitudeDegrees: 55, LongitudeDegrees: 12}},
-		{ID: "two", DistanceNM: 100, CourseTrueDegrees: 90, Start: WindCoordinate{LatitudeDegrees: 55, LongitudeDegrees: 12}, End: WindCoordinate{LatitudeDegrees: 55, LongitudeDegrees: 14}},
+	repo := profilesRepository{profiles: []PerformanceProfile{
+		{ID: "medium-z", Version: "v1", WakeTurbulenceCategory: CategoryMedium, CruiseTrueAirspeedKnots: 400},
+		{ID: "a320", Version: "v2", AircraftICAOTypes: []string{"A320"}, WakeTurbulenceCategory: CategoryMedium, CruiseTrueAirspeedKnots: 430},
+		{ID: "medium-a", Version: "v1", WakeTurbulenceCategory: CategoryMedium, CruiseTrueAirspeedKnots: 410},
 	}}
-	requests := windRequests(input, 400, PerformanceWindConfig{MinimumGroundspeedKnots: 120, MaximumGroundspeedKnots: 600})
-	require.Len(t, requests, 2)
-	require.InDelta(t, 11, requests[0].Position.LongitudeDegrees, .01)
-	require.InDelta(t, 13, requests[1].Position.LongitudeDegrees, .01)
-	require.Equal(t, now.Add(7*time.Minute+30*time.Second), requests[0].At)
-	require.Equal(t, now.Add(22*time.Minute+30*time.Second), requests[1].At)
-}
-
-func TestEstimatePerformanceWindClampsNoWindTAS(t *testing.T) {
-	now, input := performanceNow(), performanceInput()
-	for _, test := range []struct {
-		name          string
-		tas, min, max float64
-		want          time.Duration
-	}{
-		{"minimum", 20, 120, 600, time.Duration(float64(time.Hour) * 100 / 120)},
-		{"maximum", 900, 120, 600, time.Duration(float64(time.Hour) * 100 / 600)},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			repository := profilesRepository{profiles: []PerformanceProfile{{ID: "profile", Version: "v1", AircraftICAOTypes: []string{"A320"}, CruiseTrueAirspeedKnots: test.tas}}}
-			got, err := EstimatePerformanceWind(context.Background(), repository, nil, input, PerformanceWindConfig{MinimumGroundspeedKnots: test.min, MaximumGroundspeedKnots: test.max, MaxWindCorrectionPercent: .2})
-			require.NoError(t, err)
-			require.Equal(t, test.want, got.NoWindDuration)
-			require.Equal(t, now.Add(test.want), got.RawTETA)
-		})
-	}
-}
-
-func TestEstimatePerformanceWindAllowsFutureRouteSamplesWhileWeatherIsFreshAtPrediction(t *testing.T) {
-	now, input := performanceNow(), performanceInput()
-	input.Remaining[0].DistanceNM = 500 // midpoint traversal is 37m30s ahead at 400 kt.
-	repository := profilesRepository{profiles: []PerformanceProfile{{ID: "profile", Version: "v1", AircraftICAOTypes: []string{"A320"}, CruiseTrueAirspeedKnots: 400}}}
-	weather := fixedWind{now: now, expires: now.Add(30 * time.Minute)}
-	got, err := EstimatePerformanceWind(context.Background(), repository, weather, input, PerformanceWindConfig{})
-	require.NoError(t, err)
-	require.NotContains(t, got.DegradationReasons, "WEATHER_UNAVAILABLE")
-	require.NotNil(t, got.WeatherSource)
-	require.Equal(t, "test-v1", *got.WeatherSourceRevision)
-}
-
-func TestEstimatePerformanceWindLabelsDeterministicProfileFallback(t *testing.T) {
-	input := performanceInput()
-	input.AircraftICAO = "UNKNOWN"
-	input.WakeTurbulenceCategory = CategoryHeavy
-	repository := profilesRepository{profiles: []PerformanceProfile{{ID: "heavy-default", Version: "v1", WakeTurbulenceCategory: CategoryHeavy, CruiseTrueAirspeedKnots: 440}}}
-	got, err := EstimatePerformanceWind(context.Background(), repository, nil, input, PerformanceWindConfig{})
-	require.NoError(t, err)
-	require.Contains(t, got.DegradationReasons, "PERFORMANCE_PROFILE_FALLBACK")
-	require.NotContains(t, got.DegradationReasons, "PERFORMANCE_PROFILE_UNAVAILABLE")
+	got, _, _ := selectProfile(context.Background(), repo, PerformanceWindInput{PredictionAt: now, AircraftICAO: "a320", WakeTurbulenceCategory: CategoryMedium})
+	require.Equal(t, "a320", got.ID)
 }
 
 func TestValidWindProfileFreshnessBoundaries(t *testing.T) {
@@ -162,42 +138,32 @@ func TestValidWindProfileFreshnessBoundaries(t *testing.T) {
 	requests := []WindSampleRequest{{Position: WindCoordinate{LatitudeDegrees: 55, LongitudeDegrees: 12}, At: now, AltitudeFeet: 10000}}
 	profile, err := (fixedWind{now: now}).WindProfile(context.Background(), WindProfileRequest{Samples: requests})
 	require.NoError(t, err)
-	require.True(t, validWindProfile(profile, requests, now), "observation at the prediction instant is valid")
+	require.True(t, validWindProfile(profile, requests, now))
 	profile.ObservedAt = now.Add(time.Second)
-	require.False(t, validWindProfile(profile, requests, now), "future observation is not valid for this prediction")
-	profile.ObservedAt, profile.ExpiresAt = now, now.Add(-time.Second)
-	require.False(t, validWindProfile(profile, requests, now), "expiry must not precede observation")
+	require.False(t, validWindProfile(profile, requests, now))
 }
 
-type profilesRepository struct {
-	profiles []PerformanceProfile
-	err      error
+func firstDescentDistance(segments []descentSegment) float64 {
+	distance := 0.0
+	for _, segment := range segments {
+		if !segment.preTOD {
+			break
+		}
+		distance += segment.distanceNM
+	}
+	return distance
 }
+
+type profilesRepository struct{ profiles []PerformanceProfile }
 
 func (p profilesRepository) PerformanceProfiles(context.Context, time.Time) ([]PerformanceProfile, error) {
-	return p.profiles, p.err
-}
-
-type failingProfiles struct{}
-
-func (failingProfiles) PerformanceProfiles(context.Context, time.Time) ([]PerformanceProfile, error) {
-	return nil, errors.New("down")
+	return p.profiles, nil
 }
 
 type failingWind struct{}
 
 func (failingWind) WindProfile(context.Context, WindProfileRequest) (WindProfile, error) {
 	return WindProfile{}, errors.New("down")
-}
-
-type incompleteWind struct{ now time.Time }
-
-func (w incompleteWind) WindProfile(_ context.Context, request WindProfileRequest) (WindProfile, error) {
-	samples := make([]WindSample, len(request.Samples))
-	for i, sample := range request.Samples {
-		samples[i] = WindSample{Position: sample.Position, At: sample.At}
-	}
-	return WindProfile{SourceID: "fixture", SourceRevision: "test-v1", ObservedAt: w.now, ExpiresAt: w.now.Add(time.Hour), Samples: samples}, nil
 }
 
 type fixedWind struct {
@@ -212,11 +178,16 @@ func (w fixedWind) WindProfile(_ context.Context, request WindProfileRequest) (W
 	}
 	samples := make([]WindSample, len(request.Samples))
 	for i, sample := range request.Samples {
-		samples[i] = WindSample{Position: sample.Position, At: sample.At, Levels: []WindLevel{{AltitudeFeet: 0, EastKnots: w.east}, {AltitudeFeet: 20000, EastKnots: w.east}}}
+		samples[i] = WindSample{Position: sample.Position, At: sample.At, Levels: []WindLevel{{AltitudeFeet: 0, EastKnots: w.east}, {AltitudeFeet: 60000, EastKnots: w.east}}}
 	}
 	return WindProfile{SourceID: "fixture", SourceRevision: "test-v1", ObservedAt: w.now, ExpiresAt: expires, Samples: samples}, nil
 }
+
 func performanceNow() time.Time { return time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC) }
 func performanceInput() PerformanceWindInput {
-	return PerformanceWindInput{PredictionAt: performanceNow(), AircraftICAO: "A320", WakeTurbulenceCategory: CategoryMedium, AltitudeFeet: 10000, Remaining: []RouteLeg{{ID: "EAST", DistanceNM: 100, CourseTrueDegrees: 90, Start: WindCoordinate{LatitudeDegrees: 55, LongitudeDegrees: 12}, End: WindCoordinate{LatitudeDegrees: 55, LongitudeDegrees: 14}}}}
+	return PerformanceWindInput{
+		PredictionAt: performanceNow(), AircraftICAO: "A320", WakeTurbulenceCategory: CategoryMedium,
+		AltitudeFeet: 10000, CurrentGroundspeedKnots: 400,
+		Remaining: []RouteLeg{{ID: "EAST", DistanceNM: 100, CourseTrueDegrees: 90, Start: WindCoordinate{LatitudeDegrees: 55, LongitudeDegrees: 12}, End: WindCoordinate{LatitudeDegrees: 55, LongitudeDegrees: 14}}},
+	}
 }

--- a/backend/internal/aman/runtime.go
+++ b/backend/internal/aman/runtime.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	defaultReconciliationInterval = 15 * time.Second
+	defaultReconciliationInterval = time.Minute
 	defaultSurveillanceInterval   = 15 * time.Second
 
 	// NavigationAdapterAIRACNet is the approved navigation-data adapter. Its

--- a/backend/internal/aman/sequence/engine.go
+++ b/backend/internal/aman/sequence/engine.go
@@ -43,6 +43,16 @@ type Policy struct {
 	EarlyTolerance    time.Duration
 	SeparationRules   []SeparationRule
 	UnknownSeparation time.Duration
+	SameSTARSpacing   SameSTARSpacing
+}
+
+// SameSTARSpacing applies an additional grid gap between flights using the
+// same canonical STAR entry family once the active arrival rate reaches the
+// configured threshold.
+type SameSTARSpacing struct {
+	Enabled               bool
+	ActivationRatePerHour uint32
+	MinimumEmptySlots     uint32
 }
 
 // Flight is the narrow sequencing view of an AMAN flight. CapturedSlot is a
@@ -55,6 +65,7 @@ type Flight struct {
 	OperationalTETA       time.Time
 	InitialBaselineTETA   *time.Time
 	WakeCategory          WakeCategory
+	STARFamily            string
 	ManualOrder           *int
 	FreezeReason          aman.FreezeReason
 	FrozenAt              *time.Time
@@ -123,6 +134,8 @@ const (
 	WarningProtectedSlotMissing WarningCode = "protected_slot_missing"
 	WarningProtectedSlotInvalid WarningCode = "protected_slot_invalid"
 	WarningProtectedSpacing     WarningCode = "protected_spacing_conflict"
+	WarningProtectedSameSTAR    WarningCode = "protected_same_star_spacing"
+	WarningUnknownSTARFamily    WarningCode = "unknown_star_family"
 )
 
 // Warning reports degraded input or an unsatisfied protected constraint.
@@ -160,8 +173,9 @@ type categoryPair struct{ leading, trailing WakeCategory }
 
 type preparedFlight struct {
 	Flight
-	category WakeCategory
-	known    bool
+	category    WakeCategory
+	known       bool
+	stableOrder *int
 }
 
 type allocatedEntry struct {
@@ -232,6 +246,9 @@ func preparePolicies(input []Policy) (map[aman.RunwayGroupID]preparedPolicy, err
 		}
 		if raw.UnknownSeparation <= 0 {
 			return nil, fmt.Errorf("runway group %q requires positive unknown-category separation", raw.RunwayGroupID)
+		}
+		if raw.SameSTARSpacing.Enabled && (raw.SameSTARSpacing.ActivationRatePerHour == 0 || raw.SameSTARSpacing.MinimumEmptySlots == 0) {
+			return nil, fmt.Errorf("runway group %q has invalid same-STAR spacing", raw.RunwayGroupID)
 		}
 
 		prepared := preparedPolicy{Policy: raw, rates: slices.Clone(raw.Rates), spacing: map[categoryPair]time.Duration{}, categories: map[WakeCategory]struct{}{}, fallback: raw.UnknownSeparation}
@@ -324,7 +341,13 @@ func prepareFlights(input []Flight, policies map[aman.RunwayGroupID]preparedPoli
 		if !known {
 			category = WakeUnknown
 		}
-		result[raw.RunwayGroupID] = append(result[raw.RunwayGroupID], preparedFlight{Flight: raw, category: category, known: known})
+		raw.STARFamily = strings.ToUpper(strings.TrimSpace(raw.STARFamily))
+		prepared := preparedFlight{Flight: raw, category: category, known: known}
+		if raw.State == aman.StateStable && raw.ManualOrder == nil && raw.CurrentSlot != nil {
+			order := raw.CurrentSlot.Sequence
+			prepared.stableOrder = &order
+		}
+		result[raw.RunwayGroupID] = append(result[raw.RunwayGroupID], prepared)
 	}
 	return result, nil
 }
@@ -336,6 +359,9 @@ func generateGroup(policy preparedPolicy, flights []preparedFlight) ([]allocated
 	for _, flight := range flights {
 		if !flight.known {
 			warnings = append(warnings, Warning{Severity: SeverityDegraded, Code: WarningUnknownWakeCategory, RunwayGroupID: policy.RunwayGroupID, FlightID: flight.ID})
+		}
+		if policy.SameSTARSpacing.Enabled && flight.STARFamily == "" {
+			warnings = append(warnings, Warning{Severity: SeverityDegraded, Code: WarningUnknownSTARFamily, RunwayGroupID: policy.RunwayGroupID, FlightID: flight.ID})
 		}
 		if flight.State == aman.StateLanded || flight.State == aman.StateRemoved {
 			continue
@@ -369,7 +395,11 @@ func generateGroup(policy preparedPolicy, flights []preparedFlight) ([]allocated
 		leading, trailing := entries[index-1], entries[index]
 		if !adjacentValid(policy, leading, trailing) {
 			related := leading.flight.ID
-			warnings = append(warnings, Warning{Severity: SeverityConflict, Code: WarningProtectedSpacing, RunwayGroupID: policy.RunwayGroupID, FlightID: trailing.flight.ID, RelatedFlightID: &related})
+			code := WarningProtectedSpacing
+			if sameSTARGap(policy, leading.flight, trailing.flight, trailing.time) > 0 && trailing.time.Sub(leading.time) < sameSTARGap(policy, leading.flight, trailing.flight, trailing.time) {
+				code = WarningProtectedSameSTAR
+			}
+			warnings = append(warnings, Warning{Severity: SeverityConflict, Code: code, RunwayGroupID: policy.RunwayGroupID, FlightID: trailing.flight.ID, RelatedFlightID: &related})
 		}
 	}
 
@@ -429,12 +459,23 @@ func findCandidate(policy preparedPolicy, entries []allocatedEntry, flight prepa
 // earlier/later attempt. Crossing an adjacent entry recomputes both directional
 // WTC boundaries, so allocation never validates only one side of an insertion.
 func placement(policy preparedPolicy, entries []allocatedEntry, flight preparedFlight, candidate time.Time) (bool, time.Time, time.Time) {
+	return placementWithStableOrder(policy, entries, flight, candidate, true)
+}
+
+// queuePlacement evaluates a possible queue offer. Stable order constrains
+// allocation, but an offered stable flight is intentionally eligible to move
+// into an earlier vacant slot without making that allocation invariant apply.
+func queuePlacement(policy preparedPolicy, entries []allocatedEntry, flight preparedFlight, candidate time.Time) (bool, time.Time, time.Time) {
+	return placementWithStableOrder(policy, entries, flight, candidate, false)
+}
+
+func placementWithStableOrder(policy preparedPolicy, entries []allocatedEntry, flight preparedFlight, candidate time.Time, preserveStableOrder bool) (bool, time.Time, time.Time) {
 	index := sort.Search(len(entries), func(i int) bool { return !entries[i].time.Before(candidate) })
 	valid := true
 	earlier, later := candidate.Add(-time.Nanosecond), candidate.Add(time.Nanosecond)
 	if index > 0 {
 		leading := entries[index-1]
-		if orderAfter(flight.ManualOrder, leading.flight.ManualOrder) {
+		if orderAfter(flight.ManualOrder, leading.flight.ManualOrder) || (preserveStableOrder && orderAfter(flight.stableOrder, leading.flight.stableOrder)) {
 			valid = false
 			boundEarlier := leading.time.Add(-requiredGap(policy, flight, leading.flight, leading.time))
 			if boundEarlier.Before(earlier) {
@@ -456,7 +497,7 @@ func placement(policy preparedPolicy, entries []allocatedEntry, flight preparedF
 	}
 	if index < len(entries) {
 		trailing := entries[index]
-		if orderBefore(flight.ManualOrder, trailing.flight.ManualOrder) {
+		if orderBefore(flight.ManualOrder, trailing.flight.ManualOrder) || (preserveStableOrder && orderBefore(flight.stableOrder, trailing.flight.stableOrder)) {
 			valid = false
 			boundLater := trailing.time.Add(requiredGap(policy, trailing.flight, flight, trailing.time))
 			if boundLater.After(later) {
@@ -500,18 +541,39 @@ func requiredGap(policy preparedPolicy, leading, trailing preparedFlight, traili
 		wtc = policy.spacing[categoryPair{leading.category, trailing.category}]
 	}
 	base := policy.intervalAt(trailingAt)
-	if base > wtc {
-		return base
+	required := max(base, wtc)
+	if star := sameSTARGap(policy, leading, trailing, trailingAt); star > required {
+		required = star
 	}
-	return wtc
+	return required
+}
+
+func sameSTARGap(policy preparedPolicy, leading, trailing preparedFlight, trailingAt time.Time) time.Duration {
+	spacing := policy.SameSTARSpacing
+	if !spacing.Enabled || leading.STARFamily == "" || trailing.STARFamily == "" || leading.STARFamily != trailing.STARFamily {
+		return 0
+	}
+	rate := policy.rateAt(trailingAt)
+	if rate < spacing.ActivationRatePerHour {
+		return 0
+	}
+	return time.Duration(spacing.MinimumEmptySlots+1) * rateInterval(rate)
 }
 
 func (p preparedPolicy) intervalAt(at time.Time) time.Duration {
+	rate := p.rateAt(at)
+	if rate == 0 {
+		return 0
+	}
+	return rateInterval(rate)
+}
+
+func (p preparedPolicy) rateAt(at time.Time) uint32 {
 	index := sort.Search(len(p.rates), func(i int) bool { return p.rates[i].EffectiveAt.After(at) }) - 1
 	if index < 0 {
 		return 0
 	}
-	return rateInterval(p.rates[index].ArrivalsPerHour)
+	return p.rates[index].ArrivalsPerHour
 }
 
 func rateInterval(rate uint32) time.Duration {
@@ -566,6 +628,17 @@ func flightLess(a, b preparedFlight) bool {
 		}
 		if *a.ManualOrder != *b.ManualOrder {
 			return *a.ManualOrder < *b.ManualOrder
+		}
+	}
+	// Stable order is retained from the last committed sequence. A stable
+	// aircraft may move into a legal vacancy, but recalculation never sorts two
+	// stable aircraft back by their changing TETAs.
+	if a.State == aman.StateStable && b.State == aman.StateStable && a.CurrentSlot != nil && b.CurrentSlot != nil {
+		if a.CurrentSlot.Sequence != b.CurrentSlot.Sequence {
+			return a.CurrentSlot.Sequence < b.CurrentSlot.Sequence
+		}
+		if !a.CurrentSlot.Time.Equal(b.CurrentSlot.Time) {
+			return a.CurrentSlot.Time.Before(b.CurrentSlot.Time)
 		}
 	}
 	if aPriority, bPriority := lifecyclePriority(a.State), lifecyclePriority(b.State); aPriority != bPriority {

--- a/backend/internal/aman/sequence/engine_test.go
+++ b/backend/internal/aman/sequence/engine_test.go
@@ -95,6 +95,94 @@ func TestUnknownCategoryUsesConservativeSpacingAndWarns(t *testing.T) {
 	require.False(t, result.HasConflicts())
 }
 
+func TestSameSTARSpacingActivatesAtConfiguredRate(t *testing.T) {
+	start := testTime()
+	for _, test := range []struct {
+		name string
+		rate uint32
+		want time.Duration
+	}{
+		{name: "below threshold", rate: 19, want: rateIntervalForTest(19)},
+		{name: "at threshold", rate: 20, want: 6 * time.Minute},
+		{name: "above threshold", rate: 30, want: 4 * time.Minute},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			policy := simplePolicy("A", start, test.rate)
+			policy.SameSTARSpacing = sequence.SameSTARSpacing{Enabled: true, ActivationRatePerHour: 20, MinimumEmptySlots: 1}
+			first := flight("MONAK-1", "A", start, "M")
+			first.STARFamily = "monak"
+			second := flight("MONAK-2", "A", start, "M")
+			second.STARFamily = " MONAK "
+			result, err := sequence.Generate(sequence.Input{Policies: []sequence.Policy{policy}, Flights: []sequence.Flight{first, second}})
+			require.NoError(t, err)
+			require.Equal(t, start.Add(test.want), entryFor(t, result, "MONAK-2").Time)
+		})
+	}
+}
+
+func TestSameSTARSpacingAllowsDifferentFamiliesAndCountsWTCGap(t *testing.T) {
+	start := testTime()
+	policy := wtcPolicy("A", start, 20)
+	policy.SameSTARSpacing = sequence.SameSTARSpacing{Enabled: true, ActivationRatePerHour: 20, MinimumEmptySlots: 1}
+	monak := flight("MONAK", "A", start, "H")
+	monak.STARFamily = "MONAK"
+	tudlo := flight("TUDLO", "A", start, "M")
+	tudlo.STARFamily = "TUDLO"
+	secondMonak := flight("MONAK-2", "A", start, "M")
+	secondMonak.STARFamily = "MONAK"
+
+	result, err := sequence.Generate(sequence.Input{Policies: []sequence.Policy{policy}, Flights: []sequence.Flight{monak, tudlo, secondMonak}})
+	require.NoError(t, err)
+	require.Equal(t, []time.Time{start, start.Add(3 * time.Minute), start.Add(6 * time.Minute)}, entryTimes(result))
+
+	// WTC spacing longer than the same-STAR requirement is not extended again.
+	policy = wtcPolicy("A", start, 60)
+	policy.SameSTARSpacing = sequence.SameSTARSpacing{Enabled: true, ActivationRatePerHour: 20, MinimumEmptySlots: 1}
+	lead := protectedFlight("LEAD", "A", start, "J", start, aman.FreezeManual)
+	lead.STARFamily = "MONAK"
+	trail := flight("TRAIL", "A", start, "M")
+	trail.STARFamily = "MONAK"
+	result, err = sequence.Generate(sequence.Input{Policies: []sequence.Policy{policy}, Flights: []sequence.Flight{lead, trail}})
+	require.NoError(t, err)
+	require.Equal(t, start.Add(3*time.Minute), entryFor(t, result, "TRAIL").Time)
+}
+
+func TestSameSTARSpacingWarningsAreDeterministic(t *testing.T) {
+	start := testTime()
+	policy := simplePolicy("A", start, 20)
+	policy.SameSTARSpacing = sequence.SameSTARSpacing{Enabled: true, ActivationRatePerHour: 20, MinimumEmptySlots: 1}
+	lead := protectedFlight("LEAD", "A", start, "M", start, aman.FreezeManual)
+	lead.STARFamily = "MONAK"
+	trail := protectedFlight("TRAIL", "A", start.Add(3*time.Minute), "M", start.Add(3*time.Minute), aman.FreezeSuperstable)
+	trail.STARFamily = "MONAK"
+	unknown := flight("UNKNOWN", "A", start.Add(9*time.Minute), "M")
+
+	result, err := sequence.Generate(sequence.Input{Policies: []sequence.Policy{policy}, Flights: []sequence.Flight{trail, unknown, lead}})
+	require.NoError(t, err)
+	require.True(t, result.HasConflicts())
+	require.Contains(t, result.Warnings, sequence.Warning{Severity: sequence.SeverityConflict, Code: sequence.WarningProtectedSameSTAR, RunwayGroupID: "A", FlightID: "TRAIL", RelatedFlightID: flightIDPointer("LEAD")})
+	require.Contains(t, result.Warnings, sequence.Warning{Severity: sequence.SeverityDegraded, Code: sequence.WarningUnknownSTARFamily, RunwayGroupID: "A", FlightID: "UNKNOWN"})
+}
+
+func TestStableFlightsRetainCommittedRelativeOrder(t *testing.T) {
+	start := testTime()
+	policy := simplePolicy("A", start, 60)
+	first := withState(flight("FIRST", "A", start.Add(10*time.Minute), "M"), aman.StateStable)
+	first.CurrentSlot = &aman.Slot{Time: start, RunwayGroupID: "A", Sequence: 1, Revision: 1, Reason: "rate_wtc"}
+	second := withState(flight("SECOND", "A", start, "M"), aman.StateStable)
+	second.CurrentSlot = &aman.Slot{Time: start.Add(time.Minute), RunwayGroupID: "A", Sequence: 2, Revision: 1, Reason: "rate_wtc"}
+
+	result, err := sequence.Generate(sequence.Input{Revision: 1, Policies: []sequence.Policy{policy}, Flights: []sequence.Flight{second, first}})
+	require.NoError(t, err)
+	require.Equal(t, []aman.FlightID{"FIRST", "SECOND"}, entryIDs(result))
+}
+
+func rateIntervalForTest(rate uint32) time.Duration {
+	return time.Duration((uint64(time.Hour) + uint64(rate) - 1) / uint64(rate))
+}
+
+func flightIDPointer(value aman.FlightID) *aman.FlightID { return &value }
+
 func TestProtectedConstraintsArePreservedOrReportedAsConflicts(t *testing.T) {
 	start := testTime()
 	policy := wtcPolicy("A", start, 30)

--- a/backend/internal/aman/sequence/queue.go
+++ b/backend/internal/aman/sequence/queue.go
@@ -97,7 +97,7 @@ func CalculateQueueOffers(input Input, config QueueOfferConfig, at time.Time) ([
 					}
 					remaining = append(remaining, allocatedEntry{flight: entry.flight, time: entry.slot.Time, reason: CandidateReason(entry.slot.Reason)})
 				}
-				valid, _, _ := placement(policy, remaining, target.flight, candidate.slot.Time)
+				valid, _, _ := queuePlacement(policy, remaining, target.flight, candidate.slot.Time)
 				if !valid {
 					continue
 				}

--- a/backend/internal/aman/terminal/config.go
+++ b/backend/internal/aman/terminal/config.go
@@ -6,6 +6,7 @@ package terminal
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -104,6 +105,16 @@ type RunwayGroup struct {
 	Aliases         []aman.RunwayGroupID      `json:"aliases"`
 	Runways         []navdata.RunwayID        `json:"runways"`
 	FinalApproaches []FinalApproachDefinition `json:"finalApproaches"`
+	SameSTARSpacing *SameSTARSpacing          `json:"sameStarSpacing,omitempty"`
+}
+
+// SameSTARSpacing prevents consecutive high-rate slot opportunities from
+// being occupied by arrivals using the same terminal entry family. The
+// canonical feeder is the family identity (for example MONAK or TUDLO).
+type SameSTARSpacing struct {
+	Enabled               bool   `json:"enabled"`
+	ActivationRatePerHour uint32 `json:"activationRatePerHour"`
+	MinimumEmptySlots     uint32 `json:"minimumEmptySlots"`
 }
 
 type Feeder struct {
@@ -207,6 +218,27 @@ func LoadFile(path string) (Configuration, error) {
 	return value, nil
 }
 
+// ValidateOperationalSettings performs source-independent validation for the
+// sequencing settings that must fail startup before navigation acquisition.
+func (c Configuration) ValidateOperationalSettings() error {
+	var errs ValidationErrors
+	for i, group := range c.RunwayGroups {
+		if spacing := group.SameSTARSpacing; spacing != nil && spacing.Enabled {
+			if spacing.ActivationRatePerHour == 0 {
+				add(&errs, fmt.Sprintf("runwayGroups[%d].sameStarSpacing.activationRatePerHour", i), "must be greater than zero when enabled")
+			}
+			if spacing.MinimumEmptySlots == 0 {
+				add(&errs, fmt.Sprintf("runwayGroups[%d].sameStarSpacing.minimumEmptySlots", i), "must be greater than zero when enabled")
+			}
+		}
+	}
+	if len(errs) == 0 {
+		return nil
+	}
+	sort.Slice(errs, func(i, j int) bool { return errs[i].Error() < errs[j].Error() })
+	return errs
+}
+
 // ValidationErrors holds every configuration problem, preserving JSON-style
 // field paths so an operator can correct a candidate in one edit cycle.
 type ValidationErrors []error
@@ -227,6 +259,14 @@ func add(errs *ValidationErrors, path, message string) {
 // manifest. It never calls a source or derives a runway group from surveillance.
 func (c Configuration) Validate(refs ReferenceSet) error {
 	var errs ValidationErrors
+	if operationalErr := c.ValidateOperationalSettings(); operationalErr != nil {
+		var operational ValidationErrors
+		if errors.As(operationalErr, &operational) {
+			errs = append(errs, operational...)
+		} else {
+			errs = append(errs, operationalErr)
+		}
+	}
 	if c.SchemaVersion != SchemaVersion {
 		add(&errs, "schemaVersion", "must equal "+SchemaVersion)
 	}

--- a/backend/internal/aman/terminal/config_test.go
+++ b/backend/internal/aman/terminal/config_test.go
@@ -40,6 +40,9 @@ func TestGoldenEKCHConfigurationMatchesIndependentOfficialContent(t *testing.T) 
 	require.Equal(t, config.ApplicabilityFrom, config.Dataset.EffectiveFrom)
 	require.Equal(t, config.ApplicabilityUntil, config.Dataset.EffectiveUntil)
 	require.Equal(t, []aman.RunwayGroupID{"ARRIVAL-04", "ARRIVAL-22", "ARRIVAL-12", "ARRIVAL-30"}, groupIDs(config.RunwayGroups))
+	for _, group := range config.RunwayGroups {
+		require.Equal(t, &SameSTARSpacing{Enabled: true, ActivationRatePerHour: 20, MinimumEmptySlots: 1}, group.SameSTARSpacing, group.ID)
+	}
 
 	wantFinals := map[navdata.RunwayID]struct{ latitude, longitude, course float64 }{
 		"04L": {55.5922, 12.6035361111, 41.2}, "04R": {55.6031, 12.6330472222, 41.2},
@@ -188,6 +191,21 @@ func TestEKCHConfigurationReportsEveryInvalidFieldPath(t *testing.T) {
 	for _, path := range []string{"sources[0]", "paths: missing enabled path", "paths[0].fixes", "paths[0].selectedHolding", "runwayGroups[0].runways[0]", "dataset"} {
 		require.Contains(t, message, path)
 	}
+}
+
+func TestSameSTARSpacingValidation(t *testing.T) {
+	config := goldenConfig(t)
+	refs := referencesFor(t, config)
+
+	config.RunwayGroups[0].SameSTARSpacing = nil
+	require.NoError(t, config.Validate(refs), "omitted spacing disables the rule")
+	config.RunwayGroups[0].SameSTARSpacing = &SameSTARSpacing{Enabled: false}
+	require.NoError(t, config.Validate(refs), "disabled spacing does not require thresholds")
+
+	config.RunwayGroups[0].SameSTARSpacing = &SameSTARSpacing{Enabled: true}
+	err := config.Validate(refs)
+	require.ErrorContains(t, err, "sameStarSpacing.activationRatePerHour")
+	require.ErrorContains(t, err, "sameStarSpacing.minimumEmptySlots")
 }
 
 func TestConfigurationRejectsTerminalSafetyViolations(t *testing.T) {

--- a/backend/internal/aman/types.go
+++ b/backend/internal/aman/types.go
@@ -248,6 +248,7 @@ type FlightObservation struct {
 	TakeoffDetected *time.Time
 	ReconciledAt    time.Time
 	SourceStatus    DataStatus
+	Missing         bool
 }
 
 // PlannedTiming contains provider-neutral planned times. Durations are domain
@@ -281,6 +282,7 @@ type SurveillanceFact struct {
 // freeze; OperationalTETA is the only value consumers sequence.
 type Prediction struct {
 	RawTETA           time.Time
+	RawRETA           *time.Time
 	OperationalTETA   time.Time
 	OperationalReason OperationalReason
 
@@ -521,7 +523,29 @@ type AbsenceState struct {
 // RunwayGroupPolicy is the airport-state identity for a runway group. The
 // sequence component owns the policy's rate and spacing declarations.
 type RunwayGroupPolicy struct {
-	ID RunwayGroupID
+	ID                RunwayGroupID
+	Selected          bool
+	SelectionSchedule []RunwayGroupSelectionPoint
+	ActiveRatePerHour uint32
+	RateEffectiveAt   *time.Time
+	RateSchedule      []RunwayGroupRatePoint
+	SameSTARSpacing   *SameSTARSpacingPolicy
+}
+
+type RunwayGroupSelectionPoint struct {
+	EffectiveAt     time.Time
+	CommandRevision SequenceRevision
+}
+
+type RunwayGroupRatePoint struct {
+	EffectiveAt     time.Time
+	ArrivalsPerHour uint32
+}
+
+type SameSTARSpacingPolicy struct {
+	Enabled               bool
+	ActivationRatePerHour uint32
+	MinimumEmptySlots     uint32
 }
 
 // AMANFlight is the persisted aggregate shape. All operational TETA, state,
@@ -537,10 +561,13 @@ type AMANFlight struct {
 	Prediction            *Prediction
 	RawTETASamples        []RawTETASample
 	ArrivalBaseline       *BaselineState
+	LatestObservation     *FlightObservation
 	SelectedRunwayGroup   *RunwayGroupID
 	SelectedFeeder        *string
 	SelectedHolding       *string
 	ActiveRouteFact       *RouteFact
+	ActiveRouteKey        *string
+	ActiveRouteDatasetID  *string
 	RouteProgress         *RouteProgress
 	FreezeReason          FreezeReason
 	FrozenAt              *time.Time
@@ -548,6 +575,7 @@ type AMANFlight struct {
 	FrozenSlot            *Slot
 	Slot                  *Slot
 	Order                 *int
+	ManualOrder           *int
 	QueueOffers           []QueueOffer
 	ETAReview             *ETAReview
 	OperationalException  *OperationalException
@@ -673,6 +701,11 @@ func (p Prediction) Validate() error {
 	if err := requireUTCTime("operational TETA", p.OperationalTETA); err != nil {
 		return err
 	}
+	if p.RawRETA != nil {
+		if err := requireUTCTime("raw RETA", *p.RawRETA); err != nil {
+			return err
+		}
+	}
 	if !p.OperationalReason.Valid() {
 		return invalid("operational reason is invalid")
 	}
@@ -760,6 +793,14 @@ func (f AMANFlight) Validate() error {
 			return err
 		}
 	}
+	if f.LatestObservation != nil {
+		if err := f.LatestObservation.Validate(); err != nil {
+			return err
+		}
+		if f.LatestObservation.FlightID != f.ID || f.LatestObservation.VATSIMCID != f.VATSIMCID || f.LatestObservation.Callsign != f.CurrentCallsign {
+			return invalid("latest observation identity does not match flight")
+		}
+	}
 	if len(f.RawTETASamples) > 3 {
 		return invalid("raw TETA smoothing window exceeds three samples")
 	}
@@ -776,6 +817,9 @@ func (f AMANFlight) Validate() error {
 			return err
 		}
 	}
+	if f.ManualOrder != nil && *f.ManualOrder < 1 {
+		return invalid("manual sequence order must be positive")
+	}
 	if f.ETAReview != nil {
 		if err := f.ETAReview.Validate(); err != nil {
 			return err
@@ -786,6 +830,12 @@ func (f AMANFlight) Validate() error {
 	}
 	if f.ActiveRouteFact != nil && !f.ActiveRouteFact.State.Valid() {
 		return invalid("route fact state is invalid")
+	}
+	if f.ActiveRouteKey != nil && strings.TrimSpace(*f.ActiveRouteKey) == "" {
+		return invalid("active route key cannot be empty")
+	}
+	if f.ActiveRouteDatasetID != nil && strings.TrimSpace(*f.ActiveRouteDatasetID) == "" {
+		return invalid("active route dataset ID cannot be empty")
 	}
 	if f.RouteProgress != nil {
 		if strings.TrimSpace(f.RouteProgress.GeometryDigest) == "" || f.RouteProgress.ManifestRevision < 1 || f.RouteProgress.LegIndex < 0 || f.RouteProgress.RejoinLegIndex < 0 || f.RouteProgress.AlongTrackNM < 0 || math.IsNaN(f.RouteProgress.AlongTrackNM) || math.IsInf(f.RouteProgress.AlongTrackNM, 0) {
@@ -1169,6 +1219,7 @@ func (s AirportState) Validate() error {
 		}
 	}
 	groupIDs := make(map[RunwayGroupID]struct{}, len(s.RunwayGroups))
+	selectedGroups := 0
 	for _, group := range s.RunwayGroups {
 		if strings.TrimSpace(string(group.ID)) == "" {
 			return invalid("runway group ID is required")
@@ -1177,6 +1228,42 @@ func (s AirportState) Validate() error {
 			return invalid("airport state contains duplicate runway group")
 		}
 		groupIDs[group.ID] = struct{}{}
+		if group.Selected {
+			selectedGroups++
+			if selectedGroups > 1 {
+				return invalid("airport state cannot select more than one runway group")
+			}
+		}
+		for index, selection := range group.SelectionSchedule {
+			if err := requireUTCTime("runway group selection effective at", selection.EffectiveAt); err != nil {
+				return err
+			}
+			if index > 0 && !selection.EffectiveAt.After(group.SelectionSchedule[index-1].EffectiveAt) {
+				return invalid("runway group selection schedule must be strictly ordered")
+			}
+		}
+		if group.RateEffectiveAt != nil {
+			if group.ActiveRatePerHour == 0 {
+				return invalid("runway group active rate must be greater than zero")
+			}
+			if err := requireUTCTime("runway group rate effective at", *group.RateEffectiveAt); err != nil {
+				return err
+			}
+		}
+		for index, rate := range group.RateSchedule {
+			if rate.ArrivalsPerHour == 0 {
+				return invalid("runway group scheduled rate must be greater than zero")
+			}
+			if err := requireUTCTime("runway group scheduled rate effective at", rate.EffectiveAt); err != nil {
+				return err
+			}
+			if index > 0 && !rate.EffectiveAt.After(group.RateSchedule[index-1].EffectiveAt) {
+				return invalid("runway group rate schedule must be strictly ordered")
+			}
+		}
+		if spacing := group.SameSTARSpacing; spacing != nil && spacing.Enabled && (spacing.ActivationRatePerHour == 0 || spacing.MinimumEmptySlots == 0) {
+			return invalid("runway group same-STAR spacing is invalid")
+		}
 	}
 	return nil
 }

--- a/backend/internal/app/aman_assembly.go
+++ b/backend/internal/app/aman_assembly.go
@@ -1,0 +1,132 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/aman/materializer"
+	"FlightStrips/internal/aman/navdata/airacnet"
+	"FlightStrips/internal/aman/operational"
+	"FlightStrips/internal/aman/predictor/openmeteo"
+	"FlightStrips/internal/aman/sequence"
+	"FlightStrips/internal/aman/terminal"
+	internalFrontend "FlightStrips/internal/frontend"
+	"FlightStrips/internal/repository/postgres"
+	events "FlightStrips/pkg/events/frontend"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type operationalAMANAssembly struct {
+	dependencies aman.Dependencies
+	commands     aman.CommandService
+	transport    *amanTransport
+}
+
+type amanTransport struct {
+	repository aman.AirportStateReader
+	mode       aman.RolloutMode
+	health     aman.TechnicalHealthReporter
+
+	mu  sync.RWMutex
+	hub *internalFrontend.Hub
+}
+
+func (*amanTransport) Name() string { return "AMAN frontend state publisher" }
+
+func (p *amanTransport) setHub(hub *internalFrontend.Hub) {
+	p.mu.Lock()
+	p.hub = hub
+	p.mu.Unlock()
+}
+
+func (p *amanTransport) CurrentAMANState(ctx context.Context, airport string) (events.AMANStateEvent, error) {
+	state, err := p.repository.LoadAirportState(ctx, airport)
+	if err != nil {
+		return events.AMANStateEvent{}, err
+	}
+	health := p.health.TechnicalHealth(ctx)
+	return events.NewAMANStateEvent(state, health.EffectiveMode, health)
+}
+
+func (p *amanTransport) PublishAMANState(ctx context.Context, state aman.AirportState) error {
+	health := p.health.TechnicalHealth(ctx)
+	event, err := events.NewAMANStateEvent(state, health.EffectiveMode, health)
+	if err != nil {
+		return err
+	}
+	p.mu.RLock()
+	hub := p.hub
+	p.mu.RUnlock()
+	if hub != nil {
+		hub.PublishAMANStateEvent(event)
+	}
+	return nil
+}
+
+func assembleOperationalAMAN(config aman.RuntimeConfig, pool *pgxpool.Pool) (operationalAMANAssembly, error) {
+	terminalConfig, err := terminal.LoadFile(config.TerminalGeometryPath)
+	if err != nil {
+		return operationalAMANAssembly{}, fmt.Errorf("load AMAN terminal configuration: %w", err)
+	}
+	if err := terminalConfig.ValidateOperationalSettings(); err != nil {
+		return operationalAMANAssembly{}, fmt.Errorf("validate AMAN terminal operational settings: %w", err)
+	}
+	if err := validateTerminalAirportCoverage(terminalConfig, config.EnabledAirports); err != nil {
+		return operationalAMANAssembly{}, err
+	}
+	repository := postgres.NewAMANRepository(pool)
+	cache := postgres.NewNavigationCache(pool)
+	source, err := airacnet.New(airacnet.Config{Checkpoints: airacnet.NewPostgresCheckpoints(pool)})
+	if err != nil {
+		return operationalAMANAssembly{}, fmt.Errorf("initialize AIRAC.NET adapter: %w", err)
+	}
+	navigation, err := materializer.New(materializer.Dependencies{
+		Cycles: source, Airports: source, Runways: terminalConfig, Procedures: source, Fixes: source, Routes: source,
+		Cache: cache, Terminal: terminalConfig,
+	})
+	if err != nil {
+		return operationalAMANAssembly{}, fmt.Errorf("initialize AMAN navigation materializer: %w", err)
+	}
+	transport := &amanTransport{repository: repository, mode: config.Mode}
+	service, err := operational.New(operational.Dependencies{
+		Repository: repository, Retirer: repository, Materializer: navigation, Geometry: cache, Wind: openmeteo.New(openmeteo.Config{}),
+		Terminal: terminalConfig, Airports: config.EnabledAirports, Mode: config.Mode, Publisher: transport,
+	})
+	if err != nil {
+		return operationalAMANAssembly{}, fmt.Errorf("initialize AMAN operational service: %w", err)
+	}
+	transport.health = service
+	coordinator, err := sequence.NewCoordinator(sequence.CoordinatorDependencies{
+		States: repository, Outcomes: repository, Committer: repository, Publisher: transport,
+	})
+	if err != nil {
+		return operationalAMANAssembly{}, fmt.Errorf("initialize AMAN sequence coordinator: %w", err)
+	}
+	actions, err := sequence.NewActionService(coordinator, service)
+	if err != nil {
+		return operationalAMANAssembly{}, fmt.Errorf("initialize AMAN action service: %w", err)
+	}
+	return operationalAMANAssembly{
+		commands: actions, transport: transport,
+		dependencies: aman.Dependencies{
+			Repositories: repository, NavigationMaterializer: navigation, NavigationReader: cache,
+			Predictor: service, StateEngine: service, SequenceService: actions, Publisher: transport,
+			ValidationService: service, HealthService: service, ObservationSink: service, ReconciliationWorker: service,
+		},
+	}, nil
+}
+
+func validateTerminalAirportCoverage(terminalConfig terminal.Configuration, enabledAirports []string) error {
+	if len(enabledAirports) != 1 || strings.ToUpper(strings.TrimSpace(enabledAirports[0])) != string(terminalConfig.Airport) {
+		return fmt.Errorf("AMAN terminal configuration for %q requires exactly that enabled airport", terminalConfig.Airport)
+	}
+	return nil
+}
+
+var _ sequence.FullStatePublisher = (*amanTransport)(nil)
+var _ internalFrontend.AMANStateProvider = (*amanTransport)(nil)
+var _ aman.Component = (*amanTransport)(nil)

--- a/backend/internal/app/aman_assembly_test.go
+++ b/backend/internal/app/aman_assembly_test.go
@@ -1,0 +1,17 @@
+package app
+
+import (
+	"testing"
+
+	"FlightStrips/internal/aman/navdata"
+	"FlightStrips/internal/aman/terminal"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateTerminalAirportCoverage(t *testing.T) {
+	configuration := terminal.Configuration{Airport: navdata.AirportID("EKCH")}
+
+	require.NoError(t, validateTerminalAirportCoverage(configuration, []string{"ekch"}))
+	require.ErrorContains(t, validateTerminalAirportCoverage(configuration, []string{"EKCH", "EGLL"}), "requires exactly that enabled airport")
+	require.ErrorContains(t, validateTerminalAirportCoverage(configuration, []string{"EGLL"}), "requires exactly that enabled airport")
+}

--- a/backend/internal/app/aman_command_gate.go
+++ b/backend/internal/app/aman_command_gate.go
@@ -1,0 +1,99 @@
+package app
+
+import (
+	"context"
+	"strings"
+
+	"FlightStrips/internal/aman"
+)
+
+// amanCommandGate keeps controller authority tied to the current technical
+// health snapshot instead of treating configured authoritative mode as a
+// permanent mutation grant.
+type amanCommandGate struct {
+	health   func(context.Context) aman.TechnicalHealth
+	commands aman.CommandService
+}
+
+func (*amanCommandGate) Name() string { return "health-gated AMAN command service" }
+
+func (g *amanCommandGate) CurrentRevision(ctx context.Context, airport string) (aman.SequenceRevision, error) {
+	return g.commands.CurrentRevision(ctx, airport)
+}
+
+func (g *amanCommandGate) authorize(ctx context.Context) error {
+	health := g.health(ctx)
+	if health.AuthorityAllowed {
+		return nil
+	}
+	reason := strings.Join(health.BlockedReasons, ",")
+	if reason == "" {
+		reason = "technical_authority_unavailable"
+	}
+	return &aman.DomainError{Class: aman.ErrorReadOnly, Message: "AMAN controller mutations are blocked: " + reason}
+}
+
+func (g *amanCommandGate) MoveFlight(ctx context.Context, auth aman.CommandContext, command aman.MoveFlightCommand) (aman.CommandExecution, error) {
+	if err := g.authorize(ctx); err != nil {
+		return aman.CommandExecution{}, err
+	}
+	return g.commands.MoveFlight(ctx, auth, command)
+}
+
+func (g *amanCommandGate) LockFlight(ctx context.Context, auth aman.CommandContext, command aman.LockFlightCommand) (aman.CommandExecution, error) {
+	if err := g.authorize(ctx); err != nil {
+		return aman.CommandExecution{}, err
+	}
+	return g.commands.LockFlight(ctx, auth, command)
+}
+
+func (g *amanCommandGate) UnlockFlight(ctx context.Context, auth aman.CommandContext, command aman.UnlockFlightCommand) (aman.CommandExecution, error) {
+	if err := g.authorize(ctx); err != nil {
+		return aman.CommandExecution{}, err
+	}
+	return g.commands.UnlockFlight(ctx, auth, command)
+}
+
+func (g *amanCommandGate) SetRate(ctx context.Context, auth aman.CommandContext, command aman.SetRateCommand) (aman.CommandExecution, error) {
+	if err := g.authorize(ctx); err != nil {
+		return aman.CommandExecution{}, err
+	}
+	return g.commands.SetRate(ctx, auth, command)
+}
+
+func (g *amanCommandGate) AcceptTETA(ctx context.Context, auth aman.CommandContext, command aman.AcceptTETACommand) (aman.CommandExecution, error) {
+	if err := g.authorize(ctx); err != nil {
+		return aman.CommandExecution{}, err
+	}
+	return g.commands.AcceptTETA(ctx, auth, command)
+}
+
+func (g *amanCommandGate) KeepFPLETA(ctx context.Context, auth aman.CommandContext, command aman.KeepFPLETACommand) (aman.CommandExecution, error) {
+	if err := g.authorize(ctx); err != nil {
+		return aman.CommandExecution{}, err
+	}
+	return g.commands.KeepFPLETA(ctx, auth, command)
+}
+
+func (g *amanCommandGate) SetManualETA(ctx context.Context, auth aman.CommandContext, command aman.SetManualETACommand) (aman.CommandExecution, error) {
+	if err := g.authorize(ctx); err != nil {
+		return aman.CommandExecution{}, err
+	}
+	return g.commands.SetManualETA(ctx, auth, command)
+}
+
+func (g *amanCommandGate) ResetTETAOverride(ctx context.Context, auth aman.CommandContext, command aman.ResetTETAOverrideCommand) (aman.CommandExecution, error) {
+	if err := g.authorize(ctx); err != nil {
+		return aman.CommandExecution{}, err
+	}
+	return g.commands.ResetTETAOverride(ctx, auth, command)
+}
+
+func (g *amanCommandGate) ReportGoAround(ctx context.Context, auth aman.CommandContext, command aman.ReportGoAroundCommand) (aman.CommandExecution, error) {
+	if err := g.authorize(ctx); err != nil {
+		return aman.CommandExecution{}, err
+	}
+	return g.commands.ReportGoAround(ctx, auth, command)
+}
+
+var _ aman.CommandService = (*amanCommandGate)(nil)

--- a/backend/internal/app/aman_command_gate_test.go
+++ b/backend/internal/app/aman_command_gate_test.go
@@ -1,0 +1,29 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"FlightStrips/internal/aman"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAMANCommandGateUsesCurrentTechnicalAuthority(t *testing.T) {
+	ready := aman.ComponentHealth{Status: aman.HealthReady}
+	blocked := aman.EvaluateTechnicalHealth(
+		aman.ModeAuthoritative,
+		ready,
+		aman.ComponentHealth{Status: aman.HealthUnavailable, Reason: "navigation_refresh_failed"},
+		ready, ready, ready, ready,
+	)
+	gate := &amanCommandGate{health: func(context.Context) aman.TechnicalHealth { return blocked }}
+	err := gate.authorize(context.Background())
+	var domain *aman.DomainError
+	require.ErrorAs(t, err, &domain)
+	require.Equal(t, aman.ErrorReadOnly, domain.Class)
+	require.ErrorContains(t, err, "navigation:navigation_refresh_failed")
+
+	allowed := aman.EvaluateTechnicalHealth(aman.ModeAuthoritative, ready, ready, ready, ready, ready, ready)
+	gate.health = func(context.Context) aman.TechnicalHealth { return allowed }
+	require.NoError(t, gate.authorize(context.Background()))
+}

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -116,13 +116,15 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	if err := validateAMANTerminalGeometry(cfg.AMAN); err != nil {
 		return nil, err
 	}
-	amanRuntime, err := aman.NewRuntime(cfg.AMAN, deps.AMAN)
-	if err != nil {
+	if err := cfg.AMAN.Validate(); err != nil {
 		return nil, fmt.Errorf("initialize AMAN runtime: %w", err)
 	}
-	amanCommands, hasAMANCommands := deps.AMAN.SequenceService.(aman.CommandService)
-	if amanRuntime.Ownership().ControllerMutationAuthorized && !hasAMANCommands {
-		return nil, errors.New("initialize AMAN commands: authoritative runtime requires typed command service")
+	amanEnabled := cfg.AMAN.Mode != "" && cfg.AMAN.Mode != aman.ModeDisabled
+	amanOwnership := aman.OwnershipForRolloutGate(cfg.AMAN.Mode, true)
+	if amanOwnership.ControllerMutationAuthorized && deps.AMAN.ObservationSink != nil {
+		if _, ok := deps.AMAN.SequenceService.(aman.CommandService); !ok {
+			return nil, errors.New("initialize AMAN commands: authoritative runtime requires typed command service")
+		}
 	}
 	standAssignmentReadiness := configureStandAssignment(cfg.EnableStandAssignment, cfg.StandAssignmentAircraftJSON)
 	var testClock *testtools.Clock
@@ -182,7 +184,7 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	cdmClient := cdm.NewClient(cdm.WithAPIKey(cfg.CDMKey))
 
 	requireLiveCIDVerification := isLiveEnvironment(cfg.Environment)
-	vatsimGraph := assembleVATSIMSource(cfg, deps, requireLiveCIDVerification, standAssignmentReadiness.Ready || amanRuntime.Enabled())
+	vatsimGraph := assembleVATSIMSource(cfg, deps, requireLiveCIDVerification, standAssignmentReadiness.Ready || amanEnabled)
 
 	var fsServer *server.Server
 	transports := assembleTransports(cfg, deps, func(ctx context.Context) error {
@@ -192,7 +194,42 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	serverFrequencyProviders := transports.serverFrequencyProviders
 	pdcFrequencyProviders := transports.pdcFrequencyProviders
 
-	realtime, err := assembleRealtime(stripService, controllerService, authService, amanCommands, cfg.AMAN.FMPRoles, amanRuntime.Ownership().ControllerMutationAuthorized)
+	amanDependencies := deps.AMAN
+	var defaultAMAN operationalAMANAssembly
+	if amanEnabled && amanDependencies.ObservationSink == nil {
+		defaultAMAN, err = assembleOperationalAMAN(cfg.AMAN, dbpool)
+		if err != nil {
+			if closeDB {
+				dbpool.Close()
+			}
+			return nil, err
+		}
+		amanDependencies = defaultAMAN.dependencies
+	}
+	amanRuntime, err := aman.NewRuntime(cfg.AMAN, amanDependencies)
+	if err != nil {
+		if closeDB {
+			dbpool.Close()
+		}
+		return nil, fmt.Errorf("initialize AMAN runtime: %w", err)
+	}
+	amanCommands, hasAMANCommands := amanDependencies.SequenceService.(aman.CommandService)
+	if amanRuntime.Ownership().ControllerMutationAuthorized && !hasAMANCommands {
+		if closeDB {
+			dbpool.Close()
+		}
+		return nil, errors.New("initialize AMAN commands: authoritative runtime requires typed command service")
+	}
+	if amanRuntime.Ownership().ControllerMutationAuthorized {
+		amanCommands = &amanCommandGate{health: amanRuntime.Health, commands: amanCommands}
+	}
+	var amanStateProvider frontend.AMANStateProvider
+	if defaultAMAN.transport != nil {
+		amanStateProvider = defaultAMAN.transport
+	} else if provider, ok := amanDependencies.Publisher.(frontend.AMANStateProvider); ok {
+		amanStateProvider = provider
+	}
+	realtime, err := assembleRealtime(stripService, controllerService, authService, amanStateProvider, amanCommands, cfg.AMAN.FMPRoles, amanRuntime.Ownership().ControllerMutationAuthorized)
 	if err != nil {
 		if closeDB {
 			dbpool.Close()
@@ -201,6 +238,9 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	}
 	frontendHub := realtime.frontend
 	euroscopeHub := realtime.euroscope
+	if defaultAMAN.transport != nil {
+		defaultAMAN.transport.setHub(frontendHub)
+	}
 	stripValidationService, err := services.NewStripValidationService(services.StripValidationDependencies{
 		Strips: stripRepo, Statuses: stripRepo, Publisher: frontendHub,
 	})
@@ -241,7 +281,7 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 			DepartureLifecycle: departureLifecycle,
 			ArrivalLifecycle:   arrivalLifecycle,
 			Notifier:           frontendHub,
-		}, deps.VATSIMPollInterval, vatsim.WithAirportCoordinates(latitude, longitude), vatsim.WithClock(satNow), vatsim.WithLegacyArrivalETAWriter(amanRuntime.Ownership().LegacyArrivalETAWriter))
+		}, deps.VATSIMPollInterval, vatsim.WithAirportCoordinates(latitude, longitude), vatsim.WithClock(satNow), vatsim.WithLegacyArrivalETAWriter(amanOwnership.LegacyArrivalETAWriter))
 		if err != nil {
 			if closeDB {
 				dbpool.Close()
@@ -259,7 +299,7 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 			return nil, errors.New("initialize AMAN VATSIM observations: VATSIM source is unavailable")
 		}
 		amanObservationWorker, err = vatsim.NewObservationWorker(vatsim.ObservationWorkerDependencies{
-			Cache: vatsimGraph.source, Identities: postgres.NewAMANRepository(dbpool), Sink: deps.AMAN.ObservationSink,
+			Cache: vatsimGraph.source, Identities: postgres.NewAMANRepository(dbpool), Sink: amanDependencies.ObservationSink,
 			EnabledAirports: cfg.AMAN.EnabledAirports, StaleAfter: satStaleAfter(deps.VATSIMPollInterval), Now: satNow,
 		})
 		if err != nil {
@@ -573,9 +613,9 @@ type realtimeAssembly struct {
 	euroscope *euroscope.Hub
 }
 
-func assembleRealtime(stripService shared.StripService, controllerService shared.ControllerService, authService shared.AuthenticationService, amanCommands aman.CommandService, amanFMPRoles []string, amanMutations bool) (realtimeAssembly, error) {
+func assembleRealtime(stripService shared.StripService, controllerService shared.ControllerService, authService shared.AuthenticationService, amanState frontend.AMANStateProvider, amanCommands aman.CommandService, amanFMPRoles []string, amanMutations bool) (realtimeAssembly, error) {
 	frontendHub, err := frontend.NewHub(frontend.HubDependencies{
-		Strips: stripService, Authentication: authService, AMANCommands: amanCommands, AMANFMPRoles: amanFMPRoles, AMANMutations: amanMutations,
+		Strips: stripService, Authentication: authService, AMANState: amanState, AMANCommands: amanCommands, AMANFMPRoles: amanFMPRoles, AMANMutations: amanMutations,
 	})
 	if err != nil {
 		return realtimeAssembly{}, fmt.Errorf("initialize frontend hub: %w", err)

--- a/backend/internal/repository/postgres/aman.go
+++ b/backend/internal/repository/postgres/aman.go
@@ -35,7 +35,11 @@ func NewAMANRepository(pool *pgxpool.Pool) *amanRepository {
 func (*amanRepository) Name() string { return "postgres AMAN repository" }
 
 func (r *amanRepository) LoadAirportState(ctx context.Context, airport string) (aman.AirportState, error) {
-	return loadAMANAirportState(ctx, r.queries, airport)
+	state, err := loadAMANAirportState(ctx, r.queries, airport)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return aman.AirportState{}, &aman.DomainError{Class: aman.ErrorNotFound, Message: "AMAN airport state was not found"}
+	}
+	return state, err
 }
 
 func (r *amanRepository) LoadCommandOutcome(ctx context.Context, commandID string) (aman.CommandOutcome, error) {

--- a/backend/internal/vatsim/aman_observations.go
+++ b/backend/internal/vatsim/aman_observations.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"reflect"
 	"strconv"
 	"strings"
@@ -108,6 +109,11 @@ func (w *ObservationWorker) Publish(ctx context.Context) error {
 	current := make(map[string]aman.FlightObservation)
 	failed := make(map[string]struct{})
 	var publishErrors []error
+	if healthSink, ok := w.sink.(aman.ObservationSourceHealthSink); ok {
+		if err := healthSink.ObserveSourceHealth(ctx, status, now); err != nil {
+			publishErrors = append(publishErrors, fmt.Errorf("publish VATSIM source health: %w", err))
+		}
+	}
 	if status != aman.DataDisconnected && !snapshot.Timestamp.IsZero() {
 		for _, flight := range snapshot.Flights() {
 			if _, enabled := w.airports[strings.ToUpper(strings.TrimSpace(flight.FlightPlan.Destination))]; !enabled {
@@ -150,6 +156,14 @@ func (w *ObservationWorker) Publish(ctx context.Context) error {
 				continue
 			}
 			if _, present := current[cid]; !present {
+				missing := w.known[cid]
+				missing.Missing = true
+				missing.SourceStatus = status
+				missing.ReconciledAt = now
+				if err := w.sink.Observe(ctx, missing); err != nil {
+					publishErrors = append(publishErrors, fmt.Errorf("publish missing VATSIM observation for CID %s: %w", cid, err))
+					continue
+				}
 				delete(w.known, cid)
 			}
 		}
@@ -179,7 +193,7 @@ func (w *ObservationWorker) mapFlight(ctx context.Context, flight Flight, snapsh
 		AircraftType: optionalString(flight.FlightPlan.AircraftShort), WakeCategory: wakeCategory(flight.FlightPlan.Aircraft),
 		FiledRoute: optionalString(flight.FlightPlan.Route), RequestedLevel: requestedLevelFeet(flight.FlightPlan.RequestedLevel),
 		PlannedTiming: plannedTiming(observedAt, flight.FlightPlan), FlightPlan: flightPlanFact(flight.FlightPlan.Revision, observedAt),
-		Surveillance: surveillanceFact(flight, observedAt), TakeoffDetected: takeoffDetected(flight, observedAt),
+		Surveillance: surveillanceFact(flight, observedAt, previous), TakeoffDetected: takeoffDetected(flight, observedAt),
 		ReconciledAt: reconciledAt, SourceStatus: status,
 	}
 	if err := observation.Validate(); err != nil {
@@ -207,17 +221,36 @@ func flightPlanFact(revision int64, observedAt time.Time) aman.FlightPlanFact {
 	return aman.FlightPlanFact{Revision: sourceRevision, ObservedAt: &observedAt}
 }
 
-func surveillanceFact(flight Flight, observedAt time.Time) *aman.SurveillanceFact {
+func surveillanceFact(flight Flight, observedAt time.Time, previous *aman.FlightObservation) *aman.SurveillanceFact {
 	if !flight.Online() || !validCoordinates(flight.Latitude, flight.Longitude) {
 		return nil
 	}
 	altitude := flight.Altitude
 	groundspeed := float64(flight.Groundspeed)
 	sequence := uint64(observedAt.UnixMilli())
-	return &aman.SurveillanceFact{
+	fact := &aman.SurveillanceFact{
 		LatitudeDegrees: flight.Latitude, LongitudeDegrees: flight.Longitude, AltitudeFeet: &altitude,
 		GroundspeedKnots: &groundspeed, Sequence: &sequence, ObservedAt: &observedAt,
 	}
+	if track, ok := derivedGroundTrack(previous, fact); ok {
+		fact.TrackTrueDegrees = &track
+	}
+	return fact
+}
+
+func derivedGroundTrack(previous *aman.FlightObservation, current *aman.SurveillanceFact) (float64, bool) {
+	if previous == nil || previous.Surveillance == nil || previous.Surveillance.ObservedAt == nil || current == nil || current.ObservedAt == nil || !current.ObservedAt.After(*previous.Surveillance.ObservedAt) {
+		return 0, false
+	}
+	from := previous.Surveillance
+	if from.LatitudeDegrees == current.LatitudeDegrees && from.LongitudeDegrees == current.LongitudeDegrees {
+		return 0, false
+	}
+	lat1, lat2 := from.LatitudeDegrees*math.Pi/180, current.LatitudeDegrees*math.Pi/180
+	dLon := (current.LongitudeDegrees - from.LongitudeDegrees) * math.Pi / 180
+	y := math.Sin(dLon) * math.Cos(lat2)
+	x := math.Cos(lat1)*math.Sin(lat2) - math.Sin(lat1)*math.Cos(lat2)*math.Cos(dLon)
+	return math.Mod(math.Atan2(y, x)*180/math.Pi+360, 360), true
 }
 
 func takeoffDetected(flight Flight, observedAt time.Time) *time.Time {
@@ -301,6 +334,10 @@ func preserveNewerObservationFacts(previous, next aman.FlightObservation) aman.F
 	}
 	if surveillanceIsOlder(previous.Surveillance, next.Surveillance) {
 		next.Surveillance, next.TakeoffDetected = previous.Surveillance, previous.TakeoffDetected
+	}
+	if previous.TakeoffDetected != nil && (next.TakeoffDetected == nil || previous.TakeoffDetected.Before(*next.TakeoffDetected)) {
+		takeoff := *previous.TakeoffDetected
+		next.TakeoffDetected = &takeoff
 	}
 	return next
 }

--- a/backend/internal/vatsim/aman_observations_test.go
+++ b/backend/internal/vatsim/aman_observations_test.go
@@ -45,6 +45,7 @@ func (b *observationTestBinder) BindVATSIMFlight(_ context.Context, identity ama
 
 type observationTestSink struct {
 	observations []aman.FlightObservation
+	sourceHealth []aman.DataStatus
 	err          error
 	errsByCID    map[string]error
 }
@@ -57,6 +58,11 @@ func (s *observationTestSink) Observe(_ context.Context, observation aman.Flight
 		return err
 	}
 	s.observations = append(s.observations, observation)
+	return nil
+}
+
+func (s *observationTestSink) ObserveSourceHealth(_ context.Context, status aman.DataStatus, _ time.Time) error {
+	s.sourceHealth = append(s.sourceHealth, status)
 	return nil
 }
 
@@ -129,6 +135,18 @@ func TestObservationWorkerUsesSourceObservedTimeForPlannedTimingAcrossRetry(t *t
 	require.Equal(t, time.Date(2026, time.July, 19, 0, 5, 0, 0, time.UTC), *retrySink.observations[0].PlannedTiming.EstimatedOffBlockTime)
 }
 
+func TestPreserveNewerObservationFactsKeepsFirstTakeoffDetection(t *testing.T) {
+	first := time.Date(2026, time.July, 18, 12, 0, 0, 0, time.UTC)
+	later := first.Add(time.Minute)
+	previous := aman.FlightObservation{TakeoffDetected: &first}
+	next := aman.FlightObservation{TakeoffDetected: &later}
+
+	preserved := preserveNewerObservationFacts(previous, next)
+
+	require.NotNil(t, preserved.TakeoffDetected)
+	require.Equal(t, first, *preserved.TakeoffDetected)
+}
+
 func TestWakeCategoryAndRequestedLevelMappingRejectInvalidSourceValues(t *testing.T) {
 	for _, test := range []struct {
 		aircraft, level string
@@ -187,6 +205,33 @@ func TestObservationWorkerReusesKnownIDButRebindsCallsignCorrection(t *testing.T
 	now = now.Add(time.Second)
 	require.NoError(t, worker.Publish(context.Background()))
 	require.Len(t, binder.bindings, 2, "callsign correction must verify the active binding")
+}
+
+func TestObservationWorkerPublishesExplicitDisappearance(t *testing.T) {
+	now := time.Date(2026, time.July, 18, 12, 0, 0, 0, time.UTC)
+	flight := Flight{CID: "101", Callsign: "SAS101", State: FlightStateOnline, Latitude: 55, Longitude: 12, Altitude: 10000, Groundspeed: 300, LastUpdated: now, FlightPlan: FlightPlan{Origin: "ENGM", Destination: "EKCH", Revision: 1}}
+	cache := newReconciliationTestCache(now, flight)
+	sink := &observationTestSink{}
+	worker, _ := newObservationTestWorker(t, cache, &now, sink)
+	require.NoError(t, worker.Publish(context.Background()))
+
+	now = now.Add(15 * time.Second)
+	setObservationCacheSnapshot(cache, now, nil)
+	require.NoError(t, worker.Publish(context.Background()))
+	require.Len(t, sink.observations, 2)
+	require.True(t, sink.observations[1].Missing)
+	require.Equal(t, aman.DataFresh, sink.observations[1].SourceStatus)
+	require.NotContains(t, worker.known, "101")
+}
+
+func TestObservationWorkerPublishesHealthForFreshEmptySnapshot(t *testing.T) {
+	now := time.Date(2026, time.July, 18, 12, 0, 0, 0, time.UTC)
+	cache := newReconciliationTestCache(now)
+	sink := &observationTestSink{}
+	worker, _ := newObservationTestWorker(t, cache, &now, sink)
+	require.NoError(t, worker.Publish(context.Background()))
+	require.Empty(t, sink.observations)
+	require.Equal(t, []aman.DataStatus{aman.DataFresh}, sink.sourceHealth)
 }
 
 func TestObservationWorkerContinuesAfterPerFlightMappingAndDeliveryFailures(t *testing.T) {

--- a/backend/pkg/events/frontend/aman.go
+++ b/backend/pkg/events/frontend/aman.go
@@ -110,11 +110,10 @@ type AMANQueueOffer struct {
 	Reason          string   `json:"reason"`
 }
 
-// AMANRunwayGroup is intentionally limited to state persisted on
-// aman.AirportState. Rate schedules are not currently part of that persisted
-// aggregate and must not be borrowed from sequence-engine policy types.
 type AMANRunwayGroup struct {
-	ID string `json:"id"`
+	ID                string  `json:"id"`
+	ActiveRatePerHour *uint32 `json:"active_rate_per_hour,omitempty"`
+	RateEffectiveAt   *string `json:"rate_effective_at,omitempty"`
 }
 
 type AMANTechnicalHealth struct {
@@ -187,7 +186,19 @@ func NewAMANStateEvent(state aman.AirportState, effectiveMode aman.EffectiveRoll
 		}
 	}
 	for i, group := range state.RunwayGroups {
-		data.RunwayGroups[i] = AMANRunwayGroup{ID: string(group.ID)}
+		mapped := AMANRunwayGroup{ID: string(group.ID)}
+		if group.ActiveRatePerHour > 0 {
+			rate := group.ActiveRatePerHour
+			mapped.ActiveRatePerHour = &rate
+		}
+		if group.RateEffectiveAt != nil {
+			formatted, formatErr := aman.FormatTime(*group.RateEffectiveAt)
+			if formatErr != nil {
+				return AMANStateEvent{}, fmt.Errorf("map AMAN runway group %q rate: %w", group.ID, formatErr)
+			}
+			mapped.RateEffectiveAt = &formatted
+		}
+		data.RunwayGroups[i] = mapped
 	}
 	return AMANStateEvent{Version: AMANWireVersion, Data: data}, nil
 }
@@ -224,7 +235,7 @@ func mapAMANFlight(generatedAt time.Time, flight aman.AMANFlight) (AMANFlight, e
 		}
 		result.RouteFact = &AMANRouteFact{ID: flight.ActiveRouteFact.ID, Fix: flight.ActiveRouteFact.Fix, ObservedAt: observedAt, State: string(state)}
 	}
-	if flight.Prediction != nil {
+	if flight.Prediction != nil && flight.Prediction.Publishable {
 		prediction := flight.Prediction
 		if result.RawTETA, err = formatOptionalValue(prediction.RawTETA); err != nil {
 			return AMANFlight{}, err
@@ -257,7 +268,7 @@ func mapAMANFlight(generatedAt time.Time, flight aman.AMANFlight) (AMANFlight, e
 			return AMANFlight{}, mapErr
 		}
 		result.Slot = &mapped
-		if flight.Prediction != nil {
+		if flight.Prediction != nil && flight.Prediction.Publishable {
 			seconds, secondsErr := aman.WholeSeconds(flight.Prediction.OperationalTETA.Sub(flight.Slot.Time))
 			if secondsErr != nil {
 				return AMANFlight{}, secondsErr

--- a/backend/pkg/events/frontend/aman_test.go
+++ b/backend/pkg/events/frontend/aman_test.go
@@ -53,6 +53,37 @@ func TestAMANStateEventNormalizesDisabledComponentHealth(t *testing.T) {
 	require.Equal(t, "disabled", event.Data.TechnicalHealth.ReplayValidation.Status)
 }
 
+func TestAMANStateEventIncludesPersistedActiveRate(t *testing.T) {
+	state := goldenAMANState()
+	effective := state.GeneratedAt.Add(time.Minute)
+	state.RunwayGroups[0].ActiveRatePerHour = 20
+	state.RunwayGroups[0].RateEffectiveAt = &effective
+	event, err := NewAMANStateEvent(state, aman.EffectiveAuthoritative, goldenAMANHealth())
+	require.NoError(t, err)
+	require.Equal(t, uint32(20), *event.Data.RunwayGroups[0].ActiveRatePerHour)
+	expected, err := aman.FormatTime(effective)
+	require.NoError(t, err)
+	require.Equal(t, expected, *event.Data.RunwayGroups[0].RateEffectiveAt)
+}
+
+func TestAMANFlightOmitsNonPublishablePredictionData(t *testing.T) {
+	state := goldenAMANState()
+	state.Flights[0].Prediction.Publishable = false
+	reason := "missing_essential_data:surveillance"
+	state.Flights[0].Prediction.DegradationReason = &reason
+
+	mapped, err := mapAMANFlight(state.GeneratedAt, state.Flights[0])
+	require.NoError(t, err)
+	require.Nil(t, mapped.RawTETA)
+	require.Nil(t, mapped.OperationalTETA)
+	require.Nil(t, mapped.Confidence)
+	require.Nil(t, mapped.Provenance)
+	require.Nil(t, mapped.InputAgeSeconds)
+	require.Nil(t, mapped.DistanceToGoNM)
+	require.Nil(t, mapped.GainLossSeconds)
+	require.NotNil(t, mapped.Slot, "protected slot publication is independent from prediction publication")
+}
+
 func TestAMANCommandRejectionCarriesStableCorrelation(t *testing.T) {
 	event, err := NewAMANCommandRejectedEvent("command-7", 9, &aman.DomainError{
 		Class: aman.ErrorRevisionConflict, Message: "revision changed",

--- a/frontend/src/api/aman.ts
+++ b/frontend/src/api/aman.ts
@@ -100,6 +100,8 @@ export interface AMANQueueOffer {
 
 export interface AMANRunwayGroup {
   id: string;
+  active_rate_per_hour?: number;
+  rate_effective_at?: string;
 }
 
 export interface AMANTechnicalHealth {
@@ -297,6 +299,12 @@ function isTechnicalHealth(value: unknown): value is AMANTechnicalHealth {
     && isComponentHealth(value.predictor) && isComponentHealth(value.replay_validation);
 }
 
+function isRunwayGroup(value: unknown): value is AMANRunwayGroup {
+  return isObject(value) && isString(value.id)
+    && (value.active_rate_per_hour === undefined || (isNonNegativeInteger(value.active_rate_per_hour) && value.active_rate_per_hour > 0))
+    && (value.rate_effective_at === undefined || isTimestamp(value.rate_effective_at));
+}
+
 export function isAMANStateEvent(value: unknown): value is AMANStateEvent {
   if (!isObject(value) || value.type !== "aman.state" || value.version !== AMAN_WIRE_VERSION || !isObject(value.data)) return false;
   const data = value.data;
@@ -304,7 +312,7 @@ export function isAMANStateEvent(value: unknown): value is AMANStateEvent {
     && isTimestamp(data.generated_at) && isString(data.policy_version) && isString(data.effective_mode)
     && effectiveModes.has(data.effective_mode as AMANEffectiveMode) && typeof data.authoritative === "boolean"
     && Array.isArray(data.flights) && data.flights.every(isFlight)
-    && Array.isArray(data.runway_groups) && data.runway_groups.every((group) => isObject(group) && isString(group.id))
+    && Array.isArray(data.runway_groups) && data.runway_groups.every(isRunwayGroup)
     && isTechnicalHealth(data.technical_health);
 }
 

--- a/frontend/src/components/aman/AMANControls.test.tsx
+++ b/frontend/src/components/aman/AMANControls.test.tsx
@@ -57,7 +57,10 @@ describe("AMAN FMP controls", () => {
   });
 
   it("maps rate, manual ETA, and go-around inputs to their typed timestamps", () => {
-    const {onCommand} = renderControls();
+    const multiRunwayState = state();
+    multiRunwayState.runway_groups.push({id: "ARRIVAL-04"});
+    const {onCommand} = renderControls({state: multiRunwayState});
+    fireEvent.change(screen.getByLabelText("Rate runway group"), {target: {value: "ARRIVAL-04"}});
     fireEvent.change(screen.getByLabelText("Arrivals per hour"), {target: {value: "24"}});
     fireEvent.change(screen.getByLabelText("Rate effective at"), {target: {value: "2026-07-22T12:05"}});
     fireEvent.click(screen.getByRole("button", {name: "Set arrival rate"}));
@@ -67,7 +70,7 @@ describe("AMAN FMP controls", () => {
     fireEvent.click(screen.getByRole("button", {name: "Report go-around"}));
 
     expect(onCommand).toHaveBeenNthCalledWith(1, {
-      type: "aman.set_rate", runway_group_id: "ARRIVAL-22", arrivals_per_hour: 24,
+      type: "aman.set_rate", runway_group_id: "ARRIVAL-04", arrivals_per_hour: 24,
       effective_at: new Date("2026-07-22T12:05").toISOString(),
     });
     expect(onCommand).toHaveBeenNthCalledWith(2, {
@@ -76,6 +79,16 @@ describe("AMAN FMP controls", () => {
     expect(onCommand).toHaveBeenNthCalledWith(3, {
       type: "aman.report_go_around", flight_id: "flight-1", detected_at: new Date("2026-07-22T12:15").toISOString(),
     });
+  });
+
+  it("keeps runway-group rate controls available without active flights", () => {
+    const empty = state();
+    empty.flights = [];
+    renderControls({state: empty});
+
+    expect(screen.getByLabelText("Rate runway group")).toBeInTheDocument();
+    expect(screen.getByRole("button", {name: "Set arrival rate"})).toBeInTheDocument();
+    expect(screen.getByText("No AMAN flights available.")).toBeInTheDocument();
   });
 
   it.each([

--- a/frontend/src/components/aman/AMANControls.tsx
+++ b/frontend/src/components/aman/AMANControls.tsx
@@ -108,6 +108,7 @@ export function AMANControlsView({
 }: AMANControlsViewProps) {
   const [flightID, setFlightID] = useState("");
   const [targetFlightID, setTargetFlightID] = useState("");
+  const [rateRunwayGroupID, setRateRunwayGroupID] = useState("");
   const [rate, setRate] = useState("30");
   const [rateEffectiveAt, setRateEffectiveAt] = useState("");
   const [manualETA, setManualETA] = useState("");
@@ -118,6 +119,9 @@ export function AMANControlsView({
   const selectedFlight = flights.find((flight) => flight.flight_id === requestedFlightID) ?? flights[0] ?? null;
   const effectiveSelectedFlightID = selectedFlight?.flight_id ?? "";
   const runwayGroupID = selectedFlight?.runway_group_id ?? state?.runway_groups[0]?.id ?? null;
+  const effectiveRateRunwayGroupID = state?.runway_groups.some((group) => group.id === rateRunwayGroupID)
+    ? rateRunwayGroupID
+    : state?.runway_groups[0]?.id ?? "";
   const gateReason = getAMANMutationBlockReason({
     state,
     connection_state: connectionState,
@@ -168,6 +172,21 @@ export function AMANControlsView({
         </div>
       ))}
 
+      <div className="grid gap-2 rounded border border-slate-600 p-3">
+        <h3 className="font-semibold">Arrival rate</h3>
+        <div className="flex flex-wrap gap-2">
+          <select aria-label="Rate runway group" className={inputClass} value={effectiveRateRunwayGroupID} onChange={(event) => setRateRunwayGroupID(event.target.value)}>
+            {state?.runway_groups.map((group) => <option key={group.id} value={group.id}>{group.id}</option>)}
+          </select>
+          <input aria-label="Arrivals per hour" className={inputClass} type="number" min="1" value={rate} onChange={(event) => setRate(event.target.value)} />
+          <input aria-label="Rate effective at" className={inputClass} type="datetime-local" value={rateEffectiveAt} onChange={(event) => setRateEffectiveAt(event.target.value)} />
+          <button className={controlClass} disabled={disabled || !effectiveRateRunwayGroupID || !toWireTimestamp(rateEffectiveAt) || Number(rate) < 1} onClick={() => {
+            const effectiveAt = toWireTimestamp(rateEffectiveAt);
+            if (effectiveRateRunwayGroupID && effectiveAt) onCommand({type: "aman.set_rate", runway_group_id: effectiveRateRunwayGroupID, arrivals_per_hour: Number(rate), effective_at: effectiveAt});
+          }}>Set arrival rate</button>
+        </div>
+      </div>
+
       {flights.length === 0 ? (
         <div>No AMAN flights available.</div>
       ) : (
@@ -195,18 +214,6 @@ export function AMANControlsView({
               <button className={controlClass} disabled={disabled || !targetFlightID || !runwayGroupID} onClick={() => sendMove("after")}>Move after</button>
               <button className={controlClass} disabled={disabled || selectedFlight?.freeze_reason === "manual"} onClick={() => sendFlightCommand("aman.lock_flight")}>Apply manual freeze</button>
               <button className={controlClass} disabled={disabled || selectedFlight?.freeze_reason !== "manual"} onClick={() => sendFlightCommand("aman.unlock_flight")}>Release manual freeze</button>
-            </div>
-          </div>
-
-          <div className="grid gap-2 rounded border border-slate-600 p-3">
-            <h3 className="font-semibold">Arrival rate</h3>
-            <div className="flex flex-wrap gap-2">
-              <input aria-label="Arrivals per hour" className={inputClass} type="number" min="1" value={rate} onChange={(event) => setRate(event.target.value)} />
-              <input aria-label="Rate effective at" className={inputClass} type="datetime-local" value={rateEffectiveAt} onChange={(event) => setRateEffectiveAt(event.target.value)} />
-              <button className={controlClass} disabled={disabled || !runwayGroupID || !toWireTimestamp(rateEffectiveAt) || Number(rate) < 1} onClick={() => {
-                const effectiveAt = toWireTimestamp(rateEffectiveAt);
-                if (runwayGroupID && effectiveAt) onCommand({type: "aman.set_rate", runway_group_id: runwayGroupID, arrivals_per_hour: Number(rate), effective_at: effectiveAt});
-              }}>Set arrival rate</button>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- replace the simplified AMAN predictor with the AMAN-CPH TETA model and production runtime assembly
- implement lifecycle sequencing, controller command handling, persistence, and terminal/frontend publication
- add configurable same-STAR-family spacing for EKCH runway groups at rates of 20 arrivals per hour or higher

## Why
This delivers the agreed AMAN-CPH behavior while preventing adjacent same-family STAR slot opportunities during high-rate arrival operations.

## Validation
- `go test ./...`
- `npm test -- --runInBand` (157 tests passed)
- `npm run build`
- `git diff --cached --check`