### PR TITLE
fix(strip): sync ES flight plan when radar target arrives

### DIFF
--- a/euroscope-plugin/src/plugin/flightplan/FlightPlan.h
+++ b/euroscope-plugin/src/plugin/flightplan/FlightPlan.h
@@ -80,6 +80,7 @@ namespace FlightStrips::flightplan {
         std::string tracking_controller{};
         std::string runway{};
         bool runway_initialized{false};
+        bool strip_synchronized{false};
         CdmState cdm{};
         std::string pdc_state{};
         std::string pdc_request_remarks{};

--- a/euroscope-plugin/src/plugin/flightplan/FlightPlanService.cpp
+++ b/euroscope-plugin/src/plugin/flightplan/FlightPlanService.cpp
@@ -109,6 +109,13 @@ namespace FlightStrips::flightplan {
         }
         if (!m_websocketService->ShouldSend()) return;
 
+        // A flight plan can arrive before its correlated radar target. EuroScope then does not
+        // dispatch the initial relevant flight-plan callback, so create the complete strip when
+        // the target first appears rather than only sending its position.
+        if (hasFp && !pair->second.strip_synchronized) {
+            FlightPlanEvent(fp);
+        }
+
         // For no-FP aircraft, on first encounter send a minimal StripUpdateEvent so the backend
         // creates a record. Without this, all subsequent position/squawk events are silently dropped.
         if (inserted && !hasFp) {
@@ -210,6 +217,7 @@ namespace FlightStrips::flightplan {
             {flightPlanData.GetEngineType()}
         };
         m_websocketService->SendEvent(event);
+        plan.strip_synchronized = true;
         plan.MarkRunwaySynced(runway);
     }
 

--- a/euroscope-plugin/test/plugin/flightplan/FlightPlanServiceTest.cpp
+++ b/euroscope-plugin/test/plugin/flightplan/FlightPlanServiceTest.cpp
@@ -78,6 +78,11 @@ TEST(FlightPlanStructTest, DefaultConstruction_TrackingControllerIsEmpty) {
     EXPECT_EQ(fp.tracking_controller, "");
 }
 
+TEST(FlightPlanStructTest, DefaultConstruction_StripIsNotSynchronized) {
+    FlightPlan fp;
+    EXPECT_FALSE(fp.strip_synchronized);
+}
+
 TEST(FlightPlanStructTest, DefaultConstruction_CdmStateIsEmpty) {
     FlightPlan fp;
     EXPECT_EQ(fp.cdm.tobt, "");
@@ -109,6 +114,7 @@ TEST(FlightPlanStructTest, MarkRunwaySynced_InitializesRunwayState) {
     fp.MarkRunwaySynced("04L");
     EXPECT_TRUE(fp.runway_initialized);
     EXPECT_EQ(fp.runway, "04L");
+    EXPECT_FALSE(fp.strip_synchronized);
 }
 
 TEST(FlightPlanStructTest, HasRunwayChanged_DoesNotConsumeAssignedRunwayChange) {


### PR DESCRIPTION
## Summary

- Send a full EuroScope strip update when a flight plan is present as its radar target first appears.
- Track complete strip synchronisation separately from timer-populated flight-plan state.
- Cover the distinction between runway initialisation and full-strip synchronisation.

## Root cause

A flight plan can be received before its correlated radar target. The initial FPL callback was filtered out, and a later target update only sent position data. If timer polling had already created the in-memory flight-plan entry, the recovery path was also skipped, leaving the backend without a strip to place in the non-cleared bay.

## Validation

- CMake build of `FlightStripsCoreTests`
- `ctest --test-dir C:\Users\fsr19\.codex\builds\flightstrips-radar-fpl --output-on-failure` (354 passed)