### PR TITLE
feat: add opt-in pprof diagnostics

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -120,6 +120,7 @@ func main() {
 		}
 	}()
 	application.StartWorkers(ctx)
+	pprofServer := startPprofServer(envBool("ENABLE_PPROF", false))
 
 	httpServer := &http.Server{
 		Addr:    *addr,
@@ -147,6 +148,11 @@ func main() {
 	if err := httpServer.Shutdown(shutdownCtx); err != nil {
 		slog.Error("Server shutdown failed", slog.Any("error", err))
 		os.Exit(1)
+	}
+	if pprofServer != nil {
+		if err := pprofServer.Shutdown(shutdownCtx); err != nil {
+			slog.Error("Failed to shut down pprof server", slog.Any("error", err))
+		}
 	}
 
 	slog.Info("Server shutdown complete")

--- a/backend/cmd/server/pprof.go
+++ b/backend/cmd/server/pprof.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/pprof"
+)
+
+const pprofAddr = "127.0.0.1:6060"
+
+func startPprofServer(enabled bool) *http.Server {
+	if !enabled {
+		return nil
+	}
+
+	server := newPprofServer()
+	go func() {
+		slog.Info("pprof server started", slog.String("address", server.Addr))
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("pprof server failed", slog.Any("error", err))
+		}
+	}()
+	return server
+}
+
+func newPprofServer() *http.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	return &http.Server{
+		Addr:    pprofAddr,
+		Handler: mux,
+	}
+}

--- a/backend/cmd/server/pprof_test.go
+++ b/backend/cmd/server/pprof_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestStartPprofServerDisabled(t *testing.T) {
+	if server := startPprofServer(false); server != nil {
+		t.Fatal("disabled pprof server should be nil")
+	}
+}
+
+func TestPprofServerIsLoopbackOnlyAndServesHeapProfile(t *testing.T) {
+	server := newPprofServer()
+	if server.Addr != pprofAddr {
+		t.Fatalf("pprof server address = %q, want %q", server.Addr, pprofAddr)
+	}
+	if !strings.HasPrefix(server.Addr, "127.0.0.1:") {
+		t.Fatalf("pprof server must bind only to loopback, got %q", server.Addr)
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/debug/pprof/heap", nil)
+	response := httptest.NewRecorder()
+	server.Handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("heap profile status = %d, want %d", response.Code, http.StatusOK)
+	}
+	if response.Body.Len() == 0 {
+		t.Fatal("heap profile response is empty")
+	}
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -45,6 +45,9 @@ services:
       ENABLE_TEST_TOOLS: "false"
       # Release EFB code disabled until the authenticated pilot surface is ready.
       ENABLE_EFB: ${ENABLE_EFB:-false}
+      # Local-only Go heap and goroutine profiling. It listens on 127.0.0.1:6060
+      # inside the backend container and is disabled unless explicitly enabled.
+      ENABLE_PPROF: ${ENABLE_PPROF:-false}
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
       OTEL_EXPORTER_OTLP_PROTOCOL: ${OTEL_EXPORTER_OTLP_PROTOCOL:-}
       OTEL_EXPORTER_OTLP_HEADERS: ${OTEL_EXPORTER_OTLP_HEADERS:-}


### PR DESCRIPTION
## What changed
- add an opt-in Go pprof server for heap and goroutine diagnostics
- bind it to `127.0.0.1:6060` inside the backend container only
- add `ENABLE_PPROF`, disabled by default, to production compose configuration

## Why
Backend containers have been hitting the 2 GiB cgroup limit. A heap profile captured during the rise will identify the allocating types and call stacks without raising the limit or exposing a public profiling endpoint.

## Impact
Operators can set `ENABLE_PPROF=true` for a diagnostic deployment and retrieve a profile through `docker exec`. Normal deployments remain unchanged.

## Validation
- `go test ./cmd/server`
- `git diff --check`