### PR TITLE
fix(cdm): clamp invalid EOBT before sequencing

### DIFF
--- a/backend/internal/cdm/action_service.go
+++ b/backend/internal/cdm/action_service.go
@@ -151,7 +151,7 @@ func (c *ActionService) normalizeMasterEobtValue(session int32, eobt string, now
 	if !s.isMasterSession(session) {
 		return normalized, false
 	}
-	if normalized == "" {
+	if _, ok := parseClock(normalized); !ok {
 		return truncateCDMClockValue(addMinutes(timeToClock(now), masterEobtClampTarget)), true
 	}
 	if minutesBetween(timeToClock(now), toHHMMSS(normalized)) <= masterEobtClampThreshold {

--- a/backend/internal/cdm/calculate.go
+++ b/backend/internal/cdm/calculate.go
@@ -72,6 +72,9 @@ func calculateWithTrace(input CalcInput, slots []SlotEntry, config *CdmAirportCo
 	if ttot == "" {
 		return CalcResult{}, nil
 	}
+	if _, ok := parseClock(ttot); !ok {
+		return CalcResult{}, nil
+	}
 
 	rate := DefaultCDMRate
 	if config != nil {

--- a/backend/internal/cdm/calculate_test.go
+++ b/backend/internal/cdm/calculate_test.go
@@ -145,6 +145,26 @@ func TestCalculate_BaseTimeSelection(t *testing.T) {
 	}
 }
 
+func TestCalculate_RejectsMalformedClockBeforeCollisionLoop(t *testing.T) {
+	t.Parallel()
+
+	result := Calculate(CalcInput{
+		Callsign: "SAS1635",
+		Origin:   "EKCH",
+		DepRwy:   "22R",
+		Sid:      "NEXEN2C",
+		Eobt:     "0",
+		TaxiMin:  10,
+	}, []SlotEntry{{
+		Callsign: "AAL745",
+		Origin:   "EKCH",
+		DepRwy:   "22R",
+		Ttot:     "0",
+	}}, NewDefaultAirportConfig("EKCH"), time.Date(2026, 7, 24, 21, 37, 58, 0, time.UTC))
+
+	assertClockResult(t, result, "", "")
+}
+
 func TestCalculate_UsesManualCtotFloor(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/cdm/service_test.go
+++ b/backend/internal/cdm/service_test.go
@@ -726,6 +726,25 @@ func TestPrepareEuroscopeEobtSync_MasterSessionClampsBeforeInitialSequenceAndLea
 	assert.Equal(t, eobtCappedReasonKind, updated.Calculation.ReasonMarkers[0].Kind)
 }
 
+func TestPrepareEuroscopeEobtSync_MasterSessionClampsSweatboxZeroEobt(t *testing.T) {
+	const sessionID = int32(147)
+	now := time.Date(2026, time.July, 24, 21, 37, 58, 0, time.UTC)
+	expectedClamped := truncateCDMClockValue(addMinutes(timeToClock(now), masterEobtClampTarget))
+
+	service := newTestCdmService(newTestClientWithAirportMasters(nil), &testutil.MockStripRepository{}, &testutil.MockSessionRepository{}, &testutil.MockControllerRepository{})
+	service.sessionMaster.Store(sessionID, true)
+
+	updated, corrected, clamped := service.PrepareEuroscopeEobtSync(sessionID, &models.CdmData{}, "0", now)
+
+	require.True(t, clamped)
+	assert.Equal(t, "2207", expectedClamped)
+	assert.Equal(t, expectedClamped, corrected)
+	assert.Equal(t, expectedClamped, valueOrEmpty(updated.Eobt))
+	assert.Equal(t, expectedClamped, valueOrEmpty(updated.Tobt))
+	assert.True(t, updated.TobtAutoSynced)
+	assert.True(t, updated.Recalculate)
+}
+
 func TestPrepareEuroscopeEobtSync_ClearsLegacyAutoConfirmationButPreservesManualConfirmation(t *testing.T) {
 	const sessionID = int32(149)
 	now := time.Date(2026, time.July, 13, 10, 0, 0, 0, time.UTC)

--- a/backend/internal/cdm/time_math.go
+++ b/backend/internal/cdm/time_math.go
@@ -139,6 +139,9 @@ func parseClock(value string) (int, bool) {
 	if err != nil {
 		return 0, false
 	}
+	if hh < 0 || hh > 23 || mm < 0 || mm > 59 || ss < 0 || ss > 59 {
+		return 0, false
+	}
 	return hh*3600 + mm*60 + ss, true
 }
 


### PR DESCRIPTION
## Summary

- Treat malformed master-session EOBTs, including the SWEATBOX placeholder `"0"`, as out-of-range and clamp them to UTC now + 30 minutes.
- Validate clock component ranges before CDM time calculations.
- Reject malformed TTOTs before entering the sequencing collision loop.
- Add regressions for the captured `AAL745`/`SAS1635` SWEATBOX collision.

## Root cause

SWEATBOX sent several EKCH departures with `"eobt":"0"`. The backend accepted that non-empty value as a calculation base. Adding 30 seconds to `"0"` returned the same unparseable value, so two strips sharing runway 22R collided forever. Each pass appended another calculation trace entry, driving CPU above one core and container memory above 1 GiB.

## Impact

Invalid EuroScope EOBTs are corrected before sequencing and synchronized back as now + 30 minutes. Malformed clock input can no longer enter the unbounded collision loop.

## Validation

- `go test ./internal/cdm ./internal/services`
- `go test ./...`
- `git diff --check`
