### PR TITLE
fix(stand): target EuroScope stand updates

### DIFF
--- a/backend/internal/frontend/hub.go
+++ b/backend/internal/frontend/hub.go
@@ -13,7 +13,6 @@ import (
 	"FlightStrips/internal/services"
 	"FlightStrips/internal/shared"
 	"FlightStrips/pkg/events"
-	euroscopeEvents "FlightStrips/pkg/events/euroscope"
 	"FlightStrips/pkg/events/frontend"
 	"FlightStrips/pkg/helpers"
 	pkgModels "FlightStrips/pkg/models"
@@ -1027,33 +1026,63 @@ func (hub *Hub) PublishStandAllocation(ctx context.Context, result services.Stan
 	}
 
 	euroscopeHub := hub.server.GetEuroscopeHub()
-	for _, assignment := range removed {
-		hub.SendStandEvent(sessionID, assignment.Callsign, "")
-		hub.sendAllocatedStandToEuroscope(euroscopeHub, assignment, "")
+	removedStandChanges := make(map[string]struct{}, len(result.RemovedStandChanges)+1)
+	if result.Removed && result.StandChanged {
+		removedStandChanges[strings.ToUpper(strings.TrimSpace(result.Assignment.Callsign))] = struct{}{}
 	}
-	if !result.Removed {
+	for _, assignment := range result.RemovedStandChanges {
+		removedStandChanges[strings.ToUpper(strings.TrimSpace(assignment.Callsign))] = struct{}{}
+	}
+	for _, assignment := range removed {
+		_, standChanged := removedStandChanges[strings.ToUpper(strings.TrimSpace(assignment.Callsign))]
+		if standChanged {
+			hub.SendStandEvent(sessionID, assignment.Callsign, "")
+		}
+		if standChanged {
+			hub.sendAllocatedStandToEuroscope(ctx, euroscopeHub, assignment, "")
+		}
+	}
+	if !result.Removed && result.StandChanged {
 		hub.SendStandEvent(sessionID, result.Assignment.Callsign, result.Assignment.Stand)
-		hub.sendAllocatedStandToEuroscope(euroscopeHub, result.Assignment, result.Assignment.Stand)
+	}
+	if !result.Removed && result.NotifyEuroscope {
+		hub.sendAllocatedStandToEuroscope(ctx, euroscopeHub, result.Assignment, result.Assignment.Stand)
 	}
 	return nil
 }
 
-func (hub *Hub) sendAllocatedStandToEuroscope(euroscopeHub shared.EuroscopeHub, assignment internalModels.StandAssignment, stand string) {
+func (hub *Hub) sendAllocatedStandToEuroscope(ctx context.Context, euroscopeHub shared.EuroscopeHub, assignment internalModels.StandAssignment, stand string) {
 	if euroscopeHub == nil {
 		return
 	}
-	if !strings.EqualFold(assignment.Direction, string(sat.AssignmentDirectionArrival)) {
-		euroscopeHub.Broadcast(assignment.SessionID, euroscopeEvents.StandEvent{Callsign: assignment.Callsign, Stand: stand})
+	if strings.EqualFold(assignment.Direction, string(sat.AssignmentDirectionArrival)) && assignment.Stage != services.StageConfirmed {
 		return
 	}
-	if assignment.Stage != services.StageConfirmed {
+
+	cid := hub.standUpdateRecipient(ctx, assignment)
+	if cid == "" {
+		cid = strings.TrimSpace(euroscopeHub.GetMasterCid(assignment.SessionID))
+	}
+	if cid == "" {
 		return
 	}
-	masterCid := strings.TrimSpace(euroscopeHub.GetMasterCid(assignment.SessionID))
-	if masterCid == "" {
-		return
+	euroscopeHub.SendStand(assignment.SessionID, cid, assignment.Callsign, stand)
+}
+
+func (hub *Hub) standUpdateRecipient(ctx context.Context, assignment internalModels.StandAssignment) string {
+	if hub.server == nil || hub.server.GetStripRepository() == nil || hub.server.GetControllerRepository() == nil {
+		return ""
 	}
-	euroscopeHub.SendStand(assignment.SessionID, masterCid, assignment.Callsign, stand)
+
+	strip, err := hub.server.GetStripRepository().GetByCallsign(ctx, assignment.SessionID, assignment.Callsign)
+	if err != nil || strip == nil || strings.TrimSpace(strip.TrackingController) == "" {
+		return ""
+	}
+	controller, err := hub.server.GetControllerRepository().GetByCallsign(ctx, assignment.SessionID, strip.TrackingController)
+	if err != nil || controller == nil || controller.Cid == nil {
+		return ""
+	}
+	return strings.TrimSpace(*controller.Cid)
 }
 
 func clientAirport(strip *internalModels.Strip, direction string) string {

--- a/backend/internal/frontend/stand_assignment_euroscope_test.go
+++ b/backend/internal/frontend/stand_assignment_euroscope_test.go
@@ -5,7 +5,7 @@ import (
 	"FlightStrips/internal/sat"
 	"FlightStrips/internal/services"
 	"FlightStrips/internal/testutil"
-	euroscopeEvents "FlightStrips/pkg/events/euroscope"
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,13 +35,13 @@ func TestSendAllocatedStandToEuroscope_ArrivalWaitsForConfirmedAndTargetsMaster(
 		Stage:     services.StageAssigned,
 	}
 
-	hub.sendAllocatedStandToEuroscope(esHub, assignment, stand)
+	hub.sendAllocatedStandToEuroscope(t.Context(), esHub, assignment, stand)
 
 	assert.Empty(t, esHub.Stands, "ASSIGNED arrivals must not update EuroScope yet")
 	assert.Empty(t, esHub.Broadcasts, "arrival stands must never be broadcast to every EuroScope client")
 
 	assignment.Stage = services.StageConfirmed
-	hub.sendAllocatedStandToEuroscope(esHub, assignment, stand)
+	hub.sendAllocatedStandToEuroscope(t.Context(), esHub, assignment, stand)
 
 	require.Len(t, esHub.Stands, 1)
 	assert.Equal(t, testutil.StandCall{
@@ -64,15 +64,15 @@ func TestSendAllocatedStandToEuroscope_ConfirmedArrivalWithoutMasterDoesNotBroad
 		Stage:     services.StageConfirmed,
 	}
 
-	hub.sendAllocatedStandToEuroscope(esHub, assignment, assignment.Stand)
+	hub.sendAllocatedStandToEuroscope(t.Context(), esHub, assignment, assignment.Stand)
 
 	assert.Empty(t, esHub.Stands)
 	assert.Empty(t, esHub.Broadcasts)
 }
 
-func TestSendAllocatedStandToEuroscope_DepartureBehaviorRemainsBroadcast(t *testing.T) {
+func TestSendAllocatedStandToEuroscope_DepartureTargetsMaster(t *testing.T) {
 	hub := &Hub{}
-	esHub := &testutil.MockEuroscopeHub{}
+	esHub := &testutil.MockEuroscopeHub{GetMasterCidFn: func(int32) string { return "MASTER-CID" }}
 	assignment := models.StandAssignment{
 		SessionID: 7,
 		Callsign:  "SAS501",
@@ -81,12 +81,49 @@ func TestSendAllocatedStandToEuroscope_DepartureBehaviorRemainsBroadcast(t *test
 		Stage:     services.StageDepartureBlock,
 	}
 
-	hub.sendAllocatedStandToEuroscope(esHub, assignment, assignment.Stand)
+	hub.sendAllocatedStandToEuroscope(t.Context(), esHub, assignment, assignment.Stand)
 
-	assert.Empty(t, esHub.Stands)
-	require.Len(t, esHub.Broadcasts, 1)
-	event, ok := esHub.Broadcasts[0].(euroscopeEvents.StandEvent)
-	require.True(t, ok)
-	assert.Equal(t, assignment.Callsign, event.Callsign)
-	assert.Equal(t, assignment.Stand, event.Stand)
+	require.Len(t, esHub.Stands, 1)
+	assert.Equal(t, testutil.StandCall{Session: assignment.SessionID, Cid: "MASTER-CID", Callsign: assignment.Callsign, Stand: assignment.Stand}, esHub.Stands[0])
+	assert.Empty(t, esHub.Broadcasts)
+}
+
+func TestSendAllocatedStandToEuroscope_PrefersTrackingController(t *testing.T) {
+	const (
+		session      = int32(7)
+		callsign     = "SAS502"
+		trackingCid  = "TRACKING-CID"
+		masterCid    = "MASTER-CID"
+		controllerID = "EKCH_APP"
+	)
+	hub := &Hub{server: &testutil.MockServer{
+		StripRepoVal: &testutil.MockStripRepository{
+			GetByCallsignFn: func(_ context.Context, gotSession int32, gotCallsign string) (*models.Strip, error) {
+				assert.Equal(t, session, gotSession)
+				assert.Equal(t, callsign, gotCallsign)
+				return &models.Strip{Callsign: callsign, TrackingController: controllerID}, nil
+			},
+		},
+		ControllerRepoVal: &testutil.MockControllerRepository{
+			GetByCallsignFn: func(_ context.Context, gotSession int32, gotCallsign string) (*models.Controller, error) {
+				assert.Equal(t, session, gotSession)
+				assert.Equal(t, controllerID, gotCallsign)
+				return &models.Controller{Callsign: controllerID, Cid: ptr(trackingCid)}, nil
+			},
+		},
+	}}
+	esHub := &testutil.MockEuroscopeHub{GetMasterCidFn: func(int32) string { return masterCid }}
+	assignment := models.StandAssignment{
+		SessionID: session,
+		Callsign:  callsign,
+		Stand:     "B13",
+		Direction: string(sat.AssignmentDirectionDeparture),
+		Stage:     services.StageDepartureBlock,
+	}
+
+	hub.sendAllocatedStandToEuroscope(t.Context(), esHub, assignment, assignment.Stand)
+
+	require.Len(t, esHub.Stands, 1)
+	assert.Equal(t, trackingCid, esHub.Stands[0].Cid)
+	assert.Empty(t, esHub.Broadcasts)
 }

--- a/backend/internal/services/arrival_lifecycle.go
+++ b/backend/internal/services/arrival_lifecycle.go
@@ -237,6 +237,9 @@ func (s *ArrivalLifecycleService) updateStageInPlace(ctx context.Context, existi
 	}
 	updated.Version++
 	slog.InfoContext(ctx, "SAT assignment stage changed", slog.String("callsign", existing.Callsign), slog.String("stand", existing.Stand), slog.String("from_stage", existing.Stage), slog.String("to_stage", stage))
+	if stage == StageConfirmed {
+		return s.allocations.PublishConfirmedArrival(ctx, updated)
+	}
 	return s.allocations.PublishAssignment(ctx, updated)
 }
 

--- a/backend/internal/services/stand_allocation.go
+++ b/backend/internal/services/stand_allocation.go
@@ -81,10 +81,18 @@ type StandAllocationRequest struct {
 // eventual event/validation layer can use its decision data without rerunning
 // compatibility or selection.
 type StandAllocationResult struct {
-	Command             StandAllocationCommand
-	Assignment          models.StandAssignment
-	Removed             bool
+	Command    StandAllocationCommand
+	Assignment models.StandAssignment
+	Removed    bool
+	// StandChanged reports whether this transaction changed the operational
+	// strip stand. Lifecycle-only assignment updates must not be mirrored to
+	// EuroScope as stand writes.
+	StandChanged bool
+	// NotifyEuroscope is set when EuroScope needs a stand write even though the
+	// strip value did not change, currently when an arrival becomes CONFIRMED.
+	NotifyEuroscope     bool
 	RemovedAssignments  []models.StandAssignment
+	RemovedStandChanges []models.StandAssignment
 	Selection           *sat.StandSelection
 	MatchedVariant      *sat.StandCompatibilityMatch
 	Compatibility       sat.StandCompatibilityEvaluation
@@ -142,6 +150,13 @@ func (s *StandAllocationService) PublishAssignment(ctx context.Context, assignme
 	return nil
 }
 
+// PublishConfirmedArrival publishes the lifecycle transition that makes an
+// arrival's previously allocated stand ready for EuroScope.
+func (s *StandAllocationService) PublishConfirmedArrival(ctx context.Context, assignment models.StandAssignment) error {
+	s.publishCommitted(ctx, StandAllocationResult{Assignment: assignment, NotifyEuroscope: true})
+	return nil
+}
+
 func (s *StandAllocationService) publishCommitted(ctx context.Context, result StandAllocationResult) {
 	if s.publish == nil {
 		return
@@ -195,7 +210,8 @@ func (s *StandAllocationService) ReleaseAssignment(ctx context.Context, assignme
 		return errAllocationVersionConflict
 	}
 
-	if strip != nil && strip.Stand != nil && strings.EqualFold(strings.TrimSpace(*strip.Stand), strings.TrimSpace(current.Stand)) {
+	standChanged := strip != nil && strip.Stand != nil && strings.EqualFold(strings.TrimSpace(*strip.Stand), strings.TrimSpace(current.Stand))
+	if standChanged {
 		updated, err := txStrips.UpdateStand(ctx, assignment.SessionID, assignment.Callsign, nil, nil)
 		if err != nil {
 			return err
@@ -214,7 +230,7 @@ func (s *StandAllocationService) ReleaseAssignment(ctx context.Context, assignme
 	if err := tx.Commit(ctx); err != nil {
 		return err
 	}
-	s.publishCommitted(ctx, StandAllocationResult{Assignment: *current, Removed: true})
+	s.publishCommitted(ctx, StandAllocationResult{Assignment: *current, Removed: true, StandChanged: standChanged, NotifyEuroscope: standChanged})
 	return nil
 }
 
@@ -587,8 +603,9 @@ func (s *StandAllocationService) allocateOnce(ctx context.Context, command Stand
 		return nil, selected, err
 	}
 	var removedAssignments []models.StandAssignment
+	var removedStandChanges []models.StandAssignment
 	if request.displacesArrivalStage() && selected != "" {
-		removedAssignments, err = s.displaceAssignments(ctx, txStrips, txAssignments, request, selected, assignments)
+		removedAssignments, removedStandChanges, err = s.displaceAssignments(ctx, txStrips, txAssignments, request, selected, assignments)
 		if err != nil {
 			return nil, selected, err
 		}
@@ -598,7 +615,8 @@ func (s *StandAllocationService) allocateOnce(ctx context.Context, command Stand
 	if err != nil {
 		return nil, selected, err
 	}
-	if strip.Stand == nil || *strip.Stand != selected {
+	standChanged := strip.Stand == nil || !strings.EqualFold(strings.TrimSpace(*strip.Stand), strings.TrimSpace(selected))
+	if standChanged {
 		updated, err := txStrips.UpdateStand(ctx, request.SessionID, request.Callsign, &selected, nil)
 		if err != nil {
 			return nil, selected, err
@@ -613,7 +631,8 @@ func (s *StandAllocationService) allocateOnce(ctx context.Context, command Stand
 	return &StandAllocationResult{
 		Command: command, Assignment: *assignment, Selection: selection, MatchedVariant: match,
 		Compatibility: evaluation, ConflictReason: conflict, Attempts: attempt, AvailableCandidates: available,
-		RemovedAssignments: removedAssignments,
+		RemovedAssignments: removedAssignments, RemovedStandChanges: removedStandChanges,
+		StandChanged: standChanged, NotifyEuroscope: standChanged,
 	}, selected, nil
 }
 
@@ -933,11 +952,12 @@ func joinAllocationReasons(reasons []string) string {
 	return strings.Join(result, "; ")
 }
 
-func (s *StandAllocationService) displaceAssignments(ctx context.Context, strips repository.StripRepository, assignments repository.StandAssignmentRepository, request StandAllocationRequest, selected string, current []*models.StandAssignment) ([]models.StandAssignment, error) {
+func (s *StandAllocationService) displaceAssignments(ctx context.Context, strips repository.StripRepository, assignments repository.StandAssignmentRepository, request StandAllocationRequest, selected string, current []*models.StandAssignment) ([]models.StandAssignment, []models.StandAssignment, error) {
 	if !request.displacesArrivalStage() || selected == "" {
-		return nil, nil
+		return nil, nil, nil
 	}
 	removed := []models.StandAssignment{}
+	standChanges := []models.StandAssignment{}
 	for _, assignment := range current {
 		if assignment == nil || strings.EqualFold(assignment.Callsign, request.Callsign) {
 			continue
@@ -948,19 +968,29 @@ func (s *StandAllocationService) displaceAssignments(ctx context.Context, strips
 		if standName(assignment.Stand) != standName(selected) {
 			continue
 		}
-		if _, err := strips.UpdateStand(ctx, request.SessionID, assignment.Callsign, nil, nil); err != nil {
-			return nil, err
+		strip, err := strips.LockByCallsign(ctx, request.SessionID, assignment.Callsign)
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil, err
+		}
+		standChanged := strip != nil && strip.Stand != nil
+		if standChanged {
+			if _, err := strips.UpdateStand(ctx, request.SessionID, assignment.Callsign, nil, nil); err != nil {
+				return nil, nil, err
+			}
 		}
 		deleted, err := assignments.DeleteAssignment(ctx, request.SessionID, assignment.ID, assignment.Version)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if deleted != 1 {
-			return nil, errAllocationVersionConflict
+			return nil, nil, errAllocationVersionConflict
 		}
 		removed = append(removed, *assignment)
+		if standChanged {
+			standChanges = append(standChanges, *assignment)
+		}
 	}
-	return removed, nil
+	return removed, standChanges, nil
 }
 
 func (request StandAllocationRequest) displacesArrivalStage() bool {

--- a/backend/internal/services/stand_allocation_test.go
+++ b/backend/internal/services/stand_allocation_test.go
@@ -37,6 +37,8 @@ func TestStandAllocationServiceTransactions(t *testing.T) {
 		result, err := service.Allocate(ctx, standAllocationRequest(session, "SAS101"))
 		require.NoError(t, err)
 		assert.Equal(t, "A1", result.Assignment.Stand)
+		assert.True(t, result.StandChanged)
+		assert.True(t, result.NotifyEuroscope)
 		strip, err := queries.GetStrip(ctx, database.GetStripParams{Session: session, Callsign: "SAS101"})
 		require.NoError(t, err)
 		require.NotNil(t, strip.Stand)
@@ -44,6 +46,7 @@ func TestStandAllocationServiceTransactions(t *testing.T) {
 		select {
 		case event := <-published:
 			assert.Equal(t, result.Assignment.ID, event.Assignment.ID)
+			assert.True(t, event.StandChanged)
 		default:
 			t.Fatal("allocation was not published after commit")
 		}
@@ -94,6 +97,7 @@ func TestStandAllocationServiceTransactions(t *testing.T) {
 		case event := <-published:
 			assert.True(t, event.Removed)
 			assert.Equal(t, retained.ID, event.Assignment.ID)
+			assert.True(t, event.StandChanged)
 		default:
 			t.Fatal("removal was not published after commit")
 		}
@@ -107,6 +111,12 @@ func TestStandAllocationServiceTransactions(t *testing.T) {
 		estimatedRequest.Stage = StageEstimated
 		_, err := service.AssignManually(ctx, estimatedRequest)
 		require.NoError(t, err)
+		observedStand := "B2"
+		updated, err := queries.UpdateStripStandByID(ctx, database.UpdateStripStandByIDParams{
+			Stand: &observedStand, Callsign: "SAS104", Session: session,
+		})
+		require.NoError(t, err)
+		require.EqualValues(t, 1, updated)
 
 		var published StandAllocationResult
 		service.SetPublisher(func(_ context.Context, result StandAllocationResult) error {
@@ -120,6 +130,8 @@ func TestStandAllocationServiceTransactions(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, result.RemovedAssignments, 1)
 		assert.Equal(t, "SAS104", result.RemovedAssignments[0].Callsign)
+		require.Len(t, result.RemovedStandChanges, 1)
+		assert.Equal(t, "SAS104", result.RemovedStandChanges[0].Callsign)
 		require.Len(t, published.RemovedAssignments, 1)
 		assert.Equal(t, "SAS104", published.RemovedAssignments[0].Callsign)
 		_, err = assignments.GetAssignment(ctx, session, "SAS104")
@@ -368,6 +380,23 @@ func TestStandAllocationServiceTransactions(t *testing.T) {
 		assert.Equal(t, 1, successes)
 		assert.Equal(t, 1, unavailable)
 	})
+}
+
+func TestPublishAssignmentOnlyNotifiesEuroscopeForConfirmedArrival(t *testing.T) {
+	service := &StandAllocationService{}
+	var published []StandAllocationResult
+	service.SetPublisher(func(_ context.Context, result StandAllocationResult) error {
+		published = append(published, result)
+		return nil
+	})
+	assignment := models.StandAssignment{Callsign: "SAS777", Direction: string(sat.AssignmentDirectionArrival), Stage: StageConfirmed}
+
+	require.NoError(t, service.PublishAssignment(context.Background(), assignment))
+	require.NoError(t, service.PublishConfirmedArrival(context.Background(), assignment))
+
+	require.Len(t, published, 2)
+	assert.False(t, published[0].NotifyEuroscope, "ordinary lifecycle refreshes must not emit stand updates")
+	assert.True(t, published[1].NotifyEuroscope, "confirmation must deliver the previously assigned arrival stand")
 }
 
 func standAllocationFixture(t *testing.T, pool *pgxpool.Pool, queries *database.Queries, a1Directive, a2Directive string) (*StandAllocationService, int32, repository.StandAssignmentRepository) {

--- a/euroscope-plugin/src/plugin/plugin/FlightStripsPlugin.cpp
+++ b/euroscope-plugin/src/plugin/plugin/FlightStripsPlugin.cpp
@@ -576,15 +576,22 @@ namespace FlightStrips {
     }
 
     void FlightStripsPlugin::SetArrivalStand(const std::string &callsign, std::string stand) const {
-        UpdateViaScratchPad(callsign.c_str(), std::format("GRP/S/{}", stand).c_str());
+        UpdateViaScratchPad(callsign.c_str(), std::format("GRP/S/{}", stand).c_str(), true);
     }
 
-    void FlightStripsPlugin::UpdateViaScratchPad(const char *callsign, const char *message) const {
+    void FlightStripsPlugin::UpdateViaScratchPad(const char *callsign, const char *message, const bool clearStaleStandCommand) const {
         auto fp = this->FlightPlanSelect(callsign);
 
         if (!fp.IsValid()) return;
 
         auto scratch = std::string(fp.GetControllerAssignedData().GetScratchPadString());
+        // A previous stand update can still be present when EuroScope delivers
+        // multiple controller-data changes in quick succession. Never restore a
+        // stale GRP/S command: it is an internal stand-update trigger, not
+        // controller scratchpad text.
+        if (clearStaleStandCommand && scratch.size() >= 6 && _strnicmp(scratch.c_str(), "GRP/S/", 6) == 0) {
+            scratch.clear();
+        }
         fp.GetControllerAssignedData().SetScratchPadString(message);
         fp.GetControllerAssignedData().SetScratchPadString(scratch.c_str());
     }

--- a/euroscope-plugin/src/plugin/plugin/FlightStripsPlugin.h
+++ b/euroscope-plugin/src/plugin/plugin/FlightStripsPlugin.h
@@ -74,7 +74,7 @@ namespace FlightStrips {
 
         void SetArrivalStand(const std::string &callsign, std::string stand) const;
 
-        void UpdateViaScratchPad(const char* callsign, const char* message) const;
+        void UpdateViaScratchPad(const char* callsign, const char* message, bool clearStaleStandCommand = false) const;
 
         EuroScopePlugIn::CRadarScreen* OnRadarScreenCreated ( const char * sDisplayName, bool NeedRadarContent, bool GeoReferenced, bool CanBeSaved, bool CanBeCreated ) override;
 


### PR DESCRIPTION
## Summary

- Send stand updates to the tracking controller when available, otherwise the session master, instead of broadcasting them to every EuroScope client.
- Emit EuroScope and frontend stand updates only when the operational stand changes, while still delivering confirmed arrival assignments.
- Clear stale `GRP/S/...` scratchpad commands only during stand updates, so unrelated ground-state and clearance updates preserve scratchpad data.

## Why

SAT events were repeatedly broadcasting stand messages to all EuroScope clients and could leave stale stand commands in the scratchpad after rapid updates.

## Validation

- `go test ./internal/services ./internal/frontend`
- `git diff --check`

The EuroScope plugin has no configured local build directory, so its C++ build was not run.
