### PR TITLE
feat(navigation): decouple source from AMAN

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -4,6 +4,7 @@ import (
 	"FlightStrips/internal/aman"
 	"FlightStrips/internal/app"
 	"FlightStrips/internal/config"
+	"FlightStrips/internal/navigation"
 	"FlightStrips/internal/telemetry"
 	"context"
 	"flag"
@@ -50,6 +51,11 @@ func main() {
 	amanConfig, err := amanConfigFromEnv()
 	if err != nil {
 		slog.Error("Failed to configure AMAN", slog.Any("error", err))
+		os.Exit(1)
+	}
+	navigationConfig, err := navigationConfigFromEnv()
+	if err != nil {
+		slog.Error("Failed to configure navigation source", slog.Any("error", err))
 		os.Exit(1)
 	}
 
@@ -104,6 +110,7 @@ func main() {
 		EnableDBSeed:                    true,
 		StandAssignmentAircraftJSON:     standAssignmentAircraftJSON,
 		AMAN:                            amanConfig,
+		Navigation:                      navigationConfig,
 	}, app.Dependencies{
 		VATSIMStatusURL:      getEnv("VATSIM_STATUS_URL", ""),
 		VATSIMPollInterval:   envDuration("VATSIM_POLL_INTERVAL", 15*time.Second),
@@ -229,8 +236,6 @@ func amanConfigFromEnv() (aman.RuntimeConfig, error) {
 	}
 	config.EnabledAirports = splitEnvList(os.Getenv("AMAN_ENABLED_AIRPORTS"))
 	config.FMPRoles = splitEnvList(os.Getenv("AMAN_FMP_ROLES"))
-	config.TerminalGeometryPath = strings.TrimSpace(os.Getenv("AMAN_TERMINAL_GEOMETRY_PATH"))
-	config.NavigationSourceAdapter = strings.TrimSpace(os.Getenv("AMAN_NAVIGATION_SOURCE"))
 	config.EnableEuroScopeGainLoseTags = envBool("ENABLE_AMAN_EUROSCOPE_GAIN_LOSE_TAGS", false)
 
 	var err error
@@ -244,6 +249,14 @@ func amanConfigFromEnv() (aman.RuntimeConfig, error) {
 		return aman.RuntimeConfig{}, err
 	}
 	return config, nil
+}
+
+func navigationConfigFromEnv() (navigation.Config, error) {
+	config := navigation.Config{
+		Source:               strings.TrimSpace(os.Getenv("NAVIGATION_SOURCE")),
+		TerminalGeometryPath: strings.TrimSpace(os.Getenv("NAVIGATION_TERMINAL_GEOMETRY_PATH")),
+	}
+	return config.Normalize(), config.Validate()
 }
 
 func requiredEnvDuration(key string, fallback time.Duration) (time.Duration, error) {

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"FlightStrips/internal/aman"
-	"os"
 	"testing"
 	"time"
 )
@@ -76,7 +75,7 @@ func TestStandAssignmentAircraftFilePreservesExplicitConfiguration(t *testing.T)
 }
 
 func TestAMANConfigFromEnvDefaultsDisabled(t *testing.T) {
-	for _, key := range []string{"AMAN_MODE", "AMAN_ENABLED_AIRPORTS", "AMAN_FMP_ROLES", "AMAN_TERMINAL_GEOMETRY_PATH", "AMAN_NAVIGATION_SOURCE", "AMAN_RECONCILIATION_INTERVAL", "AMAN_SURVEILLANCE_INTERVAL", "ENABLE_AMAN_EUROSCOPE_GAIN_LOSE_TAGS"} {
+	for _, key := range []string{"AMAN_MODE", "AMAN_ENABLED_AIRPORTS", "AMAN_FMP_ROLES", "AMAN_RECONCILIATION_INTERVAL", "AMAN_SURVEILLANCE_INTERVAL", "ENABLE_AMAN_EUROSCOPE_GAIN_LOSE_TAGS"} {
 		t.Setenv(key, "")
 	}
 	config, err := amanConfigFromEnv()
@@ -89,18 +88,9 @@ func TestAMANConfigFromEnvDefaultsDisabled(t *testing.T) {
 }
 
 func TestAMANConfigFromEnvParsesConfiguredRuntime(t *testing.T) {
-	geometry, err := os.CreateTemp(t.TempDir(), "terminal-*.geojson")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := geometry.Close(); err != nil {
-		t.Fatal(err)
-	}
 	t.Setenv("AMAN_MODE", "authoritative")
 	t.Setenv("AMAN_ENABLED_AIRPORTS", "EKCH,EKRN")
 	t.Setenv("AMAN_FMP_ROLES", "EKCH_APP,EKCH_CTR")
-	t.Setenv("AMAN_TERMINAL_GEOMETRY_PATH", geometry.Name())
-	t.Setenv("AMAN_NAVIGATION_SOURCE", "airacnet")
 	t.Setenv("AMAN_RECONCILIATION_INTERVAL", "21s")
 	t.Setenv("AMAN_SURVEILLANCE_INTERVAL", "34s")
 	t.Setenv("ENABLE_AMAN_EUROSCOPE_GAIN_LOSE_TAGS", "true")
@@ -111,6 +101,27 @@ func TestAMANConfigFromEnvParsesConfiguredRuntime(t *testing.T) {
 	}
 	if config.Mode != aman.ModeAuthoritative || len(config.EnabledAirports) != 2 || len(config.FMPRoles) != 2 || config.FMPRoles[0] != "EKCH_APP" || config.ReconciliationInterval != 21*time.Second || config.SurveillanceInterval != 34*time.Second || !config.EnableEuroScopeGainLoseTags {
 		t.Fatalf("unexpected AMAN config: %#v", config)
+	}
+}
+
+func TestNavigationConfigFromEnvParsesConfiguredSource(t *testing.T) {
+	t.Setenv("NAVIGATION_SOURCE", " AIRACNET ")
+	t.Setenv("NAVIGATION_TERMINAL_GEOMETRY_PATH", " terminal.json ")
+
+	config, err := navigationConfigFromEnv()
+	if err != nil {
+		t.Fatalf("navigationConfigFromEnv() error = %v", err)
+	}
+	if config.Source != "airacnet" || config.TerminalGeometryPath != "terminal.json" {
+		t.Fatalf("unexpected navigation config: %#v", config)
+	}
+}
+
+func TestNavigationConfigFromEnvRejectsIncompleteConfiguration(t *testing.T) {
+	t.Setenv("NAVIGATION_SOURCE", "airacnet")
+	t.Setenv("NAVIGATION_TERMINAL_GEOMETRY_PATH", "")
+	if _, err := navigationConfigFromEnv(); err == nil {
+		t.Fatal("navigationConfigFromEnv() succeeded without terminal geometry")
 	}
 }
 

--- a/backend/internal/aman/health_test.go
+++ b/backend/internal/aman/health_test.go
@@ -58,7 +58,7 @@ func TestRuntimeHealthUsesEffectiveModeAndReporter(t *testing.T) {
 		ComponentHealth{Status: HealthReady}, ComponentHealth{Status: HealthReady},
 		ComponentHealth{Status: HealthReady}, ComponentHealth{Status: HealthReady},
 	)}
-	runtime, err := NewRuntime(RuntimeConfig{Mode: ModeAuthoritative, EnabledAirports: []string{"EKCH"}, TerminalGeometryPath: "terminal.json", NavigationSourceAdapter: NavigationAdapterAIRACNet}, Dependencies{
+	runtime, err := NewRuntime(RuntimeConfig{Mode: ModeAuthoritative, EnabledAirports: []string{"EKCH"}}, Dependencies{
 		Repositories: reporter, NavigationMaterializer: reporter, NavigationReader: reporter, Predictor: reporter,
 		StateEngine: reporter, SequenceService: reporter, Publisher: reporter, ValidationService: reporter,
 		HealthService: reporter, ReconciliationWorker: healthTestWorker{}, ObservationSink: healthTestSink{},

--- a/backend/internal/aman/operational/service.go
+++ b/backend/internal/aman/operational/service.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"FlightStrips/internal/aman"
-	"FlightStrips/internal/aman/materializer"
 	"FlightStrips/internal/aman/navdata"
 	"FlightStrips/internal/aman/prediction"
 	"FlightStrips/internal/aman/predictor"
@@ -24,17 +23,15 @@ import (
 )
 
 const (
-	policyVersion          = "aman-cph-v1"
-	modelVersion           = "aman-cph-teta-v1"
-	routeResolverVersion   = "airacnet-route-v3"
-	defaultArrivalRate     = uint32(20)
-	navigationRefreshEvery = 6 * time.Hour
-	weatherRefreshEvery    = 30 * time.Minute
-	queueOfferValidity     = 2 * time.Minute
+	policyVersion        = "aman-cph-v1"
+	modelVersion         = "aman-cph-teta-v1"
+	routeResolverVersion = "airacnet-route-v3"
+	defaultArrivalRate   = uint32(20)
+	weatherRefreshEvery  = 30 * time.Minute
+	queueOfferValidity   = 2 * time.Minute
 )
 
 type NavigationMaterializer interface {
-	Refresh(context.Context, materializer.Request) error
 	MaterializeRoute(context.Context, navdata.RouteQuery, string) (navdata.RouteKey, error)
 }
 
@@ -66,7 +63,6 @@ type Service struct {
 
 	mu                 sync.Mutex
 	observed           map[string]map[aman.FlightID]aman.FlightObservation
-	lastRefresh        map[string]time.Time
 	lastWeatherRefresh map[string]time.Time
 	health             serviceHealth
 }
@@ -93,7 +89,7 @@ func New(deps Dependencies) (*Service, error) {
 		return componentHealth(aman.HealthUnavailable, reason, now)
 	}
 	return &Service{
-		deps: deps, observed: map[string]map[aman.FlightID]aman.FlightObservation{}, lastRefresh: map[string]time.Time{}, lastWeatherRefresh: map[string]time.Time{},
+		deps: deps, observed: map[string]map[aman.FlightID]aman.FlightObservation{}, lastWeatherRefresh: map[string]time.Time{},
 		health: serviceHealth{
 			vatsim: pending("source_not_observed"), navigation: pending("navigation_not_refreshed"),
 			weather: pending("weather_not_observed"), repository: pending("repository_not_checked"),
@@ -153,9 +149,7 @@ func (s *Service) Run(ctx context.Context, interval time.Duration) {
 func (s *Service) reconcileAll(ctx context.Context) {
 	for _, airport := range s.deps.Airports {
 		airport = strings.ToUpper(strings.TrimSpace(airport))
-		if err := s.refreshNavigation(ctx, airport); err != nil {
-			slog.WarnContext(ctx, "AMAN navigation refresh failed; cached geometry remains eligible", "airport", airport, "error", err)
-		}
+		s.observeNavigationCache(ctx, airport)
 		s.refreshWeather(ctx, airport, s.deps.Now().UTC().Truncate(time.Second))
 		if err := s.reconcileAirport(ctx, airport); err != nil {
 			slog.WarnContext(ctx, "AMAN reconciliation failed", "airport", airport, "error", err)
@@ -225,26 +219,16 @@ func observedWeatherProfile(profile predictor.WindProfile, request predictor.Win
 	return true
 }
 
-func (s *Service) refreshNavigation(ctx context.Context, airport string) error {
-	now := s.deps.Now().UTC().Truncate(time.Second)
+func (s *Service) observeNavigationCache(ctx context.Context, airport string) {
+	updatedAt := s.deps.Now().UTC()
+	_, err := s.deps.Geometry.ActiveGeometrySnapshot(ctx, navdata.AirportID(airport))
 	s.mu.Lock()
-	last := s.lastRefresh[airport]
-	if !last.IsZero() && now.Sub(last) < navigationRefreshEvery {
-		s.mu.Unlock()
-		return nil
-	}
-	s.mu.Unlock()
-	err := s.deps.Materializer.Refresh(ctx, materializer.Request{Airport: navdata.AirportID(airport)})
-	completedAt := s.deps.Now().UTC()
-	s.mu.Lock()
+	defer s.mu.Unlock()
 	if err != nil {
-		s.health.navigation = componentHealth(aman.HealthUnavailable, "navigation_refresh_failed", completedAt)
-	} else {
-		s.lastRefresh[airport] = completedAt
-		s.health.navigation = componentHealth(aman.HealthReady, "", completedAt)
+		s.health.navigation = componentHealth(aman.HealthUnavailable, "navigation_cache_unavailable", updatedAt)
+		return
 	}
-	s.mu.Unlock()
-	return err
+	s.health.navigation = componentHealth(aman.HealthReady, "", updatedAt)
 }
 
 func (s *Service) reconcileAirport(ctx context.Context, airport string) error {

--- a/backend/internal/aman/operational/service_test.go
+++ b/backend/internal/aman/operational/service_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"FlightStrips/internal/aman"
-	"FlightStrips/internal/aman/materializer"
 	"FlightStrips/internal/aman/navdata"
 	"FlightStrips/internal/aman/predictor"
 	"FlightStrips/internal/aman/sequence"
@@ -475,20 +474,17 @@ func TestOffRouteFallbackReasonLowersPredictionConfidenceWithoutHidingWaypoint(t
 	require.Empty(t, offRouteFallbackReason([]string{"OFF_ROUTE"}))
 }
 
-func TestFailedNavigationRefreshRetriesAndHealthFailsClosed(t *testing.T) {
+func TestNavigationHealthFailsClosedWhenNoActiveCacheSnapshotExists(t *testing.T) {
 	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
-	navigation := &countingNavigation{}
 	service, err := New(Dependencies{
-		Repository: &memoryRepository{}, Materializer: navigation, Geometry: unavailableGeometry{}, Wind: unavailableWind{},
+		Repository: &memoryRepository{}, Materializer: unavailableNavigation{}, Geometry: unavailableGeometry{}, Wind: unavailableWind{},
 		Publisher: &recordingPublisher{}, Terminal: terminal.Configuration{Airport: "EKCH", ConfigVersion: "test", RunwayGroups: []terminal.RunwayGroup{{ID: "ARRIVAL-22"}}},
 		Airports: []string{"EKCH"}, Mode: aman.ModeAuthoritative, Now: func() time.Time { return now },
 	})
 	require.NoError(t, err)
 	require.False(t, service.TechnicalHealth(context.Background()).AuthorityAllowed)
 	require.NoError(t, service.ObserveSourceHealth(context.Background(), aman.DataFresh, now))
-	require.Error(t, service.refreshNavigation(context.Background(), "EKCH"))
-	require.Error(t, service.refreshNavigation(context.Background(), "EKCH"))
-	require.Equal(t, 2, navigation.attempts)
+	service.observeNavigationCache(context.Background(), "EKCH")
 	health := service.TechnicalHealth(context.Background())
 	require.Equal(t, aman.HealthReady, health.VATSIM.Status)
 	require.Equal(t, aman.HealthUnavailable, health.Navigation.Status)
@@ -605,26 +601,12 @@ func (p *recordingPublisher) PublishAMANState(_ context.Context, state aman.Airp
 
 type unavailableNavigation struct{}
 
-func (unavailableNavigation) Refresh(context.Context, materializer.Request) error {
-	return errors.New("offline")
-}
 func (unavailableNavigation) MaterializeRoute(context.Context, navdata.RouteQuery, string) (navdata.RouteKey, error) {
-	return "", errors.New("offline")
-}
-
-type countingNavigation struct{ attempts int }
-
-func (n *countingNavigation) Refresh(context.Context, materializer.Request) error {
-	n.attempts++
-	return errors.New("offline")
-}
-func (*countingNavigation) MaterializeRoute(context.Context, navdata.RouteQuery, string) (navdata.RouteKey, error) {
 	return "", errors.New("offline")
 }
 
 type readyNavigation struct{}
 
-func (readyNavigation) Refresh(context.Context, materializer.Request) error { return nil }
 func (readyNavigation) MaterializeRoute(context.Context, navdata.RouteQuery, string) (navdata.RouteKey, error) {
 	return "", errors.New("not implemented")
 }

--- a/backend/internal/aman/runtime.go
+++ b/backend/internal/aman/runtime.go
@@ -12,11 +12,6 @@ import (
 const (
 	defaultReconciliationInterval = time.Minute
 	defaultSurveillanceInterval   = 15 * time.Second
-
-	// NavigationAdapterAIRACNet is the approved navigation-data adapter. Its
-	// implementation belongs to the navigation task; this package only names
-	// the configured boundary.
-	NavigationAdapterAIRACNet = "airacnet"
 )
 
 var airportIdentifier = regexp.MustCompile(`^[A-Z]{4}$`)
@@ -29,8 +24,6 @@ type RuntimeConfig struct {
 	Mode                        RolloutMode
 	ReconciliationInterval      time.Duration
 	SurveillanceInterval        time.Duration
-	TerminalGeometryPath        string
-	NavigationSourceAdapter     string
 	EnableEuroScopeGainLoseTags bool
 }
 
@@ -62,8 +55,6 @@ func (c RuntimeConfig) normalize() RuntimeConfig {
 	c.Mode = RolloutMode(strings.ToLower(strings.TrimSpace(string(c.Mode))))
 	c.EnabledAirports = normalizeAirports(c.EnabledAirports)
 	c.FMPRoles = normalizeRoles(c.FMPRoles)
-	c.TerminalGeometryPath = strings.TrimSpace(c.TerminalGeometryPath)
-	c.NavigationSourceAdapter = strings.ToLower(strings.TrimSpace(c.NavigationSourceAdapter))
 	return c
 }
 
@@ -108,20 +99,11 @@ func (c RuntimeConfig) Validate() error {
 		}
 		seenAirports[airport] = struct{}{}
 	}
-	if c.NavigationSourceAdapter != "" && !isSupportedNavigationAdapter(c.NavigationSourceAdapter) {
-		return fmt.Errorf("AMAN navigation source adapter %q is unsupported", c.NavigationSourceAdapter)
-	}
 	if c.Mode == ModeDisabled {
 		return nil
 	}
 	if len(c.EnabledAirports) == 0 {
 		return fmt.Errorf("AMAN enabled airports are required when mode is %q", c.Mode)
-	}
-	if !isSupportedNavigationAdapter(c.NavigationSourceAdapter) {
-		return fmt.Errorf("AMAN navigation source adapter %q is unsupported", c.NavigationSourceAdapter)
-	}
-	if strings.TrimSpace(c.TerminalGeometryPath) == "" {
-		return fmt.Errorf("AMAN terminal geometry path is required when enabled")
 	}
 	return nil
 }
@@ -170,10 +152,6 @@ func nonEmpty(values []string) []string {
 		}
 	}
 	return result
-}
-
-func isSupportedNavigationAdapter(value string) bool {
-	return strings.EqualFold(strings.TrimSpace(value), NavigationAdapterAIRACNet)
 }
 
 // Component is a narrow constructor-time seam. The owning persistence,

--- a/backend/internal/aman/runtime_test.go
+++ b/backend/internal/aman/runtime_test.go
@@ -35,12 +35,10 @@ func (w *runtimeTestWorker) Run(ctx context.Context, interval time.Duration) {
 
 func validRuntimeConfig(mode RolloutMode) RuntimeConfig {
 	return RuntimeConfig{
-		Mode:                    mode,
-		EnabledAirports:         []string{"EKCH"},
-		TerminalGeometryPath:    "testdata/terminal.geojson",
-		NavigationSourceAdapter: NavigationAdapterAIRACNet,
-		ReconciliationInterval:  3 * time.Second,
-		SurveillanceInterval:    4 * time.Second,
+		Mode:                   mode,
+		EnabledAirports:        []string{"EKCH"},
+		ReconciliationInterval: 3 * time.Second,
+		SurveillanceInterval:   4 * time.Second,
 	}
 }
 
@@ -94,8 +92,6 @@ func TestRuntimeRejectsInvalidConfiguration(t *testing.T) {
 		{"duplicate FMP role", func(c *RuntimeConfig) { c.FMPRoles = []string{" EKCH_FMH ", "ekch_fmh"} }, "unique"},
 		{"reconciliation timing", func(c *RuntimeConfig) { c.ReconciliationInterval = -time.Second }, "reconciliation interval"},
 		{"surveillance timing", func(c *RuntimeConfig) { c.SurveillanceInterval = -time.Second }, "surveillance interval"},
-		{"source adapter", func(c *RuntimeConfig) { c.NavigationSourceAdapter = "other" }, "source adapter"},
-		{"geometry", func(c *RuntimeConfig) { c.TerminalGeometryPath = "" }, "geometry path"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -104,11 +100,6 @@ func TestRuntimeRejectsInvalidConfiguration(t *testing.T) {
 			require.ErrorContains(t, config.Validate(), test.want)
 		})
 	}
-}
-
-func TestDisabledRuntimeRejectsAnExplicitInvalidSourceAdapter(t *testing.T) {
-	err := (RuntimeConfig{NavigationSourceAdapter: "other"}).Validate()
-	require.ErrorContains(t, err, "source adapter")
 }
 
 func TestRuntimeRequiresExplicitDependenciesWhenEnabled(t *testing.T) {
@@ -140,19 +131,15 @@ func TestRuntimeStoresNormalizedConfiguration(t *testing.T) {
 	config.Mode = " SHADOW "
 	config.EnabledAirports = []string{" ekch ", "ekrn"}
 	config.FMPRoles = []string{" ekch_fmh ", "ekdk_v_ctr"}
-	config.NavigationSourceAdapter = " AIRACNET "
-	config.TerminalGeometryPath = " testdata/terminal.geojson "
 
 	runtime, err := NewRuntime(config, runtimeTestDependencies())
 	require.NoError(t, err)
 	require.Equal(t, RuntimeConfig{
-		Mode:                    ModeShadow,
-		EnabledAirports:         []string{"EKCH", "EKRN"},
-		FMPRoles:                []string{"EKCH_FMH", "EKDK_V_CTR"},
-		ReconciliationInterval:  3 * time.Second,
-		SurveillanceInterval:    4 * time.Second,
-		TerminalGeometryPath:    "testdata/terminal.geojson",
-		NavigationSourceAdapter: NavigationAdapterAIRACNet,
+		Mode:                   ModeShadow,
+		EnabledAirports:        []string{"EKCH", "EKRN"},
+		FMPRoles:               []string{"EKCH_FMH", "EKDK_V_CTR"},
+		ReconciliationInterval: 3 * time.Second,
+		SurveillanceInterval:   4 * time.Second,
 	}, runtime.Config())
 }
 

--- a/backend/internal/app/aman_assembly.go
+++ b/backend/internal/app/aman_assembly.go
@@ -7,13 +7,12 @@ import (
 	"sync"
 
 	"FlightStrips/internal/aman"
-	"FlightStrips/internal/aman/materializer"
-	"FlightStrips/internal/aman/navdata/airacnet"
 	"FlightStrips/internal/aman/operational"
 	"FlightStrips/internal/aman/predictor/openmeteo"
 	"FlightStrips/internal/aman/sequence"
 	"FlightStrips/internal/aman/terminal"
 	internalFrontend "FlightStrips/internal/frontend"
+	"FlightStrips/internal/navigation"
 	"FlightStrips/internal/repository/postgres"
 	events "FlightStrips/pkg/events/frontend"
 
@@ -24,7 +23,6 @@ type operationalAMANAssembly struct {
 	dependencies aman.Dependencies
 	commands     aman.CommandService
 	transport    *amanTransport
-	terminal     terminal.Configuration
 }
 
 type amanTransport struct {
@@ -68,11 +66,11 @@ func (p *amanTransport) PublishAMANState(ctx context.Context, state aman.Airport
 	return nil
 }
 
-func assembleOperationalAMAN(config aman.RuntimeConfig, pool *pgxpool.Pool) (operationalAMANAssembly, error) {
-	terminalConfig, err := terminal.LoadFile(config.TerminalGeometryPath)
-	if err != nil {
-		return operationalAMANAssembly{}, fmt.Errorf("load AMAN terminal configuration: %w", err)
+func assembleOperationalAMAN(config aman.RuntimeConfig, source *navigation.Source, pool *pgxpool.Pool) (operationalAMANAssembly, error) {
+	if source == nil {
+		return operationalAMANAssembly{}, fmt.Errorf("AMAN requires an enabled navigation source")
 	}
+	terminalConfig := source.Terminal
 	if err := terminalConfig.ValidateOperationalSettings(); err != nil {
 		return operationalAMANAssembly{}, fmt.Errorf("validate AMAN terminal operational settings: %w", err)
 	}
@@ -80,21 +78,9 @@ func assembleOperationalAMAN(config aman.RuntimeConfig, pool *pgxpool.Pool) (ope
 		return operationalAMANAssembly{}, err
 	}
 	repository := postgres.NewAMANRepository(pool)
-	cache := postgres.NewNavigationCache(pool)
-	source, err := airacnet.New(airacnet.Config{Checkpoints: airacnet.NewPostgresCheckpoints(pool)})
-	if err != nil {
-		return operationalAMANAssembly{}, fmt.Errorf("initialize AIRAC.NET adapter: %w", err)
-	}
-	navigation, err := materializer.New(materializer.Dependencies{
-		Cycles: source, Airports: source, Runways: terminalConfig, Procedures: source, Fixes: source, Routes: source,
-		Cache: cache, Terminal: terminalConfig,
-	})
-	if err != nil {
-		return operationalAMANAssembly{}, fmt.Errorf("initialize AMAN navigation materializer: %w", err)
-	}
 	transport := &amanTransport{repository: repository, mode: config.Mode}
 	service, err := operational.New(operational.Dependencies{
-		Repository: repository, Retirer: repository, Materializer: navigation, Geometry: cache, Wind: openmeteo.New(openmeteo.Config{Cache: postgres.NewAMANWeatherCache(pool)}),
+		Repository: repository, Retirer: repository, Materializer: source, Geometry: source.Geometry, Wind: openmeteo.New(openmeteo.Config{Cache: postgres.NewAMANWeatherCache(pool)}),
 		Terminal: terminalConfig, Airports: config.EnabledAirports, Mode: config.Mode, Publisher: transport,
 	})
 	if err != nil {
@@ -112,9 +98,9 @@ func assembleOperationalAMAN(config aman.RuntimeConfig, pool *pgxpool.Pool) (ope
 		return operationalAMANAssembly{}, fmt.Errorf("initialize AMAN action service: %w", err)
 	}
 	return operationalAMANAssembly{
-		commands: actions, transport: transport, terminal: terminalConfig,
+		commands: actions, transport: transport,
 		dependencies: aman.Dependencies{
-			Repositories: repository, NavigationMaterializer: navigation, NavigationReader: cache,
+			Repositories: repository, NavigationMaterializer: source, NavigationReader: source.Geometry,
 			Predictor: service, StateEngine: service, SequenceService: actions, Publisher: transport,
 			ValidationService: service, HealthService: service, ObservationSink: service, ReconciliationWorker: service,
 		},

--- a/backend/internal/app/aman_runtime_test.go
+++ b/backend/internal/app/aman_runtime_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"FlightStrips/internal/aman"
+	"FlightStrips/internal/navigation"
 	"FlightStrips/internal/services"
 	"context"
 	"os"
@@ -54,16 +55,16 @@ func amanAppTestDependencies() aman.Dependencies {
 	}
 }
 
-func TestValidateAMANTerminalGeometry(t *testing.T) {
+func TestValidateNavigationTerminalGeometry(t *testing.T) {
 	tempFile, err := os.CreateTemp(t.TempDir(), "terminal-*.geojson")
 	require.NoError(t, err)
 	require.NoError(t, tempFile.Close())
 
-	require.NoError(t, validateAMANTerminalGeometry(aman.RuntimeConfig{}))
-	require.NoError(t, validateAMANTerminalGeometry(aman.RuntimeConfig{Mode: aman.ModeShadow, TerminalGeometryPath: tempFile.Name()}))
-	require.ErrorContains(t, validateAMANTerminalGeometry(aman.RuntimeConfig{Mode: aman.ModeShadow, TerminalGeometryPath: t.TempDir()}), "must name a file")
-	require.ErrorContains(t, validateAMANTerminalGeometry(aman.RuntimeConfig{Mode: aman.ModeShadow, TerminalGeometryPath: "missing.geojson"}), "terminal geometry path")
-	require.ErrorContains(t, validateAMANTerminalGeometry(aman.RuntimeConfig{TerminalGeometryPath: "missing.geojson"}), "terminal geometry path")
+	require.NoError(t, validateNavigationTerminalGeometry(navigation.Config{}))
+	require.NoError(t, validateNavigationTerminalGeometry(navigation.Config{Source: navigation.SourceAIRACNet, TerminalGeometryPath: tempFile.Name()}))
+	require.ErrorContains(t, validateNavigationTerminalGeometry(navigation.Config{Source: navigation.SourceAIRACNet, TerminalGeometryPath: t.TempDir()}), "must name a file")
+	require.ErrorContains(t, validateNavigationTerminalGeometry(navigation.Config{Source: navigation.SourceAIRACNet, TerminalGeometryPath: "missing.geojson"}), "terminal geometry path")
+	require.ErrorContains(t, validateNavigationTerminalGeometry(navigation.Config{TerminalGeometryPath: "missing.geojson"}), "requires a navigation source")
 }
 
 func TestApplicationConfigDefaultsAMANToDisabled(t *testing.T) {
@@ -72,13 +73,8 @@ func TestApplicationConfigDefaultsAMANToDisabled(t *testing.T) {
 }
 
 func TestBuildRejectsAuthoritativeAMANWithoutTypedCommandService(t *testing.T) {
-	geometry, err := os.CreateTemp(t.TempDir(), "terminal-*.geojson")
-	require.NoError(t, err)
-	require.NoError(t, geometry.Close())
-
-	_, err = Build(context.Background(), Config{AMAN: aman.RuntimeConfig{
+	_, err := Build(context.Background(), Config{AMAN: aman.RuntimeConfig{
 		Mode: aman.ModeAuthoritative, EnabledAirports: []string{"EKCH"},
-		TerminalGeometryPath: geometry.Name(), NavigationSourceAdapter: aman.NavigationAdapterAIRACNet,
 	}}, Dependencies{AMAN: amanAppTestDependencies()})
 
 	require.EqualError(t, err, "initialize AMAN commands: authoritative runtime requires typed command service")
@@ -90,9 +86,6 @@ func TestBuildAddsAMANWorkersOnlyWhenEnabled(t *testing.T) {
 	dbPool, err := pgxpool.NewWithConfig(context.Background(), poolConfig)
 	require.NoError(t, err)
 	t.Cleanup(dbPool.Close)
-	geometry, err := os.CreateTemp(t.TempDir(), "terminal-*.geojson")
-	require.NoError(t, err)
-	require.NoError(t, geometry.Close())
 	amanDeps := amanAppTestDependencies()
 
 	application, err := Build(context.Background(), Config{
@@ -107,12 +100,7 @@ func TestBuildAddsAMANWorkersOnlyWhenEnabled(t *testing.T) {
 		EnableVATSIM:         true,
 		EnableTraffic:        false,
 		EnableDBSeed:         false,
-		AMAN: aman.RuntimeConfig{
-			Mode:                    aman.ModeShadow,
-			EnabledAirports:         []string{"EKCH"},
-			TerminalGeometryPath:    geometry.Name(),
-			NavigationSourceAdapter: aman.NavigationAdapterAIRACNet,
-		},
+		AMAN:                 aman.RuntimeConfig{Mode: aman.ModeShadow, EnabledAirports: []string{"EKCH"}},
 	}, Dependencies{
 		DBPool:                dbPool,
 		AuthenticationService: services.NewTestAuthenticationService(),

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -4,6 +4,7 @@ import (
 	"FlightStrips/internal/alb"
 	"FlightStrips/internal/aman"
 	"FlightStrips/internal/aman/navdata"
+	"FlightStrips/internal/aman/terminal"
 	amanWebAPI "FlightStrips/internal/aman/webapi"
 	"FlightStrips/internal/cdm"
 	appconfig "FlightStrips/internal/config"
@@ -14,6 +15,7 @@ import (
 	"FlightStrips/internal/euroscope"
 	"FlightStrips/internal/frontend"
 	"FlightStrips/internal/metar"
+	"FlightStrips/internal/navigation"
 	"FlightStrips/internal/pdc"
 	"FlightStrips/internal/pilot"
 	"FlightStrips/internal/repository"
@@ -86,7 +88,8 @@ type Config struct {
 	StandAssignmentBlockExtension time.Duration
 	StandAssignmentSweepInterval  time.Duration
 
-	AMAN aman.RuntimeConfig
+	AMAN       aman.RuntimeConfig
+	Navigation navigation.Config
 }
 
 type Dependencies struct {
@@ -112,10 +115,11 @@ type App struct {
 
 func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	cfg = cfg.withDefaults()
+	cfg.Navigation = cfg.Navigation.Normalize()
 	if cfg.EnableTestTools && isLiveEnvironment(cfg.Environment) {
 		return nil, errors.New("ENABLE_TEST_TOOLS cannot be enabled in a live environment")
 	}
-	if err := validateAMANTerminalGeometry(cfg.AMAN); err != nil {
+	if err := validateNavigationTerminalGeometry(cfg.Navigation); err != nil {
 		return nil, err
 	}
 	if err := cfg.AMAN.Validate(); err != nil {
@@ -197,9 +201,16 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	pdcFrequencyProviders := transports.pdcFrequencyProviders
 
 	amanDependencies := deps.AMAN
+	navigationSource, err := navigation.Assemble(cfg.Navigation, dbpool)
+	if err != nil {
+		if closeDB {
+			dbpool.Close()
+		}
+		return nil, fmt.Errorf("initialize navigation source: %w", err)
+	}
 	var defaultAMAN operationalAMANAssembly
 	if amanEnabled && amanDependencies.ObservationSink == nil {
-		defaultAMAN, err = assembleOperationalAMAN(cfg.AMAN, dbpool)
+		defaultAMAN, err = assembleOperationalAMAN(cfg.AMAN, navigationSource, dbpool)
 		if err != nil {
 			if closeDB {
 				dbpool.Close()
@@ -233,6 +244,11 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	}
 	var amanAPI *amanWebAPI.WebAPI
 	var efbNavigation navdata.GeometrySnapshotReader
+	var efbTerminal terminal.Configuration
+	if navigationSource != nil {
+		efbNavigation = navigationSource.Geometry
+		efbTerminal = navigationSource.Terminal
+	}
 	if stateReader, ok := amanDependencies.Repositories.(aman.AirportStateReader); ok && amanEnabled {
 		amanAPI = amanWebAPI.New(authService, stateReader)
 		if geometry, geometryOK := amanDependencies.NavigationReader.(navdata.GeometryReader); geometryOK {
@@ -241,8 +257,10 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 			}
 		}
 	}
-	if snapshots, ok := amanDependencies.NavigationReader.(navdata.GeometrySnapshotReader); ok {
-		efbNavigation = snapshots
+	if efbNavigation == nil {
+		if snapshots, ok := amanDependencies.NavigationReader.(navdata.GeometrySnapshotReader); ok {
+			efbNavigation = snapshots
+		}
 	}
 	realtime, err := assembleRealtime(stripService, controllerService, authService, amanStateProvider, amanCommands, cfg.AMAN.FMPRoles, amanRuntime.Ownership().ControllerMutationAuthorized)
 	if err != nil {
@@ -454,7 +472,7 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 			efbAPI: efb.NewWebAPI(efb.WebAPIConfig{
 				Auth: authService, Callsigns: vatsimGraph.source, Flights: efbFlightFinder, Sessions: sessionRepo,
 				Assignments: standAssignmentRepo, CDM: cdmService, CDMReady: sequenceService != nil,
-				Stands: standActionService, ATIS: metarPoller, Departures: fsServer, PDCReady: pdcService != nil, Live: requireLiveCIDVerification, Terminal: defaultAMAN.terminal, Navigation: efbNavigation,
+				Stands: standActionService, ATIS: metarPoller, Departures: fsServer, PDCReady: pdcService != nil, Live: requireLiveCIDVerification, Terminal: efbTerminal, Navigation: efbNavigation,
 			}),
 			sessionRepo:                sessionRepo,
 			sequenceService:            sequenceService,
@@ -479,6 +497,9 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 	}
 
 	app.addWorker(cdmService.Start)
+	if navigationSource != nil {
+		app.addWorker(navigationSource.Start)
+	}
 	app.addWorker(fsServer.StartSessionMonitor)
 	app.addWorker(frontendHub.Run)
 	app.addWorker(euroscopeHub.Run)
@@ -664,20 +685,20 @@ func (a *App) AMANRuntime() *aman.Runtime {
 	return a.amanRuntime
 }
 
-func validateAMANTerminalGeometry(config aman.RuntimeConfig) error {
-	path := strings.TrimSpace(config.TerminalGeometryPath)
-	if (config.Mode == "" || config.Mode == aman.ModeDisabled) && path == "" {
-		return nil
+func validateNavigationTerminalGeometry(config navigation.Config) error {
+	if err := config.Validate(); err != nil {
+		return err
 	}
-	if path == "" {
-		return fmt.Errorf("AMAN terminal geometry path is required when enabled")
+	path := config.TerminalGeometryPath
+	if !config.Enabled() {
+		return nil
 	}
 	info, err := os.Stat(path)
 	if err != nil {
-		return fmt.Errorf("AMAN terminal geometry path %q: %w", path, err)
+		return fmt.Errorf("navigation terminal geometry path %q: %w", path, err)
 	}
 	if info.IsDir() {
-		return fmt.Errorf("AMAN terminal geometry path %q must name a file", path)
+		return fmt.Errorf("navigation terminal geometry path %q must name a file", path)
 	}
 	return nil
 }

--- a/backend/internal/app/app_test.go
+++ b/backend/internal/app/app_test.go
@@ -1,11 +1,13 @@
 package app
 
 import (
+	"FlightStrips/internal/navigation"
 	"FlightStrips/internal/pdc"
 	"FlightStrips/internal/services"
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -194,6 +196,39 @@ func TestBuildGatesEFBAPIBehindFeatureFlag(t *testing.T) {
 	enabled := httptest.NewRecorder()
 	build(true).Handler().ServeHTTP(enabled, httptest.NewRequest(http.MethodGet, "/api/efb/me", nil))
 	require.Equal(t, http.StatusUnauthorized, enabled.Code)
+}
+
+func TestBuildStartsNavigationSourceForEFBWithoutAMAN(t *testing.T) {
+	poolConfig, err := pgxpool.ParseConfig("postgres://user:password@127.0.0.1:1/test")
+	require.NoError(t, err)
+	dbPool, err := pgxpool.NewWithConfig(context.Background(), poolConfig)
+	require.NoError(t, err)
+	t.Cleanup(dbPool.Close)
+	terminalPath, err := filepath.Abs("../../config/aman/ekch-terminal-2607.json")
+	require.NoError(t, err)
+
+	application, err := Build(context.Background(), Config{
+		Environment:          "test",
+		EnableEFB:            true,
+		EnableCDMConfigStore: false,
+		EnablePDC:            false,
+		EnableECFMP:          false,
+		EnableECFMPAPI:       false,
+		EnablePilotAPI:       false,
+		EnableALB:            false,
+		EnableMetar:          false,
+		EnableVATSIM:         false,
+		EnableTraffic:        false,
+		EnableDBSeed:         false,
+		Navigation: navigation.Config{
+			Source: navigation.SourceAIRACNet, TerminalGeometryPath: terminalPath,
+		},
+	}, Dependencies{DBPool: dbPool, AuthenticationService: services.NewTestAuthenticationService()})
+
+	require.NoError(t, err)
+	require.False(t, application.AMANRuntime().Enabled())
+	// The navigation source adds its own cache-refresh worker; AMAN stays off.
+	require.Len(t, application.workers, 5)
 }
 
 func TestBuildRejectsTestToolsInLiveEnvironmentBeforeOpeningDatabase(t *testing.T) {

--- a/backend/internal/navigation/config.go
+++ b/backend/internal/navigation/config.go
@@ -1,0 +1,43 @@
+// Package navigation configures the independently deployable navigation-data
+// source used by flight-facing features and AMAN.
+package navigation
+
+import (
+	"fmt"
+	"strings"
+)
+
+const SourceAIRACNet = "airacnet"
+
+// Config identifies the navigation provider and the airport terminal
+// configuration it materializes. Its zero value deliberately disables the
+// navigation source without affecting AMAN's rollout setting.
+type Config struct {
+	Source               string
+	TerminalGeometryPath string
+}
+
+func (c Config) Normalize() Config {
+	c.Source = strings.ToLower(strings.TrimSpace(c.Source))
+	c.TerminalGeometryPath = strings.TrimSpace(c.TerminalGeometryPath)
+	return c
+}
+
+func (c Config) Enabled() bool { return c.Normalize().Source != "" }
+
+func (c Config) Validate() error {
+	c = c.Normalize()
+	if c.Source == "" {
+		if c.TerminalGeometryPath != "" {
+			return fmt.Errorf("navigation terminal geometry path requires a navigation source")
+		}
+		return nil
+	}
+	if c.Source != SourceAIRACNet {
+		return fmt.Errorf("navigation source %q is unsupported", c.Source)
+	}
+	if c.TerminalGeometryPath == "" {
+		return fmt.Errorf("navigation terminal geometry path is required when navigation is enabled")
+	}
+	return nil
+}

--- a/backend/internal/navigation/config_test.go
+++ b/backend/internal/navigation/config_test.go
@@ -1,0 +1,22 @@
+package navigation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigAllowsNavigationToRemainDisabled(t *testing.T) {
+	require.NoError(t, (Config{}).Validate())
+}
+
+func TestConfigNormalizesAndValidatesAIRACNet(t *testing.T) {
+	config := Config{Source: " AIRACNET ", TerminalGeometryPath: " terminal.json "}.Normalize()
+	require.Equal(t, Config{Source: SourceAIRACNet, TerminalGeometryPath: "terminal.json"}, config)
+	require.NoError(t, config.Validate())
+}
+
+func TestConfigRequiresSourceAndTerminalGeometryTogether(t *testing.T) {
+	require.ErrorContains(t, (Config{TerminalGeometryPath: "terminal.json"}).Validate(), "requires a navigation source")
+	require.ErrorContains(t, (Config{Source: SourceAIRACNet}).Validate(), "terminal geometry path")
+}

--- a/backend/internal/navigation/source.go
+++ b/backend/internal/navigation/source.go
@@ -1,0 +1,81 @@
+package navigation
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"FlightStrips/internal/aman"
+	"FlightStrips/internal/aman/materializer"
+	"FlightStrips/internal/aman/navdata"
+	"FlightStrips/internal/aman/navdata/airacnet"
+	"FlightStrips/internal/aman/terminal"
+	"FlightStrips/internal/repository/postgres"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const refreshInterval = 6 * time.Hour
+
+// GeometryCache is the cache-only view shared by AMAN and flight-facing
+// consumers. It never exposes provider acquisition methods.
+type GeometryCache interface {
+	aman.Component
+	navdata.GeometryReader
+	navdata.GeometrySnapshotReader
+}
+
+// Source is the assembled provider, canonical cache, and terminal data for a
+// single airport. AMAN may consume it, but does not own its lifecycle.
+type Source struct {
+	Materializer *materializer.Materializer
+	Geometry     GeometryCache
+	Terminal     terminal.Configuration
+}
+
+func Assemble(config Config, pool *pgxpool.Pool) (*Source, error) {
+	config = config.Normalize()
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+	if !config.Enabled() {
+		return nil, nil
+	}
+	terminalConfig, err := terminal.LoadFile(config.TerminalGeometryPath)
+	if err != nil {
+		return nil, fmt.Errorf("load navigation terminal configuration: %w", err)
+	}
+	source, err := airacnet.New(airacnet.Config{Checkpoints: airacnet.NewPostgresCheckpoints(pool)})
+	if err != nil {
+		return nil, fmt.Errorf("initialize AIRAC.NET navigation source: %w", err)
+	}
+	cache := postgres.NewNavigationCache(pool)
+	importer, err := materializer.New(materializer.Dependencies{
+		Cycles: source, Airports: source, Runways: terminalConfig, Procedures: source, Fixes: source, Routes: source,
+		Cache: cache, Terminal: terminalConfig,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("initialize navigation materializer: %w", err)
+	}
+	return &Source{Materializer: importer, Geometry: cache, Terminal: terminalConfig}, nil
+}
+
+func (*Source) Name() string { return "navigation source" }
+
+// MaterializeRoute delegates on-demand route imports to the configured source.
+// AMAN consumes this provider boundary rather than owning a second importer.
+func (s *Source) MaterializeRoute(ctx context.Context, query navdata.RouteQuery, resolverVersion string) (navdata.RouteKey, error) {
+	if s == nil || s.Materializer == nil {
+		return "", fmt.Errorf("navigation source is unavailable")
+	}
+	return s.Materializer.MaterializeRoute(ctx, query, resolverVersion)
+}
+
+// Start refreshes the configured airport immediately and then periodically so
+// non-AMAN clients can read an active geometry snapshot from the cache.
+func (s *Source) Start(ctx context.Context) {
+	if s == nil || s.Materializer == nil || s.Terminal.Airport == "" {
+		return
+	}
+	s.Materializer.Run(ctx, refreshInterval, []navdata.AirportID{s.Terminal.Airport})
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -45,6 +45,9 @@ services:
       ENABLE_TEST_TOOLS: "false"
       # Release EFB code disabled until the authenticated pilot surface is ready.
       ENABLE_EFB: ${ENABLE_EFB:-false}
+      # Navigation data is independently available to the EFB and AMAN.
+      NAVIGATION_SOURCE: ${NAVIGATION_SOURCE:-}
+      NAVIGATION_TERMINAL_GEOMETRY_PATH: ${NAVIGATION_TERMINAL_GEOMETRY_PATH:-}
       # Local-only Go heap and goroutine profiling. It listens on 127.0.0.1:6060
       # inside the backend container and is disabled unless explicitly enabled.
       ENABLE_PPROF: ${ENABLE_PPROF:-false}


### PR DESCRIPTION
## Summary

- add a shared, independently configured AIRAC.NET navigation source and cache-refresh worker
- supply EFB published-arrival data from that source without enabling AMAN
- make AMAN consume the shared navigation provider and cache rather than owning a separate configuration or periodic refresh loop
- replace AMAN-scoped navigation environment variables with `NAVIGATION_SOURCE` and `NAVIGATION_TERMINAL_GEOMETRY_PATH`

## Why

The EFB needs navigation-derived arrival information even when AMAN is disabled. A single navigation source avoids duplicate materializers and competing manifest refreshes.

## Operator impact

Configure the backend with `NAVIGATION_SOURCE=airacnet` and `NAVIGATION_TERMINAL_GEOMETRY_PATH=/app/config/aman/ekch-terminal-2607.json`. AMAN can remain disabled; when enabled, it uses this same source.

## Validation

`go test ./internal/aman/operational ./internal/aman ./internal/navigation ./internal/app ./cmd/server`