### PR TITLE
feat(sat): improve stand assignment status

### DIFF
--- a/backend/.env.dev
+++ b/backend/.env.dev
@@ -1,2 +1,21 @@
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+
+# AMAN remains disabled until the application assembles its concrete runtime
+# dependencies. Keep the Copenhagen configuration below ready for that rollout.
+# Run the backend from backend/ so this relative path resolves to the checked-in
+# terminal configuration.
+AMAN_MODE=shadow
+AMAN_ENABLED_AIRPORTS=EKCH
+AMAN_RECONCILIATION_INTERVAL=15s
+AMAN_SURVEILLANCE_INTERVAL=15s
+ENABLE_AMAN_EUROSCOPE_GAIN_LOSE_TAGS=false
+
+ENABLE_EFB=true
+
+NAVIGATION_TERMINAL_GEOMETRY_PATH=config/aman/ekch-terminal-2607.json
+NAVIGATION_SOURCE=airacnet
+
+# Enable the Stand Assignment Tool for local development. Pilot-facing
+# EuroScope messages remain disabled unless explicitly enabled separately.
+ENABLE_STAND_ASSIGNMENT=true

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -475,9 +475,11 @@ func Build(ctx context.Context, cfg Config, deps Dependencies) (*App, error) {
 				Stands: standActionService, ATIS: metarPoller, Departures: fsServer, PDCReady: pdcService != nil, Live: requireLiveCIDVerification, Terminal: efbTerminal, Navigation: efbNavigation,
 			}),
 			sessionRepo:                sessionRepo,
+			stripRepo:                  stripRepo,
 			sequenceService:            sequenceService,
 			vatsimSource:               vatsimGraph.source,
 			standAssignmentRepo:        standAssignmentRepo,
+			standActionService:         standActionService,
 			standAssignmentReadiness:   standAssignmentReadiness,
 			standAssignmentDiagnostics: standAssignmentDiagnostics(),
 			standAssignmentFailures:    standAssignmentFailures,
@@ -934,9 +936,11 @@ type buildHandlerConfig struct {
 	amanAPI                    *amanWebAPI.WebAPI
 	efbAPI                     *efb.WebAPI
 	sessionRepo                repository.SessionRepository
+	stripRepo                  repository.StripRepository
 	sequenceService            *cdm.SequenceService
 	vatsimSource               vatsim.FlightSource
 	standAssignmentRepo        repository.StandAssignmentRepository
+	standActionService         *services.StandActionService
 	standAssignmentReadiness   appconfig.StandAssignmentReadiness
 	standAssignmentDiagnostics standstatus.WebAPIDiagnostics
 	standAssignmentFailures    *standdiagnostics.AllocationFailureLog
@@ -968,11 +972,11 @@ func buildHandler(cfg buildHandlerConfig) http.Handler {
 
 	apiMux := http.NewServeMux()
 	standstatus.NewWebAPI(standstatus.WebAPIConfig{
-		Auth: cfg.authService, Sessions: cfg.sessionRepo, Assignments: cfg.standAssignmentRepo,
+		Auth: cfg.authService, Sessions: cfg.sessionRepo, Assignments: cfg.standAssignmentRepo, Strips: cfg.stripRepo,
 		Feed: cfg.vatsimSource, Enabled: cfg.standAssignmentReadiness.Enabled,
 		Ready: cfg.standAssignmentReadiness.Ready, Reason: cfg.standAssignmentReadiness.Reason,
 		StaleAfter: cfg.standAssignmentStaleAfter, Diagnostics: cfg.standAssignmentDiagnostics,
-		Failures: cfg.standAssignmentFailures,
+		Failures: cfg.standAssignmentFailures, Previewer: cfg.standActionService,
 	}).RegisterRoutes(apiMux)
 	if cfg.enableCDMAPI {
 		cdm.NewWebAPI(cfg.authService, cfg.sessionRepo, cfg.sequenceService).RegisterRoutes(apiMux)

--- a/backend/internal/sat/airline_assignment.go
+++ b/backend/internal/sat/airline_assignment.go
@@ -153,6 +153,28 @@ type StandSelection struct {
 	FallbackUsed     bool
 }
 
+// StandSelectionCandidate explains one configured stand option for an
+// allocation preview. Selectable is true only for the first eligible tier,
+// because later tiers are considered only when every earlier tier is empty.
+type StandSelectionCandidate struct {
+	Stand            string  `json:"stand"`
+	RuleID           string  `json:"rule_id"`
+	Tier             int     `json:"tier"`
+	TierName         string  `json:"tier_name"`
+	OriginalWeight   float64 `json:"original_weight"`
+	NormalizedWeight float64 `json:"normalized_weight"`
+	FallbackUsed     bool    `json:"fallback_used"`
+	Selectable       bool    `json:"selectable"`
+}
+
+// StandSelectionPreview is a deterministic explanation of the policy path
+// for a set of already compatible and available stands.
+type StandSelectionPreview struct {
+	RuleID       string                    `json:"rule_id"`
+	FallbackUsed bool                      `json:"fallback_used"`
+	Candidates   []StandSelectionCandidate `json:"candidates"`
+}
+
 // LoadAirlineAssignment strictly decodes and validates an airline assignment
 // document against the physical stand registry. SAT must not become ready
 // without this registry because physical stand references are part of the
@@ -740,6 +762,162 @@ func (c *AirlineAssignmentConfig) SelectStand(facts AssignmentFlightFacts, eligi
 	}
 
 	return c.selectFallback(facts, eligible, random)
+}
+
+// PreviewStandSelection explains every eligible tier without drawing a random
+// stand. It follows the same airline-rule and fallback precedence as
+// SelectStand, while marking the tier that would actually be selected.
+func (c *AirlineAssignmentConfig) PreviewStandSelection(facts AssignmentFlightFacts, eligibleStands []string) (StandSelectionPreview, error) {
+	if c == nil {
+		return StandSelectionPreview{}, errors.New("airline assignment configuration is nil")
+	}
+	eligible := make(map[string]struct{}, len(eligibleStands))
+	for _, stand := range eligibleStands {
+		stand = normalizeStandName(stand)
+		if stand != "" {
+			eligible[stand] = struct{}{}
+		}
+	}
+	facts = normalizeAssignmentFacts(facts)
+	match, err := c.matchAirlineRule(facts)
+	if err != nil {
+		return StandSelectionPreview{}, err
+	}
+	if match != nil {
+		preview, err := c.previewRule(match.Rule, eligible, false)
+		if err != nil || len(preview.Candidates) > 0 {
+			return preview, err
+		}
+	}
+	return c.previewFallback(facts, eligible)
+}
+
+// PreviewFallbackStandSelection explains only the configured fallback rules.
+func (c *AirlineAssignmentConfig) PreviewFallbackStandSelection(facts AssignmentFlightFacts, eligibleStands []string) (StandSelectionPreview, error) {
+	if c == nil {
+		return StandSelectionPreview{}, errors.New("airline assignment configuration is nil")
+	}
+	eligible := make(map[string]struct{}, len(eligibleStands))
+	for _, stand := range eligibleStands {
+		stand = normalizeStandName(stand)
+		if stand != "" {
+			eligible[stand] = struct{}{}
+		}
+	}
+	return c.previewFallback(normalizeAssignmentFacts(facts), eligible)
+}
+
+func (c *AirlineAssignmentConfig) previewFallback(facts AssignmentFlightFacts, eligible map[string]struct{}) (StandSelectionPreview, error) {
+	fallbackName := c.preferredFallbackName(facts)
+	if fallbackName != FallbackAirlinerDefault {
+		if fallback, ok := c.GetFallbackRule(fallbackName); ok {
+			preview, err := c.previewRule(&AirlineAssignmentRule{ID: fallbackName, Stands: fallback.Stands, Tiers: fallback.Tiers}, eligible, true)
+			if err != nil || len(preview.Candidates) > 0 {
+				return preview, err
+			}
+		}
+	}
+	fallback, ok := c.GetFallbackRule(FallbackAirlinerDefault)
+	if !ok {
+		return StandSelectionPreview{}, errors.New("airliner_default fallback is not configured")
+	}
+	return c.previewRule(&AirlineAssignmentRule{ID: FallbackAirlinerDefault, Stands: fallback.Stands, Tiers: fallback.Tiers}, eligible, true)
+}
+
+func (c *AirlineAssignmentConfig) previewRule(rule *AirlineAssignmentRule, eligible map[string]struct{}, fallbackUsed bool) (StandSelectionPreview, error) {
+	if rule == nil {
+		return StandSelectionPreview{}, nil
+	}
+	preview := StandSelectionPreview{RuleID: rule.ID, FallbackUsed: fallbackUsed, Candidates: []StandSelectionCandidate{}}
+	selectableTierFound := false
+	for tierIndex, tier := range rule.Tiers {
+		candidates, totalWeight, err := c.eligibleTierCandidates(tier, eligible)
+		if err != nil {
+			return StandSelectionPreview{}, err
+		}
+		if totalWeight == 0 {
+			continue
+		}
+		selectable := !selectableTierFound
+		selectableTierFound = true
+		for _, candidate := range candidates {
+			preview.Candidates = append(preview.Candidates, StandSelectionCandidate{
+				Stand: candidate.stand, RuleID: rule.ID, Tier: tierNumber(tier.Name, tierIndex), TierName: tier.Name,
+				OriginalWeight: candidate.weight, NormalizedWeight: candidate.weight / totalWeight,
+				FallbackUsed: fallbackUsed, Selectable: selectable,
+			})
+		}
+	}
+	return preview, nil
+}
+
+// FallbackStandPool returns the configured physical stand pool used after an
+// airline rule has no eligible candidate. The preferred use/border fallback is
+// returned first, followed by airliner_default when it is distinct.
+func (c *AirlineAssignmentConfig) FallbackStandPool(facts AssignmentFlightFacts) ([]string, error) {
+	if c == nil {
+		return nil, errors.New("airline assignment configuration is nil")
+	}
+	facts = normalizeAssignmentFacts(facts)
+	names := []string{c.preferredFallbackName(facts)}
+	if names[0] != FallbackAirlinerDefault {
+		names = append(names, FallbackAirlinerDefault)
+	}
+
+	pool := make([]string, 0)
+	seen := make(map[string]struct{})
+	for _, name := range names {
+		fallback, ok := c.GetFallbackRule(name)
+		if !ok {
+			if name == FallbackAirlinerDefault {
+				return nil, errors.New("airliner_default fallback is not configured")
+			}
+			continue
+		}
+		for _, tier := range fallback.Tiers {
+			for _, entry := range tier.Entries {
+				stands := []string{entry.Stand}
+				if entry.Group != "" {
+					var err error
+					stands, err = c.ResolveStandGroup(entry.Group)
+					if err != nil {
+						return nil, err
+					}
+				}
+				for _, stand := range stands {
+					stand = normalizeStandName(stand)
+					if stand == "" {
+						continue
+					}
+					if _, exists := seen[stand]; exists {
+						continue
+					}
+					seen[stand] = struct{}{}
+					pool = append(pool, stand)
+				}
+			}
+		}
+	}
+	return pool, nil
+}
+
+// SelectFallbackStand applies only the configured fallback rules, rather than
+// considering a matching airline-specific rule again.
+func (c *AirlineAssignmentConfig) SelectFallbackStand(facts AssignmentFlightFacts, eligibleStands []string, random func() float64) (*StandSelection, error) {
+	if c == nil {
+		return nil, errors.New("airline assignment configuration is nil")
+	}
+	if random == nil {
+		return nil, errors.New("stand selection random source is nil")
+	}
+	eligible := make(map[string]struct{}, len(eligibleStands))
+	for _, stand := range eligibleStands {
+		stand = normalizeStandName(stand)
+		if stand != "" {
+			eligible[stand] = struct{}{}
+		}
+	}
+	return c.selectFallback(normalizeAssignmentFacts(facts), eligible, random)
 }
 
 func (c *AirlineAssignmentConfig) selectFallback(facts AssignmentFlightFacts, eligible map[string]struct{}, random func() float64) (*StandSelection, error) {

--- a/backend/internal/services/arrival_lifecycle.go
+++ b/backend/internal/services/arrival_lifecycle.go
@@ -325,8 +325,8 @@ func (s *ArrivalLifecycleService) StartSweep(ctx context.Context) {
 
 func (s *ArrivalLifecycleService) buildRequest(session int32, strip *models.Strip, flight vatsim.ArrivalFlightInfo, stage string, eta *time.Time, expiresAt *time.Time) StandAllocationRequest {
 	facts, assignmentFacts := s.resolveFacts(strip, flight)
-	revision := flight.Revision
 	etaSource := "ARRIVAL_ETA"
+	vatsimCID, vatsimRevision := resolvedVatsimIdentity(strip, flight.CID, flight.Revision)
 	return StandAllocationRequest{
 		SessionID:       session,
 		Callsign:        strip.Callsign,
@@ -338,8 +338,8 @@ func (s *ArrivalLifecycleService) buildRequest(session int32, strip *models.Stri
 		ETA:             eta,
 		ETASource:       &etaSource,
 		ExpiresAt:       expiresAt,
-		VatsimCID:       parseCID(flight.CID),
-		VatsimRevision:  &revision,
+		VatsimCID:       vatsimCID,
+		VatsimRevision:  vatsimRevision,
 	}
 }
 

--- a/backend/internal/services/departure_lifecycle.go
+++ b/backend/internal/services/departure_lifecycle.go
@@ -455,10 +455,7 @@ func (s *DepartureLifecycleService) renewInPlace(ctx context.Context, strip *mod
 	updated.ExpiresAt = &expiry
 	updated.AssignedAt = &now
 	updated.Stage = StageReserved
-	if parseCID(flight.CID) != nil {
-		revision := flight.Revision
-		updated.VatsimRevision = &revision
-	}
+	applyVatsimIdentity(&updated, strip, flight.CID, flight.Revision)
 	affected, err := s.assignments.UpdateAssignment(ctx, &updated)
 	if err != nil {
 		return err
@@ -511,10 +508,7 @@ func (s *DepartureLifecycleService) activateBlock(ctx context.Context, session i
 		updated.ConflictReason = nil
 	}
 	updated.AssignedAt = &now
-	if parseCID(flight.CID) != nil {
-		revision := flight.Revision
-		updated.VatsimRevision = &revision
-	}
+	applyVatsimIdentity(&updated, strip, flight.CID, flight.Revision)
 	affected, err := s.assignments.UpdateAssignment(ctx, &updated)
 	if err != nil {
 		return err
@@ -536,10 +530,7 @@ func (s *DepartureLifecycleService) activateBlock(ctx context.Context, session i
 	reloaded.Stage = StageDepartureBlock
 	reloaded.ExpiresAt = expiry
 	reloaded.AssignedAt = &now
-	if parseCID(flight.CID) != nil {
-		revision := flight.Revision
-		reloaded.VatsimRevision = &revision
-	}
+	applyVatsimIdentity(reloaded, strip, flight.CID, flight.Revision)
 	affected, err = s.assignments.UpdateAssignment(ctx, reloaded)
 	if err != nil {
 		return err
@@ -552,15 +543,19 @@ func (s *DepartureLifecycleService) activateBlock(ctx context.Context, session i
 }
 
 // revalidateFacts re-runs compatibility against the strip's current aircraft and
-// engine facts. EuroScope often supplies a live engine type or corrected
-// aircraft type after the initial reservation; when the assigned stand no
-// longer fits, a reallocation produces the conflict and selects a replacement.
+// engine facts. A departure that has been observed on its assigned stand keeps
+// that stand: it is already physically there, so later fact corrections must
+// not trigger an automatic relocation. Reservations without a live observed
+// position can still be reallocated when their facts change.
 func (s *DepartureLifecycleService) revalidateFacts(ctx context.Context, session int32, strip *models.Strip, flight vatsim.DepartureFlightInfo) error {
 	existing, err := s.assignments.GetAssignment(ctx, session, strip.Callsign)
 	if err != nil && !isNotFound(err) {
 		return err
 	}
 	if existing == nil {
+		return nil
+	}
+	if s.flightIsAtAssignedStand(strip, flight, existing.Stand) {
 		return nil
 	}
 	facts, assignmentFacts := s.resolveFacts(strip, flight)
@@ -585,6 +580,15 @@ func (s *DepartureLifecycleService) revalidateFacts(ctx context.Context, session
 	}
 	_, err = s.allocations.Reallocate(ctx, request)
 	return err
+}
+
+func (s *DepartureLifecycleService) flightIsAtAssignedStand(strip *models.Strip, flight vatsim.DepartureFlightInfo, stand string) bool {
+	airport := strings.TrimSpace(flight.Origin)
+	if strip != nil && strings.TrimSpace(strip.Origin) != "" {
+		airport = strings.TrimSpace(strip.Origin)
+	}
+	observed, found := s.stands.StandAtPosition(airport, flight.Latitude, flight.Longitude)
+	return found && strings.EqualFold(observed.Name, stand)
 }
 
 // ReleaseExpired releases expired offline reservations and completed departure
@@ -712,12 +716,39 @@ func (s *DepartureLifecycleService) buildRequest(session int32, strip *models.St
 		ExpiresAt:       expiresAt,
 		DepartureTOBT:   departureTobtTime(strip, s.now()),
 	}
-	if cid := parseCID(flight.CID); cid != nil {
-		revision := flight.Revision
-		request.VatsimCID = cid
-		request.VatsimRevision = &revision
-	}
+	request.VatsimCID, request.VatsimRevision = resolvedVatsimIdentity(strip, flight.CID, flight.Revision)
 	return request
+}
+
+// resolvedVatsimIdentity prefers the current feed record, then falls back to
+// VATSIM identity already reconciled onto the EuroScope strip. This keeps
+// controller- and EuroScope-triggered assignments linked to the pilot when the
+// allocation does not originate directly from a VATSIM callback.
+func resolvedVatsimIdentity(strip *models.Strip, cid string, revision int64) (*int64, *int64) {
+	if parsed := parseCID(cid); parsed != nil {
+		return parsed, &revision
+	}
+	if strip == nil {
+		return nil, nil
+	}
+	parsed := parseCID(valueString(strip.VatsimCID))
+	if parsed == nil {
+		return nil, nil
+	}
+	return parsed, strip.VatsimRevision
+}
+
+func applyVatsimIdentity(assignment *models.StandAssignment, strip *models.Strip, cid string, revision int64) {
+	if assignment == nil {
+		return
+	}
+	resolvedCID, resolvedRevision := resolvedVatsimIdentity(strip, cid, revision)
+	if resolvedCID != nil {
+		assignment.VatsimCID = resolvedCID
+	}
+	if resolvedRevision != nil {
+		assignment.VatsimRevision = resolvedRevision
+	}
 }
 
 func (s *DepartureLifecycleService) resolveFacts(strip *models.Strip, flight vatsim.DepartureFlightInfo) (sat.FlightCompatibilityFacts, sat.AssignmentFlightFacts) {

--- a/backend/internal/services/departure_lifecycle_test.go
+++ b/backend/internal/services/departure_lifecycle_test.go
@@ -41,6 +41,28 @@ func TestDepartureLifecycleWithoutEuroscopeMessengerSkipsStandMessages(t *testin
 	require.NoError(t, err)
 }
 
+func TestResolvedVatsimIdentityFallsBackToStripProvenance(t *testing.T) {
+	cid, revision := "1838280", int64(4)
+	resolvedCID, resolvedRevision := resolvedVatsimIdentity(&models.Strip{VatsimCID: &cid, VatsimRevision: &revision}, "", 0)
+
+	require.NotNil(t, resolvedCID)
+	require.NotNil(t, resolvedRevision)
+	assert.Equal(t, int64(1838280), *resolvedCID)
+	assert.Equal(t, int64(4), *resolvedRevision)
+}
+
+func TestApplyVatsimIdentityBackfillsExistingAssignment(t *testing.T) {
+	cid, revision := "1838280", int64(4)
+	assignment := &models.StandAssignment{}
+
+	applyVatsimIdentity(assignment, &models.Strip{VatsimCID: &cid, VatsimRevision: &revision}, "", 0)
+
+	require.NotNil(t, assignment.VatsimCID)
+	require.NotNil(t, assignment.VatsimRevision)
+	assert.Equal(t, int64(1838280), *assignment.VatsimCID)
+	assert.Equal(t, int64(4), *assignment.VatsimRevision)
+}
+
 type wrongStandTestMessenger struct {
 	available bool
 	calls     int
@@ -630,7 +652,7 @@ func TestDepartureLifecycle(t *testing.T) {
 		require.NoError(t, err, "an online assignment without a valid CDM deadline must remain assigned")
 	})
 
-	t.Run("revalidation reallocates when EuroScope facts invalidate the stand", func(t *testing.T) {
+	t.Run("revalidation retains a stand occupied by the observed departure", func(t *testing.T) {
 		aircraft := mustLoadAircraftRegistry(t, "A320", "B737")
 		engines := mustLoadEngineRegistry(t, aircraft, []engineRecord{{ICAO: "A320", WTC: "M", Engine: "J"}, {ICAO: "B737", WTC: "M", Engine: "J"}})
 		lifecycle, _, session, assignments, strips, clock := departureLifecycleFixtureWithEngines(t, pool, queries, "ATYP:A320", "ATYP:B737", aircraft, engines)
@@ -644,10 +666,10 @@ func TestDepartureLifecycle(t *testing.T) {
 		clock.advance(2 * time.Minute)
 		require.NoError(t, lifecycle.ProcessDeparture(ctx, session, loadStrip(t, strips, session, "SAS901"), onlineFlight("SAS901", 1)))
 
-		reallocated, err := assignments.GetAssignment(ctx, session, "SAS901")
+		assigned, err := assignments.GetAssignment(ctx, session, "SAS901")
 		require.NoError(t, err)
-		assert.Equal(t, "A2", reallocated.Stand, "an incompatible stand is replaced once better facts arrive")
-		assert.Equal(t, StageDepartureBlock, reallocated.Stage)
+		assert.Equal(t, "A1", assigned.Stand, "a departure observed on its assigned stand must not be relocated")
+		assert.Equal(t, StageDepartureBlock, assigned.Stage)
 	})
 
 	t.Run("a temporary TSAT gap does not add a block expiry", func(t *testing.T) {

--- a/backend/internal/services/stand_actions.go
+++ b/backend/internal/services/stand_actions.go
@@ -46,8 +46,28 @@ func (s *StandActionService) Allocate(ctx context.Context, session int32, airpor
 	}
 	// A controller's explicit automatic request is a deliberate retry. It may
 	// restart an allocation that the feed-driven lifecycle has suppressed.
-	s.allocations.clearAutomaticNoCompatibleFailure(req)
+	s.allocations.clearAutomaticTerminalFailure(req)
 	return s.allocations.Allocate(ctx, req)
+}
+
+// Preview explains the currently selectable automatic stands without changing
+// an assignment. It deliberately uses the same request facts as a controller
+// action, but does not require a controller position or a version mutation.
+func (s *StandActionService) Preview(ctx context.Context, session int32, airport, callsign string) (StandAllocationPreview, error) {
+	if s == nil || s.allocations == nil {
+		return StandAllocationPreview{}, errors.New("stand allocation preview is unavailable")
+	}
+	version := int32(0)
+	if existing, err := s.assignments.GetAssignment(ctx, session, strings.TrimSpace(callsign)); err == nil && existing != nil {
+		version = existing.Version
+	} else if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return StandAllocationPreview{}, fmt.Errorf("load stand assignment: %w", err)
+	}
+	req, err := s.request(ctx, session, airport, "SAT_STATUS", callsign, version)
+	if err != nil {
+		return StandAllocationPreview{}, err
+	}
+	return s.allocations.Preview(ctx, req)
 }
 
 func (s *StandActionService) AssignManually(ctx context.Context, session int32, airport, position, callsign, stand string, version int32) (*StandAllocationResult, error) {
@@ -148,8 +168,9 @@ func (s *StandActionService) request(ctx context.Context, session int32, airport
 		stage = existing.Stage
 		expiresAt = existing.ExpiresAt
 	}
+	vatsimCID, vatsimRevision := resolvedVatsimIdentity(strip, "", 0)
 	return StandAllocationRequest{SessionID: session, Callsign: strip.Callsign, Airport: strings.ToUpper(airport), Direction: direction, Stage: stage,
-		FlightFacts: facts, AssignmentFacts: sat.AssignmentFlightFacts{Callsign: strip.Callsign, AircraftType: valueString(strip.AircraftType), AircraftUse: facts.Aircraft.UseCode, BorderStatus: facts.BorderStatus, Direction: direction}, ETA: arrivalETATime(strip), ETASource: existingETASource(existing), ExpiresAt: expiresAt, DepartureTOBT: departureTobtTime(strip, time.Now().UTC()), VatsimRevision: strip.VatsimRevision}, nil
+		FlightFacts: facts, AssignmentFacts: sat.AssignmentFlightFacts{Callsign: strip.Callsign, AircraftType: valueString(strip.AircraftType), AircraftUse: facts.Aircraft.UseCode, BorderStatus: facts.BorderStatus, Direction: direction}, ETA: arrivalETATime(strip), ETASource: existingETASource(existing), ExpiresAt: expiresAt, DepartureTOBT: departureTobtTime(strip, time.Now().UTC()), VatsimCID: vatsimCID, VatsimRevision: vatsimRevision}, nil
 }
 
 func (s *StandActionService) Acknowledge(ctx context.Context, session int32, position, callsign string, version int32) (*models.StandAssignment, error) {

--- a/backend/internal/services/stand_allocation.go
+++ b/backend/internal/services/stand_allocation.go
@@ -35,16 +35,18 @@ const (
 )
 
 var (
-	ErrNoAvailableStand              = errors.New("no compatible stand is available")
+	ErrNoAvailableStand              = errors.New("no safe stand is currently available")
 	ErrNoCompatibleStand             = errors.New("no stand is compatible with the flight")
 	ErrIncompatibleManualAssignment  = errors.New("manual stand is not compatible or available")
 	ErrAllocationRetriesExhausted    = errors.New("stand allocation retries exhausted")
 	ErrUnknownManualOverrideStand    = errors.New("manual override stand is not configured")
-	ErrAutomaticAllocationSuppressed = errors.New("automatic stand allocation suppressed after repeated incompatibility")
+	ErrAutomaticAllocationSuppressed = errors.New("automatic stand allocation suppressed after an unchanged terminal stand shortage")
 	errAllocationVersionConflict     = errors.New("stand assignment version conflict")
 )
 
-const automaticNoCompatibleFailureThreshold = 3
+const automaticTerminalFailureThreshold = 1
+
+const automaticPhysicalFallbackConflict = "automatic fallback: no normal compatible stand was available"
 
 // StandAllocationRequest contains facts already resolved by the SAT data
 // layer. It intentionally excludes lifecycle and controller authorization
@@ -101,6 +103,17 @@ type StandAllocationResult struct {
 	AvailableCandidates []string
 }
 
+// StandAllocationPreview is a read-only explanation of the stands an
+// automatic allocation could currently choose for one flight.
+type StandAllocationPreview struct {
+	Callsign         string                    `json:"callsign"`
+	Airport          string                    `json:"airport"`
+	FallbackUsed     bool                      `json:"fallback_used"`
+	CompatibleStands int                       `json:"compatible_stands"`
+	AvailableStands  int                       `json:"available_stands"`
+	Selection        sat.StandSelectionPreview `json:"selection"`
+}
+
 type StandAllocationPublisher func(context.Context, StandAllocationResult) error
 
 // StandAllocationService is the sole owner of the allocation transaction. It
@@ -118,11 +131,14 @@ type StandAllocationService struct {
 	now         func() time.Time
 	failures    *standdiagnostics.AllocationFailureLog
 
-	automaticFailureMu            sync.Mutex
-	automaticNoCompatibleFailures map[string]automaticNoCompatibleFailure
+	automaticFailureMu        sync.Mutex
+	automaticTerminalFailures map[string]automaticTerminalFailure
 }
 
-type automaticNoCompatibleFailure struct {
+// automaticTerminalFailure prevents a lifecycle poll from reporting the same
+// unassignable flight repeatedly. A changed flight-facts fingerprint is a new
+// allocation decision and is deliberately allowed through.
+type automaticTerminalFailure struct {
 	fingerprint string
 	failures    int
 }
@@ -384,7 +400,7 @@ func (s *StandAllocationService) allocateWithFailureLogging(ctx context.Context,
 	for attempt := 1; attempt <= s.attempts; attempt++ {
 		result, selected, err := s.allocateOnce(ctx, command, request, tried, attempt)
 		if err == nil {
-			s.clearAutomaticNoCompatibleFailure(request)
+			s.clearAutomaticTerminalFailure(request)
 			tier := 0
 			rule := ""
 			category := "manual"
@@ -416,10 +432,10 @@ func (s *StandAllocationService) allocateWithFailureLogging(ctx context.Context,
 		}
 		if !retryableStandAllocationError(err) {
 			if isAutomaticStandAllocation(command) {
-				if errors.Is(err, ErrNoCompatibleStand) {
-					s.noteAutomaticNoCompatibleFailure(request)
+				if isTerminalAutomaticStandShortage(err) {
+					s.noteAutomaticTerminalFailure(request)
 				} else {
-					s.clearAutomaticNoCompatibleFailure(request)
+					s.clearAutomaticTerminalFailure(request)
 				}
 			}
 			outcome := standAllocationFailureOutcome(err)
@@ -449,30 +465,34 @@ func (s *StandAllocationService) automaticAllocationSuppressed(request StandAllo
 	key, fingerprint := automaticFailureKeyAndFingerprint(request)
 	s.automaticFailureMu.Lock()
 	defer s.automaticFailureMu.Unlock()
-	failure, ok := s.automaticNoCompatibleFailures[key]
-	return ok && failure.fingerprint == fingerprint && failure.failures >= automaticNoCompatibleFailureThreshold
+	failure, ok := s.automaticTerminalFailures[key]
+	return ok && failure.fingerprint == fingerprint && failure.failures >= automaticTerminalFailureThreshold
 }
 
-func (s *StandAllocationService) noteAutomaticNoCompatibleFailure(request StandAllocationRequest) {
+func (s *StandAllocationService) noteAutomaticTerminalFailure(request StandAllocationRequest) {
 	key, fingerprint := automaticFailureKeyAndFingerprint(request)
 	s.automaticFailureMu.Lock()
 	defer s.automaticFailureMu.Unlock()
-	if s.automaticNoCompatibleFailures == nil {
-		s.automaticNoCompatibleFailures = make(map[string]automaticNoCompatibleFailure)
+	if s.automaticTerminalFailures == nil {
+		s.automaticTerminalFailures = make(map[string]automaticTerminalFailure)
 	}
-	failure := s.automaticNoCompatibleFailures[key]
+	failure := s.automaticTerminalFailures[key]
 	if failure.fingerprint != fingerprint {
-		failure = automaticNoCompatibleFailure{fingerprint: fingerprint}
+		failure = automaticTerminalFailure{fingerprint: fingerprint}
 	}
 	failure.failures++
-	s.automaticNoCompatibleFailures[key] = failure
+	s.automaticTerminalFailures[key] = failure
 }
 
-func (s *StandAllocationService) clearAutomaticNoCompatibleFailure(request StandAllocationRequest) {
+func (s *StandAllocationService) clearAutomaticTerminalFailure(request StandAllocationRequest) {
 	key, _ := automaticFailureKeyAndFingerprint(request)
 	s.automaticFailureMu.Lock()
 	defer s.automaticFailureMu.Unlock()
-	delete(s.automaticNoCompatibleFailures, key)
+	delete(s.automaticTerminalFailures, key)
+}
+
+func isTerminalAutomaticStandShortage(err error) bool {
+	return errors.Is(err, ErrNoCompatibleStand) || errors.Is(err, ErrNoAvailableStand)
 }
 
 func automaticFailureKeyAndFingerprint(request StandAllocationRequest) (string, string) {
@@ -678,6 +698,81 @@ func (s *StandAllocationService) StandAvailable(ctx context.Context, request Sta
 	return len(availability[target]) == 0, nil
 }
 
+// Preview reports the current policy candidates without reserving, updating,
+// or publishing anything. It is intended for controller diagnostics.
+func (s *StandAllocationService) Preview(ctx context.Context, request StandAllocationRequest) (StandAllocationPreview, error) {
+	if err := validateStandAllocationRequest(AutomaticStandAllocation, &request); err != nil {
+		return StandAllocationPreview{}, err
+	}
+	assignments, err := s.assignments.ListAssignments(ctx, request.SessionID)
+	if err != nil {
+		return StandAllocationPreview{}, err
+	}
+	blocks, err := s.assignments.ListBlocks(ctx, request.SessionID)
+	if err != nil {
+		return StandAllocationPreview{}, err
+	}
+	activeBlocks := make([]*models.StandBlock, 0, len(blocks))
+	for _, block := range blocks {
+		if block != nil && block.Manual && !expired(block.ExpiresAt, s.now()) {
+			activeBlocks = append(activeBlocks, block)
+		}
+	}
+
+	evaluation := s.stands.EvaluateCompatibility(request.Airport, request.FlightFacts)
+	matches := make(map[string]sat.StandCompatibilityMatch, len(evaluation.Matches))
+	for _, match := range evaluation.Matches {
+		matches[standName(match.Stand.Name)] = match
+	}
+	availability := s.availability(request, assignments, activeBlocks, matches)
+	available := previewAvailableStands(matches, availability)
+	selection, err := s.policy.PreviewStandSelection(request.AssignmentFacts, available)
+	if err != nil {
+		return StandAllocationPreview{}, err
+	}
+	preview := StandAllocationPreview{
+		Callsign: request.Callsign, Airport: request.Airport, FallbackUsed: selection.FallbackUsed,
+		CompatibleStands: len(matches), AvailableStands: len(available), Selection: selection,
+	}
+	if len(selection.Candidates) > 0 {
+		return preview, nil
+	}
+
+	pool, err := s.policy.FallbackStandPool(request.AssignmentFacts)
+	if err != nil {
+		return StandAllocationPreview{}, err
+	}
+	fallbackMatches := make(map[string]sat.StandCompatibilityMatch)
+	for _, name := range pool {
+		stand, found := s.stands.Lookup(request.Airport, name)
+		if !found || len(stand.Variants) == 0 || allStandVariantsManual(stand) {
+			continue
+		}
+		fallbackMatches[standName(stand.Name)] = sat.StandCompatibilityMatch{Stand: stand, Blocks: slices.Clone(stand.Blocks)}
+	}
+	fallbackAvailability := s.availability(request, assignments, activeBlocks, fallbackMatches)
+	fallbackAvailable := previewAvailableStands(fallbackMatches, fallbackAvailability)
+	fallbackSelection, err := s.policy.PreviewFallbackStandSelection(request.AssignmentFacts, fallbackAvailable)
+	if err != nil {
+		return StandAllocationPreview{}, err
+	}
+	preview.FallbackUsed = true
+	preview.AvailableStands = len(fallbackAvailable)
+	preview.Selection = fallbackSelection
+	return preview, nil
+}
+
+func previewAvailableStands(matches map[string]sat.StandCompatibilityMatch, availability map[string][]string) []string {
+	available := make([]string, 0, len(matches))
+	for stand := range matches {
+		if len(availability[stand]) == 0 {
+			available = append(available, stand)
+		}
+	}
+	slices.Sort(available)
+	return available
+}
+
 func (s *StandAllocationService) selectStand(command StandAllocationCommand, request StandAllocationRequest, evaluation sat.StandCompatibilityEvaluation, assignments []*models.StandAssignment, blocks []*models.StandBlock, tried map[string]struct{}) (string, *sat.StandSelection, *sat.StandCompatibilityMatch, []string, string, error) {
 	matches := make(map[string]sat.StandCompatibilityMatch, len(evaluation.Matches))
 	for _, match := range evaluation.Matches {
@@ -706,9 +801,6 @@ func (s *StandAllocationService) selectStand(command StandAllocationCommand, req
 		}
 		return target, nil, &match, []string{target}, "", nil
 	}
-	if len(matches) == 0 && command != IncompatibleManualOverride {
-		return "", nil, nil, nil, "", ErrNoCompatibleStand
-	}
 	availability := s.availability(request, assignments, blocks, matches)
 	if command == IncompatibleManualOverride {
 		stand, known := s.stands.Lookup(request.Airport, request.Stand)
@@ -732,6 +824,9 @@ func (s *StandAllocationService) selectStand(command StandAllocationCommand, req
 		}
 		return request.Stand, nil, &match, []string{request.Stand}, "", nil
 	}
+	if len(matches) == 0 {
+		return s.selectAutomaticPhysicalFallback(request, assignments, blocks, tried)
+	}
 
 	available := make([]string, 0, len(matches))
 	for stand := range matches {
@@ -747,10 +842,64 @@ func (s *StandAllocationService) selectStand(command StandAllocationCommand, req
 		return "", nil, nil, available, "", err
 	}
 	if selection == nil {
-		return "", nil, nil, available, "", ErrNoAvailableStand
+		return s.selectAutomaticPhysicalFallback(request, assignments, blocks, tried)
 	}
 	match := matches[selection.Stand]
 	return selection.Stand, selection, &match, available, "", nil
+}
+
+// selectAutomaticPhysicalFallback gives an automatic allocation a final safe
+// place to go in the configured fallback pool when normal candidates are
+// exhausted. It only relaxes configuration compatibility; occupied stands,
+// adjacency locks, controller blocks, and manual-only stands remain unavailable.
+func (s *StandAllocationService) selectAutomaticPhysicalFallback(request StandAllocationRequest, assignments []*models.StandAssignment, blocks []*models.StandBlock, tried map[string]struct{}) (string, *sat.StandSelection, *sat.StandCompatibilityMatch, []string, string, error) {
+	pool, err := s.policy.FallbackStandPool(request.AssignmentFacts)
+	if err != nil {
+		return "", nil, nil, nil, "", err
+	}
+	matches := make(map[string]sat.StandCompatibilityMatch)
+	for _, name := range pool {
+		stand, found := s.stands.Lookup(request.Airport, name)
+		if !found || len(stand.Variants) == 0 || allStandVariantsManual(stand) {
+			continue
+		}
+		// Stand.Blocks is the union of every configured variant's blocks. Do
+		// not attach a particular variant: future occupancy checks must retain
+		// this conservative physical adjacency footprint.
+		matches[standName(stand.Name)] = sat.StandCompatibilityMatch{Stand: stand, Blocks: slices.Clone(stand.Blocks)}
+	}
+	availability := s.availability(request, assignments, blocks, matches)
+	available := make([]string, 0, len(matches))
+	for stand := range matches {
+		if len(availability[stand]) == 0 {
+			if _, retrying := tried[stand]; !retrying {
+				available = append(available, stand)
+			}
+		}
+	}
+	slices.Sort(available)
+	if len(available) == 0 {
+		return "", nil, nil, nil, "", ErrNoAvailableStand
+	}
+
+	selection, err := s.policy.SelectFallbackStand(request.AssignmentFacts, available, s.random)
+	if err != nil {
+		return "", nil, nil, available, "", err
+	}
+	if selection == nil {
+		return "", nil, nil, available, "", ErrNoAvailableStand
+	}
+	match := matches[selection.Stand]
+	return selection.Stand, selection, &match, available, automaticPhysicalFallbackConflict, nil
+}
+
+func allStandVariantsManual(stand sat.Stand) bool {
+	for _, variant := range stand.Variants {
+		if !variant.Manual {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *StandAllocationService) availability(request StandAllocationRequest, assignments []*models.StandAssignment, blocks []*models.StandBlock, matches map[string]sat.StandCompatibilityMatch) map[string][]string {

--- a/backend/internal/services/stand_allocation_failures_test.go
+++ b/backend/internal/services/stand_allocation_failures_test.go
@@ -56,7 +56,7 @@ func TestStandActionRecordsPreAllocationRejection(t *testing.T) {
 	require.Equal(t, "A12", recorded[0].AttemptedStand)
 }
 
-func TestAutomaticNoCompatibleFailuresAreSuppressedUntilFactsChange(t *testing.T) {
+func TestAutomaticTerminalFailuresAreSuppressedUntilFactsChange(t *testing.T) {
 	service := &StandAllocationService{}
 	request := StandAllocationRequest{
 		SessionID: 7,
@@ -73,9 +73,9 @@ func TestAutomaticNoCompatibleFailuresAreSuppressedUntilFactsChange(t *testing.T
 		},
 	}
 
-	for attempt := 0; attempt < automaticNoCompatibleFailureThreshold; attempt++ {
+	for attempt := 0; attempt < automaticTerminalFailureThreshold; attempt++ {
 		require.False(t, service.automaticAllocationSuppressed(request))
-		service.noteAutomaticNoCompatibleFailure(request)
+		service.noteAutomaticTerminalFailure(request)
 	}
 	require.True(t, service.automaticAllocationSuppressed(request))
 
@@ -83,4 +83,12 @@ func TestAutomaticNoCompatibleFailuresAreSuppressedUntilFactsChange(t *testing.T
 	request.FlightFacts.Aircraft.Type = "MD82"
 	request.FlightFacts.WTC = "M"
 	require.False(t, service.automaticAllocationSuppressed(request), "new aircraft facts must allow a fresh allocation attempt")
+}
+
+func TestAutomaticNoAvailableFailureRemainsSuppressed(t *testing.T) {
+	service := &StandAllocationService{}
+	request := StandAllocationRequest{SessionID: 7, Callsign: "sas123", Airport: "ekch", Direction: sat.AssignmentDirectionDeparture}
+
+	service.noteAutomaticTerminalFailure(request)
+	require.True(t, service.automaticAllocationSuppressed(request))
 }

--- a/backend/internal/services/stand_allocation_test.go
+++ b/backend/internal/services/stand_allocation_test.go
@@ -279,6 +279,38 @@ func TestStandAllocationServiceTransactions(t *testing.T) {
 		}
 	})
 
+	t.Run("falls back only within the configured fallback pool when compatible stands are exhausted", func(t *testing.T) {
+		service, session, _ := standAllocationFixture(t, pool, queries, "ENGINETYPE:J", "ENGINETYPE:J")
+		testdata.SeedTestStrip(t, queries, session, "SAS312")
+		request := standAllocationRequest(session, "SAS312")
+		request.FlightFacts = sat.FlightCompatibilityFacts{
+			Direction: sat.Arrival, EngineType: sat.EnginePiston, WTC: "L", BorderStatus: sat.BorderStatusSchengen,
+		}
+
+		result, err := service.Allocate(ctx, request)
+		require.NoError(t, err)
+		assert.Equal(t, "A1", result.Assignment.Stand)
+		assert.Equal(t, "AUTOMATIC", result.Assignment.Source)
+		require.NotNil(t, result.Assignment.ConflictReason)
+		assert.Equal(t, automaticPhysicalFallbackConflict, *result.Assignment.ConflictReason)
+		assert.True(t, result.Selection.FallbackUsed)
+		assert.Nil(t, result.Assignment.MatchedVariant, "the fallback retains the stand's union adjacency footprint")
+		assert.Equal(t, []string{"A1"}, result.AvailableCandidates)
+	})
+
+	t.Run("suppresses repeated automatic attempts when no safe physical stand exists", func(t *testing.T) {
+		service, session, assignments := standAllocationFixture(t, pool, queries, "BLOCKS:A2", "")
+		testdata.SeedTestStrip(t, queries, session, "SAS313")
+		require.NoError(t, assignments.CreateBlock(ctx, &models.StandBlock{
+			SessionID: session, Stand: "A1", BlockType: "CLOSURE", Source: "CONTROLLER", Manual: true,
+		}))
+
+		_, err := service.Allocate(ctx, standAllocationRequest(session, "SAS313"))
+		require.ErrorIs(t, err, ErrNoAvailableStand)
+		_, err = service.Allocate(ctx, standAllocationRequest(session, "SAS313"))
+		require.ErrorIs(t, err, ErrAutomaticAllocationSuppressed)
+	})
+
 	t.Run("manual blocks use allocation occupancy and adjacency locks", func(t *testing.T) {
 		service, session, assignments := standAllocationFixture(t, pool, queries, "BLOCKS:A2", "")
 		testdata.SeedTestStrip(t, queries, session, "SAS302")

--- a/backend/internal/standstatus/webapi.go
+++ b/backend/internal/standstatus/webapi.go
@@ -2,6 +2,7 @@ package standstatus
 
 import (
 	"FlightStrips/internal/models"
+	"FlightStrips/internal/services"
 	"FlightStrips/internal/shared"
 	"FlightStrips/internal/standdiagnostics"
 	"FlightStrips/internal/vatsim"
@@ -9,6 +10,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -22,12 +24,20 @@ type standStatusAssignmentRepository interface {
 	ListBlocks(context.Context, int32) ([]*models.StandBlock, error)
 }
 
+type standStatusStripRepository interface {
+	List(context.Context, int32) ([]*models.Strip, error)
+}
+
 type standStatusFeed interface {
 	Snapshot() vatsim.Snapshot
 }
 
 type standStatusFailureSource interface {
 	List() []standdiagnostics.AllocationFailure
+}
+
+type standStatusPreviewer interface {
+	Preview(context.Context, int32, string, string) (services.StandAllocationPreview, error)
 }
 
 // WebAPIDiagnostics describes the configuration that was loaded at startup.
@@ -45,6 +55,7 @@ type WebAPIConfig struct {
 	Auth        shared.AuthenticationService
 	Sessions    standStatusSessionRepository
 	Assignments standStatusAssignmentRepository
+	Strips      standStatusStripRepository
 	Feed        standStatusFeed
 	Enabled     bool
 	Ready       bool
@@ -52,6 +63,7 @@ type WebAPIConfig struct {
 	StaleAfter  time.Duration
 	Diagnostics WebAPIDiagnostics
 	Failures    standStatusFailureSource
+	Previewer   standStatusPreviewer
 }
 
 // WebAPI exposes an authenticated, read-only snapshot of SAT's internal state.
@@ -94,29 +106,32 @@ type standStatusSessionResponse struct {
 }
 
 type standStatusAssignmentResponse struct {
-	ID             int64      `json:"id"`
-	Callsign       string     `json:"callsign"`
-	Stand          string     `json:"stand"`
-	Direction      string     `json:"direction"`
-	Stage          string     `json:"stage"`
-	Source         string     `json:"source"`
-	RuleID         *string    `json:"rule_id,omitempty"`
-	Tier           *int32     `json:"tier,omitempty"`
-	MatchedVariant *string    `json:"matched_variant,omitempty"`
-	ConflictReason *string    `json:"conflict_reason,omitempty"`
-	ETA            *time.Time `json:"eta,omitempty"`
-	ETASource      *string    `json:"eta_source,omitempty"`
-	AssignedAt     *time.Time `json:"assigned_at,omitempty"`
-	ExpiresAt      *time.Time `json:"expires_at,omitempty"`
-	Manual         bool       `json:"manual"`
-	Acknowledged   bool       `json:"acknowledged"`
-	AcknowledgedAt *time.Time `json:"acknowledged_at,omitempty"`
-	AcknowledgedBy *string    `json:"acknowledged_by,omitempty"`
-	VatsimCID      *int64     `json:"vatsim_cid,omitempty"`
-	VatsimRevision *int64     `json:"vatsim_revision,omitempty"`
-	Version        int32      `json:"version"`
-	CreatedAt      time.Time  `json:"created_at"`
-	UpdatedAt      time.Time  `json:"updated_at"`
+	ID               int64      `json:"id"`
+	Callsign         string     `json:"callsign"`
+	Stand            string     `json:"stand"`
+	Direction        string     `json:"direction"`
+	Stage            string     `json:"stage"`
+	Source           string     `json:"source"`
+	RuleID           *string    `json:"rule_id,omitempty"`
+	Tier             *int32     `json:"tier,omitempty"`
+	MatchedVariant   *string    `json:"matched_variant,omitempty"`
+	ConflictReason   *string    `json:"conflict_reason,omitempty"`
+	ETA              *time.Time `json:"eta,omitempty"`
+	ETASource        *string    `json:"eta_source,omitempty"`
+	DepartureTOBT    *string    `json:"departure_tobt,omitempty"`
+	DepartureTSAT    *string    `json:"departure_tsat,omitempty"`
+	PlannedReleaseAt *time.Time `json:"planned_release_at,omitempty"`
+	AssignedAt       *time.Time `json:"assigned_at,omitempty"`
+	ExpiresAt        *time.Time `json:"expires_at,omitempty"`
+	Manual           bool       `json:"manual"`
+	Acknowledged     bool       `json:"acknowledged"`
+	AcknowledgedAt   *time.Time `json:"acknowledged_at,omitempty"`
+	AcknowledgedBy   *string    `json:"acknowledged_by,omitempty"`
+	VatsimCID        *int64     `json:"vatsim_cid,omitempty"`
+	VatsimRevision   *int64     `json:"vatsim_revision,omitempty"`
+	Version          int32      `json:"version"`
+	CreatedAt        time.Time  `json:"created_at"`
+	UpdatedAt        time.Time  `json:"updated_at"`
 }
 
 type standStatusBlockResponse struct {
@@ -140,6 +155,38 @@ func NewWebAPI(config WebAPIConfig) *WebAPI {
 
 func (a *WebAPI) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/stand/status", a.handleStatus)
+	mux.HandleFunc("/stand/preview", a.handlePreview)
+}
+
+func (a *WebAPI) handlePreview(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	if !a.authenticate(w, r) {
+		return
+	}
+	if a.config.Previewer == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "stand allocation preview is unavailable")
+		return
+	}
+	sessionID, err := strconv.ParseInt(strings.TrimSpace(r.URL.Query().Get("session_id")), 10, 32)
+	if err != nil || sessionID <= 0 {
+		writeJSONError(w, http.StatusBadRequest, "session_id must be a positive integer")
+		return
+	}
+	callsign := strings.ToUpper(strings.TrimSpace(r.URL.Query().Get("callsign")))
+	airport := strings.ToUpper(strings.TrimSpace(r.URL.Query().Get("airport")))
+	if callsign == "" || airport == "" {
+		writeJSONError(w, http.StatusBadRequest, "airport and callsign are required")
+		return
+	}
+	preview, err := a.config.Previewer.Preview(r.Context(), int32(sessionID), airport, callsign)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to preview stand allocation")
+		return
+	}
+	writeJSON(w, http.StatusOK, preview)
 }
 
 func (a *WebAPI) handleStatus(w http.ResponseWriter, r *http.Request) {
@@ -186,7 +233,15 @@ func (a *WebAPI) handleStatus(w http.ResponseWriter, r *http.Request) {
 				writeJSONError(w, http.StatusInternalServerError, "failed to list stand blocks")
 				return
 			}
-			response.Sessions = append(response.Sessions, mapStandStatusSession(session, assignments, blocks, now))
+			var strips []*models.Strip
+			if a.config.Strips != nil {
+				strips, err = a.config.Strips.List(r.Context(), session.ID)
+				if err != nil {
+					writeJSONError(w, http.StatusInternalServerError, "failed to list strips for stand timing")
+					return
+				}
+			}
+			response.Sessions = append(response.Sessions, mapStandStatusSession(session, assignments, blocks, strips, now))
 		}
 	}
 
@@ -265,7 +320,7 @@ func (a *WebAPI) feedStatus() standStatusFeedResponse {
 	return result
 }
 
-func mapStandStatusSession(session *models.Session, assignments []*models.StandAssignment, blocks []*models.StandBlock, now time.Time) standStatusSessionResponse {
+func mapStandStatusSession(session *models.Session, assignments []*models.StandAssignment, blocks []*models.StandBlock, strips []*models.Strip, now time.Time) standStatusSessionResponse {
 	response := standStatusSessionResponse{
 		SessionID:   session.ID,
 		Name:        session.Name,
@@ -273,11 +328,17 @@ func mapStandStatusSession(session *models.Session, assignments []*models.StandA
 		Assignments: make([]standStatusAssignmentResponse, 0, len(assignments)),
 		Blocks:      make([]standStatusBlockResponse, 0, len(blocks)),
 	}
+	stripsByCallsign := make(map[string]*models.Strip, len(strips))
+	for _, strip := range strips {
+		if strip != nil {
+			stripsByCallsign[strings.ToUpper(strings.TrimSpace(strip.Callsign))] = strip
+		}
+	}
 	for _, assignment := range assignments {
 		if assignment == nil {
 			continue
 		}
-		response.Assignments = append(response.Assignments, standStatusAssignmentResponse{
+		mapped := standStatusAssignmentResponse{
 			ID: assignment.ID, Callsign: assignment.Callsign, Stand: assignment.Stand,
 			Direction: assignment.Direction, Stage: assignment.Stage, Source: assignment.Source,
 			RuleID: assignment.RuleID, Tier: assignment.Tier, MatchedVariant: assignment.MatchedVariant,
@@ -287,10 +348,18 @@ func mapStandStatusSession(session *models.Session, assignments []*models.StandA
 			AcknowledgedBy: assignment.AcknowledgedBy, VatsimCID: assignment.VatsimCID,
 			VatsimRevision: assignment.VatsimRevision, Version: assignment.Version,
 			CreatedAt: assignment.CreatedAt, UpdatedAt: assignment.UpdatedAt,
-		})
+		}
+		if assignment.Direction == "DEPARTURE" {
+			if strip := stripsByCallsign[strings.ToUpper(strings.TrimSpace(assignment.Callsign))]; strip != nil {
+				mapped.DepartureTOBT = strip.EffectiveTobt()
+				mapped.DepartureTSAT = strip.EffectiveTsat()
+				mapped.PlannedReleaseAt = scheduledDepartureReleaseAt(strip, now)
+			}
+		}
+		response.Assignments = append(response.Assignments, mapped)
 	}
 	for _, block := range blocks {
-		if block == nil || (block.ExpiresAt != nil && !block.ExpiresAt.After(now)) {
+		if block == nil {
 			continue
 		}
 		response.Blocks = append(response.Blocks, standStatusBlockResponse{
@@ -310,6 +379,52 @@ func mapStandStatusSession(session *models.Session, assignments []*models.StandA
 		return response.Blocks[i].ID < response.Blocks[j].ID
 	})
 	return response
+}
+
+// scheduledDepartureReleaseAt mirrors the operational display rule: TSAT takes
+// precedence over TOBT and the stand is planned to release ten minutes later.
+// It is intentionally a planning value; an aircraft observed at its stand is
+// retained until it moves or its strip disappears.
+func scheduledDepartureReleaseAt(strip *models.Strip, now time.Time) *time.Time {
+	if strip == nil {
+		return nil
+	}
+	invalidReason := ""
+	if calculation := strip.CdmData.EffectiveCalculation(); calculation != nil && calculation.InvalidReason != nil {
+		invalidReason = strings.TrimSpace(*calculation.InvalidReason)
+	}
+	if invalidReason != models.CdmInvalidReasonStaleTsat {
+		if release := departureReleaseAt(strip.EffectiveTsat(), now); release != nil {
+			return release
+		}
+	}
+	if invalidReason != models.CdmInvalidReasonStaleTobt {
+		return departureReleaseAt(strip.EffectiveTobt(), now)
+	}
+	return nil
+}
+
+func departureReleaseAt(clock *string, now time.Time) *time.Time {
+	if clock == nil {
+		return nil
+	}
+	value := strings.TrimSpace(*clock)
+	if len(value) != 4 {
+		return nil
+	}
+	hour, hourErr := strconv.Atoi(value[:2])
+	minute, minuteErr := strconv.Atoi(value[2:])
+	if hourErr != nil || minuteErr != nil || hour > 23 || minute > 59 {
+		return nil
+	}
+	candidate := time.Date(now.Year(), now.Month(), now.Day(), hour, minute, 0, 0, time.UTC)
+	if candidate.Sub(now) > 12*time.Hour {
+		candidate = candidate.Add(-24 * time.Hour)
+	} else if now.Sub(candidate) > 12*time.Hour {
+		candidate = candidate.Add(24 * time.Hour)
+	}
+	release := candidate.Add(10 * time.Minute)
+	return &release
 }
 
 func (a *WebAPI) authenticate(w http.ResponseWriter, r *http.Request) bool {

--- a/backend/internal/standstatus/webapi_test.go
+++ b/backend/internal/standstatus/webapi_test.go
@@ -38,6 +38,14 @@ type standStatusAssignmentStub struct {
 	blocks      map[int32][]*models.StandBlock
 }
 
+type standStatusStripStub struct {
+	strips map[int32][]*models.Strip
+}
+
+func (s standStatusStripStub) List(_ context.Context, session int32) ([]*models.Strip, error) {
+	return s.strips[session], nil
+}
+
 func (s standStatusAssignmentStub) ListAssignments(_ context.Context, session int32) ([]*models.StandAssignment, error) {
 	return s.assignments[session], nil
 }
@@ -70,6 +78,7 @@ func TestStandStatusReturnsOperationalSnapshot(t *testing.T) {
 	now := time.Date(2026, time.July, 17, 12, 0, 0, 0, time.UTC)
 	eta := now.Add(20 * time.Minute)
 	expiry := now.Add(time.Hour)
+	expiredAssignment := now.Add(-time.Minute)
 	rule := "sas-arrivals"
 	tier := int32(2)
 	variant := "NON-SCHENGEN/A320"
@@ -94,6 +103,11 @@ func TestStandStatusReturnsOperationalSnapshot(t *testing.T) {
 						Stage: "CONFIRMED", Source: "AUTO", RuleID: &rule, Tier: &tier,
 						MatchedVariant: &variant, ETA: &eta, ExpiresAt: &expiry, Acknowledged: true,
 						Version: 3, CreatedAt: now.Add(-time.Hour), UpdatedAt: now,
+					},
+					{
+						ID: 12, SessionID: 7, Callsign: "SAS124", Stand: "A13", Direction: "ARRIVAL",
+						Stage: "CONFIRMED", Source: "AUTO", ExpiresAt: &expiredAssignment,
+						Version: 1, CreatedAt: now.Add(-time.Hour), UpdatedAt: now.Add(-time.Minute),
 					},
 				},
 			},
@@ -138,10 +152,10 @@ func TestStandStatusReturnsOperationalSnapshot(t *testing.T) {
 	require.Equal(t, "SAS999", payload.Failures[0].Callsign)
 	require.Equal(t, "no_available_stand", payload.Failures[0].Outcome)
 	require.Len(t, payload.Sessions, 1)
-	require.Len(t, payload.Sessions[0].Assignments, 1)
+	require.Len(t, payload.Sessions[0].Assignments, 2)
 	require.Equal(t, "SAS123", payload.Sessions[0].Assignments[0].Callsign)
 	require.Equal(t, "sas-arrivals", *payload.Sessions[0].Assignments[0].RuleID)
-	require.Len(t, payload.Sessions[0].Blocks, 1)
+	require.Len(t, payload.Sessions[0].Blocks, 2)
 	require.Equal(t, int64(21), payload.Sessions[0].Blocks[0].ID)
 	require.Equal(t, "maintenance", *payload.Sessions[0].Blocks[0].Reason)
 }
@@ -221,4 +235,21 @@ func TestStandStatusReturnsEmptyFailureListWhenNoFailuresExist(t *testing.T) {
 	var payload map[string]json.RawMessage
 	require.NoError(t, json.NewDecoder(recorder.Body).Decode(&payload))
 	require.JSONEq(t, `[]`, string(payload["failures"]))
+}
+
+func TestStandStatusIncludesDepartureTiming(t *testing.T) {
+	now := time.Date(2026, time.July, 24, 18, 0, 0, 0, time.UTC)
+	tobt, tsat := "1810", "1820"
+	response := mapStandStatusSession(
+		&models.Session{ID: 7, Name: "LIVE", Airport: "EKCH"},
+		[]*models.StandAssignment{{ID: 11, Callsign: "SAS123", Stand: "A12", Direction: "DEPARTURE"}},
+		nil,
+		[]*models.Strip{{Callsign: "SAS123", CdmData: &models.CdmData{Tobt: &tobt, Tsat: &tsat}}},
+		now,
+	)
+
+	require.Len(t, response.Assignments, 1)
+	require.Equal(t, "1810", *response.Assignments[0].DepartureTOBT)
+	require.Equal(t, "1820", *response.Assignments[0].DepartureTSAT)
+	require.Equal(t, time.Date(2026, time.July, 24, 18, 30, 0, 0, time.UTC), *response.Assignments[0].PlannedReleaseAt)
 }

--- a/frontend/src/pages/stand-status.tsx
+++ b/frontend/src/pages/stand-status.tsx
@@ -42,6 +42,9 @@ type StandAssignment = {
   conflict_reason?: string;
   eta?: string;
   eta_source?: string;
+  departure_tobt?: string;
+  departure_tsat?: string;
+  planned_release_at?: string;
   assigned_at?: string;
   expires_at?: string;
   manual: boolean;
@@ -106,6 +109,36 @@ type StandStatusResponse = {
   sessions: StandSession[];
 };
 
+type StandSelectionCandidate = {
+  stand: string;
+  rule_id: string;
+  tier: number;
+  tier_name: string;
+  original_weight: number;
+  normalized_weight: number;
+  fallback_used: boolean;
+  selectable: boolean;
+};
+
+type StandAllocationPreview = {
+  callsign: string;
+  airport: string;
+  fallback_used: boolean;
+  compatible_stands: number;
+  available_stands: number;
+  selection: {
+    rule_id: string;
+    fallback_used: boolean;
+    candidates: StandSelectionCandidate[];
+  };
+};
+
+type SelectedFlight = {
+  sessionId: number;
+  airport: string;
+  callsign: string;
+};
+
 function formatStatus(value: string): string {
   return value.replace(/_/g, " ").replace(/\b\w/g, (letter: string) => letter.toUpperCase());
 }
@@ -152,6 +185,11 @@ function formatAge(timestamp?: string): string {
   return `${Math.floor(seconds / 60)} min ${Math.round(seconds % 60)} sec`;
 }
 
+function formatPercentage(value: number): string {
+  const percentage = value * 100;
+  return `${percentage.toFixed(percentage >= 10 ? 0 : 1)}%`;
+}
+
 function configurationEntries(configuration: StandConfiguration) {
   return [
     ["Aircraft types", configuration.aircraft_types],
@@ -163,11 +201,231 @@ function configurationEntries(configuration: StandConfiguration) {
   ] as const;
 }
 
+type StandTimelineItem = {
+  id: string;
+  stand: string;
+  label: string;
+  detail: string;
+  secondary: string;
+  start: Date;
+  end?: Date;
+  active: boolean;
+  tone: string;
+};
+
+const comfortableTimelineLayout = {
+  width: "min-w-[1280px]",
+  height: "max-h-[34rem]",
+  rowHeight: 76,
+  laneHeight: 68,
+};
+
+type StandSelectionTier = {
+  ruleID: string;
+  tier: number;
+  tierName: string;
+  selectable: boolean;
+  candidates: StandSelectionCandidate[];
+};
+
+function groupPreviewCandidates(candidates: StandSelectionCandidate[]): StandSelectionTier[] {
+  const groups = new Map<string, StandSelectionTier>();
+  for (const candidate of candidates) {
+    const key = `${candidate.rule_id}:${candidate.tier}:${candidate.tier_name}`;
+    const group = groups.get(key) ?? {
+      ruleID: candidate.rule_id,
+      tier: candidate.tier,
+      tierName: candidate.tier_name,
+      selectable: candidate.selectable,
+      candidates: [],
+    };
+    group.selectable ||= candidate.selectable;
+    group.candidates.push(candidate);
+    groups.set(key, group);
+  }
+  return [...groups.values()].sort((left, right) => left.tier - right.tier || left.ruleID.localeCompare(right.ruleID));
+}
+
+function clockValue(value?: string): string {
+  if (!value) return "—";
+  const digits = value.replace(/\D/g, "");
+  return digits.length === 4 ? `${digits.slice(0, 2)}:${digits.slice(2)}` : value;
+}
+
+function timelineDate(value?: string): Date | undefined {
+  if (!value) return undefined;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+function entryIsActive(expiresAt: string | undefined, now: Date): boolean {
+  const expiry = timelineDate(expiresAt);
+  return !expiry || expiry > now;
+}
+
+function activeAssignments(session: StandSession, now: Date): StandAssignment[] {
+  return session.assignments.filter((assignment) => entryIsActive(assignment.expires_at, now));
+}
+
+function activeBlocks(session: StandSession, now: Date): StandBlock[] {
+  return session.blocks.filter((block) => entryIsActive(block.expires_at, now));
+}
+
+function buildTimelineItems(session: StandSession, now: Date): StandTimelineItem[] {
+  const assignments = session.assignments.flatMap((assignment) => {
+    // An arrival is a future reservation until it reaches its ETA. Displaying
+    // it from the assignment timestamp falsely makes its stand look occupied
+    // hours before the aircraft is due to arrive.
+    const start = assignment.direction === "ARRIVAL"
+      ? timelineDate(assignment.eta) ?? timelineDate(assignment.assigned_at) ?? timelineDate(assignment.created_at)
+      : timelineDate(assignment.assigned_at) ?? timelineDate(assignment.created_at);
+    if (!start || !assignment.stand) return [];
+    const displayEnd = timelineDate(assignment.expires_at) ?? (assignment.direction === "ARRIVAL" && assignment.eta
+      ? new Date(new Date(assignment.eta).getTime() + 30 * 60 * 1000)
+      : undefined);
+    const active = entryIsActive(assignment.expires_at, now);
+    const timing = assignment.direction === "DEPARTURE"
+      ? `TOBT ${clockValue(assignment.departure_tobt)} · TSAT ${clockValue(assignment.departure_tsat)}`
+      : `ETA ${formatTimestamp(assignment.eta)}`;
+    return [{
+      id: `assignment-${assignment.id}`,
+      stand: assignment.stand.toUpperCase(),
+      label: assignment.callsign,
+      detail: `${formatStatus(assignment.direction)} · ${formatStatus(assignment.stage)}${assignment.rule_id ? ` · ${assignment.rule_id}` : ""}`,
+      secondary: `${timing} · ${displayEnd ? `ends ${formatTimestamp(displayEnd.toISOString())}` : "open-ended"}`,
+      start,
+      end: displayEnd,
+      active,
+      tone: !active
+        ? "border-slate-400/70 bg-slate-500/70 text-slate-50 dark:border-slate-500 dark:bg-slate-600/70"
+        : assignment.direction === "ARRIVAL"
+          ? "border-sky-600/60 bg-sky-600/85 text-white dark:border-sky-300/60 dark:bg-sky-400/80 dark:text-slate-950"
+          : "border-emerald-700/60 bg-emerald-600/85 text-white dark:border-emerald-300/60 dark:bg-emerald-400/80 dark:text-slate-950",
+    } satisfies StandTimelineItem];
+  });
+  const blocks = session.blocks.flatMap((block) => {
+    const start = timelineDate(block.created_at);
+    if (!start || !block.stand) return [];
+    const end = timelineDate(block.expires_at);
+    const active = entryIsActive(block.expires_at, now);
+    return [{
+      id: `block-${block.id}`,
+      stand: block.stand.toUpperCase(),
+      label: block.callsign || formatStatus(block.block_type || "block"),
+      detail: `${formatStatus(block.block_type || "block")} · ${formatStatus(block.source || "system")}${block.manual ? " · manual" : ""}`,
+      secondary: `${block.reason || "No reason supplied"}${block.callsign ? ` · ${block.callsign}` : ""} · ${end ? `ends ${formatTimestamp(end.toISOString())}` : "open-ended"}`,
+      start,
+      end,
+      active,
+      tone: !active
+        ? "border-violet-400/70 bg-violet-500/70 text-white dark:border-violet-300/60 dark:bg-violet-400/70 dark:text-slate-950"
+        : "border-amber-600/60 bg-amber-500/90 text-amber-950 dark:border-amber-300/60 dark:bg-amber-400/80 dark:text-slate-950",
+    } satisfies StandTimelineItem];
+  });
+  return [...assignments, ...blocks].sort((left, right) => left.stand.localeCompare(right.stand) || left.start.getTime() - right.start.getTime());
+}
+
+function StandAllocationTimeline({ session, selectedStand, onSelectStand }: {
+  session: StandSession;
+  selectedStand: string;
+  onSelectStand: (stand: string) => void;
+}) {
+  const layout = comfortableTimelineLayout;
+  const now = new Date();
+  const items = buildTimelineItems(session, now);
+  const requestedStand = selectedStand.trim().toUpperCase();
+  const stands = [...new Set(items.map((item) => item.stand))];
+  const visibleStands = requestedStand ? [requestedStand] : stands;
+  const earliest = items.reduce<Date | undefined>((value, item) => !value || item.start < value ? item.start : value, undefined);
+  const latest = items.reduce<Date | undefined>((value, item) => {
+    const end = item.end ?? now;
+    return !value || end > value ? end : value;
+  }, undefined);
+  const rangeStart = new Date(Math.min(earliest?.getTime() ?? now.getTime(), now.getTime() - 60 * 60 * 1000));
+  const rangeEnd = new Date(Math.max(latest?.getTime() ?? now.getTime(), now.getTime() + 4 * 60 * 60 * 1000));
+  const rangeMs = Math.max(1, rangeEnd.getTime() - rangeStart.getTime());
+  const offset = (date: Date) => Math.max(0, Math.min(100, ((date.getTime() - rangeStart.getTime()) / rangeMs) * 100));
+
+  return (
+    <div className="border-t px-6 py-5">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <h3 className="text-base font-semibold">Stand occupancy timeline</h3>
+          <p className="text-sm text-muted-foreground">Active cards are coloured by type; violet/slate cards are expired history. Open-ended cards remain active.</p>
+        </div>
+        <div className="flex flex-wrap items-end gap-3">
+          <label className="flex flex-col gap-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Find stand
+            <input
+              value={selectedStand}
+              onChange={(event) => onSelectStand(event.target.value.toUpperCase())}
+              placeholder="e.g. A31"
+              className="h-9 w-40 rounded-md border bg-background px-3 text-sm font-normal normal-case text-foreground outline-none focus:ring-2 focus:ring-ring"
+            />
+          </label>
+        </div>
+      </div>
+      <div className="mt-4 overflow-x-auto rounded-lg border">
+        <div className={layout.width}>
+          <div className="grid grid-cols-[7rem_1fr] border-b bg-muted/40 text-xs text-muted-foreground">
+            <div className="px-3 py-2 font-medium uppercase tracking-wide">Stand</div>
+            <div className="flex justify-between px-3 py-2">
+              <span>{formatTimestamp(rangeStart.toISOString())}</span>
+              <span>{formatTimestamp(rangeEnd.toISOString())}</span>
+            </div>
+          </div>
+          <div className={`${layout.height} overflow-y-auto`}>
+            {visibleStands.length === 0 ? (
+              <div className="px-4 py-6 text-sm text-muted-foreground">No stands have active assignments or blocks.</div>
+            ) : visibleStands.map((stand) => {
+              const standItems = items.filter((item) => item.stand === stand);
+              const rowHeight = Math.max(layout.rowHeight, standItems.length * layout.laneHeight + 12);
+              return (
+                <div key={stand} className="grid grid-cols-[7rem_1fr] border-b last:border-b-0">
+                  <div className="flex items-center px-3 py-3 font-semibold">{stand}</div>
+                  <div className="relative overflow-hidden bg-background" style={{ minHeight: `${rowHeight}px` }}>
+                    <div className="absolute inset-y-0 z-10 border-l-2 border-red-500/90" style={{ left: `${offset(now)}%` }} />
+                    {standItems.length === 0 ? <div className="px-3 py-4 text-xs text-muted-foreground">No current allocation or block.</div> : null}
+                    {standItems.map((item, index) => {
+                      const start = offset(item.start);
+                      const end = offset(item.end ?? rangeEnd);
+                      return (
+                        <div
+                          key={item.id}
+                          title={`${item.label}: ${item.detail}. ${item.secondary}`}
+                          className={`absolute overflow-hidden rounded-md border px-2 py-1 shadow-sm ${item.tone}`}
+                          style={{ left: `${start}%`, width: `${Math.max(7, end - start)}%`, top: `${6 + index * layout.laneHeight}px`, height: `${layout.laneHeight - 6}px` }}
+                        >
+                          <div className="flex items-center justify-between gap-2 text-xs font-semibold leading-4">
+                            <span className="truncate">{item.label}</span>
+                            {!item.active ? <span className="rounded bg-black/15 px-1 py-px text-[9px] uppercase tracking-wide">History</span> : null}
+                          </div>
+                          <div className="truncate text-[11px] leading-4 opacity-90">{item.detail}</div>
+                          <div className="truncate text-[10px] leading-4 opacity-80">{item.secondary}</div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function StandStatusPage() {
   const { getAccessTokenSilently } = useAuth0();
   const [data, setData] = useState<StandStatusResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [selectedStand, setSelectedStand] = useState("");
+  const [selectedFlight, setSelectedFlight] = useState<SelectedFlight | null>(null);
+  const [preview, setPreview] = useState<StandAllocationPreview | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
 
   const authorizedFetch = useCallback(async () => {
     const token = await getAccessTokenSilently();
@@ -210,11 +468,48 @@ export default function StandStatusPage() {
     };
   }, [authorizedFetch]);
 
+  useEffect(() => {
+    if (!selectedFlight) {
+      setPreview(null);
+      setPreviewError(null);
+      return;
+    }
+    let active = true;
+    setPreviewLoading(true);
+    setPreview(null);
+    setPreviewError(null);
+    void (async () => {
+      try {
+        const token = await getAccessTokenSilently();
+        const query = new URLSearchParams({
+          session_id: String(selectedFlight.sessionId),
+          airport: selectedFlight.airport,
+          callsign: selectedFlight.callsign,
+        });
+        const response = await fetch(getApiUrl(`/api/stand/preview?${query.toString()}`), {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!response.ok) {
+          const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+          throw new Error(payload?.error ?? `Preview failed (${response.status})`);
+        }
+        const payload = (await response.json()) as StandAllocationPreview;
+        if (active) setPreview(payload);
+      } catch (previewFetchError) {
+        if (active) setPreviewError(previewFetchError instanceof Error ? previewFetchError.message : "Failed to load stand possibilities.");
+      } finally {
+        if (active) setPreviewLoading(false);
+      }
+    })();
+    return () => { active = false; };
+  }, [getAccessTokenSilently, selectedFlight]);
+
   const totals = useMemo(() => {
+    const now = new Date();
     return (data?.sessions ?? []).reduce(
       (total, session) => ({
-        assignments: total.assignments + session.assignments.length,
-        blocks: total.blocks + session.blocks.length,
+        assignments: total.assignments + activeAssignments(session, now).length,
+        blocks: total.blocks + activeBlocks(session, now).length,
       }),
       { assignments: 0, blocks: 0 },
     );
@@ -375,7 +670,11 @@ export default function StandStatusPage() {
               </div>
             ) : null}
 
-            {data.sessions.map((session) => (
+            {data.sessions.map((session) => {
+              const now = new Date();
+              const sessionAssignments = activeAssignments(session, now);
+              const sessionBlocks = activeBlocks(session, now);
+              return (
               <section key={session.session_id} className="rounded-2xl border bg-card shadow-sm">
                 <div className="border-b px-6 py-4">
                   <div className="flex flex-col gap-2 md:flex-row md:items-baseline md:justify-between">
@@ -384,7 +683,7 @@ export default function StandStatusPage() {
                       <p className="text-sm text-muted-foreground">Session {session.session_id}</p>
                     </div>
                     <div className="text-sm text-muted-foreground">
-                      {session.assignments.length} assignments · {session.blocks.length} blocks
+                      {sessionAssignments.length} assignments · {sessionBlocks.length} blocks
                     </div>
                   </div>
                 </div>
@@ -402,15 +701,19 @@ export default function StandStatusPage() {
                       </tr>
                     </thead>
                     <tbody>
-                      {session.assignments.length === 0 ? (
+                      {sessionAssignments.length === 0 ? (
                         <tr className="border-t">
                           <td colSpan={6} className="px-4 py-6 text-center text-muted-foreground">
                             No active stand assignments.
                           </td>
                         </tr>
                       ) : null}
-                      {session.assignments.map((assignment) => (
-                        <tr key={assignment.id} className="border-t align-top">
+                      {sessionAssignments.map((assignment) => (
+                        <tr
+                          key={assignment.id}
+                          onClick={() => setSelectedFlight({ sessionId: session.session_id, airport: session.airport, callsign: assignment.callsign })}
+                          className={`cursor-pointer border-t align-top hover:bg-muted/50 ${selectedFlight?.sessionId === session.session_id && selectedFlight.callsign === assignment.callsign ? "bg-primary/5" : ""}`}
+                        >
                           <td className="px-4 py-3">
                             <div className="font-semibold">{assignment.callsign}</div>
                             <div className="text-xs text-muted-foreground">{assignment.direction || "—"}</div>
@@ -419,7 +722,7 @@ export default function StandStatusPage() {
                             <div className="font-semibold">{assignment.stand || "—"}</div>
                             <div className="text-xs text-muted-foreground">
                               {assignment.stage || "—"} · {assignment.source || "—"}
-                              {assignment.manual ? " · manual" : ""}
+                              {assignment.manual && assignment.source !== "MANUAL" ? " · manual" : ""}
                             </div>
                           </td>
                           <td className="px-4 py-3">
@@ -429,15 +732,30 @@ export default function StandStatusPage() {
                             </div>
                             {assignment.conflict_reason ? (
                               <div className="mt-1 text-xs text-amber-700 dark:text-amber-300">
-                                Override: {assignment.conflict_reason}
+                                {assignment.conflict_reason.startsWith("automatic fallback:") ? "Fallback" : "Override"}: {assignment.conflict_reason}
                               </div>
                             ) : null}
                           </td>
                           <td className="px-4 py-3">
-                            <div>ETA {formatTimestamp(assignment.eta)}</div>
-                            <div className="text-xs text-muted-foreground">
-                              {assignment.eta_source || "No ETA source"} · expires {formatTimestamp(assignment.expires_at)}
-                            </div>
+                            {assignment.direction === "DEPARTURE" ? (
+                              <>
+                                <div>TOBT {clockValue(assignment.departure_tobt)} · TSAT {clockValue(assignment.departure_tsat)}</div>
+                                <div className="text-xs text-muted-foreground">
+                                  {assignment.expires_at
+                                    ? `Expires ${formatTimestamp(assignment.expires_at)}`
+                                    : assignment.planned_release_at
+                                      ? `Scheduled expiry ${formatTimestamp(assignment.planned_release_at)}; held while observed on stand`
+                                      : "Held while observed on stand; no TOBT or TSAT"}
+                                </div>
+                              </>
+                            ) : (
+                              <>
+                                <div>ETA {formatTimestamp(assignment.eta)}</div>
+                                <div className="text-xs text-muted-foreground">
+                                  {assignment.eta_source || "No ETA source"} · expires {formatTimestamp(assignment.expires_at)}
+                                </div>
+                              </>
+                            )}
                             <div className="text-xs text-muted-foreground">
                               Assigned {formatTimestamp(assignment.assigned_at)}
                             </div>
@@ -463,7 +781,9 @@ export default function StandStatusPage() {
                   </table>
                 </div>
 
-                {session.blocks.length > 0 ? (
+                <StandAllocationTimeline session={session} selectedStand={selectedStand} onSelectStand={setSelectedStand} />
+
+                {sessionBlocks.length > 0 ? (
                   <div className="border-t">
                     <div className="px-6 py-3 text-sm font-semibold">Active stand blocks</div>
                     <div className="overflow-x-auto">
@@ -479,7 +799,7 @@ export default function StandStatusPage() {
                           </tr>
                         </thead>
                         <tbody>
-                          {session.blocks.map((block) => (
+                          {sessionBlocks.map((block) => (
                             <tr key={block.id} className="border-t">
                               <td className="px-4 py-3 font-semibold">{block.stand}</td>
                               <td className="px-4 py-3">{block.block_type || "—"}</td>
@@ -507,7 +827,84 @@ export default function StandStatusPage() {
                   </div>
                 ) : null}
               </section>
-            ))}
+              );
+            })}
+
+            {selectedFlight ? (
+              <div
+                className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+                onClick={() => setSelectedFlight(null)}
+              >
+                <section
+                  role="dialog"
+                  aria-modal="true"
+                  aria-labelledby="stand-possibilities-title"
+                  className="max-h-[90vh] w-full max-w-5xl overflow-y-auto rounded-xl border bg-background shadow-2xl"
+                  onClick={(event) => event.stopPropagation()}
+                >
+                  <header className="sticky top-0 z-10 flex items-start justify-between gap-4 border-b bg-background px-6 py-5">
+                    <div>
+                      <h2 id="stand-possibilities-title" className="text-xl font-semibold">Stand possibilities · {selectedFlight.callsign}</h2>
+                      <p className="mt-1 text-sm text-muted-foreground">Current compatible and available policy candidates, grouped by allocation tier.</p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => setSelectedFlight(null)}
+                      className="rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-muted"
+                    >
+                      Close
+                    </button>
+                  </header>
+                  <div className="space-y-5 px-6 py-5">
+                    {preview ? (
+                      <div className="text-sm text-muted-foreground">
+                        {preview.compatible_stands} compatible · {preview.available_stands} available
+                        {preview.fallback_used ? " · using fallback pool" : ""}
+                      </div>
+                    ) : null}
+                    {previewLoading ? <div className="text-sm text-muted-foreground">Calculating current stand possibilities…</div> : null}
+                    {previewError ? <div className="text-sm text-red-700 dark:text-red-300">{previewError}</div> : null}
+                    {preview && !previewLoading ? (
+                      preview.selection.candidates.length === 0 ? (
+                        <div className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-950 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-100">No currently available stand appears in this flight’s configured policy pool.</div>
+                      ) : (
+                        <div className="space-y-4">
+                          {groupPreviewCandidates(preview.selection.candidates).map((tier) => (
+                            <section key={`${tier.ruleID}-${tier.tier}`} className="overflow-hidden rounded-lg border bg-card">
+                              <div className="flex flex-col gap-2 border-b bg-muted/30 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                                <div>
+                                  <h3 className="font-semibold">{tier.tierName || `Tier ${tier.tier}`}</h3>
+                                  <p className="text-xs text-muted-foreground">Rule {tier.ruleID}</p>
+                                </div>
+                                <span className={`w-fit rounded-full px-2 py-1 text-xs font-medium ${tier.selectable ? "bg-emerald-100 text-emerald-900 dark:bg-emerald-950/50 dark:text-emerald-100" : "bg-muted text-muted-foreground"}`}>
+                                  {tier.selectable ? "Selectable now" : "Used if higher tiers have no stand"}
+                                </span>
+                              </div>
+                              <div className="overflow-x-auto">
+                                <table className="min-w-full text-sm">
+                                  <thead className="bg-muted/20 text-left text-xs uppercase tracking-wide text-muted-foreground">
+                                    <tr><th className="px-4 py-2 font-medium">Stand</th><th className="px-4 py-2 font-medium">Weight</th><th className="px-4 py-2 font-medium">Chance</th></tr>
+                                  </thead>
+                                  <tbody>
+                                    {tier.candidates.map((candidate) => (
+                                      <tr key={`${candidate.rule_id}-${candidate.tier}-${candidate.stand}`} className="border-t">
+                                        <td className="px-4 py-3 font-semibold">{candidate.stand}</td>
+                                        <td className="px-4 py-3">{candidate.original_weight}</td>
+                                        <td className="px-4 py-3 font-semibold">{formatPercentage(candidate.normalized_weight)}</td>
+                                      </tr>
+                                    ))}
+                                  </tbody>
+                                </table>
+                              </div>
+                            </section>
+                          ))}
+                        </div>
+                      )
+                    ) : null}
+                  </div>
+                </section>
+              </div>
+            ) : null}
           </>
         ) : null}
       </div>


### PR DESCRIPTION
## Summary

- Add configured fallback-pool allocation, terminal failure suppression, and CID propagation for stand assignments.
- Expose stand timing, candidate previews, and detailed occupancy history in the stand-status UI.
- Add a comfortable timeline view, stand filter, and tier-grouped stand-insights modal.

## Why

Controllers need transparent stand availability and allocation decisions without assigning arbitrary stands or repeatedly logging the same failed allocation.

## Validation

- `go test ./internal/sat ./internal/services ./internal/standstatus ./internal/app`
- `npm run build`
- `git diff --check`
