### PR TITLE
feat(stand): show live EFB stand availability

### DIFF
--- a/backend/internal/efb/webapi.go
+++ b/backend/internal/efb/webapi.go
@@ -30,6 +30,11 @@ type CDMUpdater interface {
 	HandleTobtUpdate(context.Context, int32, string, string, string, string) error
 }
 
+type StandActions interface {
+	AssignForPilot(context.Context, int32, string, string, string, string, int32) (*services.StandAllocationResult, error)
+	AvailableForPilot(context.Context, int32, string, string) ([]services.StandAvailability, error)
+}
+
 type ATISLookup interface {
 	GetATIS(airport string, departure bool) *metar.ATIS
 }
@@ -46,7 +51,7 @@ type WebAPIConfig struct {
 	Assignments repository.StandAssignmentRepository
 	CDM         CDMUpdater
 	CDMReady    bool
-	Stands      *services.StandActionService
+	Stands      StandActions
 	ATIS        ATISLookup
 	Departures  DepartureFrequencyLookup
 	PDCReady    bool
@@ -63,7 +68,7 @@ type WebAPI struct {
 	assignments repository.StandAssignmentRepository
 	cdm         CDMUpdater
 	cdmReady    bool
-	stands      *services.StandActionService
+	stands      StandActions
 	atis        ATISLookup
 	departures  DepartureFrequencyLookup
 	pdcReady    bool
@@ -81,6 +86,7 @@ func (a *WebAPI) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/efb/flight", a.handleFlight)
 	mux.HandleFunc("/efb/tobt", a.handleTobt)
 	mux.HandleFunc("/efb/stand", a.handleStand)
+	mux.HandleFunc("/efb/stands", a.handleStandAvailability)
 }
 
 func (a *WebAPI) handleMe(w http.ResponseWriter, r *http.Request) {
@@ -380,6 +386,32 @@ func (a *WebAPI) handleStand(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"callsign": result.Assignment.Callsign, "stand": result.Assignment.Stand, "version": result.Assignment.Version})
+}
+
+func (a *WebAPI) handleStandAvailability(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	user, ok := a.authenticate(w, r)
+	if !ok {
+		return
+	}
+	match, session, err := a.resolveFlight(r.Context(), user, r.URL.Query().Get("callsign"))
+	if err != nil {
+		a.writeResolveError(w, err)
+		return
+	}
+	if a.stands == nil {
+		writeError(w, http.StatusServiceUnavailable, "stand availability unavailable")
+		return
+	}
+	stands, err := a.stands.AvailableForPilot(r.Context(), match.SessionID, session.Airport, match.Strip.Callsign)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "stand availability unavailable")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"stands": stands})
 }
 
 var errNoOnline = errors.New("no current VATSIM flight")

--- a/backend/internal/efb/webapi_test.go
+++ b/backend/internal/efb/webapi_test.go
@@ -5,6 +5,7 @@ import (
 	"FlightStrips/internal/aman/terminal"
 	"FlightStrips/internal/models"
 	"FlightStrips/internal/pdc"
+	"FlightStrips/internal/services"
 	"FlightStrips/internal/shared"
 	"FlightStrips/internal/testutil"
 	"context"
@@ -50,6 +51,23 @@ type departureFrequencyStub struct{ frequency string }
 
 type cdmStub struct{ calls int }
 
+type standActionsStub struct {
+	availability []services.StandAvailability
+	err          error
+	session      int32
+	airport      string
+	callsign     string
+}
+
+func (s *standActionsStub) AssignForPilot(context.Context, int32, string, string, string, string, int32) (*services.StandAllocationResult, error) {
+	return nil, s.err
+}
+
+func (s *standActionsStub) AvailableForPilot(_ context.Context, session int32, airport, callsign string) ([]services.StandAvailability, error) {
+	s.session, s.airport, s.callsign = session, airport, callsign
+	return s.availability, s.err
+}
+
 func (s *cdmStub) HandleTobtUpdate(context.Context, int32, string, string, string, string) error {
 	s.calls++
 	return nil
@@ -91,6 +109,39 @@ func TestLiveFlightUsesAuthenticatedCIDCallsign(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), `"phase":"DEPARTURE"`) {
 		t.Fatalf("missing departure snapshot: %s", rec.Body.String())
+	}
+}
+
+func TestStandAvailabilityUsesAuthenticatedFlightAndReturnsTimeAwareEntries(t *testing.T) {
+	stands := &standActionsStub{availability: []services.StandAvailability{
+		{Stand: "A12", Available: true},
+		{Stand: "A14", Reason: "reserved by SAS999"},
+	}}
+	finder := &finderStub{match: pdc.WebStripMatch{SessionID: 7, Strip: &models.Strip{Callsign: "SAS123", Origin: "ESSA", Destination: "EKCH"}}}
+	sessions := &testutil.MockSessionRepository{GetByIDFn: func(context.Context, int32) (*models.Session, error) {
+		return &models.Session{ID: 7, Airport: "EKCH"}, nil
+	}}
+	api := NewWebAPI(WebAPIConfig{Auth: authStub{}, Callsigns: callsignStub{callsign: "SAS123", found: true}, Flights: finder, Sessions: sessions, Stands: stands, Live: true})
+	req := httptest.NewRequest(http.MethodGet, "/efb/stands?callsign=OTHER", nil)
+	req.Header.Set("Authorization", "Bearer token")
+	rec := httptest.NewRecorder()
+
+	api.handleStandAvailability(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if stands.session != 7 || stands.airport != "EKCH" || stands.callsign != "SAS123" {
+		t.Fatalf("unexpected availability request: session=%d airport=%s callsign=%s", stands.session, stands.airport, stands.callsign)
+	}
+	var payload struct {
+		Stands []services.StandAvailability `json:"stands"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	if len(payload.Stands) != 2 || !payload.Stands[0].Available || payload.Stands[1].Reason != "reserved by SAS999" {
+		t.Fatalf("unexpected availability response: %#v", payload.Stands)
 	}
 }
 

--- a/backend/internal/frontend/stand_assignment_euroscope_test.go
+++ b/backend/internal/frontend/stand_assignment_euroscope_test.go
@@ -5,6 +5,7 @@ import (
 	"FlightStrips/internal/sat"
 	"FlightStrips/internal/services"
 	"FlightStrips/internal/testutil"
+	frontendEvents "FlightStrips/pkg/events/frontend"
 	"context"
 	"testing"
 
@@ -126,4 +127,39 @@ func TestSendAllocatedStandToEuroscope_PrefersTrackingController(t *testing.T) {
 	require.Len(t, esHub.Stands, 1)
 	assert.Equal(t, trackingCid, esHub.Stands[0].Cid)
 	assert.Empty(t, esHub.Broadcasts)
+}
+
+func TestPublishStandAllocationForwardsPilotRequestToControllersAndEuroscope(t *testing.T) {
+	const (
+		session  = int32(7)
+		callsign = "SAS503"
+		stand    = "B14"
+	)
+	esHub := &testutil.MockEuroscopeHub{GetMasterCidFn: func(int32) string { return "MASTER-CID" }}
+	hub := &Hub{
+		send: make(chan internalMessage, 2),
+		server: &testutil.MockServer{
+			EuroscopeHubVal: esHub,
+			SessionRepoVal: &testutil.MockSessionRepository{GetByIDFn: func(context.Context, int32) (*models.Session, error) {
+				return &models.Session{ID: session, Airport: "EKCH"}, nil
+			}},
+		},
+	}
+
+	err := hub.PublishStandAllocation(t.Context(), services.StandAllocationResult{
+		Assignment: models.StandAssignment{
+			SessionID: session, Callsign: callsign, Stand: stand,
+			Direction: string(sat.AssignmentDirectionDeparture), Stage: services.StageReserved,
+		},
+		NotifyEuroscope: true,
+	})
+
+	require.NoError(t, err)
+	message := <-hub.send
+	update, ok := message.message.(frontendEvents.StandAssignmentUpdateEvent)
+	require.True(t, ok)
+	assert.Equal(t, callsign, update.Assignment.Callsign)
+	assert.Equal(t, stand, update.Assignment.Stand)
+	require.Len(t, esHub.Stands, 1)
+	require.Equal(t, testutil.StandCall{Session: session, Cid: "MASTER-CID", Callsign: callsign, Stand: stand}, esHub.Stands[0])
 }

--- a/backend/internal/services/stand_actions.go
+++ b/backend/internal/services/stand_actions.go
@@ -70,6 +70,25 @@ func (s *StandActionService) Preview(ctx context.Context, session int32, airport
 	return s.allocations.Preview(ctx, req)
 }
 
+// AvailableForPilot returns the live, time-aware availability of each
+// configured stand for an authenticated EFB flight.
+func (s *StandActionService) AvailableForPilot(ctx context.Context, session int32, airport, callsign string) ([]StandAvailability, error) {
+	if s == nil || s.allocations == nil {
+		return nil, errors.New("stand availability is unavailable")
+	}
+	version := int32(0)
+	if existing, err := s.assignments.GetAssignment(ctx, session, strings.TrimSpace(callsign)); err == nil && existing != nil {
+		version = existing.Version
+	} else if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("load stand assignment: %w", err)
+	}
+	req, err := s.request(ctx, session, airport, "PILOT_AVAILABILITY", callsign, version)
+	if err != nil {
+		return nil, err
+	}
+	return s.allocations.AvailableStands(ctx, req)
+}
+
 func (s *StandActionService) AssignManually(ctx context.Context, session int32, airport, position, callsign, stand string, version int32) (*StandAllocationResult, error) {
 	req, err := s.request(ctx, session, airport, position, callsign, version)
 	if err != nil {
@@ -93,7 +112,7 @@ func (s *StandActionService) AssignForPilot(ctx context.Context, session int32, 
 		s.recordRequestFailure(CompatibleManualStand, session, airport, callsign, stand, err)
 		return nil, err
 	}
-	req.Stand = stand
+	req.Stand, req.RequestStandSync = stand, true
 	return s.allocations.AssignManually(ctx, req)
 }
 

--- a/backend/internal/services/stand_actions_test.go
+++ b/backend/internal/services/stand_actions_test.go
@@ -29,6 +29,46 @@ func TestStandActionDepartureStartsReserved(t *testing.T) {
 	assert.WithinDuration(t, before.Add(defaultDepartureHoldDuration), *result.Assignment.ExpiresAt, time.Second)
 }
 
+func TestPilotStandRequestSyncsEuroscopeWhenTheStripAlreadyHasTheSelectedStand(t *testing.T) {
+	pool, queries := testdata.SetupTestDB(t)
+	allocation, session, assignments := standAllocationFixture(t, pool, queries, "", "")
+	testdata.SeedTestStrip(t, queries, session, "SAS803")
+	stand := "A1"
+	updated, err := queries.UpdateStripStandByID(context.Background(), database.UpdateStripStandByIDParams{
+		Callsign: "SAS803", Session: session, Stand: &stand,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, updated)
+	actions := NewStandActionService(allocation, assignments, postgres.NewStripRepository(pool), nil, nil, nil)
+
+	result, err := actions.AssignForPilot(context.Background(), session, "EKCH", "1234567", "SAS803", stand, 0)
+
+	require.NoError(t, err)
+	assert.False(t, result.StandChanged)
+	assert.True(t, result.NotifyEuroscope, "an EFB selection must be forwarded even when the stand was already persisted")
+}
+
+func TestPilotStandAvailabilityUsesTheAssignmentRules(t *testing.T) {
+	pool, queries := testdata.SetupTestDB(t)
+	allocation, session, assignments := standAllocationFixture(t, pool, queries, "", "")
+	testdata.SeedTestStrip(t, queries, session, "SAS804")
+	testdata.SeedTestStrip(t, queries, session, "SAS805")
+	actions := NewStandActionService(allocation, assignments, postgres.NewStripRepository(pool), nil, nil, nil)
+
+	_, err := actions.AssignManually(context.Background(), session, "EKCH", "GND", "SAS804", "A1", 0)
+	require.NoError(t, err)
+	availability, err := actions.AvailableForPilot(context.Background(), session, "EKCH", "SAS805")
+
+	require.NoError(t, err)
+	byStand := make(map[string]StandAvailability, len(availability))
+	for _, entry := range availability {
+		byStand[entry.Stand] = entry
+	}
+	assert.False(t, byStand["A1"].Available)
+	assert.Contains(t, byStand["A1"].Reason, "reserved by SAS804")
+	assert.True(t, byStand["A2"].Available)
+}
+
 func TestStandActionPropagatesAssignmentLookupErrors(t *testing.T) {
 	pool, queries := testdata.SetupTestDB(t)
 	allocation, session, assignments := standAllocationFixture(t, pool, queries, "", "")

--- a/backend/internal/services/stand_allocation.go
+++ b/backend/internal/services/stand_allocation.go
@@ -70,6 +70,11 @@ type StandAllocationRequest struct {
 
 	Stand          string
 	ConflictReason string
+	// RequestStandSync makes a caller-originated selection reach EuroScope even
+	// when the strip already contains that stand. This is needed for pilot EFB
+	// requests, where the persisted value alone cannot prove that EuroScope saw
+	// the selection.
+	RequestStandSync bool
 
 	DisplaceStage string
 	// DisplaceArrivalStages extends DisplaceStage for callers that may displace
@@ -112,6 +117,14 @@ type StandAllocationPreview struct {
 	CompatibleStands int                       `json:"compatible_stands"`
 	AvailableStands  int                       `json:"available_stands"`
 	Selection        sat.StandSelectionPreview `json:"selection"`
+}
+
+// StandAvailability describes whether a manually selected stand can be used
+// for a flight at its current arrival ETA or departure TOBT.
+type StandAvailability struct {
+	Stand     string `json:"stand"`
+	Available bool   `json:"available"`
+	Reason    string `json:"reason,omitempty"`
 }
 
 type StandAllocationPublisher func(context.Context, StandAllocationResult) error
@@ -652,7 +665,7 @@ func (s *StandAllocationService) allocateOnce(ctx context.Context, command Stand
 		Command: command, Assignment: *assignment, Selection: selection, MatchedVariant: match,
 		Compatibility: evaluation, ConflictReason: conflict, Attempts: attempt, AvailableCandidates: available,
 		RemovedAssignments: removedAssignments, RemovedStandChanges: removedStandChanges,
-		StandChanged: standChanged, NotifyEuroscope: standChanged,
+		StandChanged: standChanged, NotifyEuroscope: standChanged || request.RequestStandSync,
 	}, selected, nil
 }
 
@@ -696,6 +709,54 @@ func (s *StandAllocationService) StandAvailable(ctx context.Context, request Sta
 	}
 	availability := s.availability(request, assignments, blocks, matches)
 	return len(availability[target]) == 0, nil
+}
+
+// AvailableStands evaluates every configured stand for an explicit selection.
+// It uses the same compatibility and timing rules as a manual assignment but
+// does not modify an assignment or reserve a stand.
+func (s *StandAllocationService) AvailableStands(ctx context.Context, request StandAllocationRequest) ([]StandAvailability, error) {
+	if err := validateStandAllocationRequest(AutomaticStandAllocation, &request); err != nil {
+		return nil, err
+	}
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx)
+	if _, err := tx.Exec(ctx, "SELECT id FROM sessions WHERE id = $1 FOR UPDATE", request.SessionID); err != nil {
+		return nil, err
+	}
+	txAssignments := s.assignments.WithTx(tx)
+	assignments, err := txAssignments.LockAssignments(ctx, request.SessionID, request.Callsign)
+	if err != nil {
+		return nil, err
+	}
+	blocks, err := txAssignments.LockActiveManualBlocks(ctx, request.SessionID)
+	if err != nil {
+		return nil, err
+	}
+
+	evaluation := s.stands.EvaluateManualCompatibility(request.Airport, request.FlightFacts)
+	matches := make(map[string]sat.StandCompatibilityMatch, len(evaluation.Matches))
+	for _, match := range evaluation.Matches {
+		matches[standName(match.Stand.Name)] = match
+	}
+	unavailable := s.availability(request, assignments, blocks, matches)
+	stands := s.stands.Stands(request.Airport)
+	result := make([]StandAvailability, 0, len(stands))
+	for _, stand := range stands {
+		name := standName(stand.Name)
+		if _, compatible := matches[name]; !compatible {
+			result = append(result, StandAvailability{Stand: name, Reason: compatibilityReason(name, evaluation.Rejections)})
+			continue
+		}
+		if reasons := unavailable[name]; len(reasons) > 0 {
+			result = append(result, StandAvailability{Stand: name, Reason: joinAllocationReasons(reasons)})
+			continue
+		}
+		result = append(result, StandAvailability{Stand: name, Available: true})
+	}
+	return result, nil
 }
 
 // Preview reports the current policy candidates without reserving, updating,

--- a/frontend/src/components/efb/dialogs/D1Stand.tsx
+++ b/frontend/src/components/efb/dialogs/D1Stand.tsx
@@ -11,6 +11,15 @@ interface D1StandProps {
   onClose: () => void;
   stand: string;
   onRequest?: (stand: string) => Promise<void>;
+  availability?: StandAvailability[];
+  availabilityLoading?: boolean;
+  availabilityUnavailable?: boolean;
+}
+
+export interface StandAvailability {
+  stand: string;
+  available: boolean;
+  reason?: string;
 }
 
 const EST_BOARD_WIDTH = 2560;
@@ -127,18 +136,21 @@ const RAW_STANDS: RawStandDefinition[] = [
   { label: 'A34', x: 13, y: 56 },
 ];
 
-export default function D1Stand({ isOpen, onClose, stand, onRequest }: D1StandProps) {
+export default function D1Stand({ isOpen, onClose, stand, onRequest, availability, availabilityLoading = false, availabilityUnavailable = false }: D1StandProps) {
   const [selectedStand, setSelectedStand] = useState<string>(stand);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [requestError, setRequestError] = useState<string | null>(null);
+  const availabilityByStand = new Map<string, StandAvailability>(availability?.map((entry) => [entry.stand, entry]) ?? []);
+  const isStandUnavailable = (standId: string) => availability !== undefined && availabilityByStand.get(standId)?.available !== true;
 
   const handleStandClick = (standId: string) => {
+    if (availabilityLoading || availabilityUnavailable || isStandUnavailable(standId)) return;
     setSelectedStand(standId);
     setRequestError(null);
   };
 
   const handleRequestNewStand = async () => {
-    if (!selectedStand || isSubmitting) return;
+    if (!selectedStand || isSubmitting || availabilityLoading || availabilityUnavailable || isStandUnavailable(selectedStand)) return;
     setIsSubmitting(true);
     setRequestError(null);
     try {
@@ -163,8 +175,19 @@ export default function D1Stand({ isOpen, onClose, stand, onRequest }: D1StandPr
         <div className="relative mx-[5%] h-[90%] w-[90%] box-border overflow-hidden border-[10px] border-[#1D293D] bg-[#7b7b7b]">
           {RAW_STANDS.map((standDef) => {
             const isSelected = selectedStand === standDef.label;
-
-            const dotColor = isSelected ? 'bg-[#43C6E7]' : 'bg-[#6B7280]';
+            const availabilityEntry = availabilityByStand.get(standDef.label);
+            const isUnavailable = isStandUnavailable(standDef.label);
+            const isDisabled = availabilityLoading || availabilityUnavailable || isUnavailable;
+            const dotColor = availabilityUnavailable || availabilityLoading ? 'bg-[#6B7280]' : isUnavailable ? 'bg-[#B63F3F]' : isSelected ? 'bg-[#43C6E7]' : availabilityEntry?.available ? 'bg-[#3FA66B]' : 'bg-[#6B7280]';
+            const availabilityTitle = availabilityLoading
+              ? 'Checking availability…'
+              : availabilityUnavailable
+                ? 'Availability is currently unavailable'
+                : isUnavailable
+                  ? `Unavailable: ${availabilityEntry?.reason || 'not configured for this flight'}`
+                  : availabilityEntry?.available
+                    ? 'Available for this flight'
+                    : 'Availability is not configured for this stand';
             const standPosition = {
               '--stand-left': `${(standDef.x / EST_BOARD_WIDTH) * 100}%`,
               '--stand-top': `${(standDef.y / EST_BOARD_HEIGHT) * 100}%`,
@@ -175,9 +198,10 @@ export default function D1Stand({ isOpen, onClose, stand, onRequest }: D1StandPr
                 key={standDef.label}
                 type="button"
                 onClick={() => handleStandClick(standDef.label)}
-                title={`${standDef.label} (availability checked when requested)`}
+                disabled={isDisabled}
+                title={`${standDef.label}: ${availabilityTitle}`}
                 style={standPosition}
-                className={`absolute [left:var(--stand-left)] [top:var(--stand-top)] flex h-[10%] w-[3%] translate-[10%] cursor-pointer flex-col items-center justify-between rounded-md bg-[#f0f0f0] px-1 py-1.5 text-sm leading-none font-bold text-[#111] ${isSelected ? 'border-2 border-[#9be9ff]' : 'border border-[#9ea3a8]'}`}
+                className={`absolute [left:var(--stand-left)] [top:var(--stand-top)] flex h-[10%] w-[3%] translate-[10%] flex-col items-center justify-between rounded-md bg-[#f0f0f0] px-1 py-1.5 text-sm leading-none font-bold text-[#111] ${isDisabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'} ${isSelected ? 'border-2 border-[#9be9ff]' : 'border border-[#9ea3a8]'}`}
                 aria-label={`Stand ${standDef.label}`}
               >
                 <span>{standDef.label}</span>
@@ -187,16 +211,23 @@ export default function D1Stand({ isOpen, onClose, stand, onRequest }: D1StandPr
           })}
         </div>
 
+        <div className="mx-[5%] mt-1 flex items-center gap-3 text-xs font-bold text-white" aria-live="polite">
+          <span><span className="mr-1 inline-block h-2.5 w-2.5 rounded-full bg-[#3FA66B]" />AVAILABLE</span>
+          <span><span className="mr-1 inline-block h-2.5 w-2.5 rounded-full bg-[#B63F3F]" />UNAVAILABLE</span>
+          {availabilityLoading && <span>CHECKING AVAILABILITY…</span>}
+          {availabilityUnavailable && <span>AVAILABILITY UNAVAILABLE</span>}
+        </div>
+
         {requestError && <div role="alert" className="absolute bottom-[10%] left-[5%] z-10 w-[90%] bg-[#B63F3F] px-3 py-2 text-center font-bold text-white">{requestError}</div>}
 
         {/* Bottom controls */}
         <div className="mx-[5%] mt-[10px] flex h-[10%] w-[90%] gap-[10px]">
           <button
             onClick={handleRequestNewStand}
-            disabled={!selectedStand || isSubmitting}
-            className={`box-border h-full w-[61%] rounded border-[10px] border-[#1D293D] text-[clamp(12px,1.5vh,18px)] font-bold text-white transition-colors duration-200 ${!selectedStand || isSubmitting ? 'cursor-not-allowed bg-[#3a4c58]' : 'cursor-pointer bg-[#1A475F]'}`}
+            disabled={!selectedStand || isSubmitting || availabilityLoading || availabilityUnavailable || isStandUnavailable(selectedStand)}
+            className={`box-border h-full w-[61%] rounded border-[10px] border-[#1D293D] text-[clamp(12px,1.5vh,18px)] font-bold text-white transition-colors duration-200 ${!selectedStand || isSubmitting || availabilityLoading || availabilityUnavailable || isStandUnavailable(selectedStand) ? 'cursor-not-allowed bg-[#3a4c58]' : 'cursor-pointer bg-[#1A475F]'}`}
           >
-            {isSubmitting ? 'CHECKING STAND' : 'REQUEST NEW STAND'}
+            {isSubmitting ? 'CHECKING STAND' : availabilityLoading ? 'LOADING AVAILABILITY' : 'REQUEST NEW STAND'}
           </button>
 
           <button

--- a/frontend/src/components/efb/dialogs/efb-dialogs.test.tsx
+++ b/frontend/src/components/efb/dialogs/efb-dialogs.test.tsx
@@ -121,17 +121,33 @@ describe('EFB operational dialogs', () => {
     expect(screen.getByAltText('Taxi-in guidance for Bravo stands on runway 22L').getAttribute('src')).toContain('taxiin-22bravo');
   });
 
-  it('does not claim unknown stand availability and keeps a rejected request open', async () => {
+  it('shows current stand availability and keeps a rejected request open', async () => {
     const onClose = vi.fn();
     const onRequest = vi.fn().mockRejectedValue(new Error('stand is occupied'));
-    render(<D1Stand isOpen onClose={onClose} stand="A12" onRequest={onRequest} />);
+    render(<D1Stand isOpen onClose={onClose} stand="A12" onRequest={onRequest} availability={[
+      { stand: 'A18', available: true },
+      { stand: 'A19', available: false, reason: 'reserved by SAS999' },
+    ]} />);
 
-    expect(screen.getByTitle('A18 (availability checked when requested)')).toBeInTheDocument();
+    expect(screen.getByTitle('A18: Available for this flight')).toBeInTheDocument();
+    expect(screen.getByTitle('A19: Unavailable: reserved by SAS999')).toBeDisabled();
     fireEvent.click(screen.getByRole('button', { name: 'Stand A18' }));
     fireEvent.click(screen.getByRole('button', { name: 'REQUEST NEW STAND' }));
 
     expect(await screen.findByRole('alert')).toHaveTextContent('stand is occupied');
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does not submit an initial stand missing from the availability response', () => {
+    const onRequest = vi.fn();
+    render(<D1Stand isOpen onClose={vi.fn()} stand="NIL" onRequest={onRequest} availability={[
+      { stand: 'A18', available: true },
+    ]} />);
+
+    const request = screen.getByRole('button', { name: 'REQUEST NEW STAND' });
+    expect(request).toBeDisabled();
+    fireEvent.click(request);
+    expect(onRequest).not.toHaveBeenCalled();
   });
 
   it('shows ATIS as read-only current information', () => {

--- a/frontend/src/pages/efb.tsx
+++ b/frontend/src/pages/efb.tsx
@@ -21,7 +21,7 @@ import D1ArrivalBriefDialog from '../components/efb/dialogs/D1ArrivalBrief';
 import D1BRIEFDialog from '../components/efb/dialogs/D1Brief';
 import D1ChartDialog from '../components/efb/dialogs/D1Chart';
 import D1DownloadsDialog from '../components/efb/dialogs/D1DownloadsDialog';
-import D1STANDDialog from '../components/efb/dialogs/D1Stand';
+import D1STANDDialog, { type StandAvailability } from '../components/efb/dialogs/D1Stand';
 import D2CDMDialog from '../components/efb/dialogs/D2CDMDialog';
 import D2ATISDialog from '../components/efb/dialogs/D2ATISDialog';
 import D2PDCDialog from '../components/efb/dialogs/D2PDCDialog';
@@ -91,6 +91,10 @@ interface ApiFlight {
   };
 }
 
+interface StandAvailabilityResponse {
+  stands: StandAvailability[];
+}
+
 interface EfbProfile {
   live_mode: boolean;
   online_callsign?: string | null;
@@ -150,6 +154,8 @@ export default function EFBPage() {
   const [loadState, setLoadState] = useState<LoadState>('LOADING');
   const [loadError, setLoadError] = useState<string | null>(null);
   const [flightStale, setFlightStale] = useState(false);
+  const [standAvailability, setStandAvailability] = useState<StandAvailability[] | null>(null);
+  const [standAvailabilityError, setStandAvailabilityError] = useState<string | null>(null);
 
   const flightData: FlightDisplayData = apiFlight ? {
     ...unavailableFlightData,
@@ -263,6 +269,33 @@ export default function EFBPage() {
     const timer = window.setInterval(() => void refreshFlight(), 15_000);
     return () => { window.clearTimeout(initial); window.clearInterval(timer); };
   }, [profile, refreshFlight]);
+
+  useEffect(() => {
+    if (openDialog !== 'D1STAND' || !apiFlight) {
+      setStandAvailability(null);
+      setStandAvailabilityError(null);
+      return;
+    }
+    let cancelled = false;
+    const refreshAvailability = async () => {
+      try {
+        const query = profile?.live_mode === false ? `?callsign=${encodeURIComponent(devCallsignRef.current.trim().toUpperCase())}` : '';
+        const response = await authorizedFetch(`/api/efb/stands${query}`) as StandAvailabilityResponse;
+        if (!cancelled) {
+          setStandAvailability(response.stands);
+          setStandAvailabilityError(null);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setStandAvailability(null);
+          setStandAvailabilityError(error instanceof Error ? error.message : 'Stand availability unavailable');
+        }
+      }
+    };
+    void refreshAvailability();
+    const timer = window.setInterval(() => void refreshAvailability(), 15_000);
+    return () => { cancelled = true; window.clearInterval(timer); };
+  }, [apiFlight?.callsign, authorizedFetch, openDialog, profile?.live_mode]);
 
   const submitDevCallsign = (event: FormEvent) => {
     event.preventDefault();
@@ -540,6 +573,9 @@ useEffect(() => {
           isOpen
           onClose={handleCloseDialog}
           stand={flightData.stand}
+          availability={standAvailability ?? undefined}
+          availabilityLoading={standAvailability === null && standAvailabilityError === null}
+          availabilityUnavailable={standAvailabilityError !== null}
           onRequest={async (requestedStand) => {
             await authorizedFetch('/api/efb/stand', { method: 'PUT', body: JSON.stringify({ stand: requestedStand, version: apiFlight?.stand_version ?? 0, callsign: profile?.live_mode === false ? devCallsign : undefined }) });
             await refreshFlight();


### PR DESCRIPTION
## Summary

- add a time-aware EFB stand-availability endpoint using the allocator's compatibility, ETA/TOBT, reservation, and manual-block rules
- show available and unavailable stands directly on the EFB stand map, with unavailable selections disabled and explained
- ensure pilot stand selections are forwarded to EuroScope and controller clients even when the strip already contains the selected stand

## Why

Pilots could request a stand without knowing whether it was operationally available, and an unchanged persisted stand could prevent the requested selection from reaching EuroScope.

## Validation

- `go test ./internal/app ./internal/efb ./internal/services -count=1`
- `npm test -- --run src/components/efb/dialogs/efb-dialogs.test.tsx`
- `npm run build`

The dialog test includes regression coverage ensuring an unlisted initial stand (such as `NIL`) cannot be submitted.
