### PR TITLE
fix(strip): generate squawks for VATSIM logons

### DIFF
--- a/backend/internal/services/strip_sync.go
+++ b/backend/internal/services/strip_sync.go
@@ -539,6 +539,13 @@ func (s *StripService) syncEuroscopeStrip(ctx context.Context, session int32, ci
 		if primaryChange && updateHeading != strip.Heading && s.esCommander != nil {
 			s.esCommander.SendHeading(session, cid, strip.Callsign, updateHeading)
 		}
+		// VATSIM can create a hidden departure strip before EuroScope sees the
+		// aircraft. Treat that first EuroScope sync like a new strip so the
+		// reserved VATSIM squawk is replaced, but do not re-request a squawk on
+		// later EuroScope updates.
+		if primaryChange && existingStrip.EuroscopeSeenAt == nil && shouldGenerateDepartureSquawk(strip, airport, bay) && s.esCommander != nil {
+			s.esCommander.SendGenerateSquawk(session, "", strip.Callsign)
+		}
 
 		needsStripBroadcast = true
 		needsPdcValidation = true

--- a/backend/internal/services/strip_sync_test.go
+++ b/backend/internal/services/strip_sync_test.go
@@ -1467,6 +1467,79 @@ func TestSyncEuroscopeStrip_NewLocalDepartureWithReservedAssignedSquawk_Generate
 	assert.Equal(t, "", esHub.GenerateSquawks[0].Cid)
 }
 
+func TestSyncEuroscopeStrip_FirstEuroscopeSyncOfVatsimDepartureWithReservedAssignedSquawk_GeneratesSquawk(t *testing.T) {
+	ctx := context.Background()
+	const session = int32(1)
+	reservedSquawk := "2000"
+	existingStrip := &models.Strip{
+		Callsign:       "SAS780",
+		Origin:         "EKCH",
+		Destination:    "EGLL",
+		Bay:            "DEP_HIDDEN",
+		AssignedSquawk: &reservedSquawk,
+		HasFP:          true,
+	}
+	stripRepo := &testutil.MockStripRepository{
+		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
+			return existingStrip, nil
+		},
+		UpdateFn: func(_ context.Context, _ *models.Strip) (int64, error) {
+			return 1, nil
+		},
+	}
+
+	svc, _, esHub := newSyncTestFixture(t, existingStrip, stripRepo)
+
+	err := svc.syncEuroscopeStrip(ctx, session, "", euroscope.Strip{
+		Callsign:       existingStrip.Callsign,
+		Origin:         "EKCH",
+		Destination:    "EGLL",
+		AssignedSquawk: reservedSquawk,
+		HasFP:          true,
+	}, "EKCH")
+	require.NoError(t, err)
+	require.Len(t, esHub.GenerateSquawks, 1)
+	assert.Equal(t, session, esHub.GenerateSquawks[0].Session)
+	assert.Equal(t, existingStrip.Callsign, esHub.GenerateSquawks[0].Callsign)
+	assert.Equal(t, "", esHub.GenerateSquawks[0].Cid)
+}
+
+func TestSyncEuroscopeStrip_RepeatEuroscopeSyncOfVatsimDepartureDoesNotGenerateSquawk(t *testing.T) {
+	ctx := context.Background()
+	const session = int32(1)
+	reservedSquawk := "2000"
+	euroscopeSeenAt := time.Now().UTC()
+	existingStrip := &models.Strip{
+		Callsign:        "SAS781",
+		Origin:          "EKCH",
+		Destination:     "EGLL",
+		Bay:             "DEP_HIDDEN",
+		AssignedSquawk:  &reservedSquawk,
+		EuroscopeSeenAt: &euroscopeSeenAt,
+		HasFP:           true,
+	}
+	stripRepo := &testutil.MockStripRepository{
+		GetByCallsignFn: func(_ context.Context, _ int32, _ string) (*models.Strip, error) {
+			return existingStrip, nil
+		},
+		UpdateFn: func(_ context.Context, _ *models.Strip) (int64, error) {
+			return 1, nil
+		},
+	}
+
+	svc, _, esHub := newSyncTestFixture(t, existingStrip, stripRepo)
+
+	err := svc.syncEuroscopeStrip(ctx, session, "", euroscope.Strip{
+		Callsign:       existingStrip.Callsign,
+		Origin:         "EKCH",
+		Destination:    "EGLL",
+		AssignedSquawk: reservedSquawk,
+		HasFP:          true,
+	}, "EKCH")
+	require.NoError(t, err)
+	assert.Empty(t, esHub.GenerateSquawks)
+}
+
 func TestSyncEuroscopeStrip_NewLocalDepartureWithReservedAssignedSquawkAndCleared_DoesNotGenerateSquawk(t *testing.T) {
 	ctx := context.Background()
 	const session = int32(1)


### PR DESCRIPTION
## Summary

- Generate a new squawk when a VATSIM-created local departure is first seen by EuroScope.
- Avoid requesting another code on later EuroScope updates.

## Root cause

VATSIM reconciliation created a hidden departure strip before EuroScope's first strip update. Because automatic generation only ran for newly created strips, the existing-strip sync path skipped it.

## Validation

- `go test ./internal/services -count=1`
