### PR TITLE
fix(squawk): retry pending squawk generation

### DIFF
--- a/backend/internal/euroscope/squawk_throttle.go
+++ b/backend/internal/euroscope/squawk_throttle.go
@@ -206,10 +206,10 @@ func (hub *Hub) dispatchGenerateSquawkRequest(session int32, req queuedSquawkReq
 		return
 	}
 	if isAutomatic {
-		slog.Info("Auto-generating squawk",
+		slog.Info("Dispatching automatic squawk generation",
 			slog.Int("session", int(session)),
 			slog.String("callsign", req.callsign),
-			slog.String("cid", cid),
+			slog.String("target_cid", cid),
 		)
 	}
 	hub.Send(session, cid, event)

--- a/backend/internal/services/strip_sync.go
+++ b/backend/internal/services/strip_sync.go
@@ -203,6 +203,11 @@ func (s *StripService) syncEuroscopeStrip(ctx context.Context, session int32, ci
 			s.esCommander.SendClearedAltitude(session, cid, strip.Callsign, newClearedAlt)
 		}
 		if shouldGenerateDepartureSquawk(strip, airport, bay) && s.esCommander != nil {
+			slog.InfoContext(ctx, "Triggering automatic squawk generation",
+				slog.Int("session", int(session)),
+				slog.String("callsign", strip.Callsign),
+				slog.String("trigger", "new_strip"),
+			)
 			s.esCommander.SendGenerateSquawk(session, "", strip.Callsign)
 		}
 		createdStrip = true
@@ -544,6 +549,11 @@ func (s *StripService) syncEuroscopeStrip(ctx context.Context, session int32, ci
 		// reserved VATSIM squawk is replaced, but do not re-request a squawk on
 		// later EuroScope updates.
 		if primaryChange && existingStrip.EuroscopeSeenAt == nil && shouldGenerateDepartureSquawk(strip, airport, bay) && s.esCommander != nil {
+			slog.InfoContext(ctx, "Triggering automatic squawk generation",
+				slog.Int("session", int(session)),
+				slog.String("callsign", strip.Callsign),
+				slog.String("trigger", "first_euroscope_sync"),
+			)
 			s.esCommander.SendGenerateSquawk(session, "", strip.Callsign)
 		}
 

--- a/euroscope-plugin/src/plugin/messages/MessageService.cpp
+++ b/euroscope-plugin/src/plugin/messages/MessageService.cpp
@@ -383,8 +383,11 @@ namespace FlightStrips::messages {
 
     void MessageService::HandleGenerateSquawkEvent(const GenerateSquawkEvent &event) const {
         const auto fp = m_plugin->FlightPlanSelect(event.callsign.c_str());
-        const auto radarTarget = m_plugin->RadarTargetSelect(event.callsign.c_str());
-        if (!fp.IsValid() || !radarTarget.IsValid()) return;
+        // Automatic requests are routed to the active Delivery client, which
+        // can have the flight plan before it has a radar target in range.
+        // TopSky generates the squawk from the callsign, so a valid flight plan
+        // is sufficient and avoids dropping the one-shot request on spawn.
+        if (!fp.IsValid()) return;
         m_plugin->AddNeedsSquawk(std::string(fp.GetCallsign()));
     }
 

--- a/euroscope-plugin/src/plugin/plugin/FlightStripsPlugin.cpp
+++ b/euroscope-plugin/src/plugin/plugin/FlightStripsPlugin.cpp
@@ -19,6 +19,7 @@ namespace FlightStrips {
         constexpr int kWindowProbeMaxAttempts = 20;
         constexpr int kWindowProbeMaxDepth = 8;
         constexpr int kWindowProbeMaxNodes = 512;
+        constexpr auto kSquawkRequestTimeout = std::chrono::minutes(2);
 
         auto QuoteWindowText(std::string text) -> std::string {
             for (char& ch : text) {
@@ -278,6 +279,7 @@ namespace FlightStrips {
 
     void FlightStripsPlugin::OnTimer(int Counter) {
         SafeCall("OnTimer", [this, Counter] {
+            ExpireNeedsSquawkRequests();
             const auto connectionType = static_cast<ConnectionType>(GetConnectionType());
 
             if (m_connectionState.connection_type != connectionType) {
@@ -548,17 +550,36 @@ namespace FlightStrips {
     }
 
     void FlightStripsPlugin::AddNeedsSquawk(const std::string &callsign) {
-        m_needsSquawk.push(callsign);
+        m_needsSquawk.push_back({callsign, std::chrono::steady_clock::now()});
     }
 
     std::optional<std::string> FlightStripsPlugin::GetNeedsSquawk() {
-        if (m_needsSquawk.empty()) {
-            return {};
+        ExpireNeedsSquawkRequests();
+
+        for (auto it = m_needsSquawk.begin(); it != m_needsSquawk.end(); ++it) {
+            if (!RadarTargetSelect(it->callsign.c_str()).IsValid()) {
+                continue;
+            }
+
+            auto callsign = std::move(it->callsign);
+            m_needsSquawk.erase(it);
+            return callsign;
         }
 
-        auto needsSquawk = m_needsSquawk.front();
-        m_needsSquawk.pop();
-        return needsSquawk;
+        return {};
+    }
+
+    void FlightStripsPlugin::ExpireNeedsSquawkRequests() {
+        const auto now = std::chrono::steady_clock::now();
+        for (auto it = m_needsSquawk.begin(); it != m_needsSquawk.end();) {
+            if (now - it->requestedAt < kSquawkRequestTimeout) {
+                ++it;
+                continue;
+            }
+
+            Logger::Error("Dropping pending squawk request for {} after waiting two minutes for a radar target", it->callsign);
+            it = m_needsSquawk.erase(it);
+        }
     }
 
     void FlightStripsPlugin::OnAirportRunwayActivityChanged() {

--- a/euroscope-plugin/src/plugin/plugin/FlightStripsPlugin.h
+++ b/euroscope-plugin/src/plugin/plugin/FlightStripsPlugin.h
@@ -22,6 +22,9 @@
 #include "IFlightStripsPlugin.h"
 #include "plugin/AirportResolution.h"
 
+#include <chrono>
+#include <deque>
+
 // TODO move
 #define CLEARED "CLEA"
 #define NOT_CLEARED "NOTC"
@@ -92,6 +95,11 @@ namespace FlightStrips {
         std::optional<std::string> GetNeedsSquawk();
 
     private:
+        struct PendingSquawkRequest {
+            std::string callsign;
+            std::chrono::steady_clock::time_point requestedAt;
+        };
+
         const std::shared_ptr<handlers::FlightPlanEventHandlers> m_flightPlanEventHandlerCollection;
         const std::shared_ptr<handlers::RadarTargetEventHandlers> m_radarTargetEventHandlers;
         const std::shared_ptr<handlers::ControllerEventHandlers> m_controllerEventHandlerCollection;
@@ -102,7 +110,7 @@ namespace FlightStrips {
         const std::weak_ptr<Container> m_container;
 
         ConnectionState m_connectionState = {};
-        std::queue<std::string> m_needsSquawk = {};
+        std::deque<PendingSquawkRequest> m_needsSquawk = {};
         double m_airportLatitude = 0.0;
         double m_airportLongitude = 0.0;
         std::optional<AirportFallbackProbe> m_lastAirportFallbackProbe;
@@ -111,6 +119,7 @@ namespace FlightStrips {
 
         [[nodiscard]] bool IsWithinRange(EuroScopePlugIn::CRadarTarget radarTarget, float rangeNM) const;
         void DispatchRangeCheck(EuroScopePlugIn::CRadarTarget radarTarget);
+        void ExpireNeedsSquawkRequests();
         static bool IsValidHhmm(const std::string& value);
         void LogWindowHierarchyProbe();
 


### PR DESCRIPTION
## What changed

Automatic squawk requests now remain pending until the receiving EuroScope client has a radar target for the aircraft.

## Why

The automatic request can be routed to Delivery before that client has a valid radar target. Previously, the plugin discarded that one-shot request.

## Impact

Aircraft receive the automatic squawk request as soon as the target becomes available. Requests that cannot be processed within two minutes are logged and dropped.

## Validation

Built `FlightStripsPluginCore` in the native Debug configuration.
