### PR TITLE
fix: stabilize arrival stand assignments

### DIFF
--- a/backend/internal/models/strip.go
+++ b/backend/internal/models/strip.go
@@ -27,8 +27,10 @@ type VatsimStripSource struct {
 }
 
 // ArrivalETA records the currently accepted arrival estimate and the inputs
-// that produced it. It belongs to the strip rather than a stand assignment:
-// arrivals receive an ETA before SAT is allowed to reserve a stand.
+// that produced it. It belongs to the strip rather than a stand assignment.
+// SAT may publish an advisory ESTIMATED stand before an ETA is available; that
+// assignment does not reserve physical capacity until timing or proximity
+// promotes it into the operational blocking window.
 type ArrivalETA struct {
 	Time            time.Time `json:"time"`
 	Source          string    `json:"source"`

--- a/backend/internal/sat/stand_geometry.go
+++ b/backend/internal/sat/stand_geometry.go
@@ -30,6 +30,23 @@ func (r *StandCapabilityRegistry) StandAtPosition(airport string, latitude, long
 	return closest, found
 }
 
+// PositionNearAirport reports whether a position is within maxDistanceMetres
+// of any configured stand at the airport. Stand centres provide a stable
+// airport-local reference without coupling SAT geometry to one airport's
+// coordinates or layout.
+func (r *StandCapabilityRegistry) PositionNearAirport(airport string, latitude, longitude, maxDistanceMetres float64) bool {
+	if r == nil || maxDistanceMetres < 0 {
+		return false
+	}
+	stands := r.byAirport[strings.ToUpper(strings.TrimSpace(airport))]
+	for _, stand := range stands {
+		if greatCircleMetres(latitude, longitude, stand.Latitude, stand.Longitude) <= maxDistanceMetres {
+			return true
+		}
+	}
+	return false
+}
+
 func greatCircleMetres(lat1, lon1, lat2, lon2 float64) float64 {
 	toRadians := math.Pi / 180
 	lat1, lon1, lat2, lon2 = lat1*toRadians, lon1*toRadians, lat2*toRadians, lon2*toRadians

--- a/backend/internal/sat/stand_geometry_test.go
+++ b/backend/internal/sat/stand_geometry_test.go
@@ -21,4 +21,7 @@ STAND:EKCH:A2:N055.37.42.710:E012.38.36.450:30
 
 	_, found = registry.StandAtPosition("EKCH", 55.7, 12.7)
 	assert.False(t, found)
+
+	assert.True(t, registry.PositionNearAirport("EKCH", 55.6285306, 12.644625, 200))
+	assert.False(t, registry.PositionNearAirport("EKCH", 55.7, 12.7, 200))
 }

--- a/backend/internal/services/arrival_lifecycle.go
+++ b/backend/internal/services/arrival_lifecycle.go
@@ -19,12 +19,17 @@ const (
 	StageAssigned  = "ASSIGNED"
 	StageConfirmed = "CONFIRMED"
 
-	defaultEstimatedBefore = 45 * time.Minute
 	defaultAssignedBefore  = 10 * time.Minute
 	defaultConfirmedBefore = 2 * time.Minute
 
 	assignedAltitudeThreshold  = 10000
 	confirmedAltitudeThreshold = 3000
+	// Once a low-altitude arrival is within two nautical miles of the airport's
+	// configured stands, its operational stand must no longer be changed by the
+	// planning allocator. This covers runways, taxiways, and aprons rather than
+	// only the small stand-position circles.
+	arrivalAirportProximity   = 2 * 1852.0
+	arrivalAirportMaxAltitude = 1000
 
 	defaultArrivalSweepInterval = 30 * time.Second
 )
@@ -100,25 +105,30 @@ func (s *ArrivalLifecycleService) ProcessArrival(ctx context.Context, session in
 		return nil
 	}
 	eta := arrivalETATime(strip)
-	if eta == nil {
-		return nil
-	}
 	now := s.now()
-	timeUntilETA := eta.Sub(now)
 	altitude := arrivalAltitude(strip)
-	targetStage := determineArrivalTargetStage(timeUntilETA, altitude)
-	if targetStage == "" {
-		return nil
-	}
+	atAirport := s.arrivalIsAtAirport(strip, flight.Destination)
+	targetStage := determineArrivalTargetStage(eta, now, altitude, atAirport)
 	existing, err := s.assignments.GetAssignment(ctx, session, strip.Callsign)
 	if err != nil && !isNotFound(err) {
 		return err
 	}
 	if existing == nil {
+		// The airport-area guard only freezes an existing operational stand.
+		// An unassigned arrival still needs a compatible stand.
 		return s.ensureAssignment(ctx, session, strip, flight, eta, targetStage)
 	}
 	currentStage := existing.Stage
 	if !isArrivalStage(currentStage) {
+		return nil
+	}
+	// A low-altitude position within the airport area is operational evidence
+	// that this arrival is no longer a movable planning reservation. It may
+	// still advance its lifecycle stage in place.
+	if atAirport {
+		if shouldPromoteArrival(currentStage, targetStage) || arrivalTimingChanged(existing, eta, arrivalETASource(eta)) {
+			return s.updateArrivalInPlace(ctx, existing, targetStage, eta, arrivalETASource(eta))
+		}
 		return nil
 	}
 	if !shouldPromoteArrival(currentStage, targetStage) {
@@ -130,6 +140,29 @@ func (s *ArrivalLifecycleService) ProcessArrival(ctx context.Context, session in
 	return s.promoteArrival(ctx, session, strip, flight, existing, eta, targetStage)
 }
 
+func (s *ArrivalLifecycleService) arrivalIsAtAirport(strip *models.Strip, flightDestination string) bool {
+	if s == nil || s.stands == nil || strip == nil || strip.PositionLatitude == nil || strip.PositionLongitude == nil {
+		return false
+	}
+	if !validArrivalPosition(*strip.PositionLatitude, *strip.PositionLongitude) {
+		return false
+	}
+	airport := strings.ToUpper(strings.TrimSpace(flightDestination))
+	if airport == "" {
+		airport = strings.ToUpper(strings.TrimSpace(strip.Destination))
+	}
+	if airport == "" {
+		return false
+	}
+	if strip.PositionAltitude == nil || *strip.PositionAltitude > arrivalAirportMaxAltitude {
+		return false
+	}
+	if _, found := s.stands.StandAtPosition(airport, *strip.PositionLatitude, *strip.PositionLongitude); found {
+		return true
+	}
+	return s.stands.PositionNearAirport(airport, *strip.PositionLatitude, *strip.PositionLongitude, arrivalAirportProximity)
+}
+
 func (s *ArrivalLifecycleService) ensureAssignment(ctx context.Context, session int32, strip *models.Strip, flight vatsim.ArrivalFlightInfo, eta *time.Time, stage string) error {
 	request := s.buildRequest(session, strip, flight, stage, eta, nil)
 	_, err := s.allocations.Allocate(ctx, request)
@@ -138,13 +171,12 @@ func (s *ArrivalLifecycleService) ensureAssignment(ctx context.Context, session 
 
 func (s *ArrivalLifecycleService) promoteArrival(ctx context.Context, session int32, strip *models.Strip, flight vatsim.ArrivalFlightInfo, existing *models.StandAssignment, eta *time.Time, targetStage string) error {
 	request := s.buildRequest(session, strip, flight, targetStage, eta, nil)
-	request.DisplaceStage = StageEstimated
 	available, err := s.allocations.StandAvailable(ctx, request, existing.Stand)
 	if err != nil {
 		return err
 	}
 	if available && s.currentStandIsOptimal(ctx, request, existing) {
-		return s.updateStageInPlace(ctx, existing, targetStage, eta)
+		return s.updateArrivalInPlace(ctx, existing, targetStage, eta, request.ETASource)
 	}
 	_, err = s.allocations.Reallocate(ctx, request)
 	return err
@@ -152,12 +184,14 @@ func (s *ArrivalLifecycleService) promoteArrival(ctx context.Context, session in
 
 func (s *ArrivalLifecycleService) reallocateIfBlocked(ctx context.Context, session int32, strip *models.Strip, flight vatsim.ArrivalFlightInfo, existing *models.StandAssignment, eta *time.Time, targetStage string) error {
 	request := s.buildRequest(session, strip, flight, existing.Stage, eta, nil)
-	request.DisplaceStage = StageEstimated
 	available, err := s.allocations.StandAvailable(ctx, request, existing.Stand)
 	if err != nil {
 		return err
 	}
 	if available {
+		if arrivalTimingChanged(existing, eta, request.ETASource) {
+			return s.updateArrivalInPlace(ctx, existing, existing.Stage, eta, request.ETASource)
+		}
 		return nil
 	}
 	if s.blockedByPastDeparture(ctx, session, strip, existing, eta) {
@@ -197,24 +231,18 @@ func (s *ArrivalLifecycleService) currentStandIsOptimal(ctx context.Context, req
 	if existing.Tier == nil {
 		return false
 	}
-	evaluation := s.stands.EvaluateCompatibility(request.Airport, request.FlightFacts)
-	available := make([]string, 0)
-	for _, match := range evaluation.Matches {
-		candidate := standName(match.Stand.Name)
-		free, err := s.allocations.StandAvailable(ctx, request, candidate)
-		if err != nil {
-			return false
-		}
-		if free {
-			available = append(available, candidate)
-		}
+	preview, err := s.allocations.Preview(ctx, request)
+	if err != nil {
+		return false
 	}
-	selection, err := s.allocations.policy.SelectStand(request.AssignmentFacts, available, s.allocations.random)
-	if err != nil || selection == nil {
+	selection, found := selectablePreviewCandidate(preview.Selection)
+	if !found {
 		return true
 	}
-	if standName(selection.Stand) == standName(existing.Stand) {
-		return true
+	for _, candidate := range preview.Selection.Candidates {
+		if candidate.Selectable && standName(candidate.Stand) == standName(existing.Stand) {
+			return true
+		}
 	}
 	if existing.RuleID == nil || !strings.EqualFold(*existing.RuleID, selection.RuleID) {
 		return false
@@ -222,11 +250,12 @@ func (s *ArrivalLifecycleService) currentStandIsOptimal(ctx context.Context, req
 	return selection.Tier >= int(*existing.Tier)
 }
 
-func (s *ArrivalLifecycleService) updateStageInPlace(ctx context.Context, existing *models.StandAssignment, stage string, eta *time.Time) error {
+func (s *ArrivalLifecycleService) updateArrivalInPlace(ctx context.Context, existing *models.StandAssignment, stage string, eta *time.Time, etaSource *string) error {
 	updated := *existing
 	now := s.now().UTC()
 	updated.Stage = stage
 	updated.ETA = eta
+	updated.ETASource = etaSource
 	updated.AssignedAt = &now
 	affected, err := s.assignments.UpdateAssignment(ctx, &updated)
 	if err != nil {
@@ -236,8 +265,10 @@ func (s *ArrivalLifecycleService) updateStageInPlace(ctx context.Context, existi
 		return fmt.Errorf("arrival stage update version conflict for %s", existing.Callsign)
 	}
 	updated.Version++
-	slog.InfoContext(ctx, "SAT assignment stage changed", slog.String("callsign", existing.Callsign), slog.String("stand", existing.Stand), slog.String("from_stage", existing.Stage), slog.String("to_stage", stage))
-	if stage == StageConfirmed {
+	if existing.Stage != stage {
+		slog.InfoContext(ctx, "SAT assignment stage changed", slog.String("callsign", existing.Callsign), slog.String("stand", existing.Stand), slog.String("from_stage", existing.Stage), slog.String("to_stage", stage))
+	}
+	if stage == StageConfirmed && existing.Stage != StageConfirmed {
 		return s.allocations.PublishConfirmedArrival(ctx, updated)
 	}
 	return s.allocations.PublishAssignment(ctx, updated)
@@ -325,18 +356,17 @@ func (s *ArrivalLifecycleService) StartSweep(ctx context.Context) {
 
 func (s *ArrivalLifecycleService) buildRequest(session int32, strip *models.Strip, flight vatsim.ArrivalFlightInfo, stage string, eta *time.Time, expiresAt *time.Time) StandAllocationRequest {
 	facts, assignmentFacts := s.resolveFacts(strip, flight)
-	etaSource := "ARRIVAL_ETA"
 	vatsimCID, vatsimRevision := resolvedVatsimIdentity(strip, flight.CID, flight.Revision)
 	return StandAllocationRequest{
 		SessionID:       session,
 		Callsign:        strip.Callsign,
-		Airport:         strings.ToUpper(strings.TrimSpace(strip.Destination)),
+		Airport:         facts.Destination,
 		Direction:       sat.AssignmentDirectionArrival,
 		Stage:           stage,
 		FlightFacts:     facts,
 		AssignmentFacts: assignmentFacts,
 		ETA:             eta,
-		ETASource:       &etaSource,
+		ETASource:       arrivalETASource(eta),
 		ExpiresAt:       expiresAt,
 		VatsimCID:       vatsimCID,
 		VatsimRevision:  vatsimRevision,
@@ -345,13 +375,17 @@ func (s *ArrivalLifecycleService) buildRequest(session int32, strip *models.Stri
 
 func (s *ArrivalLifecycleService) resolveFacts(strip *models.Strip, flight vatsim.ArrivalFlightInfo) (sat.FlightCompatibilityFacts, sat.AssignmentFlightFacts) {
 	aircraftType := flight.AircraftType
-	if strip != nil && strip.AircraftType != nil && strings.TrimSpace(*strip.AircraftType) != "" {
-		aircraftType = *strip.AircraftType
-	}
-	origin, destination := "", ""
+	origin, destination := flight.Origin, flight.Destination
 	if strip != nil {
-		origin = strip.Origin
-		destination = strip.Destination
+		if strip.AircraftType != nil && strings.TrimSpace(*strip.AircraftType) != "" {
+			aircraftType = *strip.AircraftType
+		}
+		if strings.TrimSpace(strip.Origin) != "" {
+			origin = strip.Origin
+		}
+		if strings.TrimSpace(destination) == "" && strings.TrimSpace(strip.Destination) != "" {
+			destination = strip.Destination
+		}
 	}
 	input := sat.FlightCompatibilityInput{
 		Direction:      sat.Arrival,
@@ -361,9 +395,31 @@ func (s *ArrivalLifecycleService) resolveFacts(strip *models.Strip, flight vatsi
 		LiveEngineType: engineTypeValue(strip),
 	}
 	facts := sat.ResolveFlightCompatibilityFacts(input, s.aircraft, s.engines, s.borders)
+	// A freshly created EuroScope session can briefly contain a strip whose
+	// source fields are incomplete or unrecognized while the same VATSIM flight
+	// already has usable facts. Do not let that transient strip state downgrade
+	// a known Heavy arrival to the unrestricted "unknown" fallback policy.
+	retryWithFlightFacts := false
+	if !facts.AircraftKnown && strings.TrimSpace(flight.AircraftType) != "" &&
+		!strings.EqualFold(strings.TrimSpace(input.AircraftType), strings.TrimSpace(flight.AircraftType)) {
+		input.AircraftType = flight.AircraftType
+		retryWithFlightFacts = true
+	}
+	if facts.BorderStatus == sat.BorderStatusUnknown && strings.TrimSpace(flight.Origin) != "" &&
+		!strings.EqualFold(strings.TrimSpace(input.Origin), strings.TrimSpace(flight.Origin)) {
+		input.Origin = flight.Origin
+		retryWithFlightFacts = true
+	}
+	if strings.TrimSpace(input.Destination) == "" && strings.TrimSpace(flight.Destination) != "" {
+		input.Destination = flight.Destination
+		retryWithFlightFacts = true
+	}
+	if retryWithFlightFacts {
+		facts = sat.ResolveFlightCompatibilityFacts(input, s.aircraft, s.engines, s.borders)
+	}
 	assignmentFacts := sat.AssignmentFlightFacts{
 		Callsign:     strip.Callsign,
-		AircraftType: aircraftType,
+		AircraftType: input.AircraftType,
 		AircraftUse:  facts.Aircraft.UseCode,
 		BorderStatus: facts.BorderStatus,
 		Direction:    sat.AssignmentDirectionArrival,
@@ -371,17 +427,37 @@ func (s *ArrivalLifecycleService) resolveFacts(strip *models.Strip, flight vatsi
 	return facts, assignmentFacts
 }
 
-func determineArrivalTargetStage(timeUntilETA time.Duration, altitude *int32) string {
-	if timeUntilETA <= defaultConfirmedBefore || altitudeBelow(altitude, confirmedAltitudeThreshold) {
+func determineArrivalTargetStage(eta *time.Time, now time.Time, altitude *int32, atAirport bool) string {
+	confirmedByTime := eta != nil && eta.Sub(now) <= defaultConfirmedBefore
+	if atAirport || confirmedByTime || altitudeBelow(altitude, confirmedAltitudeThreshold) {
 		return StageConfirmed
 	}
-	if timeUntilETA <= defaultAssignedBefore || altitudeBelow(altitude, assignedAltitudeThreshold) {
+	assignedByTime := eta != nil && eta.Sub(now) <= defaultAssignedBefore
+	if assignedByTime || altitudeBelow(altitude, assignedAltitudeThreshold) {
 		return StageAssigned
 	}
-	if timeUntilETA <= defaultEstimatedBefore {
-		return StageEstimated
+	return StageEstimated
+}
+
+func arrivalETASource(eta *time.Time) *string {
+	if eta == nil {
+		return nil
 	}
-	return ""
+	source := "ARRIVAL_ETA"
+	return &source
+}
+
+func arrivalTimingChanged(existing *models.StandAssignment, eta *time.Time, etaSource *string) bool {
+	if existing == nil {
+		return false
+	}
+	if (existing.ETA == nil) != (eta == nil) || (existing.ETASource == nil) != (etaSource == nil) {
+		return true
+	}
+	if existing.ETA != nil && !existing.ETA.Equal(*eta) {
+		return true
+	}
+	return existing.ETASource != nil && *existing.ETASource != *etaSource
 }
 
 func shouldPromoteArrival(currentStage, targetStage string) bool {
@@ -402,10 +478,18 @@ func arrivalETATime(strip *models.Strip) *time.Time {
 }
 
 func arrivalAltitude(strip *models.Strip) *int32 {
-	if strip == nil || strip.PositionAltitude == nil {
+	if strip == nil || strip.PositionAltitude == nil ||
+		strip.PositionLatitude == nil || strip.PositionLongitude == nil ||
+		!validArrivalPosition(*strip.PositionLatitude, *strip.PositionLongitude) {
 		return nil
 	}
 	return strip.PositionAltitude
+}
+
+func validArrivalPosition(latitude, longitude float64) bool {
+	return latitude >= -90 && latitude <= 90 &&
+		longitude >= -180 && longitude <= 180 &&
+		(latitude != 0 || longitude != 0)
 }
 
 func altitudeBelow(altitude *int32, threshold int32) bool {

--- a/backend/internal/services/arrival_lifecycle_test.go
+++ b/backend/internal/services/arrival_lifecycle_test.go
@@ -10,6 +10,7 @@ import (
 	"FlightStrips/internal/vatsim"
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -23,7 +24,7 @@ func TestArrivalLifecycle(t *testing.T) {
 	pool, queries := testdata.SetupTestDB(t)
 	ctx := context.Background()
 
-	t.Run("at ETA−45 min allocates ESTIMATED and does not transition earlier", func(t *testing.T) {
+	t.Run("allocates ESTIMATED before ETA−45 and retains it", func(t *testing.T) {
 		lifecycle, _, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
 		arrivalETA := clock.current().Add(50 * time.Minute)
 		clock.set(arrivalETA.Add(-50 * time.Minute))
@@ -33,8 +34,10 @@ func TestArrivalLifecycle(t *testing.T) {
 		err := lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS101"), arrivalFlight("SAS101", 1))
 		require.NoError(t, err)
 
-		_, err = assignments.GetAssignment(ctx, session, "SAS101")
-		require.Error(t, err, "too early for any stage")
+		early, err := assignments.GetAssignment(ctx, session, "SAS101")
+		require.NoError(t, err)
+		assert.Equal(t, StageEstimated, early.Stage)
+		assert.NotEmpty(t, early.Stand)
 
 		clock.advance(6 * time.Minute)
 
@@ -44,7 +47,33 @@ func TestArrivalLifecycle(t *testing.T) {
 		assignment, err := assignments.GetAssignment(ctx, session, "SAS101")
 		require.NoError(t, err)
 		assert.Equal(t, StageEstimated, assignment.Stage)
+		assert.Equal(t, early.Stand, assignment.Stand)
+	})
+
+	t.Run("far arrival without ETA receives an advisory ESTIMATED stand", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
+		seedTestArrivalStrip(t, queries, session, "SAS102")
+
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS102"), arrivalFlight("SAS102", 1)))
+
+		assignment, err := assignments.GetAssignment(ctx, session, "SAS102")
+		require.NoError(t, err)
+		assert.Equal(t, StageEstimated, assignment.Stage)
 		assert.NotEmpty(t, assignment.Stand)
+		assert.Nil(t, assignment.ETA)
+		assert.Nil(t, assignment.ETASource)
+
+		eta := clock.current().Add(2 * time.Hour)
+		setArrivalETA(t, strips, session, "SAS102", eta)
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS102"), arrivalFlight("SAS102", 2)))
+
+		timed, err := assignments.GetAssignment(ctx, session, "SAS102")
+		require.NoError(t, err)
+		require.NotNil(t, timed.ETA)
+		assert.True(t, eta.Equal(*timed.ETA), "ETA instant is preserved across database timezone conversion")
+		require.NotNil(t, timed.ETASource)
+		assert.Equal(t, "ARRIVAL_ETA", *timed.ETASource)
+		assert.Equal(t, assignment.Stand, timed.Stand)
 	})
 
 	t.Run("time alone promotes to ASSIGNED without altitude", func(t *testing.T) {
@@ -80,7 +109,7 @@ func TestArrivalLifecycle(t *testing.T) {
 		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS301"), arrivalFlight("SAS301", 1)))
 		published = nil
 
-		_, err := strips.UpdateAircraftPosition(ctx, session, "SAS301", posPtr(0), posPtr(0), altPtr(8000), "FINAL", nil)
+		_, err := strips.UpdateAircraftPosition(ctx, session, "SAS301", posPtr(55), posPtr(10), altPtr(8000), "FINAL", nil)
 		require.NoError(t, err)
 
 		clock.set(arrivalETA.Add(-5 * time.Minute))
@@ -104,12 +133,12 @@ func TestArrivalLifecycle(t *testing.T) {
 
 		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS401"), arrivalFlight("SAS401", 1)))
 
-		_, err := strips.UpdateAircraftPosition(ctx, session, "SAS401", posPtr(0), posPtr(0), altPtr(8000), "FINAL", nil)
+		_, err := strips.UpdateAircraftPosition(ctx, session, "SAS401", posPtr(55), posPtr(10), altPtr(8000), "FINAL", nil)
 		require.NoError(t, err)
 		clock.set(arrivalETA.Add(-5 * time.Minute))
 		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS401"), arrivalFlight("SAS401", 1)))
 
-		_, err = strips.UpdateAircraftPosition(ctx, session, "SAS401", posPtr(0), posPtr(0), altPtr(2000), "FINAL", nil)
+		_, err = strips.UpdateAircraftPosition(ctx, session, "SAS401", posPtr(55), posPtr(10), altPtr(2000), "FINAL", nil)
 		require.NoError(t, err)
 		clock.set(arrivalETA.Add(-1 * time.Minute))
 		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS401"), arrivalFlight("SAS401", 1)))
@@ -127,7 +156,7 @@ func TestArrivalLifecycle(t *testing.T) {
 		setArrivalETA(t, strips, session, "SAS402", arrivalETA)
 		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS402"), arrivalFlight("SAS402", 1)))
 
-		_, err := strips.UpdateAircraftPosition(ctx, session, "SAS402", posPtr(0), posPtr(0), altPtr(8000), "FINAL", nil)
+		_, err := strips.UpdateAircraftPosition(ctx, session, "SAS402", posPtr(55), posPtr(10), altPtr(8000), "FINAL", nil)
 		require.NoError(t, err)
 		clock.set(arrivalETA.Add(-5 * time.Minute))
 		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS402"), arrivalFlight("SAS402", 1)))
@@ -147,7 +176,7 @@ func TestArrivalLifecycle(t *testing.T) {
 		seedTestArrivalStrip(t, queries, session, "SAS403")
 		setArrivalETA(t, strips, session, "SAS403", arrivalETA)
 
-		_, err := strips.UpdateAircraftPosition(ctx, session, "SAS403", posPtr(0), posPtr(0), altPtr(5000), "FINAL", nil)
+		_, err := strips.UpdateAircraftPosition(ctx, session, "SAS403", posPtr(55), posPtr(10), altPtr(5000), "FINAL", nil)
 		require.NoError(t, err)
 
 		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS403"), arrivalFlight("SAS403", 1)))
@@ -164,7 +193,7 @@ func TestArrivalLifecycle(t *testing.T) {
 		seedTestArrivalStrip(t, queries, session, "SAS404")
 		setArrivalETA(t, strips, session, "SAS404", arrivalETA)
 
-		_, err := strips.UpdateAircraftPosition(ctx, session, "SAS404", posPtr(0), posPtr(0), altPtr(2000), "FINAL", nil)
+		_, err := strips.UpdateAircraftPosition(ctx, session, "SAS404", posPtr(55), posPtr(10), altPtr(2000), "FINAL", nil)
 		require.NoError(t, err)
 
 		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS404"), arrivalFlight("SAS404", 1)))
@@ -201,7 +230,7 @@ func TestArrivalLifecycle(t *testing.T) {
 		setArrivalETA(t, strips, session, "SAS601", arrivalETA)
 		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS601"), arrivalFlight("SAS601", 1)))
 
-		_, err := strips.UpdateAircraftPosition(ctx, session, "SAS601", posPtr(0), posPtr(0), altPtr(8000), "FINAL", nil)
+		_, err := strips.UpdateAircraftPosition(ctx, session, "SAS601", posPtr(55), posPtr(10), altPtr(8000), "FINAL", nil)
 		require.NoError(t, err)
 		clock.set(arrivalETA.Add(-5 * time.Minute))
 		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS601"), arrivalFlight("SAS601", 1)))
@@ -218,7 +247,7 @@ func TestArrivalLifecycle(t *testing.T) {
 		assert.Equal(t, StageAssigned, assignment.Stage, "never downgrades from ASSIGNED back to ESTIMATED")
 	})
 
-	t.Run("ESTIMATED is displaced by later-stage arrival", func(t *testing.T) {
+	t.Run("later-stage arrival uses an open same-tier stand before displacing ESTIMATED", func(t *testing.T) {
 		lifecycle, _, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
 		arrivalETA := clock.current().Add(45 * time.Minute)
 		clock.set(arrivalETA.Add(-45 * time.Minute))
@@ -236,7 +265,7 @@ func TestArrivalLifecycle(t *testing.T) {
 		_, err := strips.UpdateStand(ctx, session, "SAS702", strp("A1"), nil)
 		require.NoError(t, err)
 
-		_, err = strips.UpdateAircraftPosition(ctx, session, "SAS702", posPtr(0), posPtr(0), altPtr(8000), "FINAL", nil)
+		_, err = strips.UpdateAircraftPosition(ctx, session, "SAS702", posPtr(55), posPtr(10), altPtr(8000), "FINAL", nil)
 		require.NoError(t, err)
 		clock.set(arrivalETA.Add(-5 * time.Minute))
 		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS702"), arrivalFlight("SAS702", 2)))
@@ -244,16 +273,14 @@ func TestArrivalLifecycle(t *testing.T) {
 		updated702, err := assignments.GetAssignment(ctx, session, "SAS702")
 		require.NoError(t, err)
 		assert.Equal(t, StageAssigned, updated702.Stage)
-		assert.Equal(t, "A1", updated702.Stand, "promoted arrival keeps A1")
+		assert.Equal(t, "A2", updated702.Stand, "an equal-tier open stand avoids unnecessary displacement")
 
-		displaced701, err := assignments.GetAssignment(ctx, session, "SAS701")
-		if err == nil && displaced701 != nil {
-			assert.NotEqual(t, "A1", displaced701.Stand, "displaced ESTIMATED arrival must not keep A1")
-		}
+		retained701, err := assignments.GetAssignment(ctx, session, "SAS701")
+		require.NoError(t, err)
+		assert.Equal(t, "A1", retained701.Stand, "the ESTIMATED reservation remains stable")
 		strip701 := loadStrip(t, strips, session, "SAS701")
-		if strip701.Stand != nil {
-			assert.NotEqual(t, "A1", *strip701.Stand, "displaced ESTIMATED arrival's strip stand must not be A1")
-		}
+		require.NotNil(t, strip701.Stand)
+		assert.Equal(t, "A1", *strip701.Stand)
 	})
 
 	t.Run("departure block expiring before arrival ETA is compatible", func(t *testing.T) {
@@ -313,7 +340,7 @@ func TestArrivalLifecycle(t *testing.T) {
 		original, err := assignments.GetAssignment(ctx, session, "SAS801")
 		require.NoError(t, err)
 
-		_, err = strips.UpdateAircraftPosition(ctx, session, "SAS801", posPtr(0), posPtr(0), altPtr(2000), "FINAL", nil)
+		_, err = strips.UpdateAircraftPosition(ctx, session, "SAS801", posPtr(55), posPtr(10), altPtr(2000), "FINAL", nil)
 		require.NoError(t, err)
 		clock.set(arrivalETA.Add(-1 * time.Minute))
 		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS801"), arrivalFlight("SAS801", 1)))
@@ -388,6 +415,189 @@ func TestArrivalLifecycle(t *testing.T) {
 		assert.Equal(t, StageEstimated, reallocated.Stage)
 		assert.NotEqual(t, original.Stand, reallocated.Stand, "reallocated to a different stand when original is blocked")
 	})
+
+	t.Run("arrival at the airport keeps its stand when the allocation becomes blocked", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, clock := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
+		arrivalETA := clock.current().Add(45 * time.Minute)
+		clock.set(arrivalETA.Add(-45 * time.Minute))
+		seedTestArrivalStrip(t, queries, session, "SAS921")
+		setArrivalETA(t, strips, session, "SAS921", arrivalETA)
+
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS921"), arrivalFlight("SAS921", 1)))
+		original, err := assignments.GetAssignment(ctx, session, "SAS921")
+		require.NoError(t, err)
+		require.Equal(t, "A1", original.Stand)
+
+		require.NoError(t, assignments.CreateBlock(ctx, &models.StandBlock{
+			SessionID: session, Stand: original.Stand, BlockType: "CLOSURE", Source: "CONTROLLER", Manual: true,
+		}))
+		// This is near A1 but outside every configured stand radius, exercising
+		// the airport-area guard rather than exact stand detection.
+		_, err = strips.UpdateAircraftPosition(ctx, session, "SAS921", posPtr(55.6285306), posPtr(12.644625), altPtr(0), "TAXI", nil)
+		require.NoError(t, err)
+
+		clock.advance(5 * time.Minute)
+		parked := arrivalFlight("SAS921", 2)
+		parked.Online = true
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS921"), parked))
+
+		retained, err := assignments.GetAssignment(ctx, session, "SAS921")
+		require.NoError(t, err)
+		assert.Equal(t, original.Stand, retained.Stand, "an arrival at the airport is never automatically moved to another stand")
+		assert.Equal(t, StageConfirmed, retained.Stage, "the lifecycle still advances without changing the stand")
+	})
+
+	t.Run("arrival at the airport without an assignment receives a stand", func(t *testing.T) {
+		lifecycle, _, session, assignments, strips, _ := arrivalLifecycleFixture(t, pool, queries, "", "", nil)
+		seedTestArrivalStrip(t, queries, session, "SAS922")
+		_, err := strips.UpdateAircraftPosition(ctx, session, "SAS922", posPtr(55.6285306), posPtr(12.644625), altPtr(0), "TAXI", nil)
+		require.NoError(t, err)
+
+		arrived := arrivalFlight("SAS922", 1)
+		arrived.Online = true
+		require.NoError(t, lifecycle.ProcessArrival(ctx, session, loadStrip(t, strips, session, "SAS922"), arrived))
+
+		assignment, err := assignments.GetAssignment(ctx, session, "SAS922")
+		require.NoError(t, err)
+		assert.NotEmpty(t, assignment.Stand, "an unassigned arrival still receives a compatible stand at the airport")
+		assert.Equal(t, StageConfirmed, assignment.Stage)
+		assert.Nil(t, assignment.ETA)
+	})
+}
+
+func TestDetermineArrivalTargetStageWithoutETA(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+
+	assert.Equal(t, StageEstimated, determineArrivalTargetStage(nil, now, nil, false))
+	assert.Equal(t, StageAssigned, determineArrivalTargetStage(nil, now, altPtr(8000), false))
+	assert.Equal(t, StageConfirmed, determineArrivalTargetStage(nil, now, altPtr(2000), false))
+	assert.Equal(t, StageConfirmed, determineArrivalTargetStage(nil, now, nil, true))
+}
+
+func TestArrivalAltitudeRequiresValidPosition(t *testing.T) {
+	altitude := int32(0)
+	zero := float64(0)
+	strip := &models.Strip{
+		PositionLatitude:  &zero,
+		PositionLongitude: &zero,
+		PositionAltitude:  &altitude,
+	}
+
+	assert.Nil(t, arrivalAltitude(strip), "an omitted EuroScope position must not confirm a distant arrival")
+
+	latitude, longitude := 55.0, 10.0
+	strip.PositionLatitude = &latitude
+	strip.PositionLongitude = &longitude
+	assert.Equal(t, &altitude, arrivalAltitude(strip))
+
+	invalidLatitude := 91.0
+	strip.PositionLatitude = &invalidLatitude
+	assert.Nil(t, arrivalAltitude(strip), "out-of-range coordinates must not make altitude operational")
+}
+
+func TestArrivalIsAtAirportUsesReconciledDestination(t *testing.T) {
+	stands, err := sat.LoadStandCapabilities(strings.NewReader(`
+STAND:EKCH:A1:N055.37.42.710:E012.38.33.450:30
+`))
+	require.NoError(t, err)
+	lifecycle := &ArrivalLifecycleService{stands: stands}
+	strip := &models.Strip{
+		Destination:       "ZZZZ",
+		PositionLatitude:  posPtr(55.6285306),
+		PositionLongitude: posPtr(12.644625),
+		PositionAltitude:  altPtr(0),
+	}
+
+	assert.True(t, lifecycle.arrivalIsAtAirport(strip, "EKCH"))
+
+	invalidLatitude := 91.0
+	strip.PositionLatitude = &invalidLatitude
+	assert.False(t, lifecycle.arrivalIsAtAirport(strip, "EKCH"))
+
+	strip.PositionLatitude = posPtr(55.6285306)
+	strip.PositionAltitude = altPtr(12000)
+	assert.False(t, lifecycle.arrivalIsAtAirport(strip, "EKCH"), "an aircraft over the airport at cruise altitude has not arrived")
+}
+
+func TestArrivalResolveFactsUsesVatsimFactsWhenFreshSessionStripIsUnrecognized(t *testing.T) {
+	aircraft := mustLoadAircraftRegistry(t, "A359")
+	engines := mustLoadEngineRegistry(t, aircraft, []engineRecord{
+		{ICAO: "A359", Engine: "J", WTC: "H"},
+	})
+	lifecycle := &ArrivalLifecycleService{
+		aircraft: aircraft,
+		engines:  engines,
+		borders:  sat.NewAirportCountryRegistry(),
+	}
+	strip := &models.Strip{
+		Callsign:     "SAS926",
+		Origin:       "ZZZZ",
+		Destination:  "ZZZZ",
+		AircraftType: strp("UNRECOGNIZED"),
+	}
+	flight := vatsim.ArrivalFlightInfo{
+		Callsign: "SAS926", Origin: "VABB", Destination: "EKCH", AircraftType: "A359",
+	}
+
+	facts, assignmentFacts := lifecycle.resolveFacts(strip, flight)
+
+	assert.True(t, facts.AircraftKnown)
+	assert.Equal(t, "A359", facts.Aircraft.Type)
+	assert.Equal(t, "H", facts.WTC)
+	assert.Equal(t, sat.BorderStatusNonSchengen, facts.BorderStatus)
+	assert.Equal(t, "EKCH", facts.Destination)
+	assert.Equal(t, "A359", assignmentFacts.AircraftType)
+	assert.Equal(t, sat.AircraftUseCodeA, assignmentFacts.AircraftUse)
+	assert.Equal(t, sat.BorderStatusNonSchengen, assignmentFacts.BorderStatus)
+
+	request := lifecycle.buildRequest(1225, strip, flight, StageEstimated, nil, nil)
+	assert.Equal(t, "EKCH", request.Airport)
+}
+
+func TestFreshSessionSASHeavyUsesNormalNonSchengenRule(t *testing.T) {
+	configDir := filepath.Join("config", "ekch")
+	stands, err := sat.LoadStandCapabilityFile(filepath.Join(configDir, "GRpluginStands.txt"))
+	require.NoError(t, err)
+	policy, err := sat.LoadAirlineAssignmentFile(filepath.Join(configDir, "airline_assignment.json"), stands)
+	require.NoError(t, err)
+	aircraft, err := sat.LoadAircraftReferenceFile(filepath.Join(configDir, "GRpluginAircraftInfo.txt"))
+	require.NoError(t, err)
+	engines := mustLoadEngineRegistry(t, aircraft, []engineRecord{
+		{ICAO: "A359", Engine: "J", WTC: "H"},
+	})
+	allocations := &StandAllocationService{
+		stands: stands,
+		policy: policy,
+		random: func() float64 { return 0 },
+		now:    time.Now,
+	}
+	lifecycle := &ArrivalLifecycleService{
+		allocations: allocations,
+		stands:      stands,
+		aircraft:    aircraft,
+		engines:     engines,
+		borders:     sat.NewAirportCountryRegistry(),
+	}
+	strip := &models.Strip{
+		Callsign: "SAS926", Origin: "ZZZZ", Destination: "EKCH", AircraftType: strp("UNRECOGNIZED"),
+	}
+	flight := vatsim.ArrivalFlightInfo{
+		Callsign: "SAS926", Origin: "VABB", Destination: "EKCH", AircraftType: "A359",
+	}
+	request := lifecycle.buildRequest(1225, strip, flight, StageEstimated, nil, nil)
+	evaluation := stands.EvaluateCompatibility(request.Airport, request.FlightFacts)
+
+	selected, selection, match, _, _, err := allocations.selectStand(
+		AutomaticStandAllocation, request, evaluation, nil, nil, nil,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.NotNil(t, match)
+	assert.Equal(t, "SAS_NON-SCHENGEN", selection.RuleID)
+	assert.False(t, selection.FallbackUsed)
+	assert.True(t, strings.HasPrefix(selected, "C"), "a SAS non-Schengen Heavy should use its configured Charlie rule")
+	assert.Contains(t, strings.Join(match.Variant.WTC, ""), "H")
 }
 
 func seedTestArrivalStrip(t *testing.T, queries *database.Queries, sessionID int32, callsign string) {

--- a/backend/internal/services/stand_allocation.go
+++ b/backend/internal/services/stand_allocation.go
@@ -46,8 +46,6 @@ var (
 
 const automaticTerminalFailureThreshold = 1
 
-const automaticPhysicalFallbackConflict = "automatic fallback: no normal compatible stand was available"
-
 // StandAllocationRequest contains facts already resolved by the SAT data
 // layer. It intentionally excludes lifecycle and controller authorization
 // policy, which belong to later tasks.
@@ -635,6 +633,9 @@ func (s *StandAllocationService) allocateOnce(ctx context.Context, command Stand
 	if err != nil {
 		return nil, selected, err
 	}
+	if isAutomaticStandAllocation(command) && selectedHasEstimatedReservation(assignments, selected, request.Callsign) {
+		request.addDisplaceArrivalStage(StageEstimated)
+	}
 	var removedAssignments []models.StandAssignment
 	var removedStandChanges []models.StandAssignment
 	if request.displacesArrivalStage() && selected != "" {
@@ -785,9 +786,7 @@ func (s *StandAllocationService) Preview(ctx context.Context, request StandAlloc
 	for _, match := range evaluation.Matches {
 		matches[standName(match.Stand.Name)] = match
 	}
-	availability := s.availability(request, assignments, activeBlocks, matches)
-	available := previewAvailableStands(matches, availability)
-	selection, err := s.policy.PreviewStandSelection(request.AssignmentFacts, available)
+	available, selection, err := s.automaticStandPool(request, assignments, activeBlocks, matches, nil)
 	if err != nil {
 		return StandAllocationPreview{}, err
 	}
@@ -795,43 +794,7 @@ func (s *StandAllocationService) Preview(ctx context.Context, request StandAlloc
 		Callsign: request.Callsign, Airport: request.Airport, FallbackUsed: selection.FallbackUsed,
 		CompatibleStands: len(matches), AvailableStands: len(available), Selection: selection,
 	}
-	if len(selection.Candidates) > 0 {
-		return preview, nil
-	}
-
-	pool, err := s.policy.FallbackStandPool(request.AssignmentFacts)
-	if err != nil {
-		return StandAllocationPreview{}, err
-	}
-	fallbackMatches := make(map[string]sat.StandCompatibilityMatch)
-	for _, name := range pool {
-		stand, found := s.stands.Lookup(request.Airport, name)
-		if !found || len(stand.Variants) == 0 || allStandVariantsManual(stand) {
-			continue
-		}
-		fallbackMatches[standName(stand.Name)] = sat.StandCompatibilityMatch{Stand: stand, Blocks: slices.Clone(stand.Blocks)}
-	}
-	fallbackAvailability := s.availability(request, assignments, activeBlocks, fallbackMatches)
-	fallbackAvailable := previewAvailableStands(fallbackMatches, fallbackAvailability)
-	fallbackSelection, err := s.policy.PreviewFallbackStandSelection(request.AssignmentFacts, fallbackAvailable)
-	if err != nil {
-		return StandAllocationPreview{}, err
-	}
-	preview.FallbackUsed = true
-	preview.AvailableStands = len(fallbackAvailable)
-	preview.Selection = fallbackSelection
 	return preview, nil
-}
-
-func previewAvailableStands(matches map[string]sat.StandCompatibilityMatch, availability map[string][]string) []string {
-	available := make([]string, 0, len(matches))
-	for stand := range matches {
-		if len(availability[stand]) == 0 {
-			available = append(available, stand)
-		}
-	}
-	slices.Sort(available)
-	return available
 }
 
 func (s *StandAllocationService) selectStand(command StandAllocationCommand, request StandAllocationRequest, evaluation sat.StandCompatibilityEvaluation, assignments []*models.StandAssignment, blocks []*models.StandBlock, tried map[string]struct{}) (string, *sat.StandSelection, *sat.StandCompatibilityMatch, []string, string, error) {
@@ -886,64 +849,14 @@ func (s *StandAllocationService) selectStand(command StandAllocationCommand, req
 		return request.Stand, nil, &match, []string{request.Stand}, "", nil
 	}
 	if len(matches) == 0 {
-		return s.selectAutomaticPhysicalFallback(request, assignments, blocks, tried)
+		return "", nil, nil, nil, "", ErrNoCompatibleStand
 	}
 
-	available := make([]string, 0, len(matches))
-	for stand := range matches {
-		if len(availability[stand]) == 0 {
-			if _, retrying := tried[stand]; !retrying {
-				available = append(available, stand)
-			}
-		}
-	}
-	slices.Sort(available)
-	selection, err := s.policy.SelectStand(request.AssignmentFacts, available, s.random)
-	if err != nil {
-		return "", nil, nil, available, "", err
-	}
-	if selection == nil {
-		return s.selectAutomaticPhysicalFallback(request, assignments, blocks, tried)
-	}
-	match := matches[selection.Stand]
-	return selection.Stand, selection, &match, available, "", nil
-}
-
-// selectAutomaticPhysicalFallback gives an automatic allocation a final safe
-// place to go in the configured fallback pool when normal candidates are
-// exhausted. It only relaxes configuration compatibility; occupied stands,
-// adjacency locks, controller blocks, and manual-only stands remain unavailable.
-func (s *StandAllocationService) selectAutomaticPhysicalFallback(request StandAllocationRequest, assignments []*models.StandAssignment, blocks []*models.StandBlock, tried map[string]struct{}) (string, *sat.StandSelection, *sat.StandCompatibilityMatch, []string, string, error) {
-	pool, err := s.policy.FallbackStandPool(request.AssignmentFacts)
+	available, _, err := s.automaticStandPool(request, assignments, blocks, matches, tried)
 	if err != nil {
 		return "", nil, nil, nil, "", err
 	}
-	matches := make(map[string]sat.StandCompatibilityMatch)
-	for _, name := range pool {
-		stand, found := s.stands.Lookup(request.Airport, name)
-		if !found || len(stand.Variants) == 0 || allStandVariantsManual(stand) {
-			continue
-		}
-		// Stand.Blocks is the union of every configured variant's blocks. Do
-		// not attach a particular variant: future occupancy checks must retain
-		// this conservative physical adjacency footprint.
-		matches[standName(stand.Name)] = sat.StandCompatibilityMatch{Stand: stand, Blocks: slices.Clone(stand.Blocks)}
-	}
-	availability := s.availability(request, assignments, blocks, matches)
-	available := make([]string, 0, len(matches))
-	for stand := range matches {
-		if len(availability[stand]) == 0 {
-			if _, retrying := tried[stand]; !retrying {
-				available = append(available, stand)
-			}
-		}
-	}
-	slices.Sort(available)
-	if len(available) == 0 {
-		return "", nil, nil, nil, "", ErrNoAvailableStand
-	}
-
-	selection, err := s.policy.SelectFallbackStand(request.AssignmentFacts, available, s.random)
+	selection, err := s.policy.SelectStand(request.AssignmentFacts, available, s.random)
 	if err != nil {
 		return "", nil, nil, available, "", err
 	}
@@ -951,19 +864,82 @@ func (s *StandAllocationService) selectAutomaticPhysicalFallback(request StandAl
 		return "", nil, nil, available, "", ErrNoAvailableStand
 	}
 	match := matches[selection.Stand]
-	return selection.Stand, selection, &match, available, automaticPhysicalFallbackConflict, nil
+	return selection.Stand, selection, &match, available, "", nil
 }
 
-func allStandVariantsManual(stand sat.Stand) bool {
-	for _, variant := range stand.Variants {
-		if !variant.Manual {
-			return false
+// automaticStandPool keeps ESTIMATED arrivals as soft reservations. It only
+// releases those reservations when doing so prevents the requesting aircraft
+// from falling to a later rule/tier, a fallback, or no stand at all.
+func (s *StandAllocationService) automaticStandPool(request StandAllocationRequest, assignments []*models.StandAssignment, blocks []*models.StandBlock, matches map[string]sat.StandCompatibilityMatch, tried map[string]struct{}) ([]string, sat.StandSelectionPreview, error) {
+	strict := availableStandNames(matches, s.availability(request, assignments, blocks, matches), tried)
+	strictPreview, err := s.policy.PreviewStandSelection(request.AssignmentFacts, strict)
+	if err != nil {
+		return nil, sat.StandSelectionPreview{}, err
+	}
+	relaxed := availableStandNames(matches, s.availabilityYieldingEstimated(request, assignments, blocks, matches), tried)
+	relaxedPreview, err := s.policy.PreviewStandSelection(request.AssignmentFacts, relaxed)
+	if err != nil {
+		return nil, sat.StandSelectionPreview{}, err
+	}
+	if relaxedSelectionImproves(strictPreview, relaxedPreview) {
+		return relaxed, relaxedPreview, nil
+	}
+	return strict, strictPreview, nil
+}
+
+func availableStandNames(matches map[string]sat.StandCompatibilityMatch, availability map[string][]string, tried map[string]struct{}) []string {
+	available := make([]string, 0, len(matches))
+	for stand := range matches {
+		if len(availability[stand]) != 0 {
+			continue
+		}
+		if _, retrying := tried[stand]; retrying {
+			continue
+		}
+		available = append(available, stand)
+	}
+	slices.Sort(available)
+	return available
+}
+
+func relaxedSelectionImproves(strict, relaxed sat.StandSelectionPreview) bool {
+	strictCandidate, strictOK := selectablePreviewCandidate(strict)
+	relaxedCandidate, relaxedOK := selectablePreviewCandidate(relaxed)
+	if !relaxedOK {
+		return false
+	}
+	if !strictOK {
+		return true
+	}
+	if strictCandidate.FallbackUsed != relaxedCandidate.FallbackUsed {
+		return strictCandidate.FallbackUsed && !relaxedCandidate.FallbackUsed
+	}
+	if strictCandidate.RuleID != relaxedCandidate.RuleID {
+		// The relaxed pool is a superset of the strict pool, so a different
+		// selected rule can only be an earlier preferred policy path.
+		return true
+	}
+	return relaxedCandidate.Tier < strictCandidate.Tier
+}
+
+func selectablePreviewCandidate(preview sat.StandSelectionPreview) (sat.StandSelectionCandidate, bool) {
+	for _, candidate := range preview.Candidates {
+		if candidate.Selectable {
+			return candidate, true
 		}
 	}
-	return true
+	return sat.StandSelectionCandidate{}, false
 }
 
 func (s *StandAllocationService) availability(request StandAllocationRequest, assignments []*models.StandAssignment, blocks []*models.StandBlock, matches map[string]sat.StandCompatibilityMatch) map[string][]string {
+	return s.availabilityWithEstimated(request, assignments, blocks, matches, false)
+}
+
+func (s *StandAllocationService) availabilityYieldingEstimated(request StandAllocationRequest, assignments []*models.StandAssignment, blocks []*models.StandBlock, matches map[string]sat.StandCompatibilityMatch) map[string][]string {
+	return s.availabilityWithEstimated(request, assignments, blocks, matches, true)
+}
+
+func (s *StandAllocationService) availabilityWithEstimated(request StandAllocationRequest, assignments []*models.StandAssignment, blocks []*models.StandBlock, matches map[string]sat.StandCompatibilityMatch, yieldEstimated bool) map[string][]string {
 	now := s.now()
 	result := map[string][]string{}
 	for candidate, match := range matches {
@@ -972,13 +948,25 @@ func (s *StandAllocationService) availability(request StandAllocationRequest, as
 				continue
 			}
 			futureArrivalBlocks := false
-			// Arrival assignments are planning information until their ETA. A
-			// flight that has not landed must not physically occupy its planned
-			// stand or prevent a departure from using it.
-			if assignment.Direction == string(sat.AssignmentDirectionArrival) && assignment.ETA != nil && assignment.ETA.After(now) {
-				futureArrivalBlocks = futureArrivalBlocksRequest(*assignment.ETA, request)
-				if !futureArrivalBlocks {
+			if assignment.Direction == string(sat.AssignmentDirectionArrival) {
+				if assignment.Stage == StageEstimated {
+					// An ESTIMATED arrival reserves only its selected stand. It
+					// is not physically present, so it must not block adjacent
+					// stands through the stand geometry.
+					if request.displacesAssignment(assignment) ||
+						(yieldEstimated && estimatedReservationCanYield(request, assignment)) {
+						continue
+					}
+					if candidate == standName(assignment.Stand) {
+						result[candidate] = append(result[candidate], "soft-reserved by "+assignment.Callsign)
+					}
 					continue
+				}
+				if assignment.ETA != nil && assignment.ETA.After(now) {
+					futureArrivalBlocks = futureArrivalBlocksRequest(*assignment.ETA, request)
+					if !futureArrivalBlocks {
+						continue
+					}
 				}
 			}
 			if candidate == standName(assignment.Stand) {
@@ -1013,6 +1001,19 @@ func (s *StandAllocationService) availability(request StandAllocationRequest, as
 		}
 	}
 	return result
+}
+
+func estimatedReservationCanYield(request StandAllocationRequest, assignment *models.StandAssignment) bool {
+	if assignment == nil || !strings.EqualFold(assignment.Stage, StageEstimated) {
+		return false
+	}
+	if !strings.EqualFold(request.Stage, StageEstimated) {
+		return true
+	}
+	if request.ETA == nil {
+		return false
+	}
+	return assignment.ETA == nil || request.ETA.Before(*assignment.ETA)
 }
 
 func sameArrivalETA(left, right *time.Time) bool {
@@ -1207,6 +1208,17 @@ func (request StandAllocationRequest) displacesArrivalStage() bool {
 	return request.DisplaceStage != "" || len(request.DisplaceArrivalStages) > 0
 }
 
+func (request *StandAllocationRequest) addDisplaceArrivalStage(stage string) {
+	if request == nil || stage == "" || request.DisplaceStage == stage || slices.Contains(request.DisplaceArrivalStages, stage) {
+		return
+	}
+	if request.DisplaceStage == "" {
+		request.DisplaceStage = stage
+		return
+	}
+	request.DisplaceArrivalStages = append(request.DisplaceArrivalStages, stage)
+}
+
 func (request StandAllocationRequest) displacesAssignment(assignment *models.StandAssignment) bool {
 	if assignment == nil || assignment.Direction != string(sat.AssignmentDirectionArrival) {
 		return false
@@ -1215,6 +1227,21 @@ func (request StandAllocationRequest) displacesAssignment(assignment *models.Sta
 		return true
 	}
 	return slices.Contains(request.DisplaceArrivalStages, assignment.Stage)
+}
+
+func selectedHasEstimatedReservation(assignments []*models.StandAssignment, selected, callsign string) bool {
+	selected = standName(selected)
+	for _, assignment := range assignments {
+		if assignment == nil || strings.EqualFold(assignment.Callsign, callsign) {
+			continue
+		}
+		if assignment.Direction == string(sat.AssignmentDirectionArrival) &&
+			assignment.Stage == StageEstimated &&
+			standName(assignment.Stand) == selected {
+			return true
+		}
+	}
+	return false
 }
 
 func standName(value string) string      { return strings.ToUpper(strings.TrimSpace(value)) }

--- a/backend/internal/services/stand_allocation_test.go
+++ b/backend/internal/services/stand_allocation_test.go
@@ -279,23 +279,16 @@ func TestStandAllocationServiceTransactions(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back only within the configured fallback pool when compatible stands are exhausted", func(t *testing.T) {
-		service, session, _ := standAllocationFixture(t, pool, queries, "ENGINETYPE:J", "ENGINETYPE:J")
+	t.Run("never bypasses WTC compatibility when no compatible stand exists", func(t *testing.T) {
+		service, session, assignments := standAllocationFixture(t, pool, queries, "WTC:M", "WTC:M")
 		testdata.SeedTestStrip(t, queries, session, "SAS312")
 		request := standAllocationRequest(session, "SAS312")
-		request.FlightFacts = sat.FlightCompatibilityFacts{
-			Direction: sat.Arrival, EngineType: sat.EnginePiston, WTC: "L", BorderStatus: sat.BorderStatusSchengen,
-		}
+		request.FlightFacts = sat.FlightCompatibilityFacts{Direction: sat.Arrival, WTC: "H"}
 
-		result, err := service.Allocate(ctx, request)
-		require.NoError(t, err)
-		assert.Equal(t, "A1", result.Assignment.Stand)
-		assert.Equal(t, "AUTOMATIC", result.Assignment.Source)
-		require.NotNil(t, result.Assignment.ConflictReason)
-		assert.Equal(t, automaticPhysicalFallbackConflict, *result.Assignment.ConflictReason)
-		assert.True(t, result.Selection.FallbackUsed)
-		assert.Nil(t, result.Assignment.MatchedVariant, "the fallback retains the stand's union adjacency footprint")
-		assert.Equal(t, []string{"A1"}, result.AvailableCandidates)
+		_, err := service.Allocate(ctx, request)
+		require.ErrorIs(t, err, ErrNoCompatibleStand)
+		_, err = assignments.GetAssignment(ctx, session, "SAS312")
+		require.Error(t, err, "a Heavy aircraft must not be assigned to a Medium-only stand")
 	})
 
 	t.Run("suppresses repeated automatic attempts when no safe physical stand exists", func(t *testing.T) {
@@ -429,6 +422,182 @@ func TestPublishAssignmentOnlyNotifiesEuroscopeForConfirmedArrival(t *testing.T)
 	require.Len(t, published, 2)
 	assert.False(t, published[0].NotifyEuroscope, "ordinary lifecycle refreshes must not emit stand updates")
 	assert.True(t, published[1].NotifyEuroscope, "confirmation must deliver the previously assigned arrival stand")
+}
+
+func TestStandAllocationRejectsHeavyAircraftOnMediumOnlyFallback(t *testing.T) {
+	registry, err := sat.LoadStandCapabilities(strings.NewReader(`
+STAND:EKCH:A1:N055.37.42.710:E012.38.33.450:30
+WTC:M
+`))
+	require.NoError(t, err)
+	policy, err := sat.LoadAirlineAssignment(strings.NewReader(`{
+  "rules": [{"id":"test","callsigns":["TST"],"stands":{"tier1":{"A1":100}}}],
+  "stand_groups": {}, "fallback_rules": {`+testFallbackJSON("A1")+`}
+}`), registry)
+	require.NoError(t, err)
+	service := &StandAllocationService{
+		stands: registry,
+		policy: policy,
+		random: func() float64 { return 0 },
+		now:    time.Now,
+	}
+	request := StandAllocationRequest{
+		Callsign: "TST1", Airport: "EKCH", Direction: sat.AssignmentDirectionArrival,
+		FlightFacts: sat.FlightCompatibilityFacts{Direction: sat.Arrival, WTC: "H"},
+	}
+	evaluation := registry.EvaluateCompatibility(request.Airport, request.FlightFacts)
+
+	_, _, _, _, _, err = service.selectStand(AutomaticStandAllocation, request, evaluation, nil, nil, nil)
+
+	require.ErrorIs(t, err, ErrNoCompatibleStand)
+}
+
+func TestEstimatedArrivalIsSoftReservationUntilPromoted(t *testing.T) {
+	registry, err := sat.LoadStandCapabilities(strings.NewReader(`
+STAND:EKCH:A1:N055.37.42.710:E012.38.33.450:30
+WTC:M
+`))
+	require.NoError(t, err)
+	evaluation := registry.EvaluateCompatibility("EKCH", sat.FlightCompatibilityFacts{
+		Direction: sat.Departure,
+		WTC:       "M",
+	})
+	require.Len(t, evaluation.Matches, 1)
+	service := &StandAllocationService{
+		stands: registry,
+		now:    func() time.Time { return time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC) },
+	}
+	request := StandAllocationRequest{
+		Callsign:  "DEP1",
+		Airport:   "EKCH",
+		Direction: sat.AssignmentDirectionDeparture,
+	}
+	matches := map[string]sat.StandCompatibilityMatch{"A1": evaluation.Matches[0]}
+	arrival := &models.StandAssignment{
+		Callsign:  "ARR1",
+		Stand:     "A1",
+		Direction: string(sat.AssignmentDirectionArrival),
+		Stage:     StageEstimated,
+	}
+
+	unavailable := service.availability(request, []*models.StandAssignment{arrival}, nil, matches)
+	assert.Contains(t, unavailable["A1"], "soft-reserved by ARR1", "an advisory arrival reserves its exact stand")
+
+	eta := service.now().Add(30 * time.Minute)
+	arrival.ETA = &eta
+	unavailable = service.availability(request, []*models.StandAssignment{arrival}, nil, matches)
+	assert.Contains(t, unavailable["A1"], "soft-reserved by ARR1", "the soft reservation remains after an ETA becomes available")
+
+	request.DisplaceStage = StageEstimated
+	unavailable = service.availability(request, []*models.StandAssignment{arrival}, nil, matches)
+	assert.Empty(t, unavailable["A1"], "a request explicitly allowed to displace ESTIMATED may use the stand")
+	request.DisplaceStage = ""
+
+	arrival.Stage = StageAssigned
+	departureTOBT := eta.Add(-5 * time.Minute)
+	request.DepartureTOBT = &departureTOBT
+	unavailable = service.availability(request, []*models.StandAssignment{arrival}, nil, matches)
+	assert.Contains(t, unavailable["A1"], "reserved by ARR1", "ASSIGNED begins the normal ETA reservation window")
+
+	arrival.ETA = nil
+	unavailable = service.availability(request, []*models.StandAssignment{arrival}, nil, matches)
+	assert.Contains(t, unavailable["A1"], "reserved by ARR1", "a close unknown-ETA arrival blocks immediately")
+}
+
+func TestAutomaticAllocationOnlyReleasesEstimatedReservationForBetterPolicyTier(t *testing.T) {
+	registry, err := sat.LoadStandCapabilities(strings.NewReader(`
+STAND:EKCH:A1:N055.37.42.710:E012.38.33.450:30
+WTC:M
+BLOCKS:A2
+STAND:EKCH:A2:N055.37.42.711:E012.38.33.451:30
+WTC:M
+STAND:EKCH:A3:N055.37.42.712:E012.38.33.452:30
+WTC:M
+`))
+	require.NoError(t, err)
+	policy, err := sat.LoadAirlineAssignment(strings.NewReader(`{
+  "rules": [{
+    "id":"test",
+    "callsigns":["TST"],
+    "stands":{
+      "tier1":{"A1":100,"A2":100},
+      "tier2":{"A3":100}
+    }
+  }],
+  "stand_groups": {},
+  "fallback_rules": {`+testFallbackJSON("A3")+`}
+}`), registry)
+	require.NoError(t, err)
+	service := &StandAllocationService{
+		stands: registry,
+		policy: policy,
+		random: func() float64 { return 0 },
+		now:    time.Now,
+	}
+	request := StandAllocationRequest{
+		Callsign: "TST9", Airport: "EKCH", Direction: sat.AssignmentDirectionArrival,
+		Stage:       StageAssigned,
+		FlightFacts: sat.FlightCompatibilityFacts{Direction: sat.Arrival, WTC: "M"},
+		AssignmentFacts: sat.AssignmentFlightFacts{
+			Callsign: "TST9", Direction: sat.AssignmentDirectionArrival,
+		},
+	}
+	evaluation := registry.EvaluateCompatibility(request.Airport, request.FlightFacts)
+	a1 := &models.StandAssignment{
+		Callsign: "ARR1", Stand: "A1",
+		Direction: string(sat.AssignmentDirectionArrival), Stage: StageEstimated,
+	}
+
+	selected, selection, _, _, _, err := service.selectStand(AutomaticStandAllocation, request, evaluation, []*models.StandAssignment{a1}, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "A2", selected, "an estimated reservation neither yields nor adjacency-blocks an open stand in the same tier")
+	require.NotNil(t, selection)
+	assert.Equal(t, 1, selection.Tier)
+
+	a2 := &models.StandAssignment{
+		Callsign: "ARR2", Stand: "A2",
+		Direction: string(sat.AssignmentDirectionArrival), Stage: StageEstimated,
+	}
+	selected, selection, _, _, _, err = service.selectStand(AutomaticStandAllocation, request, evaluation, []*models.StandAssignment{a1, a2}, nil, nil)
+	require.NoError(t, err)
+	assert.Contains(t, []string{"A1", "A2"}, selected, "a soft reservation yields before forcing the request to tier 2")
+	require.NotNil(t, selection)
+	assert.Equal(t, 1, selection.Tier)
+	assert.True(t, selectedHasEstimatedReservation([]*models.StandAssignment{a1, a2}, selected, request.Callsign))
+
+	request.Stage = StageEstimated
+	request.ETA = nil
+	selected, selection, _, _, _, err = service.selectStand(AutomaticStandAllocation, request, evaluation, []*models.StandAssignment{a1, a2}, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "A3", selected, "an equal-priority estimate must not churn existing reservations")
+	require.NotNil(t, selection)
+	assert.Equal(t, 2, selection.Tier)
+
+	earlierETA := time.Now().Add(15 * time.Minute)
+	laterETA := earlierETA.Add(30 * time.Minute)
+	request.ETA = &earlierETA
+	a1.ETA = &laterETA
+	selected, selection, _, _, _, err = service.selectStand(AutomaticStandAllocation, request, evaluation, []*models.StandAssignment{a1, a2}, nil, nil)
+	require.NoError(t, err)
+	assert.Contains(t, []string{"A1", "A2"}, selected, "an earlier estimated arrival may take priority over a later or untimed estimate")
+	require.NotNil(t, selection)
+	assert.Equal(t, 1, selection.Tier)
+
+	request.Stage = StageAssigned
+	request.ETA = nil
+	fallbackPolicy, err := sat.LoadAirlineAssignment(strings.NewReader(`{
+  "rules": [{"id":"test","callsigns":["TST"],"stands":{"tier1":{"A1":100}}}],
+  "stand_groups": {},
+  "fallback_rules": {`+testFallbackJSON("A3")+`}
+}`), registry)
+	require.NoError(t, err)
+	service.policy = fallbackPolicy
+
+	selected, selection, _, _, _, err = service.selectStand(AutomaticStandAllocation, request, evaluation, []*models.StandAssignment{a1}, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "A1", selected, "a soft reservation yields before forcing the request onto a fallback rule")
+	require.NotNil(t, selection)
+	assert.False(t, selection.FallbackUsed)
 }
 
 func standAllocationFixture(t *testing.T, pool *pgxpool.Pool, queries *database.Queries, a1Directive, a2Directive string) (*StandAllocationService, int32, repository.StandAssignmentRepository) {

--- a/backend/internal/vatsim/reconciliation.go
+++ b/backend/internal/vatsim/reconciliation.go
@@ -424,6 +424,13 @@ func (r *Reconciler) isAssigned(ctx context.Context, session int32, callsign str
 	if err != nil || assignment == nil {
 		return false
 	}
+	// An automatic ESTIMATED arrival is advisory only. It must not retain an
+	// API-created strip forever after the flight disappears.
+	if !assignment.Manual &&
+		strings.EqualFold(assignment.Direction, "ARRIVAL") &&
+		strings.EqualFold(assignment.Stage, "ESTIMATED") {
+		return false
+	}
 	if assignment.ExpiresAt == nil {
 		return true
 	}

--- a/backend/internal/vatsim/reconciliation_test.go
+++ b/backend/internal/vatsim/reconciliation_test.go
@@ -87,9 +87,15 @@ func (s reconciliationTestSessions) List(context.Context) ([]*models.Session, er
 	return s.items, nil
 }
 
-type reconciliationTestAssignments struct{ active map[string]bool }
+type reconciliationTestAssignments struct {
+	active      map[string]bool
+	assignments map[string]*models.StandAssignment
+}
 
 func (s reconciliationTestAssignments) GetAssignment(_ context.Context, session int32, callsign string) (*models.StandAssignment, error) {
+	if assignment := s.assignments[assignmentKey(session, callsign)]; assignment != nil {
+		return assignment, nil
+	}
 	if s.active[assignmentKey(session, callsign)] {
 		return &models.StandAssignment{SessionID: session, Callsign: callsign}, nil
 	}
@@ -334,4 +340,36 @@ func TestRetainsStripHonorsReservationExpiry(t *testing.T) {
 
 	assert.True(t, reconciler.RetainsStrip(context.Background(), 7, "SAS1"), "an active reservation keeps the strip alive")
 	assert.False(t, reconciler.RetainsStrip(context.Background(), 7, "SAS2"), "an expired reservation no longer retains the strip")
+}
+
+func TestRetainsStripDoesNotKeepAdvisoryArrivalAfterFlightDisappears(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	assignment := &models.StandAssignment{
+		SessionID: 7,
+		Callsign:  "SAS926",
+		Direction: "ARRIVAL",
+		Stage:     "ESTIMATED",
+		Source:    "AUTOMATIC",
+	}
+	assignments := reconciliationTestAssignments{assignments: map[string]*models.StandAssignment{
+		assignmentKey(7, "SAS926"): assignment,
+	}}
+	reconciler := newTestReconciler(
+		newReconciliationTestCache(now),
+		reconciliationTestSessions{items: []*models.Session{{ID: 7, Airport: "EKCH"}}},
+		&reconciliationTestStrips{bySession: map[int32][]*models.Strip{}},
+		assignments,
+		nil,
+		time.Second,
+		WithClock(func() time.Time { return now }),
+	)
+
+	assert.False(t, reconciler.RetainsStrip(context.Background(), 7, "SAS926"), "advisory assignment disappears with its VATSIM-only strip")
+
+	eta := now.Add(30 * time.Minute)
+	assignment.ETA = &eta
+	assert.False(t, reconciler.RetainsStrip(context.Background(), 7, "SAS926"), "ESTIMATED remains advisory when timing becomes available")
+
+	assignment.Stage = "ASSIGNED"
+	assert.True(t, reconciler.RetainsStrip(context.Background(), 7, "SAS926"), "a close operational arrival retains its strip")
 }


### PR DESCRIPTION
## Summary

- assign advisory stands to arrivals even when they are distant or have no ETA
- freeze an existing stand once a valid low-altitude position places the aircraft at EKCH
- treat ESTIMATED stands as soft reservations that yield only to avoid a lower tier, fallback, or no stand
- prioritize earlier estimated arrivals while preventing equal-priority/no-ETA arrivals from evicting each other
- enforce physical stand compatibility so Heavy aircraft cannot fall back to M-only stands
- use VATSIM facts when fresh EuroScope strips temporarily contain incomplete aircraft or origin data
- release advisory API-only assignments after the flight disappears

## Root cause

Fresh-session strip facts could temporarily resolve as unknown, and the allocator had an unsafe physical fallback path. Estimated arrivals also lacked stable reservation semantics, allowing repeated reallocations. Default position values could additionally promote an arrival without a meaningful position.

## Impact

Arrival stands remain stable for aircraft at EKCH and for equal-priority planned traffic. Operational or earlier arrivals can still use a preferred stand when preserving an estimated reservation would force a lower-tier or fallback assignment. All assignments continue to respect physical aircraft/stand compatibility.

## Validation

- `go test ./... -p 1 -count=1`
- `go vet ./internal/services ./internal/sat ./internal/vatsim`
- `git diff --check`

The full Docker-backed backend test suite passes, including PostgreSQL integration and e2e packages.
