### PR TITLE
feat(cdm): display active departure rates

### DIFF
--- a/backend/internal/cdm/config_store_test.go
+++ b/backend/internal/cdm/config_store_test.go
@@ -82,6 +82,41 @@ func TestParseRateData_SourceFormat(t *testing.T) {
 	}
 }
 
+func TestEKCHRateFile_AppliesThirtyDeparturesPerHourFor22RWithArrival30(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("../../config/ekch/rate.txt")
+	if err != nil {
+		t.Fatalf("read EKCH rate file: %v", err)
+	}
+	rates, err := parseRateData(data)
+	if err != nil {
+		t.Fatalf("parse EKCH rate file: %v", err)
+	}
+
+	config := NewDefaultAirportConfig("EKCH")
+	config.Rates = rates
+	config = config.SnapshotWithRunways([]string{"30"}, []string{"22R"})
+	if rate := config.RateForRunway("22R"); rate != 30 {
+		t.Fatalf("expected 22R departure rate of 30 with arrival 30, got %d", rate)
+	}
+
+	result := Calculate(CalcInput{
+		Callsign: "SAS123",
+		Origin:   "EKCH",
+		DepRwy:   "22R",
+		Tobt:     "1000",
+		TaxiMin:  10,
+	}, []SlotEntry{{
+		Callsign: "SAS122",
+		Origin:   "EKCH",
+		DepRwy:   "22R",
+		Ttot:     "101100",
+	}}, config, time.Date(2026, 3, 25, 8, 0, 0, 0, time.UTC))
+
+	assertClockResult(t, result, "100300", "101300")
+}
+
 func TestParseSidIntervalData_SourceFormat(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/cdm/sequence.go
+++ b/backend/internal/cdm/sequence.go
@@ -126,15 +126,7 @@ func (s *SequenceService) recalculateAirport(ctx context.Context, session int32,
 		return err
 	}
 
-	config := s.configProvider.ConfigForAirport(airport)
-	if config == nil {
-		if defaults, ok := s.configProvider.(*CdmConfigStore); ok {
-			config = defaults.DefaultConfigForAirport(airport)
-		} else {
-			config = &CdmAirportConfig{Airport: normalizeToken(airport), DefaultRate: 20, DefaultTaxiMinutes: 10}
-		}
-	}
-	config = config.SnapshotWithRunways(sessionData.ActiveRunways.ArrivalRunways, sessionData.ActiveRunways.DepartureRunways)
+	config := s.configForActiveRunways(airport, sessionData.ActiveRunways.ArrivalRunways, sessionData.ActiveRunways.DepartureRunways)
 	now := s.now().UTC()
 	nowHHMMSS := timeToClock(now)
 
@@ -308,6 +300,22 @@ func (s *SequenceService) recalculateAirport(ctx context.Context, session int32,
 	}
 
 	return nil
+}
+
+// configForActiveRunways returns the same config snapshot used for sequencing.
+// Keeping this resolution in one place lets read-only views report the exact
+// rate that CDM will apply for the session's current runway configuration.
+func (s *SequenceService) configForActiveRunways(airport string, arrivals, departures []string) *CdmAirportConfig {
+	config := s.configProvider.ConfigForAirport(airport)
+	if config == nil {
+		if defaults, ok := s.configProvider.(*CdmConfigStore); ok {
+			config = defaults.DefaultConfigForAirport(airport)
+		} else {
+			config = &CdmAirportConfig{Airport: normalizeToken(airport), DefaultRate: DefaultCDMRate, DefaultTaxiMinutes: DefaultCDMTaxiMinutes}
+		}
+	}
+
+	return config.SnapshotWithRunways(arrivals, departures)
 }
 
 func compareSequencingCandidates(left, right sequencingCandidate, anchor time.Time, preserveExistingSlots bool) int {

--- a/backend/internal/cdm/webapi.go
+++ b/backend/internal/cdm/webapi.go
@@ -27,13 +27,19 @@ type sequenceResponse struct {
 }
 
 type sequenceSessionResponse struct {
-	SessionID        int32                 `json:"session_id"`
-	Name             string                `json:"name"`
-	Airport          string                `json:"airport"`
-	CdmMaster        bool                  `json:"cdm_master"`
-	DepartureRunways []string              `json:"departure_runways"`
-	ArrivalRunways   []string              `json:"arrival_runways"`
-	Rows             []sequenceRowResponse `json:"rows"`
+	SessionID        int32                   `json:"session_id"`
+	Name             string                  `json:"name"`
+	Airport          string                  `json:"airport"`
+	CdmMaster        bool                    `json:"cdm_master"`
+	DepartureRunways []string                `json:"departure_runways"`
+	DepartureRates   []departureRateResponse `json:"departure_rates"`
+	ArrivalRunways   []string                `json:"arrival_runways"`
+	Rows             []sequenceRowResponse   `json:"rows"`
+}
+
+type departureRateResponse struct {
+	Runway         string `json:"runway"`
+	DeparturesHour int    `json:"departures_per_hour"`
 }
 
 type sequenceRowResponse struct {
@@ -125,10 +131,6 @@ func (a *WebAPI) handleSequence(w http.ResponseWriter, r *http.Request) {
 			writeJSONError(w, http.StatusInternalServerError, "failed to build cdm sequence")
 			return
 		}
-		if len(snapshot.Rows) == 0 {
-			continue
-		}
-
 		response.Sessions = append(response.Sessions, snapshot)
 	}
 
@@ -155,6 +157,7 @@ func buildSequenceSessionSnapshot(ctx context.Context, service *SequenceService,
 		CdmMaster:        session.CdmMaster,
 		DepartureRunways: append([]string(nil), session.ActiveRunways.DepartureRunways...),
 		ArrivalRunways:   append([]string(nil), session.ActiveRunways.ArrivalRunways...),
+		DepartureRates:   currentDepartureRates(service, session),
 		Rows:             []sequenceRowResponse{},
 	}
 
@@ -170,6 +173,41 @@ func buildSequenceSessionSnapshot(ctx context.Context, service *SequenceService,
 	}
 
 	return response, nil
+}
+
+func currentDepartureRates(service *SequenceService, session *models.Session) []departureRateResponse {
+	if service == nil || session == nil {
+		return []departureRateResponse{}
+	}
+
+	config := service.configForActiveRunways(
+		session.Airport,
+		session.ActiveRunways.ArrivalRunways,
+		session.ActiveRunways.DepartureRunways,
+	)
+	runways := append([]string(nil), session.ActiveRunways.DepartureRunways...)
+	sort.Slice(runways, func(i, j int) bool {
+		return strings.ToUpper(strings.TrimSpace(runways[i])) < strings.ToUpper(strings.TrimSpace(runways[j]))
+	})
+
+	rates := make([]departureRateResponse, 0, len(runways))
+	seen := make(map[string]struct{}, len(runways))
+	for _, runway := range runways {
+		normalized := strings.ToUpper(strings.TrimSpace(runway))
+		if normalized == "" {
+			continue
+		}
+		if _, exists := seen[normalized]; exists {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		rates = append(rates, departureRateResponse{
+			Runway:         normalized,
+			DeparturesHour: config.RateForRunway(normalized),
+		})
+	}
+
+	return rates
 }
 
 func buildSequenceSnapshotRows(strips []*models.Strip, config *CdmAirportConfig, now time.Time) []sequenceSnapshotRow {

--- a/backend/internal/cdm/webapi_test.go
+++ b/backend/internal/cdm/webapi_test.go
@@ -200,6 +200,61 @@ func TestWebAPIHandleSequenceReturnsSessionRows(t *testing.T) {
 	}
 }
 
+func TestWebAPIHandleSequenceReturnsCurrentDepartureRatesWithoutAircraft(t *testing.T) {
+	t.Parallel()
+
+	stripRepo := &testutil.MockStripRepository{
+		ListByOriginFn: func(context.Context, int32, string) ([]*models.Strip, error) {
+			return []*models.Strip{}, nil
+		},
+	}
+	sessionRepo := &testutil.MockSessionRepository{
+		ListFn: func(context.Context) ([]*models.Session, error) {
+			return []*models.Session{{
+				ID:      7,
+				Name:    "LIVE",
+				Airport: "EKCH",
+				ActiveRunways: pkgModels.ActiveRunways{
+					ArrivalRunways:   []string{"30"},
+					DepartureRunways: []string{"22R"},
+				},
+			}}, nil
+		},
+	}
+	configStore := NewCdmConfigStore("", "", "", 0, CdmConfigDefaults{}, nil)
+	configStore.configs["EKCH"] = &CdmAirportConfig{
+		Airport:     "EKCH",
+		DefaultRate: 40,
+		Rates: []CdmRate{{
+			Airport:   "EKCH",
+			ArrRwyYes: []string{"30"},
+			DepRwyYes: []string{"22R"},
+			Rates:     []string{"30"},
+		}},
+	}
+	api := NewWebAPI(cdmAuthStub{}, sessionRepo, newTestSequenceService(stripRepo, sessionRepo, configStore, nil, nil))
+
+	req := httptest.NewRequest(http.MethodGet, "/cdm/sequence", nil)
+	req.Header.Set("Authorization", "Bearer token")
+	recorder := httptest.NewRecorder()
+	api.handleSequence(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, recorder.Code, recorder.Body.String())
+	}
+	var payload sequenceResponse
+	if err := json.NewDecoder(recorder.Body).Decode(&payload); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(payload.Sessions) != 1 || len(payload.Sessions[0].Rows) != 0 {
+		t.Fatalf("expected one empty session, got %#v", payload)
+	}
+	rates := payload.Sessions[0].DepartureRates
+	if len(rates) != 1 || rates[0].Runway != "22R" || rates[0].DeparturesHour != 30 {
+		t.Fatalf("expected current 22R rate of 30 departures/hour, got %#v", rates)
+	}
+}
+
 func TestWebAPIHandleSequenceDoesNotRecalculateSlaveSessions(t *testing.T) {
 	t.Parallel()
 

--- a/frontend/src/pages/cdm.tsx
+++ b/frontend/src/pages/cdm.tsx
@@ -44,6 +44,10 @@ type SequenceSession = {
   airport: string;
   cdm_master: boolean;
   departure_runways: string[];
+  departure_rates: Array<{
+    runway: string;
+    departures_per_hour: number;
+  }>;
   arrival_runways: string[];
   rows: SequenceRow[];
 };
@@ -98,6 +102,16 @@ function formatConfirmation(row: SequenceRow): string {
   }
 
   return row.tobt_confirmed_by ? `Yes (${row.tobt_confirmed_by})` : "Yes";
+}
+
+function formatDepartureRates(session: SequenceSession): string {
+  if (session.departure_rates.length === 0) {
+    return "—";
+  }
+
+  return session.departure_rates
+    .map((rate) => `${rate.runway} ${rate.departures_per_hour}/h`)
+    .join(", ");
 }
 
 function formatOriginalTtot(row: SequenceRow): string {
@@ -245,7 +259,7 @@ export default function CdmPage() {
                 </h2>
                 <p className="text-sm text-muted-foreground">
                   Departure runways {session.departure_runways.join(", ") || "—"} | Arrival runways{" "}
-                  {session.arrival_runways.join(", ") || "—"} | CDM{" "}
+                    {session.arrival_runways.join(", ") || "—"} | Current departure rates {formatDepartureRates(session)} | CDM{" "}
                   {session.cdm_master ? "Master" : "Slave"}
                 </p>
               </div>


### PR DESCRIPTION
## Summary

- expose the resolved per-runway CDM departure rate in the sequence API and `/cdm` page
- retain empty sessions in the response so current rates remain visible before aircraft are sequenced
- verify the EKCH rate file resolves `22R` departures with landing runway `30` to 30 departures per hour and enforces its two-minute rate window

## Why

Controllers need to see the live rate that CDM applies for the active runway configuration. The prior page showed active runways but not the resulting configured rate.

## Validation

- `go test ./internal/cdm`

The frontend build is currently blocked by the installed TypeScript version not supporting existing compiler options; this is unrelated to this change.
