### PR TITLE
fix(authentication): add redirect port fallbacks

### DIFF
--- a/docs/src/content/docs/dev/local-dev.md
+++ b/docs/src/content/docs/dev/local-dev.md
@@ -86,7 +86,7 @@ baseurl = ws://localhost:8090/euroscopeEvents
 level = DEBUG
 ```
 
-All other keys (`authority`, `redirectPort`, `enabled`) stay the same as production. Full reference: `src/config_dev.ini` (dev), `src/config.ini` (prod).
+All other keys (`authority`, `redirectPorts`, `enabled`) stay the same as production. Full reference: `src/config_dev.ini` (dev), `src/config.ini` (prod).
 
 `userconfig.ini` holds personal tokens and is gitignored — do not commit it.
 

--- a/docs/src/content/docs/troubleshooting/authentication-port-conflicts.md
+++ b/docs/src/content/docs/troubleshooting/authentication-port-conflicts.md
@@ -5,20 +5,28 @@ sidebar:
   order: 1
 ---
 
-If you see the error **"Authentication redirect listener failed to start on port 27015"** when logging in via the EuroScope plugin, another application is blocking the authentication port.
+The EuroScope plugin tries local ports **27015**, **32015**, **37015**, **42015**, and **47015**, in that order, when logging in. They are deliberately spread apart so a reserved port range is less likely to block every fallback.
+
+Register these callback URLs in Auth0:
+
+- `http://127.0.0.1:27015/callback-auth0`
+- `http://127.0.0.1:32015/callback-auth0`
+- `http://127.0.0.1:37015/callback-auth0`
+- `http://127.0.0.1:42015/callback-auth0`
+- `http://127.0.0.1:47015/callback-auth0`
 
 ## What's happening
 
-The EuroScope plugin creates a local HTTP server on port 27015 to handle the OAuth callback after you authenticate. If this port is already in use, the login process fails.
+The EuroScope plugin creates a local HTTP server to handle the OAuth callback after you authenticate. Login fails only when all configured callback ports are in use.
 
 ## Resolve port conflicts
 
-### 1. Check what's using port 27015
+### 1. Check what's using the callback ports
 
 Open PowerShell and run:
 
 ```powershell
-netstat -ano | findstr :27015
+netstat -ano | findstr /C:":27015" /C:":32015" /C:":37015" /C:":42015" /C:":47015"
 ```
 
 This shows all processes using that port. Note the **PID** (Process ID) number.
@@ -60,5 +68,5 @@ A restart releases all port bindings and often resolves transient conflicts.
 
 After resolving the port conflict, try logging in again. The authentication should complete without errors.
 
-If you continue to see the error, verify port 27015 is clear by running the netstat command again.
+If you continue to see the error, verify that at least one callback port is clear by running the netstat command again.
 

--- a/euroscope-plugin/src/config.ini
+++ b/euroscope-plugin/src/config.ini
@@ -2,7 +2,7 @@
 authority = https://auth.flightstrips.dk
 audience = backend
 clientId = 6DvALo80N5ywXNlIyjR4AlLDw6e5OKNY
-redirectPort = 27015
+redirectPorts = 27015 32015 37015 42015 47015
 
 [api]
 enabled = true

--- a/euroscope-plugin/src/config_dev.ini
+++ b/euroscope-plugin/src/config_dev.ini
@@ -2,7 +2,7 @@
 authority = https://auth.flightstrips.dk
 audience = backend-dev
 clientId = oPIlNgkBODM1OEFTrcKOZl9JavEives3
-redirectPort = 27015
+redirectPorts = 27015 32015 37015 42015 47015
 
 [api]
 enabled = true

--- a/euroscope-plugin/src/plugin/authentication/AuthenticationRedirectListener.cpp
+++ b/euroscope-plugin/src/plugin/authentication/AuthenticationRedirectListener.cpp
@@ -13,16 +13,7 @@ namespace FlightStrips::authentication {
         std::promise<std::optional<std::string> > &prms, const int port) : port(port), resultPromise(std::move(prms)) {
     }
 
-    void AuthenticationRedirectListener::Start() {
-        try {
-            this->backgroundThread = std::thread(&AuthenticationRedirectListener::BackgroundThread, this);
-        } catch (...) {
-            exceptions::LogCurrentException("AuthenticationRedirectListener::Start");
-            TrySetResult({}, "AuthenticationRedirectListener::Start");
-        }
-    }
-
-    void AuthenticationRedirectListener::BackgroundThread() {
+    bool AuthenticationRedirectListener::Start() {
         try {
             server.set_exception_handler([this](const httplib::Request&, httplib::Response &res, const std::exception_ptr ep) {
                 const auto details = exceptions::GetExceptionDetails(ep);
@@ -45,20 +36,56 @@ namespace FlightStrips::authentication {
                 TrySetResult(code, "AuthenticationRedirectListener::Callback");
             });
 
+            auto startupFuture = startupPromise.get_future();
+            this->backgroundThread = std::thread(&AuthenticationRedirectListener::BackgroundThread, this);
+            if (!startupFuture.get()) {
+                backgroundThread.join();
+                return false;
+            }
+
+            server.wait_until_ready();
+            if (server.is_running()) {
+                return true;
+            }
+
+            if (backgroundThread.joinable()) {
+                backgroundThread.join();
+            }
+            return false;
+        } catch (...) {
+            exceptions::LogCurrentException("AuthenticationRedirectListener::Start");
+            Stop();
+            TrySetResult({}, "AuthenticationRedirectListener::Start");
+            return false;
+        }
+    }
+
+    void AuthenticationRedirectListener::BackgroundThread() {
+        try {
+            if (!server.bind_to_port("127.0.0.1", port)) {
+                Logger::Warning("Authentication redirect listener could not bind to port {}", port);
+                TrySetStartupResult(false);
+                return;
+            }
+
+            TrySetStartupResult(true);
             Logger::Debug(std::format("Starting HTTP server listing on http://127.0.0.1:{}", port));
-            const auto listening = server.listen("127.0.0.1", port);
+            const auto listening = server.listen_after_bind();
             if (!listening && !resultSet.load()) {
                 Logger::Error("Authentication redirect listener failed to start on port {}", port);
                 TrySetResult({}, "AuthenticationRedirectListener::Listen");
             }
             Logger::Debug(std::format("Stopping HTTP server listing on http://127.0.0.1:{}", port));
         } catch (...) {
+            TrySetStartupResult(false);
             exceptions::LogCurrentException("AuthenticationRedirectListener::BackgroundThread");
             TrySetResult({}, "AuthenticationRedirectListener::BackgroundThread");
         }
     }
 
-    AuthenticationRedirectListener::~AuthenticationRedirectListener() = default;
+    AuthenticationRedirectListener::~AuthenticationRedirectListener() {
+        Stop();
+    }
 
     void AuthenticationRedirectListener::Stop() {
         if (server.is_running()) {
@@ -67,6 +94,18 @@ namespace FlightStrips::authentication {
 
         if (backgroundThread.joinable()) {
             backgroundThread.join();
+        }
+    }
+
+    void AuthenticationRedirectListener::TrySetStartupResult(const bool value) {
+        if (startupSet.exchange(true)) {
+            return;
+        }
+
+        try {
+            startupPromise.set_value(value);
+        } catch (...) {
+            exceptions::LogCurrentException("AuthenticationRedirectListener::TrySetStartupResult");
         }
     }
 

--- a/euroscope-plugin/src/plugin/authentication/AuthenticationRedirectListener.h
+++ b/euroscope-plugin/src/plugin/authentication/AuthenticationRedirectListener.h
@@ -13,16 +13,19 @@ public:
     AuthenticationRedirectListener(std::promise<std::optional<std::string>>& prms, int port);
     ~AuthenticationRedirectListener();
     void Stop();
-    void Start();
+    [[nodiscard]] bool Start();
 
 private:
     int port;
     httplib::Server server;
     std::thread backgroundThread;
     std::promise<std::optional<std::string>> resultPromise;
+    std::promise<bool> startupPromise;
     std::atomic_bool resultSet = false;
+    std::atomic_bool startupSet = false;
 
     void BackgroundThread();
+    void TrySetStartupResult(bool value);
     void TrySetResult(std::optional<std::string> value, const std::string& context);
 };
 

--- a/euroscope-plugin/src/plugin/authentication/AuthenticationService.cpp
+++ b/euroscope-plugin/src/plugin/authentication/AuthenticationService.cpp
@@ -296,43 +296,49 @@ namespace FlightStrips::authentication {
 
     void AuthenticationService::DoAuthenticationFlowImpl() {
         Logger::Debug("Starting authentication flow");
-        std::promise<std::optional<std::string> > promise;
-        std::future<std::optional<std::string> > future = promise.get_future();
+        for (const auto port : this->appConfig->GetRedirectPorts()) {
+            std::promise<std::optional<std::string> > promise;
+            std::future<std::optional<std::string> > future = promise.get_future();
+            AuthenticationRedirectListener listener(promise, port);
 
-        AuthenticationRedirectListener listener(promise, this->appConfig->GetRedirectPort());
-        listener.Start();
+            if (!listener.Start()) {
+                continue;
+            }
 
-        const auto code_verifier = generateCodeVerifier();
-        const auto code_challenge = generateCodeChallenge(code_verifier);
-        const std::string client_id = this->appConfig->GetClientId();
-        const std::string redirect_uri = std::format("http://127.0.0.1:{}/callback-auth0",
-                                                     this->appConfig->GetRedirectPort());
-        auto url = GetAuthorizeUrl(code_challenge, client_id, redirect_uri);
-        OpenBrowser(url);
+            const auto code_verifier = generateCodeVerifier();
+            const auto code_challenge = generateCodeChallenge(code_verifier);
+            const std::string client_id = this->appConfig->GetClientId();
+            const std::string redirect_uri = std::format("http://127.0.0.1:{}/callback-auth0", port);
+            auto url = GetAuthorizeUrl(code_challenge, client_id, redirect_uri);
+            OpenBrowser(url);
 
-        const auto ready = WaitForResult(future);
-        listener.Stop();
+            const auto ready = WaitForResult(future);
+            listener.Stop();
 
-        if (!ready) {
-            Logger::Debug("Authentication cancelled");
+            if (!ready) {
+                Logger::Debug("Authentication cancelled");
+                return;
+            }
+
+            auto code_result = future.get();
+            if (!code_result.has_value()) {
+                Logger::Debug("Authentication failed, got no authorization code.");
+                return;
+            }
+
+            if (!state) return;
+
+            auto code = code_result.value();
+            Logger::Debug(std::format("Authorization code: {}", code));
+
+            auto token_result = GetTokenFromAuthorizationCode(client_id, code_verifier, code, redirect_uri);
+            Logger::Debug(std::format("Got authentication token: {}", token_result));
+
+            ParseAndSetToken(token_result);
             return;
         }
 
-        auto code_result = future.get();
-        if (!code_result.has_value()) {
-            Logger::Debug("Authentication failed, got no authorization code.");
-            return;
-        }
-
-        if (!state) return;
-
-        auto code = code_result.value();
-        Logger::Debug(std::format("Authorization code: {}", code));
-
-        auto token_result = GetTokenFromAuthorizationCode(client_id, code_verifier, code, redirect_uri);
-        Logger::Debug(std::format("Got authentication token: {}", token_result));
-
-        ParseAndSetToken(token_result);
+        Logger::Error("Authentication redirect listener could not start on any configured port");
     }
 
     void AuthenticationService::DoAuthenticationFlow() {

--- a/euroscope-plugin/src/plugin/configuration/AppConfig.cpp
+++ b/euroscope-plugin/src/plugin/configuration/AppConfig.cpp
@@ -4,6 +4,9 @@
 
 #include "AppConfig.h"
 
+#include <algorithm>
+#include <sstream>
+
 namespace FlightStrips::configuration {
     std::string AppConfig::GetAuthority() {
         return std::string(ini["authentication"]["authority"] | "error");
@@ -21,8 +24,31 @@ namespace FlightStrips::configuration {
         return std::string(ini["authentication"]["scopes"] | "openid profile offline_access");
     }
 
-    int AppConfig::GetRedirectPort() {
-        return ini["authentication"]["redirectPort"] | 27015;
+    std::vector<int> AppConfig::GetRedirectPorts() {
+        const auto configuredPorts = std::string(ini["authentication"]["redirectPorts"] | "");
+        std::istringstream ports(configuredPorts);
+        std::vector<int> result;
+        int port;
+
+        const auto addPort = [&result](const int candidate) {
+            if (candidate > 0 && candidate <= 65535 && std::find(result.begin(), result.end(), candidate) == result.end()) {
+                result.push_back(candidate);
+            }
+        };
+
+        while (ports >> port) {
+            addPort(port);
+        }
+
+        if (result.empty()) {
+            addPort(ini["authentication"]["redirectPort"] | 27015);
+            addPort(32015);
+            addPort(37015);
+            addPort(42015);
+            addPort(47015);
+        }
+
+        return result;
     }
 
     std::string AppConfig::GetBaseUrl() {

--- a/euroscope-plugin/src/plugin/configuration/AppConfig.h
+++ b/euroscope-plugin/src/plugin/configuration/AppConfig.h
@@ -35,7 +35,7 @@ public:
     [[nodiscard]] std::string GetAudience();
     [[nodiscard]] std::string GetClientId();
     [[nodiscard]] std::string GetScopes();
-    [[nodiscard]] int GetRedirectPort();
+    [[nodiscard]] std::vector<int> GetRedirectPorts();
     [[nodiscard]] std::string GetBaseUrl();
     [[nodiscard]] bool GetApiEnabled();
     [[nodiscard]] std::string GetLogLevel();

--- a/euroscope-plugin/test/plugin/configuration/AppConfigTest.cpp
+++ b/euroscope-plugin/test/plugin/configuration/AppConfigTest.cpp
@@ -45,9 +45,25 @@ TEST(AppConfigTest, GetScopes_Default_ReturnsOpenidProfile) {
     EXPECT_EQ(cfg.GetScopes(), "openid profile offline_access");
 }
 
-TEST(AppConfigTest, GetRedirectPort_Default_Returns27015) {
+TEST(AppConfigTest, GetRedirectPorts_Default_ReturnsConfiguredFallbacks) {
     auto cfg = MakeDefault();
-    EXPECT_EQ(cfg.GetRedirectPort(), 27015);
+    EXPECT_EQ(cfg.GetRedirectPorts(), (std::vector<int>{27015, 32015, 37015, 42015, 47015}));
+}
+
+TEST(AppConfigTest, GetRedirectPorts_Configured_ReturnsPortsInOrder) {
+    auto cfg = MakeConfigured(R"ini(
+[authentication]
+redirectPorts = 28000 28001 28002
+)ini");
+    EXPECT_EQ(cfg.GetRedirectPorts(), (std::vector<int>{28000, 28001, 28002}));
+}
+
+TEST(AppConfigTest, GetRedirectPorts_LegacyRedirectPort_IsTriedBeforeFallbacks) {
+    auto cfg = MakeConfigured(R"ini(
+[authentication]
+redirectPort = 28000
+)ini");
+    EXPECT_EQ(cfg.GetRedirectPorts(), (std::vector<int>{28000, 32015, 37015, 42015, 47015}));
 }
 
 TEST(AppConfigTest, GetBaseUrl_Default_ReturnsError) {


### PR DESCRIPTION
## Summary

- Try five widely spaced fixed localhost ports for the EuroScope OAuth callback.
- Bind and confirm the callback listener before opening the browser, then use the selected port consistently for authorization and token exchange.
- Preserve legacy `redirectPort` configuration while supporting the new ordered `redirectPorts` list.
- Document the five Auth0 callback URLs and update configuration coverage.

## Why

Authentication failed whenever port 27015 was occupied. Auth0 requires pre-registered callback URLs, so the plugin needs a fixed, ordered allow-list instead of random ports.

## User impact

Users can authenticate when an earlier callback port is unavailable, provided these URLs are registered in Auth0:

- `http://127.0.0.1:27015/callback-auth0`
- `http://127.0.0.1:32015/callback-auth0`
- `http://127.0.0.1:37015/callback-auth0`
- `http://127.0.0.1:42015/callback-auth0`
- `http://127.0.0.1:47015/callback-auth0`

## Validation

- `FlightStripsCoreTests.exe --gtest_brief=1` — 356 tests passed.